### PR TITLE
Histogram (Server)

### DIFF
--- a/components/blitz/resources/omero/Collections.ice
+++ b/components/blitz/resources/omero/Collections.ice
@@ -139,6 +139,7 @@ module omero {
         dictionary<long,   ByteArray>                  LongByteArrayMap;
         dictionary<long,   omero::model::Pixels>       LongPixelsMap;
         dictionary<int,    string>                     IntStringMap;
+        dictionary<int,    IntegerArray>               LongIntegerArrayMap;
         dictionary<string, omero::RType>               StringRTypeMap;
         dictionary<string, omero::model::Experimenter> UserMap;
         dictionary<string, omero::model::OriginalFile> OriginalFileMap;

--- a/components/blitz/resources/omero/Collections.ice
+++ b/components/blitz/resources/omero/Collections.ice
@@ -139,7 +139,7 @@ module omero {
         dictionary<long,   ByteArray>                  LongByteArrayMap;
         dictionary<long,   omero::model::Pixels>       LongPixelsMap;
         dictionary<int,    string>                     IntStringMap;
-        dictionary<int,    IntegerArray>               LongIntegerArrayMap;
+        dictionary<int,    IntegerArray>               IntegerIntegerArrayMap;
         dictionary<string, omero::RType>               StringRTypeMap;
         dictionary<string, omero::model::Experimenter> UserMap;
         dictionary<string, omero::model::OriginalFile> OriginalFileMap;

--- a/components/blitz/resources/omero/ModelF.ice
+++ b/components/blitz/resources/omero/ModelF.ice
@@ -48,6 +48,7 @@ module omero {
         class Plate;
         class Plate;
         class Project;
+        class ProjectionDef;
         class QuantumDef;
         class RenderingDef;
         class RenderingModel;

--- a/components/blitz/resources/omero/ModelF.ice
+++ b/components/blitz/resources/omero/ModelF.ice
@@ -48,7 +48,6 @@ module omero {
         class Plate;
         class Plate;
         class Project;
-        class ProjectionDef;
         class QuantumDef;
         class RenderingDef;
         class RenderingModel;

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -331,9 +331,10 @@ module omero {
                  * @param channels the channels to generate the histogram data for
                  * @param binSize the number of the histogram bins (optional, default: 256)
                  * @param plane the plane (optional, default: whole region of first z/t plane)
+                 * @param globalRange use the global minimum/maximum to determine the histogram range, otherwise use plane minimum/maximum value
                  * @return See above.
                  **/
-                idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binSize, omero::romio::PlaneDef plane) throws ServerError;
+                idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binSize, bool globalRange, omero::romio::PlaneDef plane) throws ServerError;
                 
                 /**
                  * Returns the byte width for the pixel store.

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -329,7 +329,7 @@ module omero {
 				/**
                  * Retrieves the histogram data for the specified plane and channels
                  * @param channels the channels to generate the histogram data for
-                 * @param binSize the size of the histogram bins
+                 * @param binSize the number of the histogram bins (optional, default: 256)
                  * @param plane the plane
                  * @return See above.
                  **/

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -11,8 +11,8 @@
 
 #include <omero/ModelF.ice>
 #include <omero/Collections.ice>
-#include <omero/api/PyramidService.ice>
 #include <omero/ROMIO.ice>
+#include <omero/api/PyramidService.ice>
 
 module omero {
 
@@ -327,15 +327,13 @@ module omero {
                 idempotent void setTimepoint(Ice::ByteSeq buf, int t) throws ServerError;
 
 				/**
-                 * Retrieves the histogram data for specified plane and channels
+                 * Retrieves the histogram data for the specified plane and channels
                  * @param channels the channels to generate the histogram data for
                  * @param binSize the size of the histogram bins
-                 * @param renderingDef the rendering definition
-                 * @param projectionDef the projection definition (optional
-                 * @param planeDef the plane definition
+                 * @param plane the plane
                  * @return See above.
                  **/
-                idempotent LongIntegerArrayMap getHistogram(IntegerList channels, int binSize, omero::model::RenderingDef renderingDef, omero::model::ProjectionDef projectionDef, omero::romio::PlaneDef planeDef) throws ServerError;
+                idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binSize, omero::romio::PlaneDef plane) throws ServerError;
                 
                 /**
                  * Returns the byte width for the pixel store.

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -326,7 +326,7 @@ module omero {
                  **/
                 idempotent void setTimepoint(Ice::ByteSeq buf, int t) throws ServerError;
 
-				/**
+                /**
                  * Retrieves the histogram data for the specified plane and channels
                  * @param channels the channels to generate the histogram data for
                  * @param binSize the number of the histogram bins (optional, default: 256)

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -12,6 +12,7 @@
 #include <omero/ModelF.ice>
 #include <omero/Collections.ice>
 #include <omero/api/PyramidService.ice>
+#include <omero/ROMIO.ice>
 
 module omero {
 
@@ -325,6 +326,17 @@ module omero {
                  **/
                 idempotent void setTimepoint(Ice::ByteSeq buf, int t) throws ServerError;
 
+				/**
+                 * Retrieves the histogram data for specified plane and channels
+                 * @param channels the channels to generate the histogram data for
+                 * @param binSize the size of the histogram bins
+                 * @param renderingDef the rendering definition
+                 * @param projectionDef the projection definition (optional
+                 * @param planeDef the plane definition
+                 * @return See above.
+                 **/
+                idempotent LongIntegerArrayMap getHistogram(IntegerList channels, int binSize, omero::model::RenderingDef renderingDef, omero::model::ProjectionDef projectionDef, omero::romio::PlaneDef planeDef) throws ServerError;
+                
                 /**
                  * Returns the byte width for the pixel store.
                  * @return See above.

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -327,7 +327,7 @@ module omero {
                 idempotent void setTimepoint(Ice::ByteSeq buf, int t) throws ServerError;
 
                 /**
-                 * Retrieves the histogram data for the specified plane and channels
+                 * Retrieves the histogram data for the specified plane and channels. This method can currently only handle non-pyramid images.
                  * @param channels the channels to generate the histogram data for
                  * @param binCount the number of the histogram bins (optional, default: 256)
                  * @param plane the plane (optional, default: whole region of first z/t plane)

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -330,7 +330,7 @@ module omero {
                  * Retrieves the histogram data for the specified plane and channels
                  * @param channels the channels to generate the histogram data for
                  * @param binSize the number of the histogram bins (optional, default: 256)
-                 * @param plane the plane
+                 * @param plane the plane (optional, default: whole region of first z/t plane)
                  * @return See above.
                  **/
                 idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binSize, omero::romio::PlaneDef plane) throws ServerError;

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -329,12 +329,12 @@ module omero {
                 /**
                  * Retrieves the histogram data for the specified plane and channels
                  * @param channels the channels to generate the histogram data for
-                 * @param binSize the number of the histogram bins (optional, default: 256)
+                 * @param binCount the number of the histogram bins (optional, default: 256)
                  * @param plane the plane (optional, default: whole region of first z/t plane)
                  * @param globalRange use the global minimum/maximum to determine the histogram range, otherwise use plane minimum/maximum value
                  * @return See above.
                  **/
-                idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binSize, bool globalRange, omero::romio::PlaneDef plane) throws ServerError;
+                idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binCount, bool globalRange, omero::romio::PlaneDef plane) throws ServerError;
                 
                 /**
                  * Returns the byte width for the pixel store.

--- a/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
@@ -15,6 +15,7 @@ import omero.ServerError;
 import omero.api.AMD_RawPixelsStore_calculateMessageDigest;
 import omero.api.AMD_RawPixelsStore_getByteWidth;
 import omero.api.AMD_RawPixelsStore_getCol;
+import omero.api.AMD_RawPixelsStore_getHistogram;
 import omero.api.AMD_RawPixelsStore_getHypercube;
 import omero.api.AMD_RawPixelsStore_getPixelsId;
 import omero.api.AMD_RawPixelsStore_getPixelsPath;
@@ -241,6 +242,16 @@ public class RawPixelsStoreI extends AbstractPyramidServant implements
             byte[] buf, int t, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, buf, t);
 
+    }
+    
+    public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
+            List<Integer> channels, int binSize,
+            omero.model.RenderingDef renderingDef,
+            omero.model.ProjectionDef projectionDef,
+            omero.romio.PlaneDef planeDef, Current __current)
+            throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, channels, binSize, renderingDef,
+                projectionDef, planeDef);
     }
 
     public void getCol_async(AMD_RawPixelsStore_getCol __cb, int x, int z,

--- a/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
@@ -246,9 +246,9 @@ public class RawPixelsStoreI extends AbstractPyramidServant implements
     }
     
     public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
-            int[] channels, int binSize, PlaneDef plane,
+            int[] channels, int binSize, boolean globalRange, PlaneDef plane,
             Current __current) throws ServerError {
-        callInvokerOnRawArgs(__cb, __current, channels, binSize, plane);
+        callInvokerOnRawArgs(__cb, __current, channels, binSize, globalRange, plane);
     }
 
     public void getCol_async(AMD_RawPixelsStore_getCol __cb, int x, int z,

--- a/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
@@ -246,9 +246,9 @@ public class RawPixelsStoreI extends AbstractPyramidServant implements
     }
     
     public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
-            int[] channels, int binSize, boolean globalRange, PlaneDef plane,
+            int[] channels, int binCount, boolean globalRange, PlaneDef plane,
             Current __current) throws ServerError {
-        callInvokerOnRawArgs(__cb, __current, channels, binSize, globalRange, plane);
+        callInvokerOnRawArgs(__cb, __current, channels, binCount, globalRange, plane);
     }
 
     public void getCol_async(AMD_RawPixelsStore_getCol __cb, int x, int z,

--- a/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
@@ -47,6 +47,7 @@ import omero.api.AMD_RawPixelsStore_setStack;
 import omero.api.AMD_RawPixelsStore_setTile;
 import omero.api.AMD_RawPixelsStore_setTimepoint;
 import omero.api._RawPixelsStoreOperations;
+import omero.romio.PlaneDef;
 import Ice.Current;
 
 /**
@@ -245,13 +246,9 @@ public class RawPixelsStoreI extends AbstractPyramidServant implements
     }
     
     public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
-            List<Integer> channels, int binSize,
-            omero.model.RenderingDef renderingDef,
-            omero.model.ProjectionDef projectionDef,
-            omero.romio.PlaneDef planeDef, Current __current)
-            throws ServerError {
-        callInvokerOnRawArgs(__cb, __current, channels, binSize, renderingDef,
-                projectionDef, planeDef);
+            int[] channels, int binSize, PlaneDef plane,
+            Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, channels, binSize, plane);
     }
 
     public void getCol_async(AMD_RawPixelsStore_getCol __cb, int x, int z,

--- a/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
@@ -23,6 +23,7 @@ import omero.api.AMD_PyramidService_setResolutionLevel;
 import omero.api.AMD_RawPixelsStore_calculateMessageDigest;
 import omero.api.AMD_RawPixelsStore_getByteWidth;
 import omero.api.AMD_RawPixelsStore_getCol;
+import omero.api.AMD_RawPixelsStore_getHistogram;
 import omero.api.AMD_RawPixelsStore_getHypercube;
 import omero.api.AMD_RawPixelsStore_getPixelsId;
 import omero.api.AMD_RawPixelsStore_getPixelsPath;
@@ -341,6 +342,15 @@ public class BfPixelsStoreI extends _RawPixelsStoreDisp {
     public void setTimepoint_async(AMD_RawPixelsStore_setTimepoint __cb,
             byte[] buf, int t, Current __current) throws ServerError {
         throw new UnsupportedOperationException("Cannot write to repository");
+    }
+    
+    public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
+            List<Integer> channels, int binSize,
+            omero.model.RenderingDef renderingDef,
+            omero.model.ProjectionDef projectionDef,
+            omero.romio.PlaneDef planeDef, Current __current)
+            throws ServerError {
+        // TODO: !?!?
     }
 
     public void activate_async(AMD_StatefulServiceInterface_activate __cb,

--- a/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
@@ -59,6 +59,7 @@ import omero.api.AMD_StatefulServiceInterface_close;
 import omero.api.AMD_StatefulServiceInterface_getCurrentEventContext;
 import omero.api.AMD_StatefulServiceInterface_passivate;
 import omero.api._RawPixelsStoreDisp;
+import omero.romio.PlaneDef;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -345,11 +346,7 @@ public class BfPixelsStoreI extends _RawPixelsStoreDisp {
     }
     
     public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
-            List<Integer> channels, int binSize,
-            omero.model.RenderingDef renderingDef,
-            omero.model.ProjectionDef projectionDef,
-            omero.romio.PlaneDef planeDef, Current __current)
-            throws ServerError {
+            int[] channels, int binSize, PlaneDef plane, Current __current) throws ServerError {
         // TODO: !?!?
     }
 

--- a/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
@@ -346,8 +346,8 @@ public class BfPixelsStoreI extends _RawPixelsStoreDisp {
     }
     
     public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
-            int[] channels, int binSize, boolean globalRange, PlaneDef plane, Current __current) throws ServerError {
-        // TODO: !?!?
+            int[] channels, int binCount, boolean globalRange, PlaneDef plane, Current __current) throws ServerError {
+        throw new UnsupportedOperationException("NYI");
     }
 
     public void activate_async(AMD_StatefulServiceInterface_activate __cb,

--- a/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
@@ -346,7 +346,7 @@ public class BfPixelsStoreI extends _RawPixelsStoreDisp {
     }
     
     public void getHistogram_async(AMD_RawPixelsStore_getHistogram __cb,
-            int[] channels, int binSize, PlaneDef plane, Current __current) throws ServerError {
+            int[] channels, int binSize, boolean globalRange, PlaneDef plane, Current __current) throws ServerError {
         // TODO: !?!?
     }
 

--- a/components/common/src/ome/api/RawPixelsStore.java
+++ b/components/common/src/ome/api/RawPixelsStore.java
@@ -8,10 +8,12 @@
 package ome.api;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import ome.annotations.Validate;
 import ome.model.core.Pixels;
+import omeis.providers.re.data.PlaneDef;
 
 /**
  * Binary data provider. Initialized with the id of a
@@ -87,6 +89,8 @@ public interface RawPixelsStore extends StatefulServiceInterface {
     public byte[] getRow(int y, int z, int c, int t);
     
     public byte[] getCol(int x, int z, int c, int t);
+    
+    public Map<Integer, int[]> getHistogram(int[] channels, int binSize, PlaneDef plane);
 
     public byte[] getHypercube(@Validate(Integer.class) List<Integer> offset, @Validate(Integer.class) List<Integer> size, @Validate(Integer.class) List<Integer> step);
 

--- a/components/common/src/ome/api/RawPixelsStore.java
+++ b/components/common/src/ome/api/RawPixelsStore.java
@@ -90,7 +90,7 @@ public interface RawPixelsStore extends StatefulServiceInterface {
     
     public byte[] getCol(int x, int z, int c, int t);
     
-    public Map<Integer, int[]> getHistogram(int[] channels, int binSize, PlaneDef plane);
+    public Map<Integer, int[]> getHistogram(int[] channels, int binSize, boolean globalRange, PlaneDef plane);
 
     public byte[] getHypercube(@Validate(Integer.class) List<Integer> offset, @Validate(Integer.class) List<Integer> size, @Validate(Integer.class) List<Integer> step);
 

--- a/components/common/src/ome/api/RawPixelsStore.java
+++ b/components/common/src/ome/api/RawPixelsStore.java
@@ -90,7 +90,7 @@ public interface RawPixelsStore extends StatefulServiceInterface {
     
     public byte[] getCol(int x, int z, int c, int t);
     
-    public Map<Integer, int[]> getHistogram(int[] channels, int binSize, boolean globalRange, PlaneDef plane);
+    public Map<Integer, int[]> getHistogram(int[] channels, int binCount, boolean globalRange, PlaneDef plane);
 
     public byte[] getHypercube(@Validate(Integer.class) List<Integer> offset, @Validate(Integer.class) List<Integer> size, @Validate(Integer.class) List<Integer> step);
 

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -700,7 +700,13 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             for (int ch : channels) {
                 PixelData px = buffer.getPlane(z, ch, t);
                 int[] data = new int[binSize];
-                double range = (px.getMaximum() - px.getMinimum()) + 1;
+                double min = Double.MAX_VALUE;
+                double max = 0;
+                for (int i = 0; i < px.size(); i++) {
+                    min = Math.min(px.getPixelValue(i), min);
+                    max = Math.max(px.getPixelValue(i), max);
+                }
+                double range = (max - min) + 1;
                 double binRange = range / binSize;
                 for (int i = 0; i < px.size(); i++) {
                     int pxx = i % imgWidth;

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -700,8 +700,8 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             for (int ch : channels) {
                 PixelData px = buffer.getPlane(z, ch, t);
                 int[] data = new int[binSize];
-                double range = px.getMaximum() - px.getMinimum();
-                double binRange = range / (binSize - 1);
+                double range = (px.getMaximum() - px.getMinimum()) + 1;
+                double binRange = range / binSize;
                 for (int i = 0; i < px.size(); i++) {
                     int pxx = i % imgWidth;
                     int pxy = i / imgWidth;

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -732,6 +732,20 @@ public class RawPixelsBean extends AbstractStatefulBean implements
     // ~ Helpers
     // =========================================================================
     
+    /**
+     * Get the minimum and maximum value to use for the histogram. If useGlobal
+     * is <code>true</code> and the channel has stats calculated the global
+     * minimum and maximum will be used, otherwise the minimum and maximum value
+     * of the plane will be used.
+     * 
+     * @param px
+     *            The {@link PixelData}
+     * @param channel
+     *            The {@link Channel}
+     * @param useGlobal
+     *            Try to use the global minimum/maximum
+     * @return See above
+     */
     private double[] determineHistogramMinMax(PixelData px, Channel channel,
             boolean useGlobal) {
         double min, max;
@@ -741,12 +755,12 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             max = channel.getStatsInfo().getGlobalMax();
             // if max == 1.0 the global min/max probably has not been
             // calculated; fall back to plane min/max
-            if (max > 1.0)
+            if (max != 1.0)
                 return new double[] { min, max };
         }
 
         min = Double.MAX_VALUE;
-        max = 0;
+        max = -Double.MAX_VALUE;
 
         for (int i = 0; i < px.size(); i++) {
             min = Math.min(min, px.getPixelValue(i));

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -675,11 +675,11 @@ public class RawPixelsBean extends AbstractStatefulBean implements
     
     @RolesAllowed("user")
     public synchronized Map<Integer, int[]> getHistogram(int[] channels,
-            int binSize, boolean globalRange, PlaneDef plane) {
+            int binCount, boolean globalRange, PlaneDef plane) {
         errorIfNotLoaded();
 
-        if (binSize <= 0)
-            binSize = DEFAULT_HISTOGRAM_BINSIZE;
+        if (binCount <= 0)
+            binCount = DEFAULT_HISTOGRAM_BINSIZE;
 
         int imgWidth = buffer.getSizeX();
 
@@ -703,7 +703,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
                 Channel channel = metadataService.retrievePixDescription(id)
                         .getChannel(ch);
                 PixelData px = buffer.getPlane(z, ch, t);
-                int[] data = new int[binSize];
+                int[] data = new int[binCount];
 
                 double[] minmax = determineHistogramMinMax(px, channel,
                         globalRange);
@@ -711,13 +711,13 @@ public class RawPixelsBean extends AbstractStatefulBean implements
                 double max = minmax[1];
 
                 double range = (max - min) + 1;
-                double binRange = range / binSize;
+                double binRange = range / binCount;
                 for (int i = 0; i < px.size(); i++) {
                     int pxx = i % imgWidth;
                     int pxy = i / imgWidth;
                     if (pxx >= x && pxx < (x + w) && pxy >= y && pxy < (y + h)) {
                         int bin = (int) ((px.getPixelValue(i) - min) / binRange);
-                        if (bin >= 0 && bin < binSize)
+                        if (bin >= 0 && bin < binCount)
                             data[bin]++;
                     }
                 }

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -680,7 +680,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
 
         if (requiresPixelsPyramid())
             throw new ApiUsageException(
-                    "This method can not handle tiled images yet.\n");
+                    "This method can not handle tiled images yet.");
 
         if (binCount <= 0)
             binCount = DEFAULT_HISTOGRAM_BINSIZE;

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -681,26 +681,27 @@ public class RawPixelsBean extends AbstractStatefulBean implements
         
         int imgWidth = buffer.getSizeX();
 
-        int z = plane.getZ() >= 0 ? plane.getZ() : 0;
-        int t = plane.getT() >= 0 ? plane.getT() : 0;
-        int x = (plane.getRegion() != null && plane.getRegion().getX() >= 0) ? plane
-                .getRegion().getX() : 0;
-        int y = (plane.getRegion() != null && plane.getRegion().getY() >= 0) ? plane
-                .getRegion().getY() : 0;
-        int w = (plane.getRegion() != null && plane.getRegion().getWidth() > 0) ? plane
-                .getRegion().getWidth() : imgWidth;
-        int h = (plane.getRegion() != null && plane.getRegion().getHeight() > 0) ? plane
-                .getRegion().getHeight() : buffer.getSizeY();
+        int z = (plane != null && plane.getZ() >= 0) ? plane.getZ() : 0;
+        int t = (plane != null && plane.getT() >= 0) ? plane.getT() : 0;
+        int x = (plane != null && plane.getRegion() != null && plane
+                .getRegion().getX() >= 0) ? plane.getRegion().getX() : 0;
+        int y = (plane != null && plane.getRegion() != null && plane
+                .getRegion().getY() >= 0) ? plane.getRegion().getY() : 0;
+        int w = (plane != null && plane.getRegion() != null && plane
+                .getRegion().getWidth() > 0) ? plane.getRegion().getWidth()
+                : imgWidth;
+        int h = (plane != null && plane.getRegion() != null && plane
+                .getRegion().getHeight() > 0) ? plane.getRegion().getHeight()
+                : buffer.getSizeY();
 
-        Map<Integer, int[]> result = null;
+        Map<Integer, int[]> result = new HashMap<Integer, int[]>();
 
         try {
-            result = new HashMap<Integer, int[]>();
             for (int ch : channels) {
                 PixelData px = buffer.getPlane(z, ch, t);
                 int[] data = new int[binSize];
                 double range = px.getMaximum() - px.getMinimum();
-                double binRange = range / binSize;
+                double binRange = range / (binSize - 1);
                 for (int i = 0; i < px.size(); i++) {
                     int pxx = i % imgWidth;
                     int pxy = i / imgWidth;

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -678,6 +678,10 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             int binCount, boolean globalRange, PlaneDef plane) {
         errorIfNotLoaded();
 
+        if (requiresPixelsPyramid())
+            throw new ApiUsageException(
+                    "This method can not handle tiled images yet.\n");
+
         if (binCount <= 0)
             binCount = DEFAULT_HISTOGRAM_BINSIZE;
 

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -38,6 +38,7 @@ import ome.util.PixelData;
 import ome.util.ShallowCopy;
 import ome.util.SqlAction;
 import omeis.providers.re.data.PlaneDef;
+import omeis.providers.re.metadata.StatsFactory;
 
 import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
@@ -759,8 +760,11 @@ public class RawPixelsBean extends AbstractStatefulBean implements
                 return new double[] { min, max };
         }
 
-        min = Double.MAX_VALUE;
-        max = -Double.MAX_VALUE;
+        StatsFactory sf = new StatsFactory();
+        double[] pixelMinMax = sf.initPixelsRange(channel.getPixels());
+
+        min = pixelMinMax[1];
+        max = pixelMinMax[0];
 
         for (int i = 0; i < px.size(); i++) {
             min = Math.min(min, px.getPixelValue(i));

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -713,7 +713,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
                     int pxy = i / imgWidth;
                     if (pxx >= x && pxx < (x + w) && pxy >= y
                             && pxy < (y + h)) {
-                        int bin = (int) (px.getPixelValue(i) / binRange);
+                        int bin = (int) ((px.getPixelValue(i) - min) / binRange);
                         data[bin]++;
                     }
                 }

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -736,7 +736,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             boolean useGlobal) {
         double min, max;
 
-        if (useGlobal) {
+        if (useGlobal && channel != null && channel.getStatsInfo() != null) {
             min = channel.getStatsInfo().getGlobalMin();
             max = channel.getStatsInfo().getGlobalMax();
             // if max == 1.0 the global min/max probably has not been

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -675,11 +675,6 @@ public class RawPixelsBean extends AbstractStatefulBean implements
 
         int imgWidth = buffer.getSizeX();
 
-        if (plane.getSlice() != PlaneDef.XY) {
-            handleException(new RuntimeException("XY planes supported only"));
-            // TODO: How to handle other plane types?
-        }
-
         int z = plane.getZ() >= 0 ? plane.getZ() : 0;
         int t = plane.getT() >= 0 ? plane.getT() : 0;
         int x = (plane.getRegion() != null && plane.getRegion().getX() >= 0) ? plane

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -1,7 +1,7 @@
 /*
  *   $Id$
  *
- *   Copyright 2006-2015 University of Dundee. All rights reserved.
+ *   Copyright 2006-2016 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -31,10 +31,13 @@ import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
 import ome.io.nio.RomioPixelBuffer;
 import ome.model.core.Pixels;
+import ome.model.display.ProjectionDef;
+import ome.model.display.RenderingDef;
 import ome.parameters.Parameters;
 import ome.util.PixelData;
 import ome.util.ShallowCopy;
 import ome.util.SqlAction;
+import omeis.providers.re.data.PlaneDef;
 
 import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
@@ -664,6 +667,17 @@ public class RawPixelsBean extends AbstractStatefulBean implements
         } catch (Exception e) {
             handleException(e);
         }
+    }
+    
+    @RolesAllowed("user")
+    public synchronized int[][] getHistogram(List<Integer> channels,
+            int binSize, RenderingDef renderingDef,
+            ProjectionDef projectionDef, PlaneDef planeDef) {
+        errorIfNotLoaded();
+
+        // TODO: Implement!
+
+        return null;
     }
 
     // ~ Helpers

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -63,6 +63,9 @@ public class RawPixelsBean extends AbstractStatefulBean implements
 
     private static final long serialVersionUID = -6640632220587930165L;
 
+    /** The default bin size used for histograms */
+    private static final int DEFAULT_HISTOGRAM_BINSIZE = 256;
+    
     private Long id;
 
     private transient Long reset = null;
@@ -673,6 +676,9 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             int binSize, PlaneDef plane) {
         errorIfNotLoaded();
 
+        if (binSize <= 0)
+            binSize = DEFAULT_HISTOGRAM_BINSIZE;
+        
         int imgWidth = buffer.getSizeX();
 
         int z = plane.getZ() >= 0 ? plane.getZ() : 0;

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -380,6 +380,12 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         Assert.assertEquals(byteSize, 200, "Test assumes a 100px image");
         
         final int binSize = 256;
+        
+        // channel stats are not calculated for the generated test image,
+        // so this does not test global min/max usage but rather the fallback
+        // to use the plane min/max
+        final boolean useGlobalRange = true;
+        
         final int z = 0;
         final int t = 0;
         
@@ -418,7 +424,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         int[] channels = new int[] { 0, 1 };
 
         PlaneDef plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0, z, t, null, -1);
-        Map<Integer, int[]> data = svc.getHistogram(channels, binSize, plane);
+        Map<Integer, int[]> data = svc.getHistogram(channels, binSize, useGlobalRange, plane);
 
         Assert.assertEquals(data.size(), nChannels);
 
@@ -449,7 +455,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         RegionDef region = new RegionDef(0, 0, 5, 5);
         plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0, z, t, region, -1);
         
-        data = svc.getHistogram(new int[] {0}, binSize, plane);
+        data = svc.getHistogram(new int[] {0}, binSize, useGlobalRange, plane);
         Assert.assertEquals(data.size(), 1);
         
         int[] counts = data.values().iterator().next();

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -379,7 +379,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         
         Assert.assertEquals(byteSize, 200, "Test assumes a 100px image");
         
-        final int binSize = 256;
+        final int binCount = 256;
         
         // channel stats are not calculated for the generated test image,
         // so this does not test global min/max usage but rather the fallback
@@ -424,7 +424,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         int[] channels = new int[] { 0, 1 };
 
         PlaneDef plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0, z, t, null, -1);
-        Map<Integer, int[]> data = svc.getHistogram(channels, binSize, useGlobalRange, plane);
+        Map<Integer, int[]> data = svc.getHistogram(channels, binCount, useGlobalRange, plane);
 
         Assert.assertEquals(data.size(), nChannels);
 
@@ -432,8 +432,8 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         while (it.hasNext()) {
             Entry<Integer, int[]> e = it.next();
             int[] counts = e.getValue();
-            Assert.assertEquals(counts.length, binSize);
-            for (int bin = 0; bin < binSize; bin++) {
+            Assert.assertEquals(counts.length, binCount);
+            for (int bin = 0; bin < binCount; bin++) {
                 int exp = 0;
                 if (bin == 0)
                     exp = 80;
@@ -455,13 +455,13 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         RegionDef region = new RegionDef(0, 0, 5, 5);
         plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0, z, t, region, -1);
         
-        data = svc.getHistogram(new int[] {0}, binSize, useGlobalRange, plane);
+        data = svc.getHistogram(new int[] {0}, binCount, useGlobalRange, plane);
         Assert.assertEquals(data.size(), 1);
         
         int[] counts = data.values().iterator().next();
-        Assert.assertEquals(counts.length, binSize);
+        Assert.assertEquals(counts.length, binCount);
         
-        for (int bin = 0; bin < binSize; bin++) {
+        for (int bin = 0; bin < binCount; bin++) {
             int exp = 0;
             if (bin == 0)
                 exp = 15;

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -341,6 +341,17 @@ public class RawPixelsStoreTest extends AbstractServerTest {
             }
         }
     }
+    
+    /**
+     * Tests the histogram data generation
+     *
+     * @throws Exception
+     *             Thrown if an error occurred.
+     */
+    @Test
+    public void testGetHistogram() throws Exception {
+        //TODO: Implement!
+    }
 
     /**
      * Tests to set a region that is bigger than the entire file

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import ome.api.RawPixelsStore;
 import ome.io.nio.RomioPixelBuffer;
 import omero.api.RawPixelsStorePrx;
 import omero.model.Image;
@@ -74,9 +75,21 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
     @BeforeMethod
     public void localSetUp() throws Exception {
+        localSetUp(1);
+    }
+
+    /**
+     * Setup {@link RawPixelsStore} with the specified number of channels
+     * 
+     * @param nChannels
+     *            Number of channels
+     * @throws Exception
+     *             If an error occured.
+     */
+    private void localSetUp(int nChannels) throws Exception {
         Image image = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
-                ModelMockFactory.SIZE_T, 3);
+                ModelMockFactory.SIZE_T, nChannels);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
         planeSize = pixels.getSizeX().getValue() * pixels.getSizeY().getValue();
@@ -355,18 +368,21 @@ public class RawPixelsStoreTest extends AbstractServerTest {
      */
     @Test
     public void testGetHistogram() throws Exception {
+        // Create an image with 3 channels
+        final int nChannels = 3;
+        localSetUp(nChannels);
+        
         final int bw = svc.getByteWidth();
         final int byteSize = (int) svc.getPlaneSize();
         final int pxSize = (int) (byteSize/bw);
-        final int nChannels = 3;
         final int binSize = 256;
         final int z = 0;
         final int t = 0;
         
-        // Construct an image with 3 channels, where half of the pixels
+        // Only set data for the first z/t plane, where half of the pixels
         // are set to 50 (channel 0), 100 (channel 1) or 150 (channel 2),
-        // and the other half set to 150 (channel 0), 200 (channel 1) or 250 (channel 2);
-        // only set data for the first z/t plane.
+        // and the other half set to 150 (channel 0), 200 (channel 1) 
+        // or 250 (channel 2)
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
             for (int i = 0; i < byteSize; i+=bw) {


### PR DESCRIPTION
# What this PR does

Adds a server-side method for generating histogram data.

# Testing this PR

Check the integration test is correct and passes.

# Related reading

[Trello - Histogram](https://trello.com/c/6gKn8FT2/98-histogram)

# ToDo

- `BfPixelsStoreI` implements the interface, too, but I have no idea what this class is or how it should be implemented.
- ~~What to do if a given `PlaneDef` is not `XY`?~~
- ~~Does not support projections, yet.~~ Next round.

/cc @jburel @will-moore 