### PR TITLE
Officially support redis

### DIFF
--- a/components/tools/OmeroWeb/requirements-redis.txt
+++ b/components/tools/OmeroWeb/requirements-redis.txt
@@ -1,0 +1,7 @@
+# Python installation requirements for OMERO.web
+# ==============================================
+#
+#     pip install -r requirements-redis.txt
+#
+
+django-redis>=4.4


### PR DESCRIPTION
# What this PR does

This PR adds official requirements.txt to OMERO.web package making redis officially supported

https://trello.com/c/GIJQA0kg/177-redis-out-of-experimental

DOC: https://github.com/openmicroscopy/ome-documentation/pull/1569

# Testing this PR

- Install OMERO.web

  ```
  $ mkdir test
  $ cd test
  $ virtualenv venvweb
  $ source venvweb/bin/activate
  (venvweb) $ pip install omego 
  (venvweb) $ omego download --ice 3.6 --branch OMERO-DEV-merge-build py
  (venvweb) $ mv OMERO.py[currentversion] OMERO.py
  (venvweb) $ pip install -r OMERO.py/share/web/requirements-py27-trial.txt
  (venvweb) $ OMERO.py/bin/omero web start
  ```

  then generate nginx config and reload. Web should operate as normal

  Full doc in http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/unix/install-web/install-web-trial.html

- add redis like in http://www.openmicroscopy.org/site/support/omero5.3-staging/sysadmins/unix/install-web.html?highlight=redis#omero-web-maintenance
  and restart web

- Monitor redis:

  ```
  $ redis-cli
  127.0.0.1:6379> MONITOR
  OK
  ```

  If you log in to web, on the monitor you will see session creation and all the activity


See also https://github.com/openmicroscopy/infrastructure/pull/155