### PR TITLE
Add zeroc ibiblio resolver to the end of the default chain resolver

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -91,6 +91,7 @@
         <resolver ref="user-maven"/>
         <resolver ref="maven"/>
         <resolver ref="ome-artifactory"/>
+        <resolver ref="zeroc"/>
     </chain>
 
     <!-- Resolver for OME dependencies-->
@@ -139,7 +140,6 @@
     <module organisation="omero" name="*-test" resolver="test-resolver" matcher="glob"/>
     <module organisation="org.springframework" resolver="maven-resolver"/>
     <module organisation="ome" name="appbundler" resolver="ome-resolver"/>
-    <module organisation="com.zeroc" resolver="zeroc"/>
     <module organisation="zeroc" resolver="ome-resolver"/>
     <module organisation="ome" resolver="${ome.resolver}"/>
   </modules>


### PR DESCRIPTION
## What this PR does

As part of the [Ice 3.6.3 support](https://github.com/openmicroscopy/openmicroscopy/pull/4893), the build system was also updated to retrieve Ice dependencies from the [ZeroC Nexus repository](https://repo.zeroc.com/nexus/). This was achieved in a90f97c077ea2d87ff02014b44b21f5809886f19 by introducing a new `ibiblio` resolver and configuring the com.zeroc dependencies to use it.

A downside of using the `ibiblio` resolver directly is that the default `omero-resolver` also caches external and internal dependencies under a local directory `lib/cache`. A few targets of the build system rely on this local cache being populated including the Javadoc target.

While a90f97c077ea2d87ff02014b44b21f5809886f19 has been breaking the Javadoc target with errors of type `error: package Ice does not exist`, this commit should restore it.

In particular the above caused the [submods jobs](https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-latest-submods/345) to fail and errors in the build logs of the [latest](https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-latest/) and [merge](https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-build) jobs.

## Additional notes

A side effect of this PR is that for Ice 3.6.2 and above, the artifacts should be retrieved using the generic `maven` resolver directly from Central Maven repository (http://search.maven.org/#search|ga|1|com.zeroc). This also means that the `zeroc` resolver can be simply dropped from `etc/ivysettings.xml` when Ice 3.5 support is dropped

## Testing this PR

1. local testing: from either a fresh local Maven repository or minimally after cleaning `rm -rf ~/.m2/repository/com/zeroc`, the full build should pass with either Ice 3.5 or Ice 3.6. In particular, the `release-javadoc` target should throw not error about missing packages

2. CI testing: the logs of the merge build should show no error related to a missing Ice package

## Related reading

Although this PR should fix the currently broken behavior, the fact the `release-javadoc` target failed on error in the submodules job but not in the daily build job might require a follow-up investigation. A first element to check might be the JDK used by each job.