### PR TITLE
Version history

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,21 @@
 OMERO version history
 =====================
 
+5.2.6 (September 2016)
+----------------------
+
+This is a bug-fix release focusing on services closure and a DB upgrade fix.
+Improvements include:
+
+-  fixed closure of session in Java when using Ice 3.5
+-  fixed memory leak where services were not correctly closed
+-  added a DB upgrade patch to fix errors only affecting DBs that have been
+   upgraded from OMERO 4.4
+-  fixed a MATLAB regression introduced in 5.2.2
+
+Apache has also been deprecated in preparation for removing support in OMERO
+5.3.
+
 5.2.5 (August 2016)
 -------------------
 

--- a/history.txt
+++ b/history.txt
@@ -9,14 +9,14 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 
 Changes include:
 
--  DB patches to add support for new administration roles.
--  Remove restriction on name length
--  Add support for enumeration changes
--  Add new Grid View to both UI clients
--  Introduce the new Web API
--  Reactivate codomain support in the rendering Engine
--  Support for Ice 3.6.3
--  Fix graph issues when performing chown or moving between groups.
+-  database patches to add support for new administration roles
+-  remove restriction on name length
+-  add support for enumeration changes
+-  add new Grid View to both UI clients
+-  introduce the new Web API
+-  reactivate codomain support in the rendering Engine
+-  add support for Ice 3.6.3
+-  fix graph issues when performing chown or moving between groups.
 
 5.2.6 (October 2016)
 ----------------------

--- a/history.txt
+++ b/history.txt
@@ -10,13 +10,13 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 Changes include:
 
 -  database patches to add support for new administration roles
--  remove restriction on name length
--  add support for enumeration changes
--  add new Grid View to both UI clients
--  introduce the new Web API
--  reactivate codomain support in the rendering Engine
--  add support for Ice 3.6.3
--  fix graph issues when performing chown or moving between groups.
+-  removed restriction on name length
+-  added support for enumeration changes
+-  added new Grid View to both UI clients
+-  introduced the new Web API
+-  reactivated codomain support in the rendering Engine
+-  added support for Ice 3.6.3
+-  fixed graph issues when performing chown or moving between groups.
 
 5.3.0-m4 (September 2016)
 -------------------------
@@ -26,9 +26,9 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 
 Changes include:
 
--  Web decoupling
--  CLI plugins improvements
--  Apache deprecation
+-  completed Web decoupling
+-  improved CLI plugins
+-  deprecated Apache
 
 5.3.0-m3 (August 2016)
 ----------------------
@@ -38,15 +38,15 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 
 Changes include:
 
--  DB patches including support new options in rendering
--  add support for LUT
--  windows deprecation
--  reorganize API documentation
--  enable plate download
--  allow customization of CSRF cookie
--  ROI related bug fixes
--  major cleanup
--  fix cleanse
+-  added DB patches including support new options in rendering
+-  added support for LUT
+-  deprecated windows
+-  reorganized API documentation
+-  enabled plate download
+-  allowed customization of CSRF cookie
+-  fixed ROI related bug
+-  performed major code cleanup
+-  fixed cleanse
 
 5.3.0-m2 (April 2016)
 ---------------------
@@ -56,7 +56,7 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 
 Changes include:
 
-- support for ROI folder at scale. Use IDR as a concrete example
+- added support for ROI folder at scale. Used IDR as a concrete example
 
 5.3.0-m1 (February 2016)
 ------------------------
@@ -66,11 +66,11 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 
 Changes include:
 
--  support for ROI folder in server and client
--  fix shape to match OME-XML schema 
--  improve build system integration with local Maven
--  improve graph operation performance
--  DB setup script required PostgreSQL 9.3 
+-  added support for ROI folder in server and client
+-  fixed shape to match OME-XML schema 
+-  improved build system integration with local Maven
+-  improved graph operation performance
+-  changed DB setup script to require PostgreSQL 9.3 
 
 5.2.6 (October 2016)
 ----------------------

--- a/history.txt
+++ b/history.txt
@@ -12,9 +12,10 @@ Improvements include:
 -  added a DB upgrade patch to fix errors only affecting DBs that have been
    upgraded from OMERO 4.4
 -  fixed a MATLAB regression introduced in 5.2.2
+-  fixed error in logs on getProjectedThumbnail
 
-Apache has also been deprecated in preparation for removing support in OMERO
-5.3.
+Support for OMERO.web deployment using Apache has also been deprecated and is
+likely to be removed during the 5.3.x line.
 
 5.2.5 (August 2016)
 -------------------

--- a/history.txt
+++ b/history.txt
@@ -1,6 +1,23 @@
 OMERO version history
 =====================
 
+5.3.0-m5 (November 2016)
+------------------------
+
+Developer preview release - **only intended as a developer preview for
+updating code before the full public release of 5.3.0. Use at your own risk**.
+
+Changes include:
+
+-  DB patches to add support for new administration roles.
+-  Remove restriction on name length
+-  Add support for enumeration changes
+-  Add new Grid View to both UI clients
+-  Introduce the new Web API
+-  Reactivate codomain support in the rendering Engine
+-  Support for Ice 3.6.3
+-  Fix graph issues when performing chown or moving between groups.
+
 5.2.6 (October 2016)
 ----------------------
 

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,7 @@
 OMERO version history
 =====================
 
-5.2.6 (September 2016)
+5.2.6 (October 2016)
 ----------------------
 
 This is a bug-fix release focusing on services closure and a DB upgrade fix.

--- a/history.txt
+++ b/history.txt
@@ -18,6 +18,60 @@ Changes include:
 -  add support for Ice 3.6.3
 -  fix graph issues when performing chown or moving between groups.
 
+5.3.0-m4 (September 2016)
+-------------------------
+
+Developer preview release - **only intended as a developer preview for
+updating code before the full public release of 5.3.0. Use at your own risk**.
+
+Changes include:
+
+-  Web decoupling
+-  CLI plugins improvements
+-  Apache deprecation
+
+5.3.0-m3 (August 2016)
+----------------------
+
+Developer preview release - **only intended as a developer preview for
+updating code before the full public release of 5.3.0. Use at your own risk**.
+
+Changes include:
+
+-  DB patches including support new options in rendering
+-  add support for LUT
+-  windows deprecation
+-  reorganize API documentation
+-  enable plate download
+-  allow customization of CSRF cookie
+-  ROI related bug fixes
+-  major cleanup
+-  fix cleanse
+
+5.3.0-m2 (April 2016)
+---------------------
+
+Developer preview release - **only intended as a developer preview for
+updating code before the full public release of 5.3.0. Use at your own risk**.
+
+Changes include:
+
+- support for ROI folder at scale. Use IDR as a concrete example
+
+5.3.0-m1 (February 2016)
+------------------------
+
+Developer preview release - **only intended as a developer preview for
+updating code before the full public release of 5.3.0. Use at your own risk**.
+
+Changes include:
+
+-  support for ROI folder in server and client
+-  fix shape to match OME-XML schema 
+-  improve build system integration with local Maven
+-  improve graph operation performance
+-  DB setup script required PostgreSQL 9.3 
+
 5.2.6 (October 2016)
 ----------------------
 

--- a/history.txt
+++ b/history.txt
@@ -16,7 +16,10 @@ Changes include:
 -  introduced the new Web API
 -  reactivated codomain support in the rendering Engine
 -  added support for Ice 3.6.3
--  fixed graph issues when performing chown or moving between groups.
+-  fixed graph issues when performing chown or moving between groups
+-  made web applications installable from PyPI
+-  added "Option With" feature to OMERO.web
+
 
 5.3.0-m4 (September 2016)
 -------------------------
@@ -38,7 +41,7 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 
 Changes include:
 
--  added DB patches including support new options in rendering
+-  added DB patches including support for new options in rendering engine
 -  added support for LUT
 -  deprecated windows
 -  reorganized API documentation
@@ -47,6 +50,7 @@ Changes include:
 -  fixed ROI related bug
 -  performed major code cleanup
 -  fixed cleanse
+-  deprecated some utils Python methods
 
 5.3.0-m2 (April 2016)
 ---------------------
@@ -56,7 +60,8 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 
 Changes include:
 
-- added support for ROI folder at scale. Used IDR as a concrete example
+-  added support for ROI folder at scale. Used IDR as a concrete example
+-  cleaned up shape attributes names
 
 5.3.0-m1 (February 2016)
 ------------------------

--- a/history.txt
+++ b/history.txt
@@ -18,7 +18,7 @@ Changes include:
 -  added support for Ice 3.6.3
 -  fixed graph issues when performing chown or moving between groups
 -  made web applications installable from PyPI
--  added "Option With" feature to OMERO.web
+-  added option "Open With" feature to OMERO.web
 
 
 5.3.0-m4 (September 2016)
@@ -61,7 +61,7 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 Changes include:
 
 -  added support for ROI folder at scale. Used IDR as a concrete example
--  cleaned up shape attributes names
+-  cleaned up shape attribute names
 
 5.3.0-m1 (February 2016)
 ------------------------

--- a/history.txt
+++ b/history.txt
@@ -11,7 +11,7 @@ Improvements include:
 -  fixed memory leak where services were not correctly closed
 -  added a DB upgrade patch to fix errors only affecting DBs that have been
    upgraded from OMERO 4.4
--  fixed a MATLAB regression introduced in 5.2.2
+-  fixed a MATLAB regression introduced in 5.2.2, casting error.
 -  fixed error in logs on getProjectedThumbnail
 
 Support for OMERO.web deployment using Apache has also been deprecated and is


### PR DESCRIPTION
Add section for 5.3.0-m5 and cherry-pick commits for 5.2.6 that did not get backported.
cc @hflynn 
