### PR TITLE
Missing pk

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
@@ -191,7 +191,7 @@ class MapAnnotationManager(object):
 
     def add_from_namespace_query(self, session, ns, primary_keys):
         """
-        Fetches all map-annotations with the given namespace
+        Fetches all map-annotations with the given namespace and primary keys
         This will only work if there are no duplicates, otherwise an
         exception will be thrown
 

--- a/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
@@ -25,7 +25,7 @@ Utilities for manipulating map-annotations used as metadata
 
 import logging
 from omero.model import NamedValue
-from omero.rtypes import rstring, unwrap
+from omero.rtypes import rstring, rlist, unwrap
 from omero.sys import ParametersI
 
 
@@ -206,9 +206,11 @@ class MapAnnotationManager(object):
         :param primary_keys: Primary keys
         """
         qs = session.getQueryService()
-        q = 'FROM MapAnnotation WHERE ns=:ns ORDER BY id DESC'
+        q = ('FROM MapAnnotation as a JOIN a.mapvalue mv'
+             'WHERE ns=:ns and mv.name in (:pks) ORDER BY id DESC')
         p = ParametersI()
         p.addString('ns', ns)
+        p.add('pks', rlist([rstring(str(pk)) for pk in primary_keys]))
         results = qs.findAllByQuery(q, p)
         log.debug('Found %d MapAnnotations in ns:%s', len(results), ns)
         for ma in results:


### PR DESCRIPTION
# What this PR does

Attempt to fix `MapAnnotationPrimaryKeyException`

```
omero.util.metadata_mapannotations.MapAnnotationPrimaryKeyException: Missing primary key fields: set(['siRNA Pool Identifier']), set(['siRNA Pool Identifier']), [('siRNA Identifier', 's19893')]
```

When metadata is populated for each key listed in bulk config file it will then have to query for all the existing maps matching given primary keys to avoid duplicates. It is possible that for the given namespace there will be different PKs across the database. To avoid `MapAnnotationPrimaryKeyException` I propose to filter given PKs, not just NS
