### PR TITLE
JNA compliancy

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/appdata/LANGANDCODEPAGE.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/appdata/LANGANDCODEPAGE.java
@@ -1,7 +1,7 @@
 /*
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2012 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2016 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -21,6 +21,9 @@
  *------------------------------------------------------------------------------
  */
 package org.openmicroscopy.shoola.env.data.model.appdata;
+
+import java.util.Arrays;
+import java.util.List;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -60,4 +63,8 @@ public class LANGANDCODEPAGE extends Structure {
 	public LANGANDCODEPAGE(Pointer pointer) {
 		super(pointer);
 	}
+	
+    protected List getFieldOrder() {
+        return Arrays.asList(new String[] { "wLanguage", "wCodePage" });
+    }
 }


### PR DESCRIPTION
# What this PR does

In newer versions of JNA the method `getFieldOrder()` for `Structure` objects is abstract and has to be implemented by subclasses (see https://github.com/java-native-access/jna/blob/master/src/com/sun/jna/Structure.java#L891 ). 

# Testing this PR

I noticed this error when testing the Insight-ImageJ plugin with latest Fiji. So that might be a good test. Get latest Fiji, add ImageJ plugin, connect to an OMERO server. Without the PR you'd get an `AbstractMethodError`. Also test plugin with ImageJ, just to be sure, it doesn't break anything there.

# Related reading

https://github.com/java-native-access/jna/blob/master/www/GettingStarted.md

Thanks @waxenegger for pointing me in the JNA direction!
