### PR TITLE
RGBA shape colors

### DIFF
--- a/components/blitz/src/omero/gateway/model/ShapeSettingsData.java
+++ b/components/blitz/src/omero/gateway/model/ShapeSettingsData.java
@@ -81,6 +81,37 @@ public class ShapeSettingsData
     public final static String FONT_REGULAR = "Normal";
 
     /**
+     * Returns the Color's RGBA value as integer
+     * 
+     * @param c
+     *            The {@link Color}
+     * @return See above.
+     */
+    public static int getRGBA(Color c) {
+        int rgba = 0;
+        rgba |= (c.getRed() & 255) << 24;
+        rgba |= (c.getGreen() & 255) << 16;
+        rgba |= (c.getBlue() & 255) << 8;
+        rgba |= (c.getAlpha() & 255);
+        return rgba;
+    }
+
+    /**
+     * Creates a {@link Color} object from an RGBA integer value
+     * 
+     * @param rgba
+     *            The RGBA value
+     * @return See above.
+     */
+    public static Color getColor(int rgba) {
+        int r = (rgba >> 24) & 0xFF;
+        int g = (rgba >> 16) & 0xFF;
+        int b = (rgba >> 8) & 0xFF;
+        int a = rgba & 0xFF;
+        return new Color(r, g, b, a);
+    }
+    
+    /**
      * Returns the font style is supported.
      *
      * @param value The value to format.
@@ -147,8 +178,7 @@ public class ShapeSettingsData
         Shape shape = (Shape) asIObject();
         RInt value = shape.getFillColor();
         if (value == null) return DEFAULT_FILL_COLOUR;
-        Color c = new Color(value.getValue(), true);
-        if (c.getAlpha() == 0) return new Color(value.getValue(), false);
+        Color c = getColor(value.getValue()); 
         return c;
     }
 
@@ -162,8 +192,10 @@ public class ShapeSettingsData
         Shape shape = (Shape) asIObject();
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
-        if (fillColour == null) return;
-        shape.setFillColor(rtypes.rint(fillColour.getRGB()));
+        if (fillColour == null) 
+            return;
+        
+       shape.setFillColor(rtypes.rint(getRGBA(fillColour)));
         setDirty(true);
     }
 
@@ -177,8 +209,7 @@ public class ShapeSettingsData
         Shape shape = (Shape) asIObject();
         RInt value = shape.getStrokeColor();
         if (value == null) return DEFAULT_STROKE_COLOUR;
-        Color c = new Color(value.getValue(), true);
-        if (c.getAlpha() == 0) return new Color(value.getValue(), false);
+        Color c =  getColor(value.getValue()); 
         return c;
     }
 
@@ -193,7 +224,7 @@ public class ShapeSettingsData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         if (strokeColour == null) return;
-        shape.setStrokeColor(rtypes.rint(strokeColour.getRGB()));
+        shape.setStrokeColor(rtypes.rint(getRGBA(strokeColour)));
         setDirty(true);
     }
 

--- a/components/tools/OmeroJava/test/integration/RoiServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/RoiServiceTest.java
@@ -6,6 +6,7 @@
  */
 package integration;
 
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -42,6 +43,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.ROIData;
+import omero.gateway.model.ShapeData;
 
 /**
  * Collections of tests for the handling ROIs.
@@ -441,6 +444,47 @@ public class RoiServiceTest extends AbstractServerTest {
             shapes = roi.copyShapes();
             Assert.assertEquals(shapes.size(), 3);
         }
+    }
+    
+    /**
+     * Tests that shape fill and stroke color is stored as RGBA integer.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testShapeColor() throws Exception {
+        Image image = (Image) iUpdate.saveAndReturnObject(mmFactory
+                .simpleImage());
+
+        Roi roi = createRoi(image, 0, 0);
+        ROIData roiData = new ROIData(roi);
+
+        final int a = 10;
+        final int r = 20;
+        final int g = 30;
+        final int b = 40;
+
+        final Color c = new Color(r, g, b, a);
+        int rgba = 0;
+        rgba |= r << 24;
+        rgba |= g << 16;
+        rgba |= b << 8;
+        rgba |= (a & 255);
+
+        ShapeData shape = roiData.getShapes(0, 0).iterator().next();
+        shape.getShapeSettings().setStroke(c);
+        shape.getShapeSettings().setFill(c);
+
+        roi = (RoiI) iUpdate.saveAndReturnObject(roi);
+        roiData = new ROIData(roi);
+        shape = roiData.getShapes(0, 0).iterator().next();
+        Shape iShape = (Shape) shape.asIObject();
+
+        Assert.assertEquals(iShape.getStrokeColor().getValue(), rgba);
+        Assert.assertEquals(iShape.getFillColor().getValue(), rgba);
+
+        Assert.assertEquals(shape.getShapeSettings().getStroke(), c);
+        Assert.assertEquals(shape.getShapeSettings().getFill(), c);
     }
     
     /**


### PR DESCRIPTION
# What this PR does

Makes sure that stroke and fill colors for Shapes are always RGBA integers.

# Testing this PR

Check that the measurement tool still works with respect to setting stroke and fill colors.

# Related reading

[Trello - Color in shape settings](https://trello.com/c/sGlYbbvB/213-color-in-shape-settings)

/cc @jburel  - Does that already fix the issue for Insight or are there other things which have to be adjusted?

