### PR TITLE
Scripts utils

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -1235,32 +1235,32 @@ def findROIByImage(roiService, image, namespace):
     return roiList
 
 
-def numpyToImage(plane, minMax, dtype):
+def numpy_to_image(plane, min_max, dtype):
     """
     Converts the numpy plane to a PIL Image, converting data type if necessary.
     @param plane The plane to handle
-    @param minMax the min and the max values for the plane
+    @param min_max the min and the max values for the plane
     @param dtype the data type to use for scaling
     """
 
-    convArray = convertNumpyArray(plane, minMax, dtype)
+    conv_array = convert_numpy_array(plane, min_max, dtype)
     if plane.dtype.name not in ('uint8', 'int8'):
-        return Image.frombytes('I', plane.shape, convArray)
+        return Image.frombytes('I', plane.shape, conv_array)
     else:
-        return Image.fromarray(convArray)
+        return Image.fromarray(conv_array)
 
 
-def numpySaveAsImage(plane, minMax, dtype, name):
+def numpy_save_as_image(plane, min_max, dtype, name):
     """
     Converts the numpy plane, converting data type if necessary
     and saves it as png, jpeg etc.
     @param plane The plane to handle
-    @param minMax the min and the max values for the plane
+    @param min_max the min and the max values for the plane
     @param type the data type to use for scaling
     @param name the name of the image
     """
 
-    image = numpyToImage(plane, minMax, dtype)
+    image = numpy_to_image(plane, min_max, dtype)
     try:
         image.save(name)
     except (IOError, KeyError) as e:
@@ -1272,26 +1272,26 @@ def numpySaveAsImage(plane, minMax, dtype, name):
             os.remove(name)
 
 
-def convertNumpyArray(plane, minMax, type):
+def convert_numpy_array(plane, min_max, type):
     """
     Converts the numpy plane to a PIL Image, converting data type if necessary.
     @param plane The plane to handle
-    @param minMax the min and the max values for the plane
+    @param min_max the min and the max values for the plane
     @param type the data type to use for scaling
     """
 
     if plane.dtype.name not in ('uint8', 'int8'):   # we need to scale...
-        minVal, maxVal = minMax
-        valRange = maxVal - minVal
-        if (valRange == 0):
-            valRange = 1
-        scaled = (plane - minVal) * (float(255) / valRange)
-        convArray = zeros(plane.shape, dtype=type)
+        min_val, max_val = min_max
+        val_range = max_val - min_val
+        if (val_range == 0):
+            val_range = 1
+        scaled = (plane - min_val) * (float(255) / val_range)
+        conv_array = zeros(plane.shape, dtype=type)
         try:
-            convArray += scaled
+            conv_array += scaled
         except TypeError:
             # casting required with newer version of numpy
-            add(convArray, scaled, out=convArray, casting="unsafe")
-        return convArray
+            add(conv_array, scaled, out=conv_array, casting="unsafe")
+        return conv_array
     else:
         return plane

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -27,7 +27,7 @@ import os
 import warnings
 
 from struct import unpack
-from numpy import add, zeros
+from numpy import add, array, asarray, fromstring, reshape, zeros
 from os.path import exists
 
 import omero.clients
@@ -469,7 +469,6 @@ def readFileAsArray(rawFileService, iQuery, fileId, row, col, separator=' '):
     @param sep the column separator.
     @return The file as an NumPy array.
     """
-    from numpy import fromstring, reshape
     textBlock = readFromOriginalFile(rawFileService, iQuery, fileId)
     arrayFromFile = fromstring(textBlock, sep=separator)
     return reshape(arrayFromFile, (row, col))
@@ -482,7 +481,6 @@ def readFlimImageFile(rawPixelsStore, pixels):
     @param pixels The pixels of the image.
     @return The Contents of the image for z = 0, t = 0, all channels;
     """
-    from numpy import zeros
     sizeC = pixels.getSizeC().getValue()
     sizeX = pixels.getSizeX().getValue()
     sizeY = pixels.getSizeY().getValue()
@@ -510,7 +508,6 @@ def downloadPlane(rawPixelsStore, pixels, z, c, t):
     @param t The T-Section to retrieve.
     @return The Plane of the image for z, c, t
     """
-    from numpy import array
     rawPlane = rawPixelsStore.getPlane(z, c, t)
     sizeX = pixels.getSizeX().getValue()
     sizeY = pixels.getSizeY().getValue()
@@ -531,12 +528,6 @@ def getPlaneFromImage(imagePath, rgbIndex=None):
 
     @param imagePath   Path to image.
     """
-    from numpy import asarray
-    try:
-        from PIL import Image  # see ticket:2597
-    except ImportError:
-        import Image  # see ticket:2597
-
     i = Image.open(imagePath)
     a = asarray(i)
     if rgbIndex is None:
@@ -560,7 +551,6 @@ def uploadDirAsImages(sf, queryService, updateService,
     """
 
     import re
-    from numpy import zeros
 
     regex_token = re.compile(r'(?P<Token>.+)\.')
     regex_time = re.compile(r'T(?P<T>\d+)')

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -31,7 +31,6 @@ from numpy import add, array, asarray, fromstring, reshape, zeros
 from os.path import exists
 
 import omero.clients
-from omero.rtypes import rstring
 from omero.rtypes import unwrap
 import omero.util.pixelstypetopython as pixelstypetopython
 
@@ -721,7 +720,7 @@ def uploadDirAsImages(sf, queryService, updateService,
     for c in pixels.iterateChannels():
         # returns omero.model.LogicalChannelI
         lc = c.getLogicalChannel()
-        lc.setName(rstring(channels[i]))
+        lc.setName(omero.rtypes.rstring(channels[i]))
         updateService.saveObject(lc)
         i += 1
 

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -1283,13 +1283,14 @@ def convertNumpyArray(plane, minMax, type):
     if plane.dtype.name not in ('uint8', 'int8'):   # we need to scale...
         minVal, maxVal = minMax
         valRange = maxVal - minVal
-        if (valRange <= 0):
+        if (valRange == 0):
             valRange = 1
         scaled = (plane - minVal) * (float(255) / valRange)
         convArray = zeros(plane.shape, dtype=type)
         try:
             convArray += scaled
         except TypeError:
+            # casting required with newer version of numpy
             add(convArray, scaled, out=convArray, casting="unsafe")
         return convArray
     else:

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+   Integration test which checks the various methods from script_utils
+
+"""
+
+import pytest
+from omero.testlib import ITest
+import omero
+import omero.util.script_utils as scriptUtil
+from omero.gateway import BlitzGateway
+import tempfile
+import shutil
+from os import listdir, remove
+from os.path import isfile, join, exists
+from numpy import int32, uint8
+
+try:
+    from PIL import Image  # see ticket:2597
+except:  # pragma: nocover
+    import Image  # see ticket:2597
+
+
+class TestScriptUtils(ITest):
+
+    def testSplitImage(self):
+        imported_pix = ",".join(self.import_image())
+        dir = tempfile.mkdtemp()
+        params = omero.sys.Parameters()
+        params.map = {}
+        params.map["id"] = omero.rtypes.rlong(imported_pix)
+
+        query_string = "select p from Pixels p where p.id=:id"
+        pixels = self.query.findByQuery(query_string, params)
+        sizeZ = pixels.getSizeZ().getValue()
+        sizeC = pixels.getSizeC().getValue()
+        sizeT = pixels.getSizeT().getValue()
+        # split the image into file
+        imported_img = self.query.findByQuery(
+            "select i from Image i join fetch i.pixels pixels\
+            where pixels.id=:id", params)
+        scriptUtil.split_image(self.client, imported_img.getId().getValue(), dir,
+                               unformattedImageName="a_T%05d_C%s_Z%d_S1.tiff")
+        files = [f for f in listdir(dir) if isfile(join(dir, f))]
+        shutil.rmtree(dir)
+        assert sizeZ*sizeC*sizeT == len(files)
+
+    def testNumpyToImage(self):
+        client = self.new_client()
+        imported_pix = ",".join(self.import_image(client=client))
+        params = omero.sys.Parameters()
+        params.map = {}
+        params.map["id"] = omero.rtypes.rlong(imported_pix)
+        imported_img = client.getSession().getQueryService().findByQuery(
+            "select i from Image i join fetch i.pixels pixels\
+            where pixels.id=:id", params)
+
+        conn = BlitzGateway(client_obj=client)
+        image = conn.getObject("Image", imported_img.getId().getValue())
+        pixels = image.getPrimaryPixels()
+        channelMinMax = []
+        for c in image.getChannels():
+            minC = c.getWindowMin()
+            maxC = c.getWindowMax()
+            channelMinMax.append((minC, maxC))
+        theZ = image.getSizeZ() / 2
+        theT = 0
+        cIndex = 0
+        try:
+            for minMax in channelMinMax:
+                plane = pixels.getPlane(theZ, cIndex, theT)
+                i = scriptUtil.numpyToImage(plane, minMax, int32)
+                assert i is not None
+                try:
+                    # check if the image can be handled.
+                    i.load()
+                    assert True
+                except IOError:
+                    assert False
+                cIndex += 1
+        finally:
+            conn.close()
+
+    def testConvertNumpyArray(self):
+        client = self.new_client()
+        imported_pix = ",".join(self.import_image(client=client))
+        params = omero.sys.Parameters()
+        params.map = {}
+        params.map["id"] = omero.rtypes.rlong(imported_pix)
+
+        imported_img = client.getSession().getQueryService().findByQuery(
+            "select i from Image i join fetch i.pixels pixels\
+            where pixels.id=:id", params)
+        # session is closed during teardown
+        conn = BlitzGateway(client_obj=client)
+        image = conn.getObject("Image", imported_img.getId().getValue())
+        pixels = image.getPrimaryPixels()
+        channelMinMax = []
+        for c in image.getChannels():
+            minC = c.getWindowMin()
+            maxC = c.getWindowMax()
+            channelMinMax.append((minC, maxC))
+        theZ = image.getSizeZ() / 2
+        theT = 0
+        cIndex = 0
+        try:
+            for minMax in channelMinMax:
+                plane = pixels.getPlane(theZ, cIndex, theT)
+                i = scriptUtil.convertNumpyArray(plane, minMax, uint8)
+                assert i is not None
+                cIndex += 1
+        finally:
+            conn.close()
+
+    @pytest.mark.parametrize('format', ['tiff', 'foo'])
+    @pytest.mark.parametrize('is_file', [True, False])
+    def testNumpySaveAsImage(self, format, is_file):
+        client = self.new_client()
+        imported_pix = ",".join(self.import_image(client=client))
+        params = omero.sys.Parameters()
+        params.map = {}
+        params.map["id"] = omero.rtypes.rlong(imported_pix)
+
+        imported_img = client.getSession().getQueryService().findByQuery(
+            "select i from Image i join fetch i.pixels pixels\
+            where pixels.id=:id", params)
+        # session is closed during teardown
+        conn = BlitzGateway(client_obj=client)
+        image = conn.getObject("Image", imported_img.getId().getValue())
+        pixels = image.getPrimaryPixels()
+        channelMinMax = []
+        for c in image.getChannels():
+            minC = c.getWindowMin()
+            maxC = c.getWindowMax()
+            channelMinMax.append((minC, maxC))
+        theZ = image.getSizeZ() / 2
+        theT = 0
+        cIndex = 0
+
+        try:
+            for minMax in channelMinMax:
+                plane = pixels.getPlane(theZ, cIndex, theT)
+                suffix = ".%s" % format
+                name = None
+                if is_file is True:
+                    # create a temporary file
+                    tf = tempfile.NamedTemporaryFile(mode='r+b', suffix=suffix)
+                    name = tf.name
+                else:
+                    name = "test%s.%s" % (cIndex, format)
+                scriptUtil.numpySaveAsImage(plane, minMax, int32, name)
+                # try to open the image
+                try:
+                    Image.open(name)
+                    assert format == "tiff"
+                    # delete it since to handle case where it is not a tmp file
+                    remove(name)
+                except IOError:
+                    # error expected for "foo"
+                    assert format != "tiff"
+                    # file should have been deleted
+                    assert exists(name) is False
+                cIndex += 1
+        finally:
+            conn.close()

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
@@ -41,7 +41,7 @@ except:  # pragma: nocover
 
 class TestScriptUtils(ITest):
 
-    def testSplitImage(self):
+    def test_split_image(self):
         imported_pix = ",".join(self.import_image())
         dir = tempfile.mkdtemp()
         params = omero.sys.Parameters()
@@ -50,20 +50,21 @@ class TestScriptUtils(ITest):
 
         query_string = "select p from Pixels p where p.id=:id"
         pixels = self.query.findByQuery(query_string, params)
-        sizeZ = pixels.getSizeZ().getValue()
-        sizeC = pixels.getSizeC().getValue()
-        sizeT = pixels.getSizeT().getValue()
+        size_z = pixels.getSizeZ().getValue()
+        size_c = pixels.getSizeC().getValue()
+        size_t = pixels.getSizeT().getValue()
         # split the image into file
         imported_img = self.query.findByQuery(
             "select i from Image i join fetch i.pixels pixels\
             where pixels.id=:id", params)
-        scriptUtil.split_image(self.client, imported_img.getId().getValue(), dir,
+        id = imported_img.getId().getValue()
+        scriptUtil.split_image(self.client, id, dir,
                                unformattedImageName="a_T%05d_C%s_Z%d_S1.tiff")
         files = [f for f in listdir(dir) if isfile(join(dir, f))]
         shutil.rmtree(dir)
-        assert sizeZ*sizeC*sizeT == len(files)
+        assert size_z*size_c*size_t == len(files)
 
-    def testNumpyToImage(self):
+    def test_numpy_to_image(self):
         client = self.new_client()
         imported_pix = ",".join(self.import_image(client=client))
         params = omero.sys.Parameters()
@@ -76,18 +77,18 @@ class TestScriptUtils(ITest):
         conn = BlitzGateway(client_obj=client)
         image = conn.getObject("Image", imported_img.getId().getValue())
         pixels = image.getPrimaryPixels()
-        channelMinMax = []
+        channel_min_max = []
         for c in image.getChannels():
-            minC = c.getWindowMin()
-            maxC = c.getWindowMax()
-            channelMinMax.append((minC, maxC))
-        theZ = image.getSizeZ() / 2
-        theT = 0
-        cIndex = 0
+            min_c = c.getWindowMin()
+            max_c = c.getWindowMax()
+            channel_min_max.append((min_c, max_c))
+        z = image.getSizeZ() / 2
+        t = 0
+        c = 0
         try:
-            for minMax in channelMinMax:
-                plane = pixels.getPlane(theZ, cIndex, theT)
-                i = scriptUtil.numpyToImage(plane, minMax, int32)
+            for min_max in channel_min_max:
+                plane = pixels.getPlane(z, c, t)
+                i = scriptUtil.numpy_to_image(plane, min_max, int32)
                 assert i is not None
                 try:
                     # check if the image can be handled.
@@ -95,11 +96,11 @@ class TestScriptUtils(ITest):
                     assert True
                 except IOError:
                     assert False
-                cIndex += 1
+                c += 1
         finally:
             conn.close()
 
-    def testConvertNumpyArray(self):
+    def test_convert_numpy_array(self):
         client = self.new_client()
         imported_pix = ",".join(self.import_image(client=client))
         params = omero.sys.Parameters()
@@ -113,26 +114,26 @@ class TestScriptUtils(ITest):
         conn = BlitzGateway(client_obj=client)
         image = conn.getObject("Image", imported_img.getId().getValue())
         pixels = image.getPrimaryPixels()
-        channelMinMax = []
+        channel_min_max = []
         for c in image.getChannels():
-            minC = c.getWindowMin()
-            maxC = c.getWindowMax()
-            channelMinMax.append((minC, maxC))
-        theZ = image.getSizeZ() / 2
-        theT = 0
-        cIndex = 0
+            min_c = c.getWindowMin()
+            max_c = c.getWindowMax()
+            channel_min_max.append((min_c, max_c))
+        z = image.getSizeZ() / 2
+        t = 0
+        c = 0
         try:
-            for minMax in channelMinMax:
-                plane = pixels.getPlane(theZ, cIndex, theT)
-                i = scriptUtil.convertNumpyArray(plane, minMax, uint8)
+            for min_max in channel_min_max:
+                plane = pixels.getPlane(z, c, t)
+                i = scriptUtil.convert_numpy_array(plane, min_max, uint8)
                 assert i is not None
-                cIndex += 1
+                c += 1
         finally:
             conn.close()
 
     @pytest.mark.parametrize('format', ['tiff', 'foo'])
     @pytest.mark.parametrize('is_file', [True, False])
-    def testNumpySaveAsImage(self, format, is_file):
+    def test_numpy_save_as_image(self, format, is_file):
         client = self.new_client()
         imported_pix = ",".join(self.import_image(client=client))
         params = omero.sys.Parameters()
@@ -146,18 +147,18 @@ class TestScriptUtils(ITest):
         conn = BlitzGateway(client_obj=client)
         image = conn.getObject("Image", imported_img.getId().getValue())
         pixels = image.getPrimaryPixels()
-        channelMinMax = []
+        channel_min_max = []
         for c in image.getChannels():
-            minC = c.getWindowMin()
-            maxC = c.getWindowMax()
-            channelMinMax.append((minC, maxC))
-        theZ = image.getSizeZ() / 2
-        theT = 0
-        cIndex = 0
+            min_c = c.getWindowMin()
+            max_c = c.getWindowMax()
+            channel_min_max.append((min_c, max_c))
+        z = image.getSizeZ() / 2
+        t = 0
+        c = 0
 
         try:
-            for minMax in channelMinMax:
-                plane = pixels.getPlane(theZ, cIndex, theT)
+            for min_max in channel_min_max:
+                plane = pixels.getPlane(z, c, t)
                 suffix = ".%s" % format
                 name = None
                 if is_file is True:
@@ -165,8 +166,8 @@ class TestScriptUtils(ITest):
                     tf = tempfile.NamedTemporaryFile(mode='r+b', suffix=suffix)
                     name = tf.name
                 else:
-                    name = "test%s.%s" % (cIndex, format)
-                scriptUtil.numpySaveAsImage(plane, minMax, int32, name)
+                    name = "test%s.%s" % (c, format)
+                scriptUtil.numpy_save_as_image(plane, min_max, int32, name)
                 # try to open the image
                 try:
                     Image.open(name)
@@ -178,6 +179,6 @@ class TestScriptUtils(ITest):
                     assert format != "tiff"
                     # file should have been deleted
                     assert exists(name) is False
-                cIndex += 1
+                c += 1
         finally:
             conn.close()


### PR DESCRIPTION
# What this PR does

Add new methods to script utils
Many similar block of code found in training examples, in scripts (see https://github.com/ome/scripts/pull/120 and https://github.com/openmicroscopy/omero-example-scripts/pull/4/files)


# Testing this PR

Make sure that the tests pass

initial PR https://github.com/openmicroscopy/openmicroscopy/pull/4914

The "full" cleaning of script_utils will happen in another PR
see https://trello.com/c/NPvjShf8/219-review-utils-script-omeropy