### PR TITLE
adjust test to create maps when one of PKs is empty

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/metadata_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_utils.py
@@ -385,7 +385,7 @@ class KeyValueListTransformer(object):
             values = [v for v in values if v is not None and (
                 not isinstance(v, basestring) or v.strip())]
 
-        if cfg["clientvalue"]:
+        if cfg["clientvalue"] is not None:
             values = [valuesub(v, cfg["clientvalue"]) for v in values]
         return key, values
 

--- a/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns.csv
+++ b/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns.csv
@@ -2,6 +2,8 @@ Well,FlyBase,Gene,Gene Names
 a1,FBgn0004644,hh,hedgehog;bar-3;CG4637
 a2,FBgn0003656,sws,swiss cheese;olfE;CG2212
 a3,FBgn0011236,ken,ken and barbie;CG5575
+a4,FBgn0086378,,Alg-2
 b1,,hh,DHH;IHH;SHH;Desert hedgehog;Indian hedgehog;Sonic hedgehog
 b2,,sws,PNPLA6;patatin like phospholipase domain containing 6
 b3,,ken,BCL6;B-cell lymphoma 6 protein
+b4,,,Alg-2

--- a/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2_empty.yml
+++ b/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2_empty.yml
@@ -1,0 +1,45 @@
+---
+name: test_bulk_to_map_annotation_context_ns2
+version: 2
+
+defaults:
+    include: yes
+
+columns:
+- name: Gene
+- name: Gene Names
+  clientname: Gene name
+  split: ;
+- name: Gene
+  clientname: Gene ID
+  clientvalue: ""
+- name: Well
+  include: no
+  includeclient: no
+- name: Well Name
+  include: no
+  includeclient: no
+- group:
+    namespace: openmicroscopy.org/mapr/gene
+    columns:
+    # Intentionally duplicate a column in a different group
+    - name: Gene
+    - name: Gene Names
+      clientname: Gene name
+      split: ;
+    - name: Gene
+      clientname: Gene ID
+      clientvalue: ""
+
+advanced:
+#    well_to_images: yes
+    primary_group_keys:
+    - namespace: openmicroscopy.org/mapr/gene
+      keys:
+      - Gene
+      - Gene ID
+    - namespace: openmicroscopy.org/omero/bulk_annotations
+      keys:
+      - Gene
+      - Gene ID
+    

--- a/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2_fail.yml
+++ b/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2_fail.yml
@@ -1,0 +1,24 @@
+---
+name: test_bulk_to_map_annotation_context_ns2
+version: 2
+
+defaults:
+    include: yes
+
+columns:
+- group:
+    namespace: openmicroscopy.org/mapr/gene_fail
+    columns:
+    # Intentionally duplicate a column in a different group
+    - name: Gene
+      omitempty: yes
+    - name: Gene Names
+      clientname: Gene name
+      split: ;
+
+advanced:
+#    well_to_images: yes
+    primary_group_keys:
+    - namespace: openmicroscopy.org/mapr/gene_fail
+      keys:
+      - Gene


### PR DESCRIPTION
# What this PR does

adjust test:
 - test empty PK
 - if omitempty throws MapAnnotationPrimaryKeyException

# Testing this PR

https://idr-ci.openmicroscopy.org:8443/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.metadata.test_populate/TestPopulateMetadata/ should pass