### PR TITLE
fix ImporterTest.testImportSimpleImageOddlyNamedUser

### DIFF
--- a/components/tools/OmeroJava/test/integration/ImporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ImporterTest.java
@@ -704,7 +704,7 @@ public class ImporterTest extends AbstractServerTest {
     @Test
     public void testImportSimpleImageOddlyNamedUser() throws Exception {
         /* conceive a new user with an awkward name */
-        final String username = "a / strange \\ name";
+        final String username = "a / strange \\ name " + UUID.randomUUID();
         final String password = UUID.randomUUID().toString();
         Experimenter user = new ExperimenterI();
         user.setOmeName(omero.rtypes.rstring(username));


### PR DESCRIPTION
# What this PR does

ImporterTest.testImportSimpleImageOddlyNamedUser starts by creating a user with a specific name. This means that the test can succeed only once, subsequent runs fail. This PR changes the test so as to use a new username each time.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/ImporterTest/ should pass and the code change should make sense.