### PR TITLE
search for dist directly

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -141,7 +141,8 @@ class ITest(object):
                     a = path(os.path.join(root, f))
                     # find OMERO dist by searching for bin/omero
                     # exclude OmeroPy as is a source
-                    if (str(a.dirname().dirname().basename()) != 'OmeroPy' and
+                    if (str(a.dirname().dirname().basename())
+                            not in ('OmeroPy', 'build', 'target') and
                             str(a.basename()) == 'omero' and
                             str(a.dirname().basename()) == 'bin'):
                         dist = a.dirname().dirname()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -24,6 +24,7 @@
 
 """
 
+import os
 import sys
 import time
 import weakref
@@ -83,7 +84,7 @@ class ITest(object):
     @classmethod
     def setup_class(cls):
 
-        cls.OmeroPy = cls.omeropydir()
+        cls.omero_dist = cls.omerodistdir()
 
         cls.__clients = Clients()
 
@@ -132,26 +133,37 @@ class ITest(object):
             raise
 
     @classmethod
-    def omeropydir(self):
+    def omerodistdir(self):
+        def travers(p):
+            dist = None
+            for root, dirs, files in os.walk(p):
+                for f in files:
+                    a = path(os.path.join(root, f))
+                    # find OMERO dist by searching for bin/omero
+                    # exclude OmeroPy as is a source
+                    if (str(a.dirname().dirname().basename()) != 'OmeroPy' and
+                            str(a.basename()) == 'omero' and
+                            str(a.dirname().basename()) == 'bin'):
+                        dist = a.dirname().dirname()
+            return dist
         count = 10
         searched = []
         p = path(".").abspath()
         # "" means top of directory
-        while str(p.basename()) not in ("OmeroPy", ""):
+        dist_dir = None
+        while dist_dir is None:
+            dist_dir = travers(p)
             searched.append(p)
             p = p / ".."  # Walk up, in case test runner entered a subdirectory
-            try:
-                p, = p.dirs("OmeroPy")
-            except ValueError:
-                pass
             p = p.abspath()
             count -= 1
             if not count:
                 break
-        if str(p.basename()) == "OmeroPy":
-            return p
+        if dist_dir is not None:
+            return dist_dir
         else:
-            assert False, "Could not find OmeroPy/; searched %s" % searched
+            assert False, ("Could not find bin/omero executable; "
+                           "searched %s" % searched)
 
     def skip_if(self, config_key, condition, message=None):
         """Skip test if configuration does not meet condition"""
@@ -238,7 +250,7 @@ class ITest(object):
     def import_image(self, filename=None, client=None, extra_args=None,
                      skip="all", **kwargs):
         if filename is None:
-            filename = self.OmeroPy / ".." / ".." / ".." / \
+            filename = self.omero_dist / ".." / \
                 "components" / "common" / "test" / "tinyTest.d3d.dv"
         if client is None:
             client = self.client
@@ -246,9 +258,6 @@ class ITest(object):
         server = client.getProperty("omero.host")
         port = client.getProperty("omero.port")
         key = client.getSessionId()
-
-        # Search up until we find "OmeroPy"
-        dist_dir = self.OmeroPy / ".." / ".." / ".." / "dist"
 
         args = [sys.executable]
         args.append(str(path(".") / "bin" / "omero"))
@@ -262,7 +271,7 @@ class ITest(object):
             args.extend(extra_args)
         args.append(filename)
 
-        popen = subprocess.Popen(args, cwd=str(dist_dir),
+        popen = subprocess.Popen(args, cwd=str(self.omero_dist),
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -138,14 +138,14 @@ class ITest(object):
             dist = None
             for root, dirs, files in os.walk(p):
                 for f in files:
-                    a = path(os.path.join(root, f))
+                    t = path(os.path.join(root, f))
                     # find OMERO dist by searching for bin/omero
                     # exclude OmeroPy as is a source
-                    if (str(a.dirname().dirname().basename())
+                    if (str(t.dirname().dirname().basename())
                             not in ('OmeroPy', 'build', 'target') and
-                            str(a.basename()) == 'omero' and
-                            str(a.dirname().basename()) == 'bin'):
-                        dist = a.dirname().dirname()
+                            str(t.basename()) == 'omero' and
+                            str(t.dirname().basename()) == 'bin'):
+                        dist = t.dirname().dirname()
             return dist
         count = 10
         searched = []

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -149,8 +149,7 @@ class TestImport(CLITest):
         return o, e
 
     def add_client_dir(self):
-        dist_dir = self.OmeroPy / ".." / ".." / ".." / "dist"
-        client_dir = dist_dir / "lib" / "client"
+        client_dir = self.omero_dist / "lib" / "client"
         self.args += ["--clientdir", client_dir]
 
     def check_other_output(self, out):

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
@@ -34,11 +34,8 @@ SENDFILE = """
 #!/usr/bin/env python
 
 # Setup to run as an integration test
-rundir = "%s"
 import os
 import sys
-sys.path.insert(0, rundir)
-sys.path.insert(0, os.path.join(rundir, "target"))
 
 import omero.scripts as s
 import omero.util.script_utils as su
@@ -97,9 +94,8 @@ class TestInputs(ITest):
         logging.basicConfig(level=10)
         root_client = self.new_client(system=True)
         scripts = root_client.sf.getScriptService()
-        sendfile = SENDFILE % self.omeropydir()
         id = scripts.uploadScript(
-            "/tests/inputs_py/%s.py" % self.uuid(), sendfile)
+            "/tests/inputs_py/%s.py" % self.uuid(), SENDFILE)
         input = {"a": rint(100)}
         impl = omero.processor.usermode_processor(root_client)
         try:


### PR DESCRIPTION
# What this PR does

This PR removes hard-coded OmeroPy and dist path in favour of finding OMERO dist based on bin/omero.

# Testing this PR

all integration tests should be green. Especially import
