### PR TITLE
Tweak m6 history for sphinx build

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -10,7 +10,7 @@ updating code before the full public release of 5.3.0. Use at your own risk**.
 Changes include:
 
  - bumped Bio-Formats version to 5.3.0-m2. This includes JPEG-XR support for CZI.
-   `See whats-new for more information <https://www.openmicroscopy.org/site/support/bio-formats5.3/about/whats-new.html>`_. 
+   See the `Bio-Formats version history <https://www.openmicroscopy.org/site/support/bio-formats5.3/about/whats-new.html>`_ for more information.
  - fixed numpy-pillow version incompatibility
  - made python testing package public so it can be used by external clients
 


### PR DESCRIPTION
# What this PR does

Makes the history in the codebase match the docs as proposed on https://github.com/openmicroscopy/ome-documentation/pull/1578 as the current version fails the sphinx build in Travis because the link text is duplicated from a previous link.

# Testing this PR

Check the text matches the docs PR linked above

