### PR TITLE
allow running pytest in parallel

### DIFF
--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -59,10 +59,7 @@ build_year = "${python_build_year}"
 
     <target name="python-test-suite" unless="TEST">
         <mkdir dir="${testreports.dir}"/>
-        <if>
-            <not>
-                <equals arg1="${MARK}" arg2=""/>
-            </not>
+        <if><isset property="MARK"/>
             <then>
                 <py_test target="${basedir}/test/unit">
                     <optionalArgs>
@@ -80,10 +77,7 @@ build_year = "${python_build_year}"
 
     <target name="python-integration" unless="env.NOPYTHON">
         <mkdir dir="${testreports.dir}"/>
-        <if>
-            <not>
-                <equals arg1="${MARK}" arg2=""/>
-            </not>
+        <if><isset property="MARK"/>
             <then>
                 <py_test target="${basedir}/test/integration">
                     <optionalArgs>

--- a/components/tools/test_setup.py
+++ b/components/tools/test_setup.py
@@ -33,6 +33,7 @@ class PyTest(TestCommand):
         ('test-failfast', 'x', "Exit on first error"),
         ('test-verbose', 'v', "more verbose output"),
         ('test-quiet', 'q', "less verbose output"),
+        ('test-xdist', 'n', "parallel, requires pytest-xdist"),
         ('junitxml=', None, "create junit-xml style report file at 'path'"),
         ('pdb', None, "fallback to pdb on error"),
         ('markers', None, "list available markers'"),
@@ -52,6 +53,7 @@ class PyTest(TestCommand):
         self.junitxml = None
         self.pdb = False
         self.markers = False
+        self.test_xdist = None
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -78,6 +80,8 @@ class PyTest(TestCommand):
         self.test_suite = True
         if self.markers:
             self.test_args = "--markers"
+        if self.test_xdist is not None:
+            self.test_args.extend(['-n', self.test_xdist])
         if self.test_ice_config is None:
             self.test_ice_config = os.path.abspath('ice.config')
         if 'ICE_CONFIG' not in os.environ:


### PR DESCRIPTION
# What this PR does

This PR allows running python integration tests in parallel using `pytest-xdist`. It requires pytest-xdist to install separately. 

This PR was opened to see if parallelization of tests will affect our ci (tested via devspace)

```
pip install "pytest-xdist"

$SRC/build.py -f components/tools/OmeroPy/build.xml integration -DXDIST=4 -Dtestreports.dir=target/reports/integration 
```

# Testing this PR

check if tests are green
