### PR TITLE
Testlib improvement

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -24,6 +24,7 @@
 
 """
 
+import os
 import sys
 import time
 import weakref
@@ -83,7 +84,7 @@ class ITest(object):
     @classmethod
     def setup_class(cls):
 
-        cls.OmeroPy = cls.omeropydir()
+        cls.omero_dist = cls.omerodistdir()
 
         cls.__clients = Clients()
 
@@ -132,26 +133,37 @@ class ITest(object):
             raise
 
     @classmethod
-    def omeropydir(cls):
+    def omerodistdir(cls):
+        def travers(p):
+            dist = None
+            for root, dirs, files in os.walk(p):
+                for f in files:
+                    a = path(os.path.join(root, f))
+                    # find OMERO dist by searching for bin/omero
+                    # exclude OmeroPy as is a source
+                    if (str(a.dirname().dirname().basename()) != 'OmeroPy' and
+                            str(a.basename()) == 'omero' and
+                            str(a.dirname().basename()) == 'bin'):
+                        dist = a.dirname().dirname()
+            return dist
         count = 10
         searched = []
         p = path(".").abspath()
         # "" means top of directory
-        while str(p.basename()) not in ("OmeroPy", ""):
+        dist_dir = None
+        while dist_dir is None:
+            dist_dir = travers(p)
             searched.append(p)
             p = p / ".."  # Walk up, in case test runner entered a subdirectory
-            try:
-                p, = p.dirs("OmeroPy")
-            except ValueError:
-                pass
             p = p.abspath()
             count -= 1
             if not count:
                 break
-        if str(p.basename()) == "OmeroPy":
-            return p
+        if dist_dir is not None:
+            return dist_dir
         else:
-            assert False, "Could not find OmeroPy/; searched %s" % searched
+            assert False, ("Could not find bin/omero executable; "
+                           "searched %s" % searched)
 
     def skip_if(self, config_key, condition, message=None):
         """Skip test if configuration does not meet condition"""
@@ -238,7 +250,7 @@ class ITest(object):
     def import_image(self, filename=None, client=None, extra_args=None,
                      skip="all", **kwargs):
         if filename is None:
-            filename = self.OmeroPy / ".." / ".." / ".." / \
+            filename = self.omero_dist / ".." / \
                 "components" / "common" / "test" / "tinyTest.d3d.dv"
         if client is None:
             client = self.client
@@ -246,9 +258,6 @@ class ITest(object):
         server = client.getProperty("omero.host")
         port = client.getProperty("omero.port")
         key = client.getSessionId()
-
-        # Search up until we find "OmeroPy"
-        dist_dir = self.OmeroPy / ".." / ".." / ".." / "dist"
 
         args = [sys.executable]
         args.append(str(path(".") / "bin" / "omero"))
@@ -262,7 +271,7 @@ class ITest(object):
             args.extend(extra_args)
         args.append(filename)
 
-        popen = subprocess.Popen(args, cwd=str(dist_dir),
+        popen = subprocess.Popen(args, cwd=str(self.omero_dist),
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         out, err = popen.communicate()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -141,7 +141,8 @@ class ITest(object):
                     a = path(os.path.join(root, f))
                     # find OMERO dist by searching for bin/omero
                     # exclude OmeroPy as is a source
-                    if (str(a.dirname().dirname().basename()) != 'OmeroPy' and
+                    if (str(a.dirname().dirname().basename())
+                            not in ('OmeroPy', 'build', 'target') and
                             str(a.basename()) == 'omero' and
                             str(a.dirname().basename()) == 'bin'):
                         dist = a.dirname().dirname()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -117,7 +117,7 @@ class ITest(object):
         cls.root = None
         cls.__clients.__del__()
 
-    def keepRootAlive(self):
+    def keep_root_alive(self):
         """
         Keeps root connection alive.
         """
@@ -286,16 +286,16 @@ class ITest(object):
     the file and then return the image.
     """
 
-    def importSingleImage(self, name=None, client=None,
-                          with_companion=False, **kwargs):
+    def import_single_image(self, name=None, client=None,
+                            with_companion=False, **kwargs):
         if client is None:
             client = self.client
         if name is None:
-            name = "importSingleImage"
+            name = "import_single_image"
 
-        images = self.importMIF(1, name=name, client=client,
-                                with_companion=with_companion,
-                                **kwargs)
+        images = self.import_mif(1, name=name, client=client,
+                                 with_companion=with_companion,
+                                 **kwargs)
         return images[0]
 
     """
@@ -303,14 +303,14 @@ class ITest(object):
     the file and then return the image..
     """
 
-    def importSingleImageWithCompanion(self, name=None, client=None):
+    def import_single_image_with_companion(self, name=None, client=None):
         if client is None:
             client = self.client
         if name is None:
-            name = "importSingleImageWithCompanion"
+            name = "import_single_image_with_companion"
 
-        images = self.importMIF(1, name=name, client=client,
-                                with_companion=True)
+        images = self.import_mif(1, name=name, client=client,
+                                 with_companion=True)
         return images[0]
 
     """
@@ -318,12 +318,12 @@ class ITest(object):
     the file and then return the list of images.
     """
 
-    def importMIF(self, seriesCount=0, name=None, client=None,
-                  with_companion=False, skip="all", **kwargs):
+    def import_mif(self, series_count=0, name=None, client=None,
+                   with_companion=False, skip="all", **kwargs):
         if client is None:
             client = self.client
         if name is None:
-            name = "importMIF"
+            name = "import_mif"
 
         try:
             global_metadata = kwargs.pop("GlobalMetadata")
@@ -336,8 +336,8 @@ class ITest(object):
 
         # Only include series count if enabled; in the case of plates,
         # this will be unused
-        if seriesCount >= 1:
-            append = "series=%d%s" % (seriesCount, append)
+        if series_count >= 1:
+            append = "series=%d%s" % (series_count, append)
 
         if kwargs:
             for k, v in kwargs.items():
@@ -355,8 +355,8 @@ class ITest(object):
         pixel_ids = self.import_image(
             filename=fake.abspath(), client=client, skip=skip, **kwargs)
 
-        if seriesCount >= 1:
-            assert seriesCount == len(pixel_ids)
+        if series_count >= 1:
+            assert series_count == len(pixel_ids)
 
         images = []
         for pix_id_str in pixel_ids:
@@ -364,10 +364,10 @@ class ITest(object):
             images.append(pixels.getImage())
         return images
 
-    def importPlates(
+    def import_plates(
         self, client=None,
-        plates=1, plateAcqs=1,
-        plateCols=1, plateRows=1,
+        plates=1, plate_acqs=1,
+        plate_cols=1, plate_rows=1,
         fields=1, **kwargs
     ):
 
@@ -375,11 +375,11 @@ class ITest(object):
             client = self.client
 
         kwargs["plates"] = plates
-        kwargs["plateAcqs"] = plateAcqs
-        kwargs["plateCols"] = plateCols
-        kwargs["plateRows"] = plateRows
+        kwargs["plateAcqs"] = plate_acqs
+        kwargs["plateCols"] = plate_cols
+        kwargs["plateRows"] = plate_rows
         kwargs["fields"] = fields
-        images = self.importMIF(client=client, **kwargs)
+        images = self.import_mif(client=client, **kwargs)
         images = [x.id.val for x in images]
 
         query = client.sf.getQueryService()
@@ -392,8 +392,8 @@ class ITest(object):
             omero.sys.ParametersI().addIds(images))
         return plates
 
-    def createTestImage(self, sizeX=16, sizeY=16, sizeZ=1, sizeC=1, sizeT=1,
-                        session=None):
+    def create_test_image(self, size_x=16, size_y=16, size_z=1, size_c=1,
+                          size_t=1, session=None):
         """
         Creates a test image of the required dimensions, where each pixel
         value is set to the value of x+y.
@@ -435,8 +435,8 @@ class ITest(object):
 
         # code below here is very similar to combineImages.py
         # create an image in OMERO and populate the planes with numpy 2D arrays
-        channel_list = range(1, sizeC + 1)
-        iid = pixels_service.createImage(sizeX, sizeY, sizeZ, sizeT,
+        channel_list = range(1, size_c + 1)
+        iid = pixels_service.createImage(size_x, size_y, size_z, size_t,
                                          channel_list, pixels_type,
                                          "testImage", "description")
         image_id = iid.getValue()
@@ -448,13 +448,13 @@ class ITest(object):
         colour_map = {0: (0, 0, 255, 255), 1: (0, 255, 0, 255),
                       2: (255, 0, 0, 255), 3: (255, 0, 255, 255)}
         f_list = [f1, f2, f3]
-        for the_c in range(sizeC):
+        for the_c in range(size_c):
             min_value = 0
             max_value = 0
             f = f_list[the_c % len(f_list)]
-            for the_z in range(sizeZ):
-                for the_t in range(sizeT):
-                    plane_2d = fromfunction(f, (sizeY, sizeX), dtype=int16)
+            for the_z in range(size_z):
+                for the_t in range(size_t):
+                    plane_2d = fromfunction(f, (size_y, size_x), dtype=int16)
                     script_utils.uploadPlane(
                         raw_pixel_store, plane_2d, the_z, the_c, the_t)
                     min_value = min(min_value, plane_2d.min())
@@ -464,7 +464,7 @@ class ITest(object):
             rgba = None
             if the_c in colour_map:
                 rgba = colour_map[the_c]
-        for the_c in range(sizeC):
+        for the_c in range(size_c):
             script_utils.resetRenderingSettings(
                 rendering_engine, pixels_id, the_c, min_value, max_value, rgba)
 
@@ -481,8 +481,7 @@ class ITest(object):
             tb.close()
 
         # Reloading image to prevent error on old pixels updateEvent
-        image = container_service.getImages("Image", [image_id], None)[0]
-        return image
+        return container_service.getImages("Image", [image_id], None)[0]
 
     def get_fileset(self, i, client=None):
         """
@@ -506,7 +505,7 @@ class ITest(object):
                 self.root.sf.getUpdateService().indexObject(
                     obj, {"omero.group": "-1"})
 
-    def waitOnCmd(self, client, handle, loops=10, ms=500, passes=True):
+    def wait_on_cmd(self, client, handle, loops=10, ms=500, passes=True):
         """
         Wait on an omero.cmd.HandlePrx to finish processing
         and then assert pass or fail. The callback is returned
@@ -760,7 +759,7 @@ class ITest(object):
         jpeg = Image.open(tfile)  # Raises if invalid
         return jpeg
 
-    def loginAttempt(self, name, t, pw="BAD", less=False):
+    def login_attempt(self, name, t, pw="BAD", less=False):
         """
         Checks that login happens in less than or greater than
         the given time. By default, the password "BAD" is used,
@@ -769,7 +768,7 @@ class ITest(object):
         To check that logins happen more quickly, pass the
         correct password and less=True:
 
-            loginAttempt("user", 0.15, pw="REALVALUE", less=True)
+            login_attempt("user", 0.15, pw="REALVALUE", less=True)
 
         See integration.tickets4000 and 5000
         """
@@ -792,8 +791,8 @@ class ITest(object):
         finally:
             c.__del__()
 
-    def doSubmit(self, request, client, test_should_pass=True,
-                 omero_group=None):
+    def do_submit(self, request, client, test_should_pass=True,
+                  omero_group=None):
         """
         Performs the request(s), waits on completion and checks that the
         result is not an error. The request can either be a single command
@@ -930,7 +929,7 @@ class ITest(object):
         tag = self.new_tag(name=name, ns=ns)
         return client.sf.getUpdateService().saveAndReturnObject(tag)
 
-    def createDatasets(self, count, baseName, client=None):
+    def create_datasets(self, count, base_name, client=None):
         """
         Creates a list of the given number of Dataset instances with names of
         the form "name [1]", "name [2]" etc and returns them in a list.
@@ -945,7 +944,7 @@ class ITest(object):
         update = client.sf.getUpdateService()
         dsets = []
         for i in range(count):
-            name = baseName + " [" + str(i + 1) + "]"
+            name = base_name + " [" + str(i + 1) + "]"
             dsets.append(self.new_dataset(name=name))
         return update.saveAndReturnArray(dsets)
 
@@ -1037,7 +1036,7 @@ class ITest(object):
         """
         Deletes a list of model entities (ProjectI, DatasetI or ImageI)
         by creating Delete2 commands and calling
-        :func:`~test.ITest.doSubmit`.
+        :func:`~test.ITest.do_submit`.
 
         :param obj: a list of objects to be deleted
         """
@@ -1053,14 +1052,14 @@ class ITest(object):
         ids = [i.id.val for i in obj]
         command = Delete2(targetObjects={t: ids})
 
-        self.doSubmit(command, self.client)
+        self.do_submit(command, self.client)
 
     def change_group(self, obj, target, client=None):
         """
         Moves a list of model entities (ProjectI, DatasetI or ImageI)
         to the target group. Accepts a client instance to guarantee calls
         in correct user contexts. Creates Chgrp2 commands and calls
-        :func:`~test.ITest.doSubmit`.
+        :func:`~test.ITest.do_submit`.
 
         :param obj: a list of objects to be moved
         :param target: the ID of the target group
@@ -1080,13 +1079,13 @@ class ITest(object):
         ids = [i.id.val for i in obj]
         command = Chgrp2(targetObjects={t: ids}, groupId=target)
 
-        self.doSubmit(command, client)
+        self.do_submit(command, client)
 
     def change_permissions(self, gid, perms, client=None):
         """
         Changes the permissions of an ExperimenterGroup object.
         Accepts a client instance to guarantee calls in correct user contexts.
-        Creates Chmod2 commands and calls :func:`~test.ITest.doSubmit`.
+        Creates Chmod2 commands and calls :func:`~test.ITest.do_submit`.
 
         :param gid: id of an ExperimenterGroup
         :param perms: permissions string
@@ -1098,7 +1097,7 @@ class ITest(object):
         command = Chmod2(
             targetObjects={'ExperimenterGroup': [gid]}, permissions=perms)
 
-        self.doSubmit(command, client)
+        self.do_submit(command, client)
 
     def create_share(self, description="", timeout=None,
                      objects=[], experimenters=[], guests=[],
@@ -1126,18 +1125,18 @@ class ProjectionFixture(object):
     """
 
     def __init__(self, perms, writer, reader,
-                 canRead,
-                 canAnnotate=False, canDelete=False,
-                 canEdit=False, canLink=False):
+                 can_read,
+                 can_annotate=False, can_delete=False,
+                 can_edit=False, can_link=False):
         self.perms = perms
         self.writer = writer
         self.reader = reader
 
-        self.canRead = canRead
-        self.canAnnotate = canAnnotate
-        self.canDelete = canDelete
-        self.canEdit = canEdit
-        self.canLink = canLink
+        self.canRead = can_read
+        self.canAnnotate = can_annotate
+        self.canDelete = can_delete
+        self.canEdit = can_edit
+        self.canLink = can_link
 
     def get_name(self):
         name = self.perms

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -346,12 +346,11 @@ class ITest(object):
         query = client.sf.getQueryService()
         fake = create_path(name, "&%s.fake" % append)
         if with_companion:
-            ini = open(fake.abspath() + ".ini", "w")
-            if global_metadata:
-                ini.write("[GlobalMetadata]\n")
-                for k, v in global_metadata.items():
-                    ini.write("%s=%s\n" % (k, v))
-            ini.close()
+            with open(fake.abspath() + ".ini", "w") as ini:
+                if global_metadata:
+                    ini.write("[GlobalMetadata]\n")
+                    for k, v in global_metadata.items():
+                        ini.write("%s=%s\n" % (k, v))
 
         pixel_ids = self.import_image(
             filename=fake.abspath(), client=client, skip=skip, **kwargs)

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -755,8 +755,8 @@ class ITest(object):
                 import Image
             except ImportError:
                 assert False, "Pillow not installed"
-        from cStringIO import StringIO
-        tfile = StringIO(buf)
+        from io import BytesIO
+        tfile = BytesIO(buf)
         jpeg = Image.open(tfile)  # Raises if invalid
         return jpeg
 

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -132,7 +132,7 @@ class ITest(object):
             raise
 
     @classmethod
-    def omeropydir(self):
+    def omeropydir(cls):
         count = 10
         searched = []
         p = path(".").abspath()
@@ -162,26 +162,26 @@ class ITest(object):
                         % (config_key, config_value))
 
     @classmethod
-    def uuid(self):
+    def uuid(cls):
         return str(uuid.uuid4())
 
     @classmethod
-    def login_args(self, client=None):
-        p = self.client.ic.getProperties()
+    def login_args(cls, client=None):
+        p = cls.client.ic.getProperties()
         host = p.getProperty("omero.host")
         port = p.getProperty("omero.port")
         if not client:
-            key = self.sf.ice_getIdentity().name
+            key = cls.sf.ice_getIdentity().name
         else:
             key = client.sf.ice_getIdentity().name
         return ["-q", "-s", host, "-k", key, "-p", port]
 
     @classmethod
-    def root_login_args(self):
-        p = self.root.ic.getProperties()
+    def root_login_args(cls):
+        p = cls.root.ic.getProperties()
         host = p.getProperty("omero.host")
         port = p.getProperty("omero.port")
-        key = self.root.sf.ice_getIdentity().name
+        key = cls.root.sf.ice_getIdentity().name
         return ["-s", host, "-k", key, "-p", port]
 
     def tmpfile(self):
@@ -189,11 +189,11 @@ class ITest(object):
 
     # Administrative methods
     @classmethod
-    def new_group(self, experimenters=None, perms=None,
+    def new_group(cls, experimenters=None, perms=None,
                   config=None, gname=None):
-        admin = self.root.sf.getAdminService()
+        admin = cls.root.sf.getAdminService()
         if gname is None:
-            gname = self.uuid()
+            gname = cls.uuid()
         group = ExperimenterGroupI()
         group.name = rstring(gname)
         group.ldap = rbool(False)
@@ -202,15 +202,15 @@ class ITest(object):
             group.details.permissions = PermissionsI(perms)
         gid = admin.createGroup(group)
         group = admin.getGroup(gid)
-        self.add_experimenters(group, experimenters)
+        cls.add_experimenters(group, experimenters)
         return group
 
     @classmethod
-    def add_experimenters(self, group, experimenters):
-        admin = self.root.sf.getAdminService()
+    def add_experimenters(cls, group, experimenters):
+        admin = cls.root.sf.getAdminService()
         if experimenters:
             for exp in experimenters:
-                user, name = self.user_and_name(exp)
+                user, name = cls.user_and_name(exp)
                 admin.addGroups(user, [group])
 
     def add_groups(self, experimenter, groups, owner=False):
@@ -520,7 +520,7 @@ class ITest(object):
         return callback
 
     @classmethod
-    def new_user(self, group=None, perms=None,
+    def new_user(cls, group=None, perms=None,
                  owner=False, system=False, uname=None,
                  email=None):
         """
@@ -528,19 +528,19 @@ class ITest(object):
         :system: If user is to be a system admin
         """
 
-        if not self.root:
+        if not cls.root:
             raise Exception("No root client. Cannot create user")
 
-        admin_service = self.root.getSession().getAdminService()
+        admin_service = cls.root.getSession().getAdminService()
         if uname is None:
-            uname = self.uuid()
+            uname = cls.uuid()
 
         # Create group if necessary
         if not group:
-            g = self.new_group(perms=perms)
+            g = cls.new_group(perms=perms)
             group = g.getName().getValue()
         else:
-            g, group = self.group_and_name(group)
+            g, group = cls.group_and_name(group)
 
         # Create user
         e = ExperimenterI()
@@ -611,9 +611,9 @@ class ITest(object):
         return elapsed, rv
 
     @classmethod
-    def group_and_name(self, group):
+    def group_and_name(cls, group):
         group = unwrap(group)
-        admin = self.root.sf.getAdminService()
+        admin = cls.root.sf.getAdminService()
         if isinstance(group, (int, long)):
             group = admin.getGroup(group)
             name = group.name.val
@@ -636,9 +636,9 @@ class ITest(object):
         return group, name
 
     @classmethod
-    def user_and_name(self, user):
+    def user_and_name(cls, user):
         user = unwrap(user)
-        admin = self.root.sf.getAdminService()
+        admin = cls.root.sf.getAdminService()
         if isinstance(user, omero.clients.BaseClient):
             admin = user.sf.getAdminService()
             ec = admin.getEventContext()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -138,14 +138,14 @@ class ITest(object):
             dist = None
             for root, dirs, files in os.walk(p):
                 for f in files:
-                    a = path(os.path.join(root, f))
+                    t = path(os.path.join(root, f))
                     # find OMERO dist by searching for bin/omero
                     # exclude OmeroPy as is a source
-                    if (str(a.dirname().dirname().basename())
+                    if (str(t.dirname().dirname().basename())
                             not in ('OmeroPy', 'build', 'target') and
-                            str(a.basename()) == 'omero' and
-                            str(a.dirname().basename()) == 'bin'):
-                        dist = a.dirname().dirname()
+                            str(t.basename()) == 'omero' and
+                            str(t.dirname().basename()) == 'bin'):
+                        dist = t.dirname().dirname()
             return dist
         count = 10
         searched = []

--- a/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
@@ -89,7 +89,7 @@ class TestChgrp(CLITest):
 
     def testFileset(self):
         # 2 images sharing a fileset
-        images = self.importMIF(2)
+        images = self.import_mif(2)
         img = self.query.get('Image', images[0].id.val)
         filesetId = img.fileset.id.val
         fileset = self.query.get('Fileset', filesetId)
@@ -107,7 +107,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == target_group.id.val
 
     def testFilesetPartialFailing(self):
-        images = self.importMIF(2)  # 2 images sharing a fileset
+        images = self.import_mif(2)  # 2 images sharing a fileset
 
         # try to move only one image to the new group
         target_group = self.target_groups['rw----']
@@ -123,7 +123,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == gid
 
     def testFilesetOneImage(self):
-        images = self.importMIF(1)  # One image in a fileset
+        images = self.import_mif(1)  # One image in a fileset
 
         # try to move only one image to the new group
         target_group = self.target_groups['rw----']
@@ -138,7 +138,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == target_group.id.val
 
     def testFilesetAllImagesMoveImages(self):
-        images = self.importMIF(2)  # 2 images sharing a fileset
+        images = self.import_mif(2)  # 2 images sharing a fileset
 
         # try to move both the images to the new group
         target_group = self.target_groups['rw----']
@@ -153,7 +153,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == target_group.id.val
 
     def testFilesetAllImagesMoveDataset(self):
-        images = self.importMIF(2)  # 2 images sharing a fileset
+        images = self.import_mif(2)  # 2 images sharing a fileset
         dataset_id = self.create_object('Dataset')  # ... in a dataset
 
         # put the images into the dataset

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -93,7 +93,7 @@ class TestChown(CLITest):
     @pytest.mark.parametrize('arguments', ['image', 'fileset'])
     def testFileset(self, nimages, arguments):
         # 2 images sharing a fileset
-        images = self.importMIF(nimages)
+        images = self.import_mif(nimages)
         img = self.query.get('Image', images[0].id.val)
         filesetId = img.fileset.id.val
         fileset = self.query.get('Fileset', filesetId)
@@ -119,7 +119,7 @@ class TestChown(CLITest):
             assert obj.details.owner.id.val == user.id.val
 
     def testFilesetPartialFailing(self):
-        images = self.importMIF(2)  # 2 images sharing a fileset
+        images = self.import_mif(2)  # 2 images sharing a fileset
 
         # Create user and try to transfer only one image to the user
         client, user = self.new_client_and_user(group=self.group)
@@ -134,7 +134,7 @@ class TestChown(CLITest):
             assert obj.details.owner.id.val == self.user.id.val
 
     def testFilesetAllImagesChownDataset(self):
-        images = self.importMIF(2)  # 2 images sharing a fileset
+        images = self.import_mif(2)  # 2 images sharing a fileset
         dataset_id = self.create_object('Dataset')  # ... in a dataset
 
         # put the images into the dataset

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -53,7 +53,7 @@ class TestDelete(CLITest):
     @pytest.mark.parametrize('arguments', ['image', 'fileset'])
     def testFileset(self, nimages, arguments):
         # 2 images sharing a fileset
-        images = self.importMIF(nimages)
+        images = self.import_mif(nimages)
         img = self.query.get('Image', images[0].id.val)
         filesetId = img.fileset.id.val
         fileset = self.query.get('Fileset', filesetId)
@@ -73,7 +73,7 @@ class TestDelete(CLITest):
             assert not self.query.find('Image', i.id.val)
 
     def testFilesetPartialFailing(self):
-        images = self.importMIF(2)  # 2 images sharing a fileset
+        images = self.import_mif(2)  # 2 images sharing a fileset
 
         # try to delete only one image
         self.args += ['/Image:%s' % images[0].id.val]
@@ -84,7 +84,7 @@ class TestDelete(CLITest):
             assert self.query.get('Image', i.id.val) is not None
 
     def testFilesetAllImagesDeleteDataset(self):
-        images = self.importMIF(2)  # 2 images sharing a fileset
+        images = self.import_mif(2)  # 2 images sharing a fileset
         dataset_id = self.create_object('Dataset')  # ... in a dataset
 
         # put the images into the dataset
@@ -517,7 +517,7 @@ class TestDelete(CLITest):
         # Import several images
         ids = []
         for i in range(IMAGES):
-            ids.append(self.importSingleImage().id.val)
+            ids.append(self.import_single_image().getId().getValue())
         ids = sorted(ids)
         assert len(ids) == IMAGES
         assert ids[-1] - ids[0] + 1 == IMAGES

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -291,10 +291,10 @@ class TestDownload(CLITest):
         upper = self.new_client(group=group)
         upper_q = upper.sf.getQueryService()
 
-        pimage = self.importSingleImage(client=upper,
-                                        plates=1, plateRows=1,
-                                        plateCols=1, fields=1,
-                                        plateAcqs=1)
+        pimage = self.import_single_image(client=upper,
+                                          plates=1, plateRows=1,
+                                          plateCols=1, fields=1,
+                                          plateAcqs=1)
 
         pfile = upper_q.findByQuery((
             "select f from OriginalFile f join f.filesetEntries fe "

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -157,7 +157,7 @@ class TestDownload(CLITest):
     # Image tests
     # ========================================================================
     def testNonExistingImage(self, tmpdir):
-        image = self.importSingleImageWithCompanion()
+        image = self.import_single_image_with_companion()
         self.args += ["Image:%s" % str(image.id.val + 1), '-']
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
@@ -179,14 +179,14 @@ class TestDownload(CLITest):
         f.close()
 
     def testSingleImageWithCompanion(self, tmpdir):
-        image = self.importSingleImageWithCompanion()
+        image = self.import_single_image_with_companion()
         tmpfile = tmpdir.join('test')
         self.args += ["Image:%s" % image.id.val, str(tmpfile)]
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
 
     def testMIF(self, tmpdir):
-        images = self.importMIF(2)
+        images = self.import_mif(2)
         tmpfile = tmpdir.join('test')
         self.args += ["Image:%s" % images[0].id.val, str(tmpfile)]
         self.cli.invoke(self.args, strict=True)
@@ -306,7 +306,7 @@ class TestDownload(CLITest):
             "join w.wellSamples ws join ws.image img "
             "where img.id = %s") % pimage.id.val, None)
 
-        image = self.importSingleImage(client=upper)
+        image = self.import_single_image(client=upper)
 
         ofile = self.create_original_file("test", upper)
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -74,11 +74,11 @@ class TestFS(CLITest):
         """Test --with-transfer option of fs sets subcommand"""
 
         f = {}
-        i0 = self.importMIF(1)
+        i0 = self.import_mif(1)
         f[None] = self.get_fileset(i0)
 
         for transfer in transfers:
-            i = self.importMIF(1, extra_args=['--transfer=%s' % transfer])
+            i = self.import_mif(1, extra_args=['--transfer=%s' % transfer])
             f[transfer] = self.get_fileset(i)
 
         self.args += ["sets", "--style=plain"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -120,7 +120,7 @@ class TestImport(CLITest):
         self.cli.register("import", plugin.ImportControl, "TEST")
         self.args += ["import"]
         self.add_client_dir()
-        self.keepRootAlive()
+        self.keep_root_alive()
 
     def set_conn_args(self):
         host = self.root.getProperty("omero.host")

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -149,8 +149,7 @@ class TestImport(CLITest):
         return o, e
 
     def add_client_dir(self):
-        dist_dir = self.OmeroPy / ".." / ".." / ".." / "dist"
-        client_dir = dist_dir / "lib" / "client"
+        client_dir = self.omero_dist / "lib" / "client"
         self.args += ["--clientdir", client_dir]
 
     def check_other_output(self, out):

--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -35,7 +35,7 @@ class MetadataTestBase(CLITest):
     def setup_method(self, method):
         super(MetadataTestBase, self).setup_method(method)
         self.name = self.uuid()
-        self.image = self.importSingleImage(
+        self.image = self.import_single_image(
             GlobalMetadata={'gmd-' + self.name: 'gmd-' + self.name})
 
         conn = BlitzGateway(client_obj=self.client)

--- a/components/tools/OmeroPy/test/integration/clitest/test_search.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_search.py
@@ -39,10 +39,10 @@ class TestSearch(CLITest):
         self._uuid = self.uuid().replace("-", "")
         if with_acquisitionDate:
             filename_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            self._image = self.importMIF(
+            self._image = self.import_mif(
                 name=self._uuid, acquisitionDate=filename_date)[0]
         else:
-            self._image = self.importMIF(name=self._uuid)[0]
+            self._image = self.import_mif(name=self._uuid)[0]
         self.root.sf.getUpdateService().indexObject(self._image)
 
     def mkdataset(self):

--- a/components/tools/OmeroPy/test/integration/fstest/test_rename.py
+++ b/components/tools/OmeroPy/test/integration/fstest/test_rename.py
@@ -99,7 +99,7 @@ class TestRename(AbstractRepoTest):
             "root": self.root,
         }
         orig_img = self.import_mif(name="rename",
-                                   size_x=16, size_y=16,
+                                   sizeX=16, sizeY=16,
                                    with_companion=True,
                                    client=clients[owner])[0]
         orig_fs = self.get_fileset([orig_img], clients[owner])

--- a/components/tools/OmeroPy/test/integration/fstest/test_rename.py
+++ b/components/tools/OmeroPy/test/integration/fstest/test_rename.py
@@ -98,7 +98,7 @@ class TestRename(AbstractRepoTest):
             "user2": self.new_client(group=group),
             "root": self.root,
         }
-        orig_img = self.importMIF(name="rename",
+        orig_img = self.import_mif(name="rename",
                                   sizeX=16, sizeY=16,
                                   with_companion=True,
                                   client=clients[owner])[0]
@@ -127,7 +127,7 @@ class TestRename(AbstractRepoTest):
     def test_rename_annotation(self):
         ns = NSFSRENAME
         mrepo = self.client.getManagedRepository()
-        orig_img = self.importMIF(with_companion=True)
+        orig_img = self.import_mif(with_companion=True)
         orig_fs = self.get_fileset(orig_img)
         new_dir = prep_directory(self.client, mrepo)
         self.assert_rename(orig_fs, new_dir)

--- a/components/tools/OmeroPy/test/integration/fstest/test_rename.py
+++ b/components/tools/OmeroPy/test/integration/fstest/test_rename.py
@@ -99,9 +99,9 @@ class TestRename(AbstractRepoTest):
             "root": self.root,
         }
         orig_img = self.import_mif(name="rename",
-                                  sizeX=16, sizeY=16,
-                                  with_companion=True,
-                                  client=clients[owner])[0]
+                                   size_x=16, size_y=16,
+                                   with_companion=True,
+                                   client=clients[owner])[0]
         orig_fs = self.get_fileset([orig_img], clients[owner])
 
         uid = orig_fs.details.owner.id.val

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_ticket10618.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_ticket10618.py
@@ -64,7 +64,7 @@ for perms, testertype, direct, grpctx, size in generate_parameters():
 
         group = self.new_group(perms=perms.ljust(6, "-"))
         owner = self.new_client(group=group)
-        image = self.createTestImage(session=owner.sf)
+        image = self.create_test_image(session=owner.sf)
 
         if testertype == "root":
             tester = self.root

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -90,7 +90,7 @@ class BasePopulate(ITest):
 
     def createPlate(self, rowCount, colCount):
         plates = self.import_plates(plate_rows=rowCount,
-                                   plate_cols=colCount)
+                                    plate_cols=colCount)
         return plates[0]
 
     def createPlate1(self, rowCount, colCount):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -89,8 +89,8 @@ class BasePopulate(ITest):
         return str(csvFileName)
 
     def createPlate(self, rowCount, colCount):
-        plates = self.importPlates(plateRows=rowCount,
-                                   plateCols=colCount)
+        plates = self.import_plates(plate_rows=rowCount,
+                                   plate_cols=colCount)
         return plates[0]
 
     def createPlate1(self, rowCount, colCount):

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_analysis_scripts.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_analysis_scripts.py
@@ -47,7 +47,7 @@ class TestAnalysisScripts(ScriptTest):
         size_y = 100
         # x,y,z,c,t
         session = client.getSession()
-        image = self.createTestImage(size_x, size_y, 1, 2, size_t, session)
+        image = self.create_test_image(size_x, size_y, 1, 2, size_t, session)
         image_id = image.getId().getValue()
         roi = create_roi(image_id, 0, size_x / 2, 0, size_y / 2, size_t)
         session.getUpdateService().saveAndReturnObject(roi)
@@ -76,7 +76,7 @@ class TestAnalysisScripts(ScriptTest):
         size_x = 100
         size_y = 100
         session = client.getSession()
-        image = self.createTestImage(size_x, size_y, 1, 2, size_t, session)
+        image = self.create_test_image(size_x, size_y, 1, 2, size_t, session)
         image_id = image.getId().getValue()
         roi = create_roi(image_id, 0, size_x / 2, 0, size_y / 2, size_t)
         session.getUpdateService().saveAndReturnObject(roi)

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_export_scripts.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_export_scripts.py
@@ -42,7 +42,7 @@ class TestExportScripts(ScriptTest):
 
         client, user = self.new_client_and_user()
         # x,y,z,c,t
-        image = self.createTestImage(100, 100, 1, 1, 1, client.getSession())
+        image = self.create_test_image(100, 100, 1, 1, 1, client.getSession())
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
         args = {
@@ -59,7 +59,7 @@ class TestExportScripts(ScriptTest):
 
         client, user = self.new_client_and_user()
         # x,y,z,c,t
-        image = self.createTestImage(100, 100, 1, 1, 1, client.getSession())
+        image = self.create_test_image(100, 100, 1, 1, 1, client.getSession())
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
         args = {

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_figure_export_figures.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_figure_export_figures.py
@@ -64,7 +64,7 @@ class TestFigureExportScripts(ScriptTest):
         image_ids = []
         for i in range(2):
             # x,y,z,c,t
-            image = self.createTestImage(100, 100, 1, 1, 1, session)
+            image = self.create_test_image(100, 100, 1, 1, 1, session)
             image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
             self.link(dataset, image, client=client)
 
@@ -116,7 +116,7 @@ class TestFigureExportScripts(ScriptTest):
         session = client.getSession()
         image_ids = []
         for i in range(2):
-            image = self.createTestImage(256, 200, 5, 4, 1, session)
+            image = self.create_test_image(256, 200, 5, 4, 1, session)
             image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
             self.link(dataset, image, client=client)
 
@@ -179,7 +179,7 @@ class TestFigureExportScripts(ScriptTest):
         image_ids = []
         session = client.getSession()
         for i in range(2):
-            image = self.createTestImage(256, 200, 5, 4, 1, session)
+            image = self.create_test_image(256, 200, 5, 4, 1, session)
             image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
             self.link(dataset, image, client=client)
             add_rectangle_roi(session.getUpdateService(),
@@ -246,7 +246,7 @@ class TestFigureExportScripts(ScriptTest):
         image_ids = []
         session = client.getSession()
         for i in range(2):
-            image = self.createTestImage(256, 256, 10, 3, 1, session)
+            image = self.create_test_image(256, 256, 10, 3, 1, session)
             image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
             self.link(dataset, image, client=client)
 
@@ -302,7 +302,7 @@ class TestFigureExportScripts(ScriptTest):
         session = client.getSession()
         image_ids = []
         for i in range(2):
-            image = self.createTestImage(256, 256, 5, 3, 20, session)
+            image = self.create_test_image(256, 256, 5, 3, 20, session)
             image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
             self.link(dataset, image, client=client)
 

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
@@ -34,11 +34,8 @@ SENDFILE = """
 #!/usr/bin/env python
 
 # Setup to run as an integration test
-rundir = "%s"
 import os
 import sys
-sys.path.insert(0, rundir)
-sys.path.insert(0, os.path.join(rundir, "target"))
 
 import omero.scripts as s
 import omero.util.script_utils as su
@@ -97,9 +94,8 @@ class TestInputs(ITest):
         logging.basicConfig(level=10)
         root_client = self.new_client(system=True)
         scripts = root_client.sf.getScriptService()
-        sendfile = SENDFILE % self.omeropydir()
         id = scripts.uploadScript(
-            "/tests/inputs_py/%s.py" % self.uuid(), sendfile)
+            "/tests/inputs_py/%s.py" % self.uuid(), SENDFILE)
         input = {"a": rint(100)}
         impl = omero.processor.usermode_processor(root_client)
         try:

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
@@ -41,7 +41,7 @@ class TestUtilScripts(ScriptTest):
 
         client = self.root
 
-        image = self.createTestImage(100, 100, 2, 3, 4)    # x,y,z,c,t
+        image = self.create_test_image(100, 100, 2, 3, 4)    # x,y,z,c,t
         image_id = image.getId().getValue()
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image_id))
@@ -67,7 +67,7 @@ class TestUtilScripts(ScriptTest):
 
         image_ids = []
         for i in range(2):
-            image = self.createTestImage(100, 100, 2, 3, 4)    # x,y,z,c,t
+            image = self.create_test_image(100, 100, 2, 3, 4)    # x,y,z,c,t
             image_ids.append(omero.rtypes.rlong(image.getId().getValue()))
 
         args = {
@@ -88,7 +88,7 @@ class TestUtilScripts(ScriptTest):
 
         size_x = 100
         size_y = 100
-        image = self.createTestImage(size_x, size_y, 5, 1, 1)    # x,y,z,c,t
+        image = self.create_test_image(size_x, size_y, 5, 1, 1)    # x,y,z,c,t
         image_id = image.getId().getValue()
         image_ids = []
         image_ids.append(omero.rtypes.rlong(image_id))

--- a/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
+++ b/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
@@ -77,7 +77,7 @@ class AnnotationPermissions(ITest):
         chmod = omero.cmd.Chmod2(
             targetObjects={'ExperimenterGroup': [self.group.id.val]},
             permissions=perms)
-        self.doSubmit(chmod, client, test_should_pass=succeed)
+        self.do_submit(chmod, client, test_should_pass=succeed)
 
     def createProjectAs(self, user):
         """ Adds a Project. """

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -56,12 +56,12 @@ class TestChgrp(ITest):
         client.sf.getAdminService().getEventContext()  # Reset session
 
         # Import an image into the client context
-        image = self.importSingleImage(
+        image = self.import_single_image(
             name="testChgrpImportedImage", client=client)
 
         # Chgrp
         chgrp = Chgrp2(targetObjects={'Image': [image.id.val]}, groupId=gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Change our context to new group...
         admin = client.sf.getAdminService()
@@ -113,7 +113,7 @@ class TestChgrp(ITest):
         self.set_context(client, first_gid)
 
         # We have to be in destination group for link Save to work
-        self.doSubmit(requests, client)
+        self.do_submit(requests, client)
 
         # ...check image
         img = client.sf.getQueryService().get("Image", img.id.val)
@@ -146,7 +146,7 @@ class TestChgrp(ITest):
         # Move Project to new group
         chgrp = Chgrp2(
             targetObjects={'Project': [project.id.val]}, groupId=gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Change our context to new group...
         admin = client.sf.getAdminService()
@@ -176,7 +176,8 @@ class TestChgrp(ITest):
         member = self.new_client(group=source_grp)
 
         # Create an image as the owner
-        image = self.importSingleImage(name="testChgrpRdef7825", client=owner)
+        image = self.import_single_image(name="testChgrpRdef7825",
+                                         client=owner)
 
         # Render as both users
         owner_g = omero.gateway.BlitzGateway(client_obj=owner)
@@ -191,12 +192,12 @@ class TestChgrp(ITest):
         # Now chgrp and try to delete
         chgrp = Chgrp2(
             targetObjects={'Image': [image.id.val]}, groupId=target_gid)
-        self.doSubmit(chgrp, owner)
+        self.do_submit(chgrp, owner)
 
         # Shouldn't be necessary to change group, but we're gonna
         owner_g.SERVICE_OPTS.setOmeroGroup("-1")
         handle = owner_g.deleteObjects("Image", [image.id.val])
-        self.waitOnCmd(owner_g.c, handle)
+        self.wait_on_cmd(owner_g.c, handle)
 
     def testChgrpOneImageFilesetErr(self):
         """
@@ -210,12 +211,12 @@ class TestChgrp(ITest):
         target_gid = target_grp.id.val
 
         # 2 images sharing a fileset
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
 
         # Now chgrp
         chgrp = Chgrp2(
             targetObjects={'Image': [images[0].id.val]}, groupId=target_gid)
-        self.doSubmit(chgrp, client, test_should_pass=False)
+        self.do_submit(chgrp, client, test_should_pass=False)
 
     def testChgrpAllImagesFilesetOK(self):
         """
@@ -228,12 +229,12 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
 
         # chgrp should succeed
         ids = [images[0].id.val, images[1].id.val]
         chgrp = Chgrp2(targetObjects={'Image': ids}, groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Check both Images moved
         queryService = client.sf.getQueryService()
@@ -256,14 +257,14 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
 
         # chgrp should succeed
         chgrp1 = Chgrp2(
             targetObjects={'Image': [images[0].id.val]}, groupId=target_gid)
         chgrp2 = Chgrp2(
             targetObjects={'Image': [images[1].id.val]}, groupId=target_gid)
-        self.doSubmit([chgrp1, chgrp2], client, test_should_pass=False)
+        self.do_submit([chgrp1, chgrp2], client, test_should_pass=False)
 
     def testChgrpOneDatasetFilesetErr(self):
         """
@@ -277,9 +278,9 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        datasets = self.createDatasets(
+        datasets = self.create_datasets(
             2, "testChgrpOneDatasetFilesetErr", client=client)
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
         for i in range(2):
             self.link(datasets[i], images[i], client=client)
 
@@ -287,7 +288,7 @@ class TestChgrp(ITest):
         chgrp = Chgrp2(
             targetObjects={"Dataset": [datasets[0].id.val]},
             groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         queryService = client.sf.getQueryService()
 
@@ -320,16 +321,16 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        datasets = self.createDatasets(
+        datasets = self.create_datasets(
             2, "testChgrpAllDatasetsFilesetOK", client=client)
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
         for i in range(2):
             self.link(datasets[i], images[i], client=client)
 
         # Now chgrp, should succeed
         ids = [datasets[0].id.val, datasets[1].id.val]
         chgrp = Chgrp2(targetObjects={"Dataset": ids}, groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Check both Datasets and Images moved
         queryService = client.sf.getQueryService()
@@ -355,14 +356,14 @@ class TestChgrp(ITest):
 
         ds = self.make_dataset(name="testChgrpOneDatasetFilesetOK",
                                client=client)
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
         for i in range(2):
             self.link(ds, images[i], client=client)
 
         # Now chgrp, should succeed
         chgrp = Chgrp2(
             targetObjects={"Dataset": [ds.id.val]}, groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Check Dataset and both Images moved
         queryService = client.sf.getQueryService()
@@ -386,13 +387,13 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        imagesFsOne = self.importMIF(2, client=client)
-        imagesFsTwo = self.importMIF(2, client=client)
+        imagesFsOne = self.import_mif(2, client=client)
+        imagesFsTwo = self.import_mif(2, client=client)
 
         # chgrp should fail...
         ids = [imagesFsOne[0].id.val, imagesFsTwo[0].id.val]
         chgrp = Chgrp2(targetObjects={"Image": ids}, groupId=target_gid)
-        self.doSubmit(chgrp, client, test_should_pass=False)
+        self.do_submit(chgrp, client, test_should_pass=False)
 
     def testChgrpDatasetTwoFilesetsErr(self):
         """
@@ -404,19 +405,19 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        imagesFsOne = self.importMIF(2, client=client)
-        imagesFsTwo = self.importMIF(2, client=client)
+        imagesFsOne = self.import_mif(2, client=client)
+        imagesFsTwo = self.import_mif(2, client=client)
 
         ds = self.make_dataset(name="testChgrpDatasetTwoFilesetsErr",
                                client=client)
-        self.importMIF(2, client=client)
+        self.import_mif(2, client=client)
         for i in (imagesFsOne, imagesFsTwo):
             self.link(ds, i[0], client=client)
 
         # chgrp should succeed with the Dataset only
         chgrp = Chgrp2(
             targetObjects={"Dataset": [ds.id.val]}, groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         queryService = client.sf.getQueryService()
 
@@ -447,14 +448,14 @@ class TestChgrp(ITest):
 
         ds = self.make_dataset(name="testChgrpDatasetCheckFsGroup",
                                client=client)
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
         for i in range(2):
             self.link(ds, images[i], client=client)
 
         # Now chgrp, should succeed
         chgrp = Chgrp2(
             targetObjects={"Dataset": [ds.id.val]}, groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Check the group of the fileset is in sync with image.
         ctx = {'omero.group': '-1'}
@@ -478,12 +479,12 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
         fsId = query.get("Image", images[0].id.val).fileset.id.val
 
         # Now chgrp, should succeed
         chgrp = Chgrp2(targetObjects={"Fileset": [fsId]}, groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Check Fileset and both Images moved and
         # thus the Fileset is in sync with Images.
@@ -506,7 +507,7 @@ class TestChgrp(ITest):
         # One user in two groups
         client, user = self.new_client_and_user(perms=PRIVATE)
         ds = self.make_dataset(name="testChgrp11000", client=client)
-        images = self.importMIF(2, client=client)
+        images = self.import_mif(2, client=client)
         for i in range(2):
             self.link(ds, images[i], client=client)
 
@@ -547,7 +548,7 @@ class TestChgrp(ITest):
         # Now chgrp, should succeed
         chgrp = Chgrp2(
             targetObjects={"Plate": [link.child.id.val]}, groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         # Check that the links have been destroyed
         query = client.sf.getQueryService()
@@ -667,7 +668,7 @@ class TestChgrp(ITest):
         chgrp = Chgrp2(
             targetObjects={"Dataset": [d1.id.val]}, childOptions=[hard],
             groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         ctx = {'omero.group': '-1'}
         assert target_gid == query.get("Dataset",
@@ -738,7 +739,7 @@ class TestChgrp(ITest):
         chgrp = Chgrp2(
             targetObjects={"Project": [p.id.val]}, childOptions=[hard],
             groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         ctx = {'omero.group': '-1'}
         assert target_gid == query.get("Project",
@@ -847,7 +848,7 @@ class TestChgrp(ITest):
         chgrp = Chgrp2(
             targetObjects={"Project": [p1.id.val]}, childOptions=[hard],
             groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         ctx = {'omero.group': '-1'}
         assert target_gid == query.get("Project",
@@ -914,7 +915,7 @@ class TestChgrp(ITest):
         chgrp = Chgrp2(
             targetObjects={"Project": [p1.id.val]}, childOptions=[hard],
             groupId=target_gid)
-        self.doSubmit(chgrp, client)
+        self.do_submit(chgrp, client)
 
         ctx = {'omero.group': '-1'}
         assert target_gid == query.get("Project",
@@ -983,7 +984,7 @@ class TestChgrp(ITest):
         # import two images into 'read-annotate'
         images = []
         for x in range(0, 2):
-            images.append(self.importSingleImage(client=io_client))
+            images.append(self.import_single_image(client=io_client))
             image = io_client.sf.getQueryService().get("Image",
                                                        images[x].id.val)
             assert ra_group.id.val == image.details.group.id.val
@@ -1048,7 +1049,7 @@ class TestChgrpTarget(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.importMIF(imgCount, client=client)
+        images = self.import_mif(imgCount, client=client)
         ds = self.createDSInGroup(target_gid, client=client)
 
         # each chgrp includes a 'save' link to target dataset
@@ -1066,7 +1067,7 @@ class TestChgrpTarget(ITest):
             targetObjects={"Image": ids}, groupId=target_gid)
         requests = [chgrp]
         requests.extend(saves)
-        self.doSubmit(requests, client, omero_group=target_gid)
+        self.do_submit(requests, client, omero_group=target_gid)
 
         # Check Images moved to correct group
         queryService = client.sf.getQueryService()
@@ -1103,7 +1104,7 @@ class TestChgrpTarget(ITest):
             self.chgrpImagesToTargetDataset(1)
         chgrp = Chgrp2(
             targetObjects={"Image": [images[0].id.val]}, groupId=old_gid)
-        self.doSubmit(chgrp, client, omero_group=old_gid)
+        self.do_submit(chgrp, client, omero_group=old_gid)
 
     def testChgrpImageToTargetDatasetAndBackDS(self):
         """
@@ -1122,7 +1123,7 @@ class TestChgrpTarget(ITest):
         chgrp = Chgrp2(
             targetObjects={"Image": [images[0].id.val]}, groupId=old_gid)
         save = Save(link)
-        self.doSubmit([chgrp, save], client, omero_group=old_gid)
+        self.do_submit([chgrp, save], client, omero_group=old_gid)
 
         dils = client.sf.getQueryService().findAllByQuery(
             "select dil from DatasetImageLink dil where dil.child.id = :id",
@@ -1171,7 +1172,7 @@ class TestChgrpTarget(ITest):
             c = client
         else:
             c = self.root
-        self.doSubmit(requests, c, omero_group=target_gid)
+        self.do_submit(requests, c, omero_group=target_gid)
 
         queryService = client.sf.getQueryService()
         ctx = {'omero.group': '-1'}  # query across groups

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -49,7 +49,7 @@ class TestDelete(ITest):
 
         command = Delete2(targetObjects={"Image": [img.id.val]})
         handle = self.client.sf.submit(command)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
 
     def testDeleteMany(self):
         images = list()
@@ -64,7 +64,7 @@ class TestDelete(ITest):
         command = Delete2(targetObjects={"Image": ids})
 
         handle = self.client.sf.submit(command)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
 
     def testDeleteProjectWithoutContent(self):
         uuid = self.ctx.sessionUuid
@@ -95,7 +95,7 @@ class TestDelete(ITest):
         dc = Delete2(
             targetObjects={'Project': [project.id.val]}, childOptions=[keep])
         handle = self.client.sf.submit(dc)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
 
         assert not self.query.find('Project', project.id.val)
         assert dataset.id.val == self.query.find(
@@ -130,7 +130,7 @@ class TestDelete(ITest):
 
         cmd = Delete2(targetObjects={"Image": [iid]})
         handle = self.client.sf.submit(cmd)
-        callback = self.waitOnCmd(self.client, handle)
+        callback = self.wait_on_cmd(self.client, handle)
         cbString = str(handle)
 
         callback.close(True)  # Don't close handle
@@ -181,7 +181,7 @@ class TestDelete(ITest):
         command = Delete2(targetObjects={"Image": ids})
 
         handle = self.client.sf.submit(command)
-        callback = self.waitOnCmd(self.client, handle, ms=1000, loops=50)
+        callback = self.wait_on_cmd(self.client, handle, ms=1000, loops=50)
 
         callback.close(True)
 
@@ -228,7 +228,7 @@ class TestDelete(ITest):
         command = Delete2(targetObjects={"Image": images})
 
         handle = self.client.sf.submit(command)
-        callback = self.waitOnCmd(self.client, handle)
+        callback = self.wait_on_cmd(self.client, handle)
         callback.close(True)
 
     def testDeleteComment(self):
@@ -253,14 +253,14 @@ class TestDelete(ITest):
             linkIds.append(l.id.val)
         command = Delete2(targetObjects={"ImageAnnotationLink": linkIds})
         handle = self.client.sf.submit(command)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
         handle.close()
 
         # Delete Dry Run...
         command = Delete2(targetObjects={"CommentAnnotation": [cid]},
                           dryRun=True)
         handle = self.client.sf.submit(command)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
 
         # ...Should tell us that remaining links will be deleted
         rsp = handle.getResponse()
@@ -279,7 +279,7 @@ class TestDelete(ITest):
         # Finally, delete Comment
         command = Delete2(targetObjects={"CommentAnnotation": [cid]})
         handle = self.client.sf.submit(command)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
         handle.close()
         assert not self.query.find("CommentAnnotation", cid)
 
@@ -387,7 +387,7 @@ class TestDelete(ITest):
 
         command = Delete2(targetObjects={"Annotation": [tagset.id.val]})
         handle = self.client.sf.submit(command)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
 
         assert not self.query.find("TagAnnotation", tagset.id.val)
         assert tag.id.val == self.query.find(
@@ -404,7 +404,7 @@ class TestDelete(ITest):
 
         command = Delete2(targetObjects={"OriginalFile": [o.id.val]})
         handle = self.client.sf.submit(command)
-        self.waitOnCmd(self.client, handle)
+        self.wait_on_cmd(self.client, handle)
 
         with pytest.raises(omero.ServerError):
             self.query.get("FileAnnotation", fa.id.val)
@@ -415,14 +415,14 @@ class TestDelete(ITest):
         a single fileset containing 2 images is split among 2 datasets.
         Delete one dataset, delete fails.
         """
-        datasets = self.createDatasets(2, "testDeleteOneDatasetFilesetErr")
-        images = self.importMIF(2)
+        datasets = self.create_datasets(2, "testDeleteOneDatasetFilesetErr")
+        images = self.import_mif(2)
         for i in range(2):
             self.link(datasets[i], images[i])
 
         # Now delete one dataset
         delete = Delete2(targetObjects={"Dataset": [datasets[0].id.val]})
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         # The dataset should be deleted, but not any images.
         assert not self.query.find("Dataset", datasets[0].id.val)
@@ -437,11 +437,11 @@ class TestDelete(ITest):
         two images in a MIF.
         Delete one image, the delete should fail.
         """
-        images = self.importMIF(2)
+        images = self.import_mif(2)
 
         # Now delete one image
         delete = Delete2(targetObjects={"Image": [images[0].id.val]})
-        self.doSubmit(delete, self.client, test_should_pass=False)
+        self.do_submit(delete, self.client, test_should_pass=False)
 
         # Neither image should be deleted.
         assert images[0].id.val == self.query.find(
@@ -456,7 +456,7 @@ class TestDelete(ITest):
         Delete the dataset, the delete should succeed.
         """
         ds = self.make_dataset("testDeleteDatasetFilesetOK")
-        images = self.importMIF(2)
+        images = self.import_mif(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         for i in range(2):
@@ -464,7 +464,7 @@ class TestDelete(ITest):
 
         # Now delete the dataset, should succeed
         delete = Delete2(targetObjects={"Dataset": [ds.id.val]})
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         # The dataset, fileset and both images should be deleted.
         assert not self.query.find("Dataset", ds.id.val)
@@ -478,8 +478,8 @@ class TestDelete(ITest):
         a single fileset containing 2 images is split among 2 datasets.
         Delete all datasets, delete succeeds.
         """
-        datasets = self.createDatasets(2, "testDeleteAllDatasetsFilesetOK")
-        images = self.importMIF(2)
+        datasets = self.create_datasets(2, "testDeleteAllDatasetsFilesetOK")
+        images = self.import_mif(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         for i in range(2):
@@ -488,7 +488,7 @@ class TestDelete(ITest):
         # Now delete all datasets, should succeed
         dids = [datasets[0].id.val, datasets[1].id.val]
         delete = Delete2(targetObjects={"Dataset": dids})
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         # Both datasets, the fileset and both images should be deleted.
         assert not self.query.find("Dataset", datasets[0].id.val)
@@ -503,13 +503,13 @@ class TestDelete(ITest):
         two images in a MIF.
         Delete all images, the delete should succeed.
         """
-        images = self.importMIF(2)
+        images = self.import_mif(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         # Now delete all images, should succeed
         iids = [images[0].id.val, images[1].id.val]
         delete = Delete2(targetObjects={"Image": iids})
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         # The fileset and both images should be deleted.
         assert not self.query.find("Fileset", fsId)
@@ -522,12 +522,12 @@ class TestDelete(ITest):
         a single fileset containing 2 images.
         Delete the fileset, the delete should succeed.
         """
-        images = self.importMIF(2)
+        images = self.import_mif(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         # Now delete the fileset, should succeed
         delete = Delete2(targetObjects={"Fileset": [fsId]})
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         # The dataset, fileset and both images should be deleted.
         assert not self.query.find("Fileset", fsId)
@@ -540,13 +540,13 @@ class TestDelete(ITest):
         by the delete error
         """
         # 2 filesets, each with 2 images
-        imagesFsOne = self.importMIF(2)
-        imagesFsTwo = self.importMIF(2)
+        imagesFsOne = self.import_mif(2)
+        imagesFsTwo = self.import_mif(2)
 
         # delete should fail...
         iids = [imagesFsOne[0].id.val, imagesFsTwo[0].id.val]
         delete = Delete2(targetObjects={"Image": iids})
-        self.doSubmit(delete, self.client, test_should_pass=False)
+        self.do_submit(delete, self.client, test_should_pass=False)
 
     def testDeleteDatasetTwoFilesetsErr(self):
         """
@@ -554,17 +554,17 @@ class TestDelete(ITest):
         by the delete error
         """
         # 2 filesets, each with 2 images
-        imagesFsOne = self.importMIF(2)
-        imagesFsTwo = self.importMIF(2)
+        imagesFsOne = self.import_mif(2)
+        imagesFsTwo = self.import_mif(2)
 
         ds = self.make_dataset("testDeleteDatasetTwoFilesetsErr")
-        self.importMIF(2)
+        self.import_mif(2)
         for i in (imagesFsOne, imagesFsTwo):
             self.link(ds, i[0])
 
         # delete should remove only the Dataset
         delete = Delete2(targetObjects={"Dataset": [ds.id.val]})
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         # The dataset should be deleted.
         assert not self.query.find("Dataset", ds.id.val)
@@ -624,7 +624,7 @@ class TestDelete(ITest):
         hard = ChildOption(includeType=["Dataset"])
         delete = Delete2(
             targetObjects={"Project": [p1.id.val]}, childOptions=[hard])
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         assert self.query.find("Project", p2.id.val)
         assert not self.query.find("Project", p1.id.val)
@@ -711,7 +711,7 @@ class TestDelete(ITest):
         hard = ChildOption(includeType=["Image"])
         delete = Delete2(
             targetObjects={"Dataset": [d1.id.val]}, childOptions=[hard])
-        self.doSubmit(delete, self.client)
+        self.do_submit(delete, self.client)
 
         assert not self.query.find("Dataset", d1.id.val)
         assert self.query.find("Dataset", d2.id.val)

--- a/components/tools/OmeroPy/test/integration/test_icontainer.py
+++ b/components/tools/OmeroPy/test/integration/test_icontainer.py
@@ -115,7 +115,7 @@ class TestSplitFilesets(ITest):
         """
         Fileset of 2 Images, we test split using 1 Image ID
         """
-        images = self.importMIF(2)
+        images = self.import_mif(2)
 
         # Lookup the fileset
         imgId = images[0].id.val
@@ -129,7 +129,7 @@ class TestSplitFilesets(ITest):
         """
         Fileset of 2 Images with No split (query with both Image IDs)
         """
-        images = self.importMIF(2)
+        images = self.import_mif(2)
 
         imgIds = [i.id.val for i in images]
 
@@ -142,7 +142,7 @@ class TestSplitFilesets(ITest):
         Fileset of 2 Images, one in a Dataset. Test split using Dataset ID
         """
         # Dataset contains 1 image of a 2-image fileset
-        images = self.importMIF(2)
+        images = self.import_mif(2)
         ds = self.make_dataset("testFilesetSplitByDataset")
         self.link(ds, images[0])
 
@@ -173,8 +173,8 @@ class TestSplitFilesets(ITest):
         Test Not split using Dataset IDs
         """
         # Datasets each contain 1 image of a 2-image fileset
-        datasets = self.createDatasets(2, "testFilesetNotSplitByDatasets")
-        images = self.importMIF(2)
+        datasets = self.create_datasets(2, "testFilesetNotSplitByDatasets")
+        images = self.import_mif(2)
         for i in range(2):
             self.link(datasets[i], images[i])
 

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -44,7 +44,7 @@ class TestIShare(ITest):
         share.addObjects(share_id, [d])
         assert len(share.getContents(share_id)) == 1
 
-        ds = self.createDatasets(4, "Dataset")
+        ds = self.create_datasets(4, "Dataset")
         share.addObjects(share_id, ds)
         assert share.getContentSize(share_id) == 5
         assert len(share.getAllUsers(share_id)) == 2

--- a/components/tools/OmeroPy/test/integration/test_librarytest.py
+++ b/components/tools/OmeroPy/test/integration/test_librarytest.py
@@ -29,7 +29,7 @@ from omero.testlib import ITest
 class TestLibrary(ITest):
 
     def test9188(self):
-        self.createTestImage(10, 10, 1, 1, 1)
-        self.createTestImage(10, 10, 10, 1, 1)
-        self.createTestImage(10, 10, 1, 10, 1)
-        self.createTestImage(10, 10, 1, 1, 10)
+        self.create_test_image(10, 10, 1, 1, 1)
+        self.create_test_image(10, 10, 10, 1, 1)
+        self.create_test_image(10, 10, 1, 10, 1)
+        self.create_test_image(10, 10, 1, 1, 10)

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -35,7 +35,7 @@ from omero.rtypes import unwrap
 class TestModel51(ITest):
 
     def testExposureTime(self):
-        img = self.importMIF(name="testExposureTime", exposureTime=1.2)[0]
+        img = self.import_mif(name="testExposureTime", exposureTime=1.2)[0]
         plane_info = self.query.findByQuery((
             "select pi from PlaneInfo pi "
             "join fetch pi.exposureTime "
@@ -54,7 +54,7 @@ class TestModel51(ITest):
         assert omero.model.enums.UnitsTime.MICROSECOND == unit
 
     def testPhysicalSize(self):
-        img = self.importMIF(name="testPhysicalSize", physicalSizeZ=2.0)[0]
+        img = self.import_mif(name="testPhysicalSize", physicalSizeZ=2.0)[0]
         pixels = self.query.findByQuery((
             "select pix from Pixels pix "
             "join fetch pix.physicalSizeZ "
@@ -191,7 +191,7 @@ class TestModel51(ITest):
             u2.saveAndReturnObject(m2)
 
     def testUnitProjections(self):
-        img = self.importMIF(name="testUnitProjections", exposureTime=1.2)[0]
+        img = self.import_mif(name="testUnitProjections", exposureTime=1.2)[0]
 
         as_map = self.query.projection((
             "select pi.exposureTime from PlaneInfo pi "

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -780,9 +780,9 @@ class TestPermissions(ITest):
 
     def testAdminUseOfRawPixelsBean(self):
         owner = self.new_client()
-        image1 = self.createTestImage(session=owner.sf)
+        image1 = self.create_test_image(session=owner.sf)
         pixid1 = image1.getPrimaryPixels().getId().getValue()
-        image2 = self.createTestImage(session=owner.sf)
+        image2 = self.create_test_image(session=owner.sf)
         pixid2 = image2.getPrimaryPixels().getId().getValue()
 
         rps = self.root.sf.createRawPixelsStore()

--- a/components/tools/OmeroPy/test/integration/test_reimport.py
+++ b/components/tools/OmeroPy/test/integration/test_reimport.py
@@ -120,8 +120,8 @@ class TestReimportArchivedFiles(ITest):
         from omero.sys import ParametersI
 
         # Produce an FS image as our template
-        orig_img = self.import_mif(name="reimport", sizeX=16, sizeY=16,
-                                  with_companion=True, skip=None)
+        orig_img = self.import_mif(name="reimport", size_x=16, size_y=16,
+                                   with_companion=True, skip=None)
         orig_img = orig_img[0]
         orig_pix = self.query.findByQuery(
             "select p from Pixels p where p.image.id = :id",

--- a/components/tools/OmeroPy/test/integration/test_reimport.py
+++ b/components/tools/OmeroPy/test/integration/test_reimport.py
@@ -120,7 +120,7 @@ class TestReimportArchivedFiles(ITest):
         from omero.sys import ParametersI
 
         # Produce an FS image as our template
-        orig_img = self.importMIF(name="reimport", sizeX=16, sizeY=16,
+        orig_img = self.import_mif(name="reimport", sizeX=16, sizeY=16,
                                   with_companion=True, skip=None)
         orig_img = orig_img[0]
         orig_pix = self.query.findByQuery(

--- a/components/tools/OmeroPy/test/integration/test_reimport.py
+++ b/components/tools/OmeroPy/test/integration/test_reimport.py
@@ -120,7 +120,7 @@ class TestReimportArchivedFiles(ITest):
         from omero.sys import ParametersI
 
         # Produce an FS image as our template
-        orig_img = self.import_mif(name="reimport", size_x=16, size_y=16,
+        orig_img = self.import_mif(name="reimport", sizeX=16, sizeY=16,
                                    with_companion=True, skip=None)
         orig_img = orig_img[0]
         orig_pix = self.query.findByQuery(

--- a/components/tools/OmeroPy/test/integration/test_render.py
+++ b/components/tools/OmeroPy/test/integration/test_render.py
@@ -59,7 +59,7 @@ class TestRendering(ITest):
         size_z = 1
         size_c = 1
         size_t = 1
-        image = self.createTestImage(size_x, size_y, size_z, size_c, size_t)
+        image = self.create_test_image(size_x, size_y, size_z, size_c, size_t)
         pixels_id = image.getPrimaryPixels().getId().getValue()
 
         rendering_engine = session.createRenderingEngine()

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -661,7 +661,7 @@ class TestRecursiveDelete(AbstractRepoTest):
     # provide a method which enables recursive delete.
     def testRecursiveDeleteMethodAvailable(self):
         handle = self.mrepo.deletePaths([self.unique_dir], True, True)
-        self.waitOnCmd(self.client, handle, passes=True)
+        self.wait_on_cmd(self.client, handle, passes=True)
         rv = unwrap(self.mrepo.treeList(self.unique_dir))
         assert 0 == len(rv)
 

--- a/components/tools/OmeroPy/test/integration/test_rois.py
+++ b/components/tools/OmeroPy/test/integration/test_rois.py
@@ -42,7 +42,7 @@ class TestRois(ITest):
         group = self.new_group(perms="rwrw--")
         owner = self.new_client(group=group)  # Owner of share
         member = self.new_client(group=group)  # Member of group
-        img = self.createTestImage(session=owner.sf)
+        img = self.create_test_image(session=owner.sf)
 
         from omero.gateway import ImageWrapper, BlitzGateway
         conn = BlitzGateway(client_obj=owner)

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -241,7 +241,7 @@ class TestSearch(ITest):
     def testFilename(self):
         client = self.new_client()
         uuid = self.simple_uuid()
-        image = self.importSingleImage(uuid, client)
+        image = self.import_single_image(uuid, client)
         self.root.sf.getUpdateService().indexObject(image)
         search = client.sf.createSearchService()
         search.onlyType("Image")
@@ -272,7 +272,7 @@ class TestSearch(ITest):
 
     def attached_image(self, uuid, client, path, mimetype):
         _ = omero.rtypes.rstring
-        image = self.importSingleImage(uuid, client)
+        image = self.import_single_image(uuid, client)
         ofile = omero.model.OriginalFileI()
         ofile.mimetype = _(mimetype)
         ofile.path = _(os.path.dirname(path))

--- a/components/tools/OmeroPy/test/integration/test_thumbnailPerms.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbnailPerms.py
@@ -161,7 +161,7 @@ class TestThumbnailPerms(ITest):
         group = self.new_group(perms="rw__--")
         owner = self.new_client(group=group, owner=True)  # Owner of group
         member = self.new_client(group=group)  # Member of group
-        privateImage = self.createTestImage(session=member.sf)
+        privateImage = self.create_test_image(session=member.sf)
         pId = privateImage.getPrimaryPixels().getId().getValue()
 
         # using owner session access thumbnailStore
@@ -202,7 +202,7 @@ class TestThumbnailPerms(ITest):
 
         # Create user in group with one image
         owner = self.new_client(group=group)
-        privateImage = self.createTestImage(session=owner.sf)
+        privateImage = self.create_test_image(session=owner.sf)
         pId = privateImage.getPrimaryPixels().getId().getValue()
 
         if preview:
@@ -279,7 +279,7 @@ class TestThumbnailPerms(ITest):
                     assert rnd is None
 
         # creation generates a first rendering image
-        image = self.createTestImage(session=owner.sf)
+        image = self.create_test_image(session=owner.sf)
         pixels = image.getPrimaryPixels().getId().getValue()
 
         owner_prx = owner.sf.createThumbnailStore()
@@ -322,7 +322,7 @@ class TestThumbnailPerms(ITest):
                     assert rnd is None
 
         # creation generates a first rendering image
-        image = self.createTestImage(session=owner.sf)
+        image = self.create_test_image(session=owner.sf)
         pixels = image.getPrimaryPixels().getId().getValue()
 
         owner_prx = owner.sf.createThumbnailStore()
@@ -378,7 +378,7 @@ class TestThumbnailPerms(ITest):
             other = self.new_client(group=group)
 
         # creation generates a first rendering image
-        image = self.createTestImage(session=owner.sf)
+        image = self.create_test_image(session=owner.sf)
         pixels = image.getPrimaryPixels().getId().getValue()
 
         def assert_rdef(sf=None, prx=None):
@@ -481,7 +481,7 @@ class TestThumbnailPerms(ITest):
             other = self.new_client(group=group)
 
         # creation generates a first rendering image
-        image = self.createTestImage(session=owner.sf)
+        image = self.create_test_image(session=owner.sf)
         pixels = image.getPrimaryPixels().getId().getValue()
         # create thumbnail for image owner 16x16
         tb = owner.sf.createThumbnailStore()
@@ -555,7 +555,7 @@ class TestThumbnailPerms(ITest):
             other = self.new_client(group=group)
 
         # creation generates a first rendering image
-        image = self.createTestImage(session=owner.sf)
+        image = self.create_test_image(session=owner.sf)
         pixels = image.getPrimaryPixels().getId().getValue()
         # create thumbnail for image owner 16x16
         tb = owner.sf.createThumbnailStore()

--- a/components/tools/OmeroPy/test/integration/test_tickets4000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets4000.py
@@ -28,11 +28,11 @@ class TestTickets4000(ITest):
         self.root.sf.getAdminService().changeUserPassword(
             name, rstring("GOOD"))
 
-        self.loginAttempt(name, 0.15, less=True)
-        self.loginAttempt(name, 3.0)
-        self.loginAttempt(name, 0.15, "GOOD", less=True)
-        self.loginAttempt(name, 0.15, less=True)
-        self.loginAttempt(name, 3.0)
+        self.login_attempt(name, 0.15, less=True)
+        self.login_attempt(name, 3.0)
+        self.login_attempt(name, 0.15, "GOOD", less=True)
+        self.login_attempt(name, 0.15, less=True)
+        self.login_attempt(name, 3.0)
 
     def testChangeActiveGroup(self):
         client = self.new_client()

--- a/components/tools/OmeroPy/test/integration/test_tickets6000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets6000.py
@@ -36,13 +36,13 @@ class TestTickets6000(ITest):
         admin.changeUserPassword(name, rstring("GOOD"))
 
         # First real password attempt is fast
-        self.loginAttempt(name, 0.15, "GOOD", less=True)
+        self.login_attempt(name, 0.15, "GOOD", less=True)
 
         # First attempt with UUID is fast
-        self.loginAttempt(uuid, 0.15, pw=uuid, less=True)
+        self.login_attempt(uuid, 0.15, pw=uuid, less=True)
 
         # Second attempt with UUID should still be fast
-        self.loginAttempt(uuid, 0.15, pw=uuid, less=True)
+        self.login_attempt(uuid, 0.15, pw=uuid, less=True)
 
         print client.sf
         print uuid

--- a/components/tools/OmeroWeb/test/integration/test_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_containers.py
@@ -154,8 +154,8 @@ class TestContainers(IWebTest):
     def test_edit_share(self):
 
         # create images
-        images = [self.createTestImage(session=self.sf),
-                  self.createTestImage(session=self.sf)]
+        images = [self.create_test_image(session=self.sf),
+                  self.create_test_image(session=self.sf)]
 
         sid = self.sf.getShareService().createShare(
             "foobar", rtime(None), images, [self.user], [], True)

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -192,7 +192,7 @@ class TestCsrf(IWebTest):
         code.
         """
 
-        img = self.createTestImage(session=self.sf)
+        img = self.create_test_image(session=self.sf)
 
         # put image id into session
         session = self.django_client.session
@@ -217,7 +217,7 @@ class TestCsrf(IWebTest):
         code.
         """
 
-        img = self.createTestImage(session=self.sf)
+        img = self.create_test_image(session=self.sf)
 
         # Reset through webclient as it is calling directly
         # webgateway.reset_image_rdef_json
@@ -235,7 +235,7 @@ class TestCsrf(IWebTest):
 
     def test_apply_owners_rendering_settings(self):
 
-        img = self.createTestImage(session=self.sf)
+        img = self.create_test_image(session=self.sf)
 
         request_url = reverse('reset_owners_rdef_json')
         data = {
@@ -255,7 +255,7 @@ class TestCsrf(IWebTest):
         code.
         """
 
-        img = self.createTestImage(session=self.sf)
+        img = self.create_test_image(session=self.sf)
 
         request_url = reverse('ome_tiff_script', args=[img.id.val])
 
@@ -266,7 +266,7 @@ class TestCsrf(IWebTest):
 
     def test_script(self):
 
-        img = self.createTestImage(session=self.sf)
+        img = self.create_test_image(session=self.sf)
 
         script_path = "omero/export_scripts/Batch_Image_Export.py"
         script = self.sf.getScriptService().getScriptID(script_path)

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -78,7 +78,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW orphaned Image.
         """
 
-        image = self.importSingleImage()
+        image = self.import_single_image()
 
         # download archived files
         request_url = reverse('webgateway.views.archived_files',
@@ -90,7 +90,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW orphaned Image.
         """
 
-        image = self.importSingleImage()
+        image = self.import_single_image()
 
         # download archived files
         request_url = reverse('webgateway.views.archived_files')
@@ -104,7 +104,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW Image in Dataset.
         """
 
-        image = self.importSingleImage()
+        image = self.import_single_image()
         ds = self.make_dataset()
         self.link(ds, image)
 
@@ -120,7 +120,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW Image in Dataset in Project.
         """
 
-        image = self.importSingleImage()
+        image = self.import_single_image()
         ds = self.make_dataset()
         pr = self.make_project()
 
@@ -152,7 +152,7 @@ class TestDownload(IWebTest):
         Download of attachement.
         """
 
-        image = self.importSingleImage()
+        image = self.import_single_image()
         fa = self.make_file_annotation()
         self.link(image, fa)
 

--- a/components/tools/OmeroWeb/test/integration/test_metadata.py
+++ b/components/tools/OmeroWeb/test/integration/test_metadata.py
@@ -36,7 +36,7 @@ class TestCoreMetadata(IWebTest):
 
     def test_pixel_size_units(self):
         # Create image
-        iid = self.createTestImage(sizeC=2, session=self.sf).id.val
+        iid = self.create_test_image(size_c=2, session=self.sf).id.val
 
         # show right panel for image
         request_url = reverse('load_metadata_details', args=['image', iid])

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -39,8 +39,8 @@ class TestRendering(IWebTest):
 
     def test_copy_past_rendering_settings_from_image(self):
         # Create 2 images with 2 channels each
-        iid1 = self.createTestImage(sizeC=2, session=self.sf).id.val
-        iid2 = self.createTestImage(sizeC=2, session=self.sf).id.val
+        iid1 = self.create_test_image(size_c=2, session=self.sf).id.val
+        iid2 = self.create_test_image(size_c=2, session=self.sf).id.val
 
         conn = omero.gateway.BlitzGateway(client_obj=self.client)
 
@@ -79,8 +79,8 @@ class TestRendering(IWebTest):
 
     def test_copy_past_rendering_settings_from_url(self):
         # Create 2 images with 2 channels each
-        iid1 = self.createTestImage(sizeC=2, session=self.sf).id.val
-        iid2 = self.createTestImage(sizeC=2, session=self.sf).id.val
+        iid1 = self.create_test_image(size_c=2, session=self.sf).id.val
+        iid2 = self.create_test_image(size_c=2, session=self.sf).id.val
 
         conn = omero.gateway.BlitzGateway(client_obj=self.client)
 
@@ -163,7 +163,7 @@ class TestRendering(IWebTest):
     """
     def test_all_rendering_defs(self):
         # Create image with 3 channels
-        iid = self.createTestImage(sizeC=3, session=self.sf).id.val
+        iid = self.create_test_image(size_c=3, session=self.sf).id.val
 
         conn = omero.gateway.BlitzGateway(client_obj=self.client)
 
@@ -236,7 +236,7 @@ class TestRenderImageRegion(IWebTest):
         HTTP status code is used and that consequently, any and all
         rendering engines that were created servicing the request are closed.
         """
-        image_id = self.createTestImage(sizeC=1, session=self.sf).id.val
+        image_id = self.create_test_image(size_c=1, session=self.sf).id.val
 
         request_url = reverse(
             'webgateway.views.render_image_region',
@@ -259,7 +259,7 @@ class TestRenderImageRegion(IWebTest):
         consequently, any and all rendering engines that were created
         servicing the request are closed.
         """
-        image_id = self.createTestImage(sizeC=1, session=self.sf).id.val
+        image_id = self.create_test_image(size_c=1, session=self.sf).id.val
 
         request_url = reverse(
             'webgateway.views.render_image_region',
@@ -282,7 +282,7 @@ class TestRenderImageRegion(IWebTest):
         consequently, any and all rendering engines that were created
         servicing the request are closed.
         """
-        image_id = self.createTestImage(sizeC=1, session=self.sf).id.val
+        image_id = self.create_test_image(size_c=1, session=self.sf).id.val
 
         request_url = reverse(
             'webgateway.views.render_image_region',

--- a/components/tools/OmeroWeb/test/integration/test_simple.py
+++ b/components/tools/OmeroWeb/test/integration/test_simple.py
@@ -21,5 +21,5 @@ class TestSimple(ITest):
         assert ec
 
     def testImport(self):
-        image = self.importSingleImage()
+        image = self.import_single_image()
         assert image.id.val

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -42,7 +42,7 @@ class TestThumbnails(IWebTest):
         Default size is 96.
         """
         # Create a square image
-        iId = self.createTestImage(sizeX=125, sizeY=125,
+        iId = self.create_test_image(size_x=125, size_y=125,
                                    session=self.sf).id.val
         args = [iId]
         if size is not None:

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -43,7 +43,7 @@ class TestThumbnails(IWebTest):
         """
         # Create a square image
         iId = self.create_test_image(size_x=125, size_y=125,
-                                   session=self.sf).id.val
+                                     session=self.sf).getId().getValue()
         args = [iId]
         if size is not None:
             args.append(size)

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -1404,7 +1404,8 @@ class TestTree(ITest):
         Returns a new image with pixels of fixed dimensions
         """
         sf = userA[0].sf
-        image = self.createTestImage(sizeX=50, sizeY=50, sizeZ=5, session=sf)
+        image = self.create_test_image(size_x=50, size_y=50, size_z=5,
+                                       session=sf)
         return image
 
     @pytest.fixture(scope='function')


### PR DESCRIPTION
# What this PR does

This PR is combining https://github.com/openmicroscopy/openmicroscopy/pull/4965 https://github.com/openmicroscopy/openmicroscopy/pull/4969  to avoid conflicts

# Testing this PR

follow instructions in:
- https://github.com/openmicroscopy/openmicroscopy/pull/4965 

  This PR removes hard-coded OmeroPy and dist path in favour of finding OMERO dist based on bin/omero.
  Test: all integration tests should be green. Especially import

- https://github.com/openmicroscopy/openmicroscopy/pull/4969

  This PR renames methods and variables.

-----

Note: speeding up running tests is tested now via https://github.com/openmicroscopy/openmicroscopy/pull/4967