### PR TITLE
Fix markers handling in OmeroMetadataStore

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
+++ b/components/blitz/src/ome/services/blitz/impl/OmeroMetadata.java
@@ -1886,7 +1886,11 @@ public class OmeroMetadata extends DummyMetadata {
         if (markerStart == null) {
             return null;
         }
-        return Marker.valueOf(markerStart.getValue());
+        try {
+            return Marker.fromString(markerStart.getValue());
+        } catch (EnumerationException ex) {
+            return null;
+        }
     }
 
     @Override
@@ -1899,7 +1903,11 @@ public class OmeroMetadata extends DummyMetadata {
         if (markerEnd == null) {
             return null;
         }
-        return Marker.valueOf(markerEnd.getValue());
+        try {
+            return Marker.fromString(markerEnd.getValue());
+        } catch (EnumerationException ex) {
+            return null;
+        }
     }
 
     @Override
@@ -2227,7 +2235,11 @@ public class OmeroMetadata extends DummyMetadata {
         if (markerStart == null) {
             return null;
         }
-        return Marker.valueOf(markerStart.getValue());
+        try {
+            return Marker.fromString(markerStart.getValue());
+        } catch (EnumerationException ex) {
+            return null;
+        }
     }
 
     @Override
@@ -2240,7 +2252,11 @@ public class OmeroMetadata extends DummyMetadata {
         if (markerEnd == null) {
             return null;
         }
-        return Marker.valueOf(markerEnd.getValue());
+        try {
+            return Marker.fromString(markerEnd.getValue());
+        } catch (EnumerationException ex) {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
## What this PR does

Reported by @dominikl, the initial implementation of line/polylines marker getters was making use of
`Marker.valueOf()` leading to enumeration exceptions on export. This commit rectifies the logic similarly to other methods in the same class by using `Marker.fromString()` instead and catching `EnumerationException`.

## Testing this PR

To test this PR, use the following workflow:

1. import an image e.g. a `test.fake` into OMERO
2. in OMERO.insight, use the Measurement Tool to draw some lines and polylines on the image including some arrows
3. export the image as OME-TIFF using the exporter service
4. re-import the exported `ome.tiff` into the OMERO server

Without this PR, the export step should fail with an enumeration exception. With the PR included, the whole round-tripping should work flawlessly and the re-imported images should also include the ROIs drawn in step 1.