### PR TITLE
Enable script menu only if script available

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -303,8 +303,8 @@ class BaseContainer(BaseController):
             'name': 'Make Movie',
             'enabled': False,
             'tooltip': "Create a movie of the image"}
-        if (self.image and (self.image.getSizeT() > 0 or
-                            self.image.getSizeZ() > 0)):
+        if (self.image and (self.image.getSizeT() > 1 or
+                            self.image.getSizeZ() > 1)):
             makeMovie['enabled'] = 'Make_Movie.py' in availableScripts
 
         figureScripts.append(splitView)

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -242,35 +242,35 @@ class BaseContainer(BaseController):
 
     def list_scripts(self, request):
         """
-        Get the file names of all available scripts 
+        Get the file names of all available scripts
         """
         scriptService = self.conn.getScriptService()
         scripts = scriptService.getScripts()
-        
+
         scriptlist = []
-        
+
         scripts_to_ignore = request.session.get('server_settings') \
-                                           .get('scripts_to_ignore').split(",")
+            .get('scripts_to_ignore').split(",")
         for s in scripts:
             path = s.path.val
             name = s.name.val
             fullpath = os.path.join(path, name)
             if fullpath in scripts_to_ignore:
                 continue
-            
+
             scriptlist.append(name)
 
         return scriptlist
-    
+
     def listFigureScripts(self, request, objDict=None):
         """
         This configures all the Figure Scripts, setting their enabled status
         given the currently selected object (self.image etc) or batch objects
         (uses objDict) and the script availability.
         """
-        
+
         availableScripts = self.list_scripts(request)
-        
+
         figureScripts = []
         # id is used in url and is mapped to full script path by
         # views.figure_script()
@@ -283,12 +283,14 @@ class BaseContainer(BaseController):
         # Split View Figure is enabled if we have at least one image with
         # SizeC > 1
         if self.image:
-            splitView['enabled'] = (self.image.getSizeC() > 1) and 'Split_View_Figure.py' in availableScripts
+            splitView['enabled'] = (self.image.getSizeC() > 1) and \
+                'Split_View_Figure.py' in availableScripts
         elif objDict is not None:
             if 'image' in objDict:
                 for i in objDict['image']:
                     if i.getSizeC() > 1:
-                        splitView['enabled'] = 'Split_View_Figure.py' in availableScripts
+                        splitView['enabled'] = 'Split_View_Figure.py' in \
+                            availableScripts
                         break
         thumbnailFig = {
             'id': 'Thumbnail',
@@ -301,7 +303,8 @@ class BaseContainer(BaseController):
             thumbnailFig['enabled'] = 'Thumbnail_Figure.py' in availableScripts
         elif objDict is not None:
             if 'image' in objDict or 'dataset' in objDict:
-                thumbnailFig['enabled'] = 'Thumbnail_Figure.py' in availableScripts
+                thumbnailFig['enabled'] = 'Thumbnail_Figure.py' in \
+                    availableScripts
 
         makeMovie = {
             'id': 'MakeMovie',

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -239,7 +239,7 @@ class BaseContainer(BaseController):
             return self.image.canDownload() or \
                 self.well.canDownload() or self.plate.canDownload()
 
-    def list_scripts(self, request):
+    def list_scripts(self):
         """
         Get the file names of all scripts
         """
@@ -254,14 +254,14 @@ class BaseContainer(BaseController):
 
         return scriptlist
 
-    def listFigureScripts(self, request, objDict=None):
+    def listFigureScripts(self, objDict=None):
         """
         This configures all the Figure Scripts, setting their enabled status
         given the currently selected object (self.image etc) or batch objects
         (uses objDict) and the script availability.
         """
 
-        availableScripts = self.list_scripts(request)
+        availableScripts = self.list_scripts()
 
         figureScripts = []
         # id is used in url and is mapped to full script path by

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -27,7 +27,6 @@ import omero
 from omero.rtypes import rstring, rlong, unwrap
 from django.utils.encoding import smart_str
 import logging
-import os
 
 from webclient.controller import BaseController
 
@@ -242,22 +241,15 @@ class BaseContainer(BaseController):
 
     def list_scripts(self, request):
         """
-        Get the file names of all available scripts
+        Get the file names of all scripts
         """
         scriptService = self.conn.getScriptService()
         scripts = scriptService.getScripts()
 
         scriptlist = []
 
-        scripts_to_ignore = request.session.get('server_settings') \
-            .get('scripts_to_ignore').split(",")
         for s in scripts:
-            path = s.path.val
             name = s.name.val
-            fullpath = os.path.join(path, name)
-            if fullpath in scripts_to_ignore:
-                continue
-
             scriptlist.append(name)
 
         return scriptlist

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1515,7 +1515,7 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
         else:
             template = "webclient/annotations/metadata_general.html"
             context['canExportAsJpg'] = manager.canExportAsJpg(request)
-            figScripts = manager.listFigureScripts(request)
+            figScripts = manager.listFigureScripts()
     context['manager'] = manager
 
     if c_type in ("tag", "tagset"):
@@ -1991,7 +1991,7 @@ def batch_annotate(request, conn=None, **kwargs):
     conn.SERVICE_OPTS.setOmeroGroup(groupId)
 
     manager = BaseContainer(conn)
-    figScripts = manager.listFigureScripts(request, objs)
+    figScripts = manager.listFigureScripts(objs)
     canExportAsJpg = manager.canExportAsJpg(request, objs)
     filesetInfo = None
     iids = []

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1515,7 +1515,7 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
         else:
             template = "webclient/annotations/metadata_general.html"
             context['canExportAsJpg'] = manager.canExportAsJpg(request)
-            figScripts = manager.listFigureScripts()
+            figScripts = manager.listFigureScripts(request)
     context['manager'] = manager
 
     if c_type in ("tag", "tagset"):
@@ -1991,7 +1991,7 @@ def batch_annotate(request, conn=None, **kwargs):
     conn.SERVICE_OPTS.setOmeroGroup(groupId)
 
     manager = BaseContainer(conn)
-    figScripts = manager.listFigureScripts(objs)
+    figScripts = manager.listFigureScripts(request, objs)
     canExportAsJpg = manager.canExportAsJpg(request, objs)
     filesetInfo = None
     iids = []


### PR DESCRIPTION
# What this PR does

Disables script menus ("Publishing Options") when the respective script is not available.

![screen shot 2016-11-30 at 11 40 27](https://cloud.githubusercontent.com/assets/6575139/20751248/b1abfd0e-b6f2-11e6-9169-d13ef236c6a6.png)

# Testing this PR

Iteratively delete the scripts `Make_Movie.py`, `Thumbnail_Figure.py` and `Split_View_Figure.py` from the server and after each deletion make sure that the respective "Publishing" menu option is disabled. 

# Related reading

[Trello - Figure scripts in Web](https://trello.com/c/237BjWLJ/228-figure-scripts-in-web)

/cc @will-moore 
