### PR TITLE
Clean up unnecessary bio-formats dependency

### DIFF
--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -470,7 +470,6 @@ omero.version=${omero.version}
             <mapping conf="server" scope="compile"/>
             <mapping conf="default" scope="compile"/>
             <mapping conf="*" scope="compile"/>
-            <dependency group="ome" artifact="bio-formats" version="${omero.version}" optional="true"/>
         </ivy:makepom>
         <publishArtifact haltonmissing="${package-extra}"/>
     </target>


### PR DESCRIPTION
## What this PR does

Noticed as part of https://github.com/openmicroscopy/openmicroscopy/pull/4893#issuecomment-264844312, all [OMERO poms](http://artifacts.openmicroscopy.org/artifactory/maven/omero) contain a broken dependency of type:

```
    <dependency>
      <groupId>ome</groupId>
      <artifactId>bio-formats</artifactId>
      <version>5.0.6-ice34-b53</version>
      <optional>true</optional>
    </dependency>
```

This dependency injection likely predates the [https://github.com/openmicroscopy/openmicroscopy/pull/3931](Bio-Formats decoupling) as the `formats-bsd` and `formats-gpl` are injected earlier in the server build.

## Testing this PR

To test this PR, generate  Maven artifacts and POMs for OMERO with this PR included. No more POM should include the `bio-formats` artifactId. Also try to consume these artifacts it in a downstream application like `minimal-omero-client` or `omero-downloader` and check the application is unaffected.
