### PR TITLE
getHistogram integration test (unit8)

### DIFF
--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -704,8 +704,12 @@ public class RawPixelsBean extends AbstractStatefulBean implements
 
         try {
             for (int ch : channels) {
-                Channel channel = metadataService.retrievePixDescription(id)
-                        .getChannel(ch);
+                Pixels pixels = metadataService.retrievePixDescription(id);
+                if (pixels == null)
+                    continue;
+                Channel channel = pixels.getChannel(ch);
+                if (channel == null)
+                    continue;
                 PixelData px = buffer.getPlane(z, ch, t);
                 int[] data = new int[binCount];
 

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -267,7 +267,11 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             {
             	pixelsInstance = iQuery.findByQuery(
             			"select p from Pixels as p " +
-            			"join fetch p.pixelsType where p.id = :id",
+            			"join fetch p.pixelsType "+ 
+            			"left outer join fetch p.channels as c " +
+            			"left outer join fetch c.logicalChannel as lc " +
+            			"left outer join fetch c.statsInfo " +
+            			"where p.id = :id",
             			new Parameters().addId(id));
             }
 
@@ -704,10 +708,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
 
         try {
             for (int ch : channels) {
-                Pixels pixels = metadataService.retrievePixDescription(id);
-                if (pixels == null)
-                    continue;
-                Channel channel = pixels.getChannel(ch);
+                Channel channel = pixelsInstance.getChannel(ch);
                 if (channel == null)
                     continue;
                 PixelData px = buffer.getPlane(z, ch, t);

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -714,13 +714,19 @@ public class RawPixelsBean extends AbstractStatefulBean implements
                 double min = minmax[0];
                 double max = minmax[1];
 
-                double range = (max - min) + 1;
+                double range = max - min + 1;
                 double binRange = range / binCount;
                 for (int i = 0; i < px.size(); i++) {
                     int pxx = i % imgWidth;
                     int pxy = i / imgWidth;
                     if (pxx >= x && pxx < (x + w) && pxy >= y && pxy < (y + h)) {
                         int bin = (int) ((px.getPixelValue(i) - min) / binRange);
+                        // if there are more bins than values (binRange < 1) the bin will be offset by -1.
+                        // e.g. min=0.0, max=127.0, binCount=256: a pixel with max value 127.0 would go
+                        // into bin 254 (expected: 255). Therefore increment by one for these cases.
+                        if (bin > 0 && binRange < 1)
+                            bin++;
+
                         if (bin >= 0 && bin < binCount)
                             data[bin]++;
                     }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -1246,7 +1246,7 @@ public class AbstractServerTest extends AbstractTest {
     protected Image createBinaryImage(int sizeX, int sizeY, int sizeZ,
             int sizeT, int sizeC) throws Exception {
         Image image = mmFactory.createImage(sizeX, sizeY, sizeZ, sizeT,
-                sizeC);
+                sizeC, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         return createBinaryImage(image);
     }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -35,6 +35,7 @@ import omero.RType;
 import omero.ServerError;
 import omero.rtypes;
 import omero.api.IAdminPrx;
+import omero.api.IPixelsPrx;
 import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
@@ -177,6 +178,9 @@ public class AbstractServerTest extends AbstractTest {
     /** Helper reference to the <code>IAdmin</code> service. */
     protected IAdminPrx iAdmin;
 
+    /** Helper reference to the <code>IPixels</code> service. */
+    protected IPixelsPrx iPix;
+    
     /** Reference to the importer store. */
     protected OMEROMetadataStoreClient importer;
 
@@ -741,6 +745,7 @@ public class AbstractServerTest extends AbstractTest {
         iQuery = factory.getQueryService();
         iUpdate = factory.getUpdateService();
         iAdmin = factory.getAdminService();
+        iPix = factory.getPixelsService();
         mmFactory = new ModelMockFactory(factory.getPixelsService());
 
         importer = new OMEROMetadataStoreClient();

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -365,7 +365,9 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* create and save an image */
 
-        final Image originalImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage(1,2,3,4,5));
+        final Image originalImage = (Image) iUpdate
+                .saveAndReturnObject(mmFactory.createImage(1, 2, 3, 4, 5,
+                        ModelMockFactory.UINT16));
 
         /* note the objects (and their IDs) that were thus created and saved */
 
@@ -487,7 +489,9 @@ public class DuplicationTest extends AbstractServerTest {
 
         /* create and save an image */
 
-        final Image originalImage = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage(1,2,3,4,5));
+        final Image originalImage = (Image) iUpdate
+                .saveAndReturnObject(mmFactory.createImage(1, 2, 3, 4, 5,
+                        ModelMockFactory.UINT16));
 
         /* note the objects (and their IDs) that were thus created and saved */
 

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -91,6 +91,9 @@ public class ModelMockFactory {
     /** The unsigned int 16 pixels Type. */
     static String UINT16 = "uint16";
 
+    /** The unsigned int 8 pixels Type. */
+    static String UINT8 = "uint8";
+    
     /** The bit pixels Type. */
     static String BIT = "bit";
 
@@ -830,12 +833,14 @@ public class ModelMockFactory {
      *            The number of time-points.
      * @param sizeC
      *            The number of channels.
+     * @param pxType
+     *            The pixels type (e.g. unit16)
      * @return See above.
      * @throws Exception
      *             Thrown if an error occurred.
      */
     public Pixels createPixels(int sizeX, int sizeY, int sizeZ, int sizeT,
-            int sizeC) throws Exception {
+            int sizeC, String pxType) throws Exception {
         List<IObject> types = pixelsService.getAllEnumerations(PixelsType.class
                 .getName());
         Iterator<IObject> i = types.iterator();
@@ -843,7 +848,7 @@ public class ModelMockFactory {
         PixelsType type = null;
         while (i.hasNext()) {
             object = (PixelsType) i.next();
-            if (UINT16.equals(object.getValue().getValue())) {
+            if (pxType.equals(object.getValue().getValue())) {
                 type = object;
                 break;
             }
@@ -939,7 +944,7 @@ public class ModelMockFactory {
      */
     public Pixels createPixels() throws Exception {
         return createPixels(SIZE_X, SIZE_Y, SIZE_Z, SIZE_T,
-                DEFAULT_CHANNELS_NUMBER);
+                DEFAULT_CHANNELS_NUMBER, UINT16);
     }
 
     /**
@@ -951,7 +956,7 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Image createImage() throws Exception {
-        return createImage(1, 1, 1, 1, 1);
+        return createImage(1, 1, 1, 1, 1, UINT16);
     }
 
     /**
@@ -967,14 +972,16 @@ public class ModelMockFactory {
      *            The number of time-points.
      * @param sizeC
      *            The number of channels.
+     * @param pxType
+     *            The pixels type (e.g. unit16)
      * @return See above.
      * @throws Exception
      *             Thrown if an error occurred.
      */
     public Image createImage(int sizeX, int sizeY, int sizeZ, int sizeT,
-            int sizeC) throws Exception {
+            int sizeC, String pxType) throws Exception {
         Image image = simpleImage();
-        Pixels pixels = createPixels(sizeX, sizeY, sizeZ, sizeT, sizeC);
+        Pixels pixels = createPixels(sizeX, sizeY, sizeZ, sizeT, sizeC, pxType);
         image.addPixels(pixels);
         return image;
     }
@@ -1059,7 +1066,7 @@ public class ModelMockFactory {
                     for (int field = 0; field < fields; field++) {
                         sample = new WellSampleI();
                         if (fullImage)
-                            sample.setImage(createImage(sizeX, sizeY, sizeZ, sizeT, sizeC));
+                            sample.setImage(createImage(sizeX, sizeY, sizeZ, sizeT, sizeC, UINT16));
                         else
                             sample.setImage(simpleImage());
                         well.addWellSample(sample);
@@ -1071,7 +1078,7 @@ public class ModelMockFactory {
                         for (int field = 0; field < fields; field++) {
                             sample = new WellSampleI();
                             if (fullImage)
-                                sample.setImage(createImage(sizeX, sizeY, sizeZ, sizeT, sizeC));
+                                sample.setImage(createImage(sizeX, sizeY, sizeZ, sizeT, sizeC, UINT16));
                             else
                                 sample.setImage(simpleImage());
                             well.addWellSample(sample);

--- a/components/tools/OmeroJava/test/integration/PixelsServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/PixelsServiceTest.java
@@ -229,7 +229,7 @@ public class PixelsServiceTest extends AbstractServerTest {
         Image image = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
         long id = pixels.getId().getValue();
@@ -324,7 +324,7 @@ public class PixelsServiceTest extends AbstractServerTest {
         Image image = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
         IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
@@ -355,7 +355,7 @@ public class PixelsServiceTest extends AbstractServerTest {
         Image image = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
         IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
@@ -408,7 +408,7 @@ public class PixelsServiceTest extends AbstractServerTest {
         Image image = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
         IRenderingSettingsPrx prx = factory.getRenderingSettingsService();

--- a/components/tools/OmeroJava/test/integration/PyramidMinMaxTest.java
+++ b/components/tools/OmeroJava/test/integration/PyramidMinMaxTest.java
@@ -264,7 +264,7 @@ public class PyramidMinMaxTest extends AbstractServerTest {
         int sizeT = 3;
         int sizeC = 4;
         Image image = mmFactory.createImage(sizeX, sizeY, sizeZ, sizeT,
-                sizeC);
+                sizeC, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
      // first write to the image

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -2726,7 +2726,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         Image image = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
         long id = pixels.getId().getValue();
@@ -2764,7 +2764,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         Image image = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         image = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixels = image.getPrimaryPixels();
         long id = pixels.getId().getValue();

--- a/components/tools/OmeroJava/test/integration/UpdateServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/UpdateServiceTest.java
@@ -1042,7 +1042,7 @@ public class UpdateServiceTest extends AbstractServerTest {
         Image i = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         i = (Image) iUpdate.saveAndReturnObject(i);
         Pixels p = i.getPrimaryPixels();
 
@@ -1080,7 +1080,7 @@ public class UpdateServiceTest extends AbstractServerTest {
         Image i = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         i = (Image) iUpdate.saveAndReturnObject(i);
 
         Pixels p = i.getPrimaryPixels();
@@ -1128,7 +1128,7 @@ public class UpdateServiceTest extends AbstractServerTest {
         Image i = mmFactory.createImage(ModelMockFactory.SIZE_X,
                 ModelMockFactory.SIZE_Y, ModelMockFactory.SIZE_Z,
                 ModelMockFactory.SIZE_T,
-                ModelMockFactory.DEFAULT_CHANNELS_NUMBER);
+                ModelMockFactory.DEFAULT_CHANNELS_NUMBER, ModelMockFactory.UINT16);
         i = (Image) iUpdate.saveAndReturnObject(i);
 
         Pixels p = i.getPrimaryPixels();


### PR DESCRIPTION
# What this PR does

- Adds another integration test for histogram generation using an `unit8` image.
- Fixes an offset in the histogram bins when `binCount` is bigger than the min/max value range. (see https://github.com/openmicroscopy/openmicroscopy/pull/4984/files#diff-91a64e96538d38370f77e8dc4535df46R731 , if someone has a better idea to address that, please let me know)
- Adds some more `null` checks (~~to prevent NPE like~~ https://github.com/openmicroscopy/openmicroscopy/pull/4931#issuecomment-264214132 - this has been been fixed by last commit)

# Testing this PR

Check that the [test](https://github.com/openmicroscopy/openmicroscopy/blob/e990861486bfc0ff629ef3b4720e52d8a40c678b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java#L398) makes sense, and [integration test job](https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-java/) passes.

# Related reading

- [Trello - Histogram](https://trello.com/c/6gKn8FT2/98-histogram)
- https://github.com/openmicroscopy/openmicroscopy/pull/4931#issuecomment-264214132

