### PR TITLE
Close RawPixelsStore when done (rebased onto metadata52)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7486,8 +7486,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     def requiresPixelsPyramid(self):
         pixels_id = self._obj.getPrimaryPixels().getId().val
         rp = self._conn.createRawPixelsStore()
-        rp.setPixelsId(pixels_id, True, self._conn.SERVICE_OPTS)
-        return rp.requiresPixelsPyramid()
+        try:
+            rp.setPixelsId(pixels_id, True, self._conn.SERVICE_OPTS)
+            return rp.requiresPixelsPyramid()
+        finally:
+            rp.close()
 
     @assert_pixels
     def getPrimaryPixels(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7783,8 +7783,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 plot = array.array(key, (axis == 'h'
                                    and rp.getRow(pos, z, c, t)
                                    or rp.getCol(pos, z, c, t)))
-                plot.byteswap()  # TODO: Assuming ours is a little endian system
-                # now move data into the windowMin..windowMax range
+                plot.byteswap()  # TODO: Assuming ours is a little endian
+                # system now move data into the windowMin..windowMax range
                 offset = -chw[c][0]
                 if offset != 0:
                     plot = map(lambda x: x+offset, plot)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7472,13 +7472,15 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         pixels_id = self._obj.getPrimaryPixels().getId().val
         rp = self._conn.createRawPixelsStore()
-        rp.setPixelsId(pixels_id, True, self._conn.SERVICE_OPTS)
-        pmax = 2 ** (8 * rp.getByteWidth())
-        rp.close()
-        if rp.isSigned():
-            return (-(pmax / 2), pmax / 2 - 1)
-        else:
-            return (0, pmax-1)
+        try:
+            rp.setPixelsId(pixels_id, True, self._conn.SERVICE_OPTS)
+            pmax = 2 ** (8 * rp.getByteWidth())
+            if rp.isSigned():
+                return (-(pmax / 2), pmax / 2 - 1)
+            else:
+                return (0, pmax-1)
+        finally:
+            rp.close()
 
     @assert_pixels
     def requiresPixelsPyramid(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7474,6 +7474,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         rp = self._conn.createRawPixelsStore()
         rp.setPixelsId(pixels_id, True, self._conn.SERVICE_OPTS)
         pmax = 2 ** (8 * rp.getByteWidth())
+        rp.close()
         if rp.isSigned():
             return (-(pmax / 2), pmax / 2 - 1)
         else:


### PR DESCRIPTION

This is the same as gh-4818 but rebased onto metadata52.

----

# What this PR does

Close RawPixelsStore before getPixelRange method returns otherwise the service stays open.
# Testing this PR

Connect to the same session uuid using BlitzGateway and omero.client. Check session.activeService() before and after calling getPixelRange() and make sure the RawPixelsStore is not on the list.
# Related reading


                