### PR TITLE
Plugin fixes

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -802,6 +802,12 @@ class BaseControl(object):
             break
         return root_pass
 
+    def _add_wait(self, parser, default=-1):
+        parser.add_argument(
+            "--wait", type=long,
+            help="Number of seconds to wait for the processing to complete "
+            "(Indefinite < 0; No wait=0).", default=default)
+
     def get_subcommands(self):
         """Return a list of subcommands"""
         parser = Parser()
@@ -1560,10 +1566,7 @@ class CmdControl(BaseControl):
 
     def _configure(self, parser):
         parser.set_defaults(func=self.main_method)
-        parser.add_argument(
-            "--wait", type=long,
-            help="Number of seconds to wait for the processing to complete "
-            "(Indefinite < 0; No wait=0).", default=-1)
+        self._add_wait(parser, default=-1)
 
     def main_method(self, args):
         client = self.ctx.conn(args)
@@ -1676,10 +1679,7 @@ class GraphControl(CmdControl):
 
     def _configure(self, parser):
         parser.set_defaults(func=self.main_method)
-        parser.add_argument(
-            "--wait", type=long,
-            help="Number of seconds to wait for the processing to complete "
-            "(Indefinite < 0; No wait=0).", default=-1)
+        self._add_wait(parser, default=-1)
         parser.add_argument(
             "--include",
             help="Modifies the given option by including a list of objects")

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1821,7 +1821,7 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-    def __del__ (self):
+    def __del__(self):
         logger.debug("##GARBAGE COLLECTOR KICK IN")
         self._assert_unregistered()
 
@@ -8006,17 +8006,18 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             tile_width, tile_height = re.getTileSize()
             tiles_wide = math.ceil(float(size_x) / tile_width)
             tiles_high = math.ceil(float(size_y) / tile_height)
-            # Since the JPEG 2000 algorithm is iterative and rounds pixel counts
-            # at each resolution level we're doing the resulting tile size
-            # calculations in a loop. Also, since the image is physically tiled
-            # the resulting size is a multiple of the tile size and not the
-            # iterative quotient of a 2**(resolutionLevels - 1).
+            # Since the JPEG 2000 algorithm is iterative and rounds pixel
+            # counts at each resolution level we're doing the resulting tile
+            # size calculations in a loop. Also, since the image is physically
+            # tiled the resulting size is a multiple of the tile size and not
+            # the iterative quotient of a 2**(resolutionLevels - 1).
             for i in range(1, re.getResolutionLevels()):
                 tile_width = round(tile_width / 2.0)
                 tile_height = round(tile_height / 2.0)
             width = int(tiles_wide * tile_width)
             height = int(tiles_high * tile_height)
-            jpeg_data = self.renderJpegRegion(z, t, x, y, width, height, level=0)
+            jpeg_data = self.renderJpegRegion(
+                z, t, x, y, width, height, level=0)
             if size is None:
                 return jpeg_data
             # We've been asked to scale the image by its longest side so we'll
@@ -8081,8 +8082,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             logger.debug(traceback.format_exc())
             return None
         except Ice.MemoryLimitException:  # pragma: no cover
-            # Make sure renderCompressed isn't called again on this re, as it
-            # hangs
+            # Make sure renderCompressed isn't called again on this re,
+            # as it hangs
             self._obj.clearPixels()
             self._obj.pixelsLoaded = False
             self._closeRE()
@@ -8090,10 +8091,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
     def _closeRE(self):
         try:
-            if self._re:
+            if self._re is not None:
                 self._re.close()
         except Exception, e:
             logger.warn("Failed to close " + self._re)
+            logger.debug(e)
         finally:
             self._re = None  # This should be the ONLY location to null _re!
 

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -151,6 +151,7 @@ class MetadataControl(BaseControl):
                               type=long,
                               default=1000,
                               help="Number of objects to process at once")
+        self._add_wait(populate)
 
         for x in (summary, original, bulkanns, measures, mapanns, allanns,
                   rois, populate, populateroi):
@@ -428,7 +429,14 @@ class MetadataControl(BaseControl):
                             cfg=args.cfg, cfgid=cfgid, attach=args.attach)
         ctx.parse()
         if not args.dry_run:
-            ctx.write_to_omero(batch_size=args.batch)
+            wait = args.wait
+            if not wait:
+                loops = 0
+                ms = 0
+            else:
+                ms = 5000
+                loops = int((wait * 1000) / ms) + 1
+            ctx.write_to_omero(batch_size=args.batch, loops=loops, ms=ms)
 
     def rois(self, args):
         "Manage ROIs"

--- a/components/tools/OmeroPy/src/omero/plugins/render.py
+++ b/components/tools/OmeroPy/src/omero/plugins/render.py
@@ -197,28 +197,6 @@ class RenderObject(object):
             self.levels = image._re.getResolutionLevels()
             self.zoomLevelScaling = image.getZoomLevelScaling()
 
-        """
-        self.nominalMagnification = \
-            image.getObjectiveSettings() is not None \
-            and image.getObjectiveSettings() \
-            .getObjective().getNominalMagnification() \
-        or None
-
-
-    try:
-        rv.update({
-            'interpolate': interpolate,
-            'size': {'width': image.getSizeX(),
-                     'height': image.getSizeY(),
-                     'z': image.getSizeZ(),
-                     't': image.getSizeT(),
-                     'c': image.getSizeC()},
-            'pixel_size': {'x': image.getPixelSizeX(),
-                           'y': image.getPixelSizeY(),
-                           'z': image.getPixelSizeZ()},
-            })
-        """
-
         self.range = image.getPixelRange()
         self.channels = map(lambda x: ChannelObject(x), image.getChannels())
         self.model = image.isGreyscaleRenderingModel() and \

--- a/components/tools/OmeroPy/src/omero/plugins/render.py
+++ b/components/tools/OmeroPy/src/omero/plugins/render.py
@@ -287,12 +287,6 @@ class RenderControl(BaseControl):
             "channels",
             help="Rendering definition, local file or OriginalFile:ID")
 
-    def _check_services(self, client):
-        for s in client.getStatefulServices():
-            # FIXME: it's not currently clear if these services
-            # were created by the current process
-            self.ctx.err("Service left open! - %s" % s)
-
     def _lookup(self, gateway, type, oid):
         # TODO: move _lookup to a _configure type
         obj = gateway.getObject(type, oid)
@@ -352,13 +346,13 @@ class RenderControl(BaseControl):
                     first = False
             finally:
                 ro.close()
-        self._check_services(client)
+        gateway._assert_unregistered("info")
 
     def copy(self, args):
         client = self.ctx.conn(args)
         gateway = BlitzGateway(client_obj=client)
         self._copy(gateway, args.object, args.target, args.skipthumbs)
-        self._check_services(client)
+        gateway._assert_unregistered("copy")
 
     def _copy(self, gateway, obj, target, skipthumbs, close=True):
         """
@@ -491,7 +485,7 @@ class RenderControl(BaseControl):
         if namedict:
             self._update_channel_names(gateway, iids, namedict)
 
-        self._check_services(client)
+        gateway._assert_unregistered("edit")
 
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/render.py
+++ b/components/tools/OmeroPy/src/omero/plugins/render.py
@@ -469,7 +469,8 @@ class RenderControl(BaseControl):
                         img.setColorRenderingModel()
 
                 img.saveDefaults()
-                self.ctx.dbg("Updated rendering settings for Image:%s" % img.id)
+                self.ctx.dbg(
+                    "Updated rendering settings for Image:%s" % img.id)
                 if not args.skipthumbs:
                     self._generate_thumbs([img])
 
@@ -477,7 +478,9 @@ class RenderControl(BaseControl):
                     # Edit first image only, copy to rest
                     # Don't close source image until outer
                     # loop is done.
-                    self._copy_single(gateway, img, args.object, args.skipthumbs)
+                    self._copy_single(gateway,
+                                      img, args.object,
+                                      args.skipthumbs)
                     break
             finally:
                 img._closeRE()

--- a/components/tools/OmeroPy/test/integration/clitest/test_render.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_render.py
@@ -67,6 +67,7 @@ class TestRender(CLITest):
                         size=(96,), direct=False)
                     img._closeRE()
         self.imgobj._closeRE()
+        assert not self.gw._assert_unregistered("create_image")
 
     def get_target_imageids(self, target):
         if target in (self.idonly, self.imageid):
@@ -193,6 +194,7 @@ class TestRender(CLITest):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
             img._closeRE()
+        assert not gw._assert_unregistered("testEdit")
 
     # Once testEdit is no longer broken testEditSingleC could be merged into
     # it with sizec and greyscale parameters
@@ -217,9 +219,14 @@ class TestRender(CLITest):
         for iid in iids:
             # Get the updated object
             img = gw.getObject('Image', iid)
+            # Note: calling _prepareRE below does NOT suffice!
+            img._prepareRenderingEngine()  # Call *before* getChannels
+            # Passing noRE to getChannels below also prevents leaking
+            # the RenderingEngine but then Nones are returned later.
             channels = img.getChannels()
             assert len(channels) == sizec
             for c in xrange(len(channels)):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
             img._closeRE()
+        assert not gw._assert_unregistered("testEditSingleC")

--- a/components/tools/OmeroPy/test/integration/clitest/test_render.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_render.py
@@ -62,8 +62,11 @@ class TestRender(CLITest):
         for p in self.plates:
             for w in p.listChildren():
                 for i in range(w.countWellSample()):
-                    w.getImage(index=i).getThumbnail(
+                    img = w.getImage(index=i)
+                    img.getThumbnail(
                         size=(96,), direct=False)
+                    img._closeRE()
+        self.imgobj._closeRE()
 
     def get_target_imageids(self, target):
         if target in (self.idonly, self.imageid):
@@ -189,6 +192,7 @@ class TestRender(CLITest):
             for c in xrange(len(channels)):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
+            img._closeRE()
 
     # Once testEdit is no longer broken testEditSingleC could be merged into
     # it with sizec and greyscale parameters
@@ -218,3 +222,4 @@ class TestRender(CLITest):
             for c in xrange(len(channels)):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
+            img._closeRE()

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -800,7 +800,7 @@ class TestPopulateMetadata(lib.ITest):
         if batch_size is None:
             ctx.write_to_omero()
         else:
-            ctx.write_to_omero(batch_size=batch_size)
+            ctx.write_to_omero(batch_size=batch_size, loops=10, ms=250)
 
         # Get file annotations
         anns = fixture.get_annotations()
@@ -908,14 +908,14 @@ class TestPopulateMetadata(lib.ITest):
         ctx = DeleteMapAnnotationContext(
             self.client, fixture1.get_target(), cfg=fixture1.get_cfg())
         ctx.parse()
-        ctx.write_to_omero()
+        ctx.write_to_omero(loops=10, ms=250)
         assert len(fixture1.get_child_annotations()) == 0
         assert len(fixture2.get_child_annotations()) == fixture2.annCount
 
         ctx = DeleteMapAnnotationContext(
             self.client, fixture2.get_target(), cfg=fixture2.get_cfg())
         ctx.parse()
-        ctx.write_to_omero()
+        ctx.write_to_omero(loops=10, ms=250)
         assert len(fixture2.get_child_annotations()) == 0
         assert len(fixture1.get_all_map_annotations()) == 0
         assert len(fixture2.get_all_map_annotations()) == 0


### PR DESCRIPTION
# What this PR does

Performance improvements for the new CLI plugins. Goal would be to have all methods be able to function on sizable datasets without timeouts, OOMs, or similar. Primarily, `render.py` should close all stateful services and `metadata.py` should not timeout when deleting, etc. large batches.

# Testing this PR

1. render.py (cc: @emilroz)
   - Primarily, all plugin behavior should remain identical
   - Large re-renderings should no longer bring the server down
1. metadata.py (cc: @aleksandra-tarkowska)
   - allow waiting indefinitely


# Related reading

 * https://trello.com/c/3vGyIffT/192-blitz-gateway-memory-leak-advice
 * https://github.com/openmicroscopy/openmicroscopy/pull/4542 - original render.py PR
 * https://github.com/openmicroscopy/openmicroscopy/pull/4818 - render.py close RPSes
 * https://github.com/openmicroscopy/openmicroscopy/pull/4754 - batch metadata.py calls
