### PR TITLE
Use reader-supplied plate names by default

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -437,14 +437,7 @@ public class ImportCandidates extends DirectoryWalker
                 ic.setDoThumbnails(config.doThumbnails.get());
                 ic.setNoStatsInfo(config.noStatsInfo.get());
                 String configImageName = config.userSpecifiedName.get();
-                if (configImageName == null)
-                {
-                    ic.setUserSpecifiedName(file.getName());
-                }
-                else
-                {
-                    ic.setUserSpecifiedName(configImageName);
-                }
+                ic.setUserSpecifiedName(configImageName);
                 ic.setUserSpecifiedDescription(config.userSpecifiedDescription.get());
                 ic.setCustomAnnotationList(config.annotations.get());
                 return ic;

--- a/components/blitz/src/ome/formats/importer/ImportFixture.java
+++ b/components/blitz/src/ome/formats/importer/ImportFixture.java
@@ -112,7 +112,6 @@ public class ImportFixture
         {
 		ic = new ImportContainer(file, fads.get(file),
 					null, null, null, null);
-		ic.setUserSpecifiedName(file.getAbsolutePath());
 		library.importImage(ic, 0, 0, 1);
         /*
 		library.importImage(file, 0, 0, 1, file.getAbsolutePath(),

--- a/components/blitz/src/ome/formats/model/PixelsProcessor.java
+++ b/components/blitz/src/ome/formats/model/PixelsProcessor.java
@@ -27,6 +27,7 @@ import static omero.rtypes.rstring;
 
 import static ome.formats.model.UnitsFactory.makeLength;
 
+import java.io.File;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -124,6 +125,8 @@ public class PixelsProcessor implements ModelProcessor {
       }
 
       // Ensure that the Image name is set
+
+      // name supplied by user
       String userSpecifiedName = store.getUserSpecifiedName();
       if (userSpecifiedName != null) {
         userSpecifiedName = userSpecifiedName.trim();
@@ -131,7 +134,9 @@ public class PixelsProcessor implements ModelProcessor {
           userSpecifiedName = null;
         }
       }
+      // name that will actually be set on the Image
       String saveName = "";
+      // name supplied by the reader
       String imageName;
       if (image.getName() != null && image.getName().getValue() != null) {
         imageName = image.getName().getValue().trim();
@@ -150,9 +155,17 @@ public class PixelsProcessor implements ModelProcessor {
           }
           saveName += " [" + imageName + "]";
         }
-      } else {
+      } else if (imageName != null) {
         saveName = imageName;
       }
+      else {
+        saveName = reader.getCurrentFile();
+        saveName = saveName.substring(saveName.lastIndexOf(File.separator) + 1);
+        if (reader.getSeriesCount() > 1) {
+          saveName += " [" + imageIndex + "]";
+        }
+      }
+      // TODO: remove this if/when name is switched to TEXT in the DB
       if (saveName != null && saveName.length() > 255) {
         saveName = '…' + saveName.substring(saveName.length() - 254);
       }

--- a/components/blitz/src/ome/formats/model/PixelsProcessor.java
+++ b/components/blitz/src/ome/formats/model/PixelsProcessor.java
@@ -125,8 +125,6 @@ public class PixelsProcessor implements ModelProcessor {
       }
 
       // Ensure that the Image name is set
-
-      // name supplied by user
       String userSpecifiedName = store.getUserSpecifiedName();
       if (userSpecifiedName != null) {
         userSpecifiedName = userSpecifiedName.trim();
@@ -134,9 +132,11 @@ public class PixelsProcessor implements ModelProcessor {
           userSpecifiedName = null;
         }
       }
-      // name that will actually be set on the Image
+      if (userSpecifiedName == null) {
+        File originalFile = new File(reader.getCurrentFile());
+        userSpecifiedName = originalFile.getName();
+      }
       String saveName = "";
-      // name supplied by the reader
       String imageName;
       if (image.getName() != null && image.getName().getValue() != null) {
         imageName = image.getName().getValue().trim();
@@ -155,17 +155,9 @@ public class PixelsProcessor implements ModelProcessor {
           }
           saveName += " [" + imageName + "]";
         }
-      } else if (imageName != null) {
+      } else {
         saveName = imageName;
       }
-      else {
-        saveName = reader.getCurrentFile();
-        saveName = saveName.substring(saveName.lastIndexOf(File.separator) + 1);
-        if (reader.getSeriesCount() > 1) {
-          saveName += " [" + imageIndex + "]";
-        }
-      }
-      // TODO: remove this if/when name is switched to TEXT in the DB
       if (saveName != null && saveName.length() > 255) {
         saveName = '…' + saveName.substring(saveName.length() - 254);
       }

--- a/components/blitz/src/ome/formats/model/WellProcessor.java
+++ b/components/blitz/src/ome/formats/model/WellProcessor.java
@@ -26,6 +26,7 @@ package ome.formats.model;
 import static omero.rtypes.rint;
 import static omero.rtypes.rstring;
 
+import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -96,23 +97,14 @@ public class WellProcessor implements ModelProcessor {
     String userSpecifiedPlateName = store.getUserSpecifiedName();
     String userSpecifiedPlateDescription = store.getUserSpecifiedDescription();
 
-    // precedence order for plate naming:
-    //
-    // 1. user specified, if not default name of imported file
-    // 2. reader supplied, if not null
-    // 3. user specified (name of imported file)
-    // 4. "Plate"
     if (userSpecifiedPlateName != null) {
-      String currentFile = store.getReader().getCurrentFile();
-      if (!currentFile.endsWith(userSpecifiedPlateName) ||
-        plate.getName() == null)
-      {
-        plate.setName(rstring(userSpecifiedPlateName));
-      }
+      plate.setName(rstring(userSpecifiedPlateName));
     }
     if (plate.getName() == null) {
       log.warn("Missing plate name for: " + container.LSID);
-      plate.setName(rstring("Plate"));
+      String filename = store.getReader().getCurrentFile();
+      filename = filename.substring(filename.lastIndexOf(File.separator) + 1);
+      plate.setName(rstring(filename));
     }
 
     if (userSpecifiedPlateDescription != null) {

--- a/components/blitz/src/ome/formats/model/WellProcessor.java
+++ b/components/blitz/src/ome/formats/model/WellProcessor.java
@@ -103,7 +103,7 @@ public class WellProcessor implements ModelProcessor {
     if (plate.getName() == null) {
       log.warn("Missing plate name for: " + container.LSID);
       String filename = store.getReader().getCurrentFile();
-      filename = filename.substring(filename.lastIndexOf(File.separator) + 1);
+      filename = new File(filename).getName();
       plate.setName(rstring(filename));
     }
 

--- a/components/blitz/src/ome/formats/model/WellProcessor.java
+++ b/components/blitz/src/ome/formats/model/WellProcessor.java
@@ -95,15 +95,28 @@ public class WellProcessor implements ModelProcessor {
     Plate plate = (Plate) container.sourceObject;
     String userSpecifiedPlateName = store.getUserSpecifiedName();
     String userSpecifiedPlateDescription = store.getUserSpecifiedDescription();
+
+    // precedence order for plate naming:
+    //
+    // 1. user specified, if not default name of imported file
+    // 2. reader supplied, if not null
+    // 3. user specified (name of imported file)
+    // 4. "Plate"
     if (userSpecifiedPlateName != null) {
-      plate.setName(rstring(userSpecifiedPlateName));
-    }
-    if (userSpecifiedPlateDescription != null) {
-      plate.setDescription(rstring(userSpecifiedPlateDescription));
+      String currentFile = store.getReader().getCurrentFile();
+      if (!currentFile.endsWith(userSpecifiedPlateName) ||
+        plate.getName() == null)
+      {
+        plate.setName(rstring(userSpecifiedPlateName));
+      }
     }
     if (plate.getName() == null) {
       log.warn("Missing plate name for: " + container.LSID);
       plate.setName(rstring("Plate"));
+    }
+
+    if (userSpecifiedPlateDescription != null) {
+      plate.setDescription(rstring(userSpecifiedPlateDescription));
     }
     if (plate.getRows() == null) {
       plate.setRows(rint(1));

--- a/components/blitz/src/ome/formats/model/WellProcessor.java
+++ b/components/blitz/src/ome/formats/model/WellProcessor.java
@@ -100,7 +100,9 @@ public class WellProcessor implements ModelProcessor {
     if (userSpecifiedPlateName != null) {
       plate.setName(rstring(userSpecifiedPlateName));
     }
-    if (plate.getName() == null) {
+    if (plate.getName() == null || plate.getName().getValue() == null ||
+      plate.getName().getValue().isEmpty())
+    {
       log.warn("Missing plate name for: " + container.LSID);
       String filename = store.getReader().getCurrentFile();
       filename = new File(filename).getName();


### PR DESCRIPTION
# What this PR does

This changes how Plates are named during import, so that the reader-supplied name is used whenever possible.  If neither the reader nor the user supply a Plate name, then the relative file path is used as a fallback.  Naming of Image-based datasets should not have changed, but needs to be tested.

# Testing this PR

Without this PR, import one plate in each of a few different formats (e.g. InCell, ScanR, Flex).  Verify that the plate names in OMERO all match the relative file path of the import file.  Also import a non-plate dataset in each of a few different formats (e.g. Imaris HDF, SVS).

With this PR, import the same set of plate and non-plate datasets as in the original test.  The Plate names should now match the ```Name``` attribute on ```Plate``` as shown by ```showinf -nopix -omexml``` on the corresponding file.  The Image names (for non-plate datasets) should be the same as before.

Finally, with this PR, import the same set of plate datasets only, but specify a plate name of your choice during import.  Verify that the Plate names match your chosen names and not what is shown by ```showinf -nopix -omexml```.

# Related reading

See https://trello.com/c/XMfgOciw/189-import-plate-image-name and https://github.com/openmicroscopy/design/issues/57.