### PR TITLE
Web marshal RGBA int

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -351,9 +351,10 @@ def rgb_int2css(rgbint):
     converts a bin int number into css colour and alpha fraction.
     E.g. -1006567680 to '#00ff00', 0.5
     """
-    alpha = rgbint // 256 // 256 // 256 % 256
-    alpha = float(alpha) / 256
-    r, g, b = (rgbint // 256 // 256 % 256, rgbint // 256 % 256, rgbint % 256)
+    alpha = rgbint % 256
+    b = rgbint / 256 % 256
+    g = rgbint / 256 / 256 % 256
+    r = rgbint / 256 / 256 /256 % 256
     return "#%02x%02x%02x" % (r, g, b), alpha
 
 
@@ -362,9 +363,10 @@ def rgb_int2rgba(rgbint):
     converts a bin int number into (r, g, b, alpha) tuple.
     E.g. 1694433280 to (255, 0, 0, 0.390625)
     """
-    alpha = rgbint // 256 // 256 // 256 % 256
-    alpha = float(alpha) / 256
-    r, g, b = (rgbint // 256 // 256 % 256, rgbint // 256 % 256, rgbint % 256)
+    alpha = rgbint % 256
+    b = rgbint / 256 % 256
+    g = rgbint / 256 / 256 % 256
+    r = rgbint / 256 / 256 /256 % 256
     return (r, g, b, alpha)
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -352,6 +352,7 @@ def rgb_int2css(rgbint):
     E.g. -1006567680 to '#00ff00', 0.5
     """
     alpha = rgbint % 256
+    alpha = float(alpha) / 256
     b = rgbint / 256 % 256
     g = rgbint / 256 / 256 % 256
     r = rgbint / 256 / 256 /256 % 256
@@ -364,6 +365,7 @@ def rgb_int2rgba(rgbint):
     E.g. 1694433280 to (255, 0, 0, 0.390625)
     """
     alpha = rgbint % 256
+    alpha = float(alpha) / 256
     b = rgbint / 256 % 256
     g = rgbint / 256 / 256 % 256
     r = rgbint / 256 / 256 /256 % 256

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -355,7 +355,7 @@ def rgb_int2css(rgbint):
     alpha = float(alpha) / 256
     b = rgbint / 256 % 256
     g = rgbint / 256 / 256 % 256
-    r = rgbint / 256 / 256 /256 % 256
+    r = rgbint / 256 / 256 / 256 % 256
     return "#%02x%02x%02x" % (r, g, b), alpha
 
 
@@ -368,7 +368,7 @@ def rgb_int2rgba(rgbint):
     alpha = float(alpha) / 256
     b = rgbint / 256 % 256
     g = rgbint / 256 / 256 % 256
-    r = rgbint / 256 / 256 /256 % 256
+    r = rgbint / 256 / 256 / 256 % 256
     return (r, g, b, alpha)
 
 

--- a/components/tools/OmeroWeb/test/unit/test_marshal.py
+++ b/components/tools/OmeroWeb/test/unit/test_marshal.py
@@ -122,8 +122,8 @@ def basic_ellipse(default_id):
     shape.y = rdouble(.1)
     shape.radiusX = rdouble(1.0)
     shape.radiusY = rdouble(.5)
-    shape.fillColor = rlong(287454020)  #0x11223344 , r=17 ,g=34 ,b=51, a=68
-    shape.strokeColor = rlong(1432778632) #0x55667788, r=85 ,g=102 ,b=119, a=136
+    shape.fillColor = rlong(287454020)     # 0x11223344,r=17,g=34,b=51,a=68
+    shape.strokeColor = rlong(1432778632)  # 0x55667788,r=85,g=102,b=119,a=136
     return shape
 
 
@@ -188,13 +188,13 @@ class TestShapeMarshal(object):
 
     def test_rgba(self, basic_ellipse):
         color = unwrap(basic_ellipse.getFillColor())
-        result = rgb_int2rgba(color) # 0x11223344
-        assert result[0] == 17 # r
-        assert result[1] == 34 # g
-        assert result[2] == 51 # b
-        assert result[3] == float(68) / 256 # a (as fraction)
+        result = rgb_int2rgba(color)         # 0x11223344
+        assert result[0] == 17               # r
+        assert result[1] == 34               # g
+        assert result[2] == 51               # b
+        assert result[3] == float(68) / 256  # a (as fraction)
 
         color = unwrap(basic_ellipse.getStrokeColor())
-        result = rgb_int2css(color) # 0x55667788
-        assert result[0] == "#556677" # rgb
-        assert result[1] == float(136) / 256 # a (as fraction)
+        result = rgb_int2css(color)            # 0x55667788
+        assert result[0] == "#556677"          # rgb
+        assert result[1] == float(136) / 256   # a (as fraction)

--- a/components/tools/OmeroWeb/test/unit/test_marshal.py
+++ b/components/tools/OmeroWeb/test/unit/test_marshal.py
@@ -21,8 +21,10 @@
 import pytest
 import omero
 import omero.clients
-from omero.rtypes import rlong, rstring, rdouble
+from omero.rtypes import rlong, rstring, rdouble, unwrap
 from omeroweb.webgateway.marshal import shapeMarshal
+from omeroweb.webgateway.marshal import rgb_int2css
+from omeroweb.webgateway.marshal import rgb_int2rgba
 
 
 @pytest.fixture(scope='module')
@@ -120,6 +122,8 @@ def basic_ellipse(default_id):
     shape.y = rdouble(.1)
     shape.radiusX = rdouble(1.0)
     shape.radiusY = rdouble(.5)
+    shape.fillColor = rlong(287454020)  #0x11223344 , r=17 ,g=34 ,b=51, a=68
+    shape.strokeColor = rlong(1432778632) #0x55667788, r=85 ,g=102 ,b=119, a=136
     return shape
 
 
@@ -181,3 +185,16 @@ class TestShapeMarshal(object):
         assert 0.1 == marshaled['y']
         assert 1.0 == marshaled['radiusX']
         assert 0.5 == marshaled['radiusY']
+
+    def test_rgba(self, basic_ellipse):
+        color = unwrap(basic_ellipse.getFillColor())
+        result = rgb_int2rgba(color) # 0x11223344
+        assert result[0] == 17 # r
+        assert result[1] == 34 # g
+        assert result[2] == 51 # b
+        assert result[3] == float(68) / 256 # a (as fraction)
+
+        color = unwrap(basic_ellipse.getStrokeColor())
+        result = rgb_int2css(color) # 0x55667788
+        assert result[0] == "#556677" # rgb
+        assert result[1] == float(136) / 256 # a (as fraction)


### PR DESCRIPTION
# What this PR does

With this PR color integers will be interpreted as RGBA (instead of ARGB).

# Testing this PR

Set a specific fill and line color for an ROI in Insight. Check that the color displayed is the same for Web and Insight. ~Ignore the opacity for now.~

# Related reading
- [Trello - Shape colour read as RGBA](https://trello.com/c/YLP2lElr/248-shape-colour-read-as-rgba)
- Insight PR: #4948

~Apparently Web does not take the alpha value into account; it is read correctly, but the color is always shown as full opaque. Is that expected @will-moore ?~


