### PR TITLE
Disable lineplot for tiled images

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1060,6 +1060,9 @@
         $("#showhistogram").attr('disabled', true)
           .parent().css('color', '#bbb')
           .attr('title', 'Histogram not supported for tiled images');
+        $("#wblitz-lp-enable").attr('disabled', true)
+          .parent().css('color', '#bbb')
+          .attr('title', 'Line plot not supported for tiled images');
       }
 
       // Enable 'Show ROIs' button


### PR DESCRIPTION
# What this PR does

~~Based on @will-moore 's PR #4703 .~~ (has been merged)
Just adds one commit which disables the 'Line Plot' feature for big images.
![screen shot 2016-12-13 at 11 05 09](https://cloud.githubusercontent.com/assets/6575139/21138034/31866ede-c124-11e6-9b0f-aa9375eb7c3d.png)

# Testing this PR

Open a big image, make sure there the Line Plot" checkbox is disabled.
Open a small image, make sure the "Line Plot" checkbox is enabled.

# Related reading

[Trello - Bug: `learning` plot error](https://trello.com/c/UWelSy4x/233-bug-learning-plot-error)
