### PR TITLE
Open_with label

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1009,7 +1009,7 @@ $(function() {
                     // build a submenu of viewers...
                     var viewers = WEBCLIENT.OPEN_WITH.map(function(v){
                         return {
-                            "label": v.label,
+                            "label": v.label || v.id,
                             "action": function() {
                                 var inst = $.jstree.reference('#dataTree'),
                                     sel = inst.get_selected(true),

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -967,10 +967,10 @@ OME.setOpenWithEnabledHandler = function(label, fn) {
 };
 // Helper can be used by 'open with' plugins to provide
 // a url for the selected objects
-OME.setOpenWithUrlProvider = function(label, fn) {
+OME.setOpenWithUrlProvider = function(id, fn) {
     // look for label in OPEN_WITH
     WEBCLIENT.OPEN_WITH.forEach(function(ow){
-        if (ow.label === label) {
+        if (ow.id === id) {
             ow.getUrl = fn;
         }
     });

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1567,7 +1567,7 @@ def open_with_options(request, **kwargs):
         if len(ow) < 2:
             continue
         viewer = {}
-        viewer['label'] = ow[0]
+        viewer['id'] = ow[0]
         try:
             viewer['url'] = reverse(ow[1])
         except NoReverseMatch:
@@ -1587,6 +1587,8 @@ def open_with_options(request, **kwargs):
                     else:
                         # ...otherwise, assume within static
                         viewer['script_url'] = static(ow[2]['script_url'])
+                if 'label' in ow[2]:
+                    viewer['label'] = ow[2]['label']
         except:
             # ignore invalid params
             pass


### PR DESCRIPTION
# What this PR does

Adds an optional "label" parameter in the ```open_with``` config which will be used
in the right-click menu in webclient.
As discussed with @jburel, this will allow users to decide how they want 'Open with'
plugins to appear in their webclient (and OMERO.figure) apps without having to
make any code changes.

# Testing this PR
 - Can use updated docs at https://github.com/openmicroscopy/ome-documentation/pull/1592
 - Set up config with ```label``` in the extra opts dictionary. E.g.
```
$ omero config append omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects": ["images"], "script_url": "omero_iviewer/openwith.js", "label": "NEW iViewer"}]'
```
 - Restart web etc.
 - Now, Open_with menu will use label.
 - Also test that without the "label" in config that the ID is used as a label instead E.g. "omero_iviewer" in the above example.

 - Also test that this works in OMERO.figure - with last commit: https://github.com/ome/omero-figure/pull/179/commits/12ae1f71ea2d152b8f2b632f4494cc7557bc5652

Need to update docs...