### PR TITLE
Zoom scale bar

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/UnitBarSizeAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/UnitBarSizeAction.java
@@ -152,6 +152,32 @@ public class UnitBarSizeAction
     	return values[index];
     }
     
+    /**
+     * Returns the index corresponding to the passed value or
+     * <code>CUSTOMIZED</code>.
+     * 
+     * @param value
+     *            The value to handle.
+     * @return See above.
+     */
+    public static int getIndex(double value) {
+        if (value < values[TWO])
+            return ONE;
+        if (value < values[FIVE])
+            return TWO;
+        if (value < values[TEN])
+            return FIVE;
+        if (value < values[TWENTY])
+            return TEN;
+        if (value < values[FIFTY])
+            return TWENTY;
+        if (value < values[HUNDRED])
+            return FIFTY;
+        if (value < 1000)
+            return HUNDRED;
+        return CUSTOMIZED;
+    }
+    
     /** One of the constant defined by this class. */
     private int     index;
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/Browser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/Browser.java
@@ -30,6 +30,7 @@ import java.awt.image.BufferedImage;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 
+import omero.model.Length;
 import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
 import org.openmicroscopy.shoola.util.ui.component.ObservableComponent;
@@ -426,5 +427,12 @@ public interface Browser
      *            The zoom factor
      */
     void setSelectedResolutionLevelZoomFactor(double ratio);
+
+    /**
+     * Get the length of the scale bar
+     * 
+     * @return See above
+     */
+    public Length getUnitBarLength();
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/Browser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/Browser.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.browser.Browser
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -418,5 +418,13 @@ public interface Browser
         * @param interpolation The value to set.
         */
         public void setInterpolation(boolean interpolation);
+
+    /**
+     * Set the zoom factor for the selected resolution level
+     * 
+     * @param ratio
+     *            The zoom factor
+     */
+    void setSelectedResolutionLevelZoomFactor(double ratio);
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.imviewer.browser.BrowserComponent
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -257,6 +257,15 @@ class BrowserComponent
     	}
     }
 
+    /**
+     * Implemented as specified by the {@link Browser} interface.
+     * 
+     * @see Browser#setSelectedResolutionLevelZoomFactor(double)
+     */
+    public void setSelectedResolutionLevelZoomFactor(double ratio) {
+        model.setZoomFactor(ratio);
+    }
+    
     /** 
      * Implemented as specified by the {@link Browser} interface.
      * @see Browser#getZoomFactor()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserComponent.java
@@ -32,6 +32,7 @@ import java.awt.image.BufferedImage;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 
+import omero.model.Length;
 import omero.model.enums.UnitsLength;
 import org.openmicroscopy.shoola.agents.imviewer.ImViewerAgent;
 import org.openmicroscopy.shoola.agents.imviewer.actions.ZoomAction;
@@ -684,5 +685,13 @@ class BrowserComponent
             model.setInterpolation(interpolation);
             paintImage();
         }
-	    
+        
+    /**
+     * Implemented as specified by the {@link Browser} interface.
+     * 
+     * @see Browser#getUnitBarLength()
+     */
+    public Length getUnitBarLength() {
+        return model.getUnitBarLength();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
@@ -675,11 +675,11 @@ class BrowserModel
             UnitsLength unit = tmp.getUnit();
 
             // Determine a reasonable size by assuming a scalebar with length of
-            // 1/10th of image width
-            int barLengthInPx = (int) (getMaxY() * zoomFactor / 10);
+            // up to 1/5th of current image display size
+            Rectangle visSize = ((BrowserUI)component.getUI()).getVisibleRect();
+            int barLengthInPx = (int)(visSize.getWidth() / 5d);
             tmp = new LengthI(getPixelsSizeX().getValue() * barLengthInPx
                     / zoomFactor, getPixelsSizeX().getUnit());
-
             try {
                 tmp = new LengthI(tmp, unit);
             } catch (BigResult e) {
@@ -705,22 +705,13 @@ class BrowserModel
      * 
      * @param size
      *            The size of the unit bar.
-     * @param unit The unit
+     * @param unit
+     *            The unit
      */
     void setUnitBarSize(double size, UnitsLength unit) {
-        if (unitBarLength != null) {
-            try {
-                LengthI tmp = new LengthI(size, unit);
-                tmp = new LengthI(tmp, unitBarLength.getUnit());
-                unitBarLength.setValue(tmp.getValue());
-            } catch (BigResult e) {
-            }
-        }
-        else {
-            unitBarLength = new LengthI(size, unit);
-        }
+        unitBarLength = new LengthI(size, unit);
     }
-    
+
     /**
      * Returns the unit used to determine the size of the unit bar. The unit
      * depends on the size stored. The unit of reference in the OME model is in

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
@@ -663,20 +663,30 @@ class BrowserModel
     /**
      * Sets the value of the flag controlling if the unit bar is painted or not.
      * 
-     * @param unitBar   Pass <code>true</code> to paint the unit bar, 
-     *                  <code>false</code> otherwise.
+     * @param unitBar
+     *            Pass <code>true</code> to paint the unit bar,
+     *            <code>false</code> otherwise.
      */
-    void setUnitBar(boolean unitBar)
-    {
+    void setUnitBar(boolean unitBar) {
         if (unitBar) {
-            int unitBarLenghtValue = UnitBarSizeAction.getDefaultValue();
-            // Guess the unit to use by assuming a 100px wide scalebar
-            Length tmp = new LengthI(getPixelsSizeX().getValue() * 100,
-                    getPixelsSizeX().getUnit());
-            tmp = UIUtilities.transformSize(tmp);
-            this.unitBarLength = new LengthI(unitBarLenghtValue, tmp.getUnit());
+            // Determine a reasonable size by assuming a 100px wide scalebar
+            Length tmp = new LengthI(getPixelsSizeX().getValue() * 100
+                    / zoomFactor, getPixelsSizeX().getUnit());
+
+            if (tmp.getValue() > 999) {
+                int dec = (int) Math.log10(tmp.getValue());
+                this.unitBarLength = new LengthI(Math.pow(10, dec),
+                        getPixelsSizeX().getUnit());
+            } else {
+                int index = UnitBarSizeAction.getIndex(tmp.getValue());
+                this.unitBarLength = new LengthI(
+                        UnitBarSizeAction.getValue(index), getPixelsSizeX()
+                                .getUnit());
+            }
+
+            this.parent.updateUnitBarMenu(this.unitBarLength);
         }
-    	this.unitBar = unitBar;
+        this.unitBar = unitBar;
     }
     
     /**
@@ -887,7 +897,7 @@ class BrowserModel
      */
 	Length getPixelsSizeZ() { return parent.getPixelsSizeZ(); }
    
-	Length getUnitBarLength() {
+	public Length getUnitBarLength() {
 	    return unitBarLength;
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
@@ -897,9 +897,14 @@ class BrowserModel
      */
 	Length getPixelsSizeZ() { return parent.getPixelsSizeZ(); }
    
-	public Length getUnitBarLength() {
-	    return unitBarLength;
-	}
+    /**
+     * Get the length of the unit bar
+     * 
+     * @return See above.
+     */
+    public Length getUnitBarLength() {
+        return unitBarLength;
+    }
 	
     /** 
      * Returns the number of column for the grid.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/ImageCanvas.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/ImageCanvas.java
@@ -134,8 +134,8 @@ class ImageCanvas
 		Rectangle imgRect = new Rectangle(0, 0, width, height);
 		Rectangle viewRect = viewPort.getBounds();
 		Point p = viewPort.getViewPosition();
-		int x = (int) p.getX();
-		int y = (int) p.getY();
+		int x = viewPort.getWidth() > width ? 0 : (int) p.getX();
+		int y = viewPort.getHeight() > height ? height : (int) p.getY();
 		int w = Math.min(x+viewRect.width, width);
 		int h = Math.min(y+viewRect.height, height);
 		if (imgRect.contains(viewRect)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1396,4 +1396,12 @@ public interface ImViewer
      */
     void reloadROICount();
 
+    /**
+     * Update the scale bar menu, according to the given length
+     * 
+     * @param unitBarLength
+     *            The current scale bar length
+     */
+    public void updateUnitBarMenu(Length unitBarLength);
+
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -3566,4 +3566,17 @@ class ImViewerComponent
     public void reloadROICount() {
         model.reloadROICount();
     }
+    
+    /**
+     * Implemented as specified by the {@link ImViewer} interface.
+     * 
+     * @see ImViewer#updateUnitBarMenu(Length)
+     */
+    public void updateUnitBarMenu(Length unitBarLength) {
+        int index = UnitBarSizeAction.CUSTOMIZED;
+        if (unitBarLength.getValue() < 999) {
+            index = UnitBarSizeAction.getIndex(unitBarLength.getValue());
+        }
+        view.setScaleBarIndex(index);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -3573,10 +3573,6 @@ class ImViewerComponent
      * @see ImViewer#updateUnitBarMenu(Length)
      */
     public void updateUnitBarMenu(Length unitBarLength) {
-        int index = UnitBarSizeAction.CUSTOMIZED;
-        if (unitBarLength.getValue() < 999) {
-            index = UnitBarSizeAction.getIndex(unitBarLength.getValue());
-        }
-        view.setScaleBarIndex(index);
+        view.setScaleBarLength(unitBarLength);
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -3574,5 +3574,6 @@ class ImViewerComponent
      */
     public void updateUnitBarMenu(Length unitBarLength) {
         view.setScaleBarLength(unitBarLength);
+        model.setScaleBarUnit(unitBarLength.getUnit());
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -680,6 +680,16 @@ class ImViewerModel
         }
         return scaleBarUnit;
     }
+    
+    /**
+     * Set the unit used for the scalebar
+     * 
+     * @param unit
+     *            The unit
+     */
+    public void setScaleBarUnit(UnitsLength unit) {
+        this.scaleBarUnit = unit;
+    }
 	
 	/**
 	 * Returns the current user's details.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -2936,6 +2936,8 @@ class ImViewerModel
 		tiles.clear();
 		rnd.setSelectedResolutionLevel(level);
 		initializeTiles();
+		
+		browser.setSelectedResolutionLevelZoomFactor(getResolutionDescription().getRatio());
 	}
 	
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -2180,10 +2180,19 @@ class ImViewerUI
     /**
      * Set the scale bar index
      * 
-     * @param index
-     *            The index.
+     * @param unitBarLength
+     *            The scale bar length.
      */
-    void setScaleBarIndex(int index) {
+    void setScaleBarLength(Length unitBarLength) {
+
+        scaleBarMenu.setText(SCALE_BAR_TEXT
+                + LengthI.lookupSymbol(unitBarLength.getUnit()) + ")");
+
+        int index = UnitBarSizeAction.CUSTOMIZED;
+        if (unitBarLength.getValue() < 999) {
+            index = UnitBarSizeAction.getIndex(unitBarLength.getValue());
+        }
+
         if (scaleBarGroup == null)
             return;
         JCheckBoxMenuItem item;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -2177,6 +2177,26 @@ class ImViewerUI
 		return -1;
 	}
 	
+    /**
+     * Set the scale bar index
+     * 
+     * @param index
+     *            The index.
+     */
+    void setScaleBarIndex(int index) {
+        if (scaleBarGroup == null)
+            return;
+        JCheckBoxMenuItem item;
+        Enumeration e;
+        for (e = scaleBarGroup.getElements(); e.hasMoreElements();) {
+            item = (JCheckBoxMenuItem) e.nextElement();
+            if (((UnitBarSizeAction) item.getAction()).getIndex() == index)
+                item.setSelected(true);
+            else
+                item.setSelected(false);
+        }
+    }
+	
 	/** Shows the list of users who viewed the image.  */
 	void showUsersList()
 	{


### PR DESCRIPTION
# What this PR does

Bugfix: For big images the zoom factor for drawing the scale bar was not set correctly.

# Testing this PR

Open a big (tiled) image. Display the scale bar. Zoom in/out. Make sure the scale bar is zoomed correctly, too.

# Related reading

[Trello - Insight Scalebar-big image issue](https://trello.com/c/OwIMt9M2/241-insight-scalebar-big-image-issue)
