### PR TITLE
Disable copy rnd on multiselection

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -42,6 +42,9 @@ $(function() {
 
         OME.tree_selection_changed(data, e);
     })
+    .on('selection_change.ome', function(e, nElements) {
+        multiselection = nElements > 1;
+    })
     .on('copy_node.jstree', function(e, data) {
         /**
         * Fired when a node is pasted
@@ -130,6 +133,7 @@ $(function() {
         * is updated to match another instance of itself elsewhere in the tree
         */
         var inst = data.instance;
+
         // Update the child count
         OME.updateNodeChildCount(inst, data.parent);
     })
@@ -138,7 +142,6 @@ $(function() {
         * Fired when the tree is loaded and ready for action
         */
         var inst = data.instance;
-
         // Global variable specifies what to select
         var nodeIds = WEBCLIENT.initially_select;
         if (nodeIds.length === 0) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -21,6 +21,9 @@
 // jQuery load callback...
 $(function() {
 
+    // Flag holding curent single / multi selection status
+    var multiselection = false;
+
     // Select jstree and then cascade handle events and setup the tree.
     var jstree = $("#dataTree")
     .on('changed.jstree', function (e, data) {
@@ -34,6 +37,8 @@ $(function() {
             !inst.is_loading(data.node)) {
             inst.load_node(data.node);
         }
+
+        multiselection = data.selected.length > 1;
 
         OME.tree_selection_changed(data, e);
     })
@@ -1170,10 +1175,10 @@ $(function() {
                         config['renderingsettings']["submenu"]['owner_rdef']['_disabled'] = false;
                     }
                 }
-                // Only enable copying if an image is the node
+                // Only enable copying if an image is the node and only one node is selected
                 if (node.type === 'image') {
                     config['renderingsettings']['_disabled'] = false;
-                    config['renderingsettings']["submenu"]['copy_rdef']['_disabled'] = false;
+                    config['renderingsettings']["submenu"]['copy_rdef']['_disabled'] = multiselection;
                 }
                 return config;
             }

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -538,6 +538,10 @@ $(document).ready(function() {
         if (buttonsShowHide) {
             buttonsShowHide(inst.get_selected(true), inst);
         }
+
+        // Tell jsTree how many elements are selected
+        $("#dataTree").trigger('selection_change.ome', inst.get_selected(true).length);
+
         // Trigger the selection changed event
         $("body").trigger('selection_change.ome');
 


### PR DESCRIPTION
# What this PR does

Disables the "copy rendering settings" context menu, when there is more than one image selected. *Not sure if that is the right approach to do these things...*

# Testing this PR

Select multiple images. Make sure the "Copy Renderings Settings" option in the context menu is disabled. Select one image. Make sure the option is enabled again. Test with selection in tree as well as center panel.

# Related reading

[Trello - Web bugs](https://trello.com/c/F4c6yUZz/183-web-bugs)

/cc @will-moore 
