### PR TITLE
web api support for single dataset and screen

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -82,6 +82,22 @@ api_project = url(
 Project url to GET or DELETE a single Project
 """
 
+api_dataset = url(
+    r'^v(?P<api_version>%s)/m/datasets/(?P<pid>[0-9]+)/$' % versions,
+    views.DatasetView.as_view(),
+    name='api_dataset')
+"""
+Dataset url to GET or DELETE a single Dataset
+"""
+
+api_screen = url(
+    r'^v(?P<api_version>%s)/m/screens/(?P<pid>[0-9]+)/$' % versions,
+    views.ScreenView.as_view(),
+    name='api_screen')
+"""
+Screen url to GET or DELETE a single Screen
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -92,4 +108,6 @@ urlpatterns = patterns(
     api_save,
     api_projects,
     api_project,
+    api_dataset,
+    api_screen,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -126,12 +126,13 @@ class ObjectView(View):
 
     def delete(self, request, pid, conn=None, **kwargs):
         """
-        Delete the Project and return marshal of deleted Project.
+        Delete the Object and return marshal of deleted Object.
 
         Return 404 if not found.
         """
         try:
-            obj = conn.getQueryService().get(self.OMERO_TYPE, long(pid))
+            obj = conn.getQueryService().get(self.OMERO_TYPE, long(pid),
+                                             conn.SERVICE_OPTS)
         except ValidationException:
             raise NotFoundError('%s %s not found' % (self.OMERO_TYPE, pid))
         encoder = get_encoder(obj.__class__)

--- a/components/tools/OmeroWeb/requirements-common.txt
+++ b/components/tools/OmeroWeb/requirements-common.txt
@@ -6,4 +6,8 @@
 
 Django>=1.8,<1.9
 django-pipeline==1.3.20
-omero-marshal==0.4.1
+
+# Until Screens are supported in release, we need to use master branch
+# See https://github.com/openmicroscopy/openmicroscopy/pull/5006
+# omero-marshal==0.4.1
+git+git://github.com/openmicroscopy/omero-marshal.git@master#egg=omero-marshal

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -28,21 +28,6 @@ from omero.gateway import BlitzGateway
 from omero_marshal import get_encoder
 
 
-def get_update_service(user):
-    """Get the update_service for the given user's client."""
-    return user[0].getSession().getUpdateService()
-
-
-def get_connection(user, group_id=None):
-    """Get a BlitzGateway connection for the given user's client."""
-    connection = BlitzGateway(client_obj=user[0])
-    # Refresh the session context
-    connection.getEventContext()
-    if group_id is not None:
-        connection.SERVICE_OPTS.setOmeroGroup(group_id)
-    return connection
-
-
 def marshal_objects(objects):
     """Marshal objects using omero_marshal."""
     expected = []
@@ -77,14 +62,6 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
 
 class TestContainers(IWebTest):
     """Tests querying & editing Datasets, Screens etc."""
-
-    # Create users in the read-only group
-    @pytest.fixture()
-    def user1(self):
-        """Return a new user in the group1 group and also add to group2."""
-        group = self.new_group(perms='rwra--')
-        user = self.new_client_and_user(group=group)
-        return user
 
     @pytest.mark.parametrize("dtype", ['Project', 'Dataset', 'Screen'])
     def test_container_crud(self, dtype):

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -93,7 +93,6 @@ class TestContainers(IWebTest):
 
         # Read Object
         object_url = "%sm/%ss/%s/" % (base_url, dtype.lower(), object_id)
-        print object_url
         object_json = _get_response_json(django_client, object_url, {})
         assert object_json['@id'] == object_id
         conn = BlitzGateway(client_obj=self.root)

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests querying & editing Containers with webgateway json api."""
+
+from omeroweb.testlib import IWebTest, _get_response_json, \
+    _csrf_post_json, _csrf_put_json, _csrf_delete_response_json
+from django.core.urlresolvers import reverse
+from django.conf import settings
+import pytest
+from omero.gateway import BlitzGateway
+from omero_marshal import get_encoder
+
+
+def get_update_service(user):
+    """Get the update_service for the given user's client."""
+    return user[0].getSession().getUpdateService()
+
+
+def get_connection(user, group_id=None):
+    """Get a BlitzGateway connection for the given user's client."""
+    connection = BlitzGateway(client_obj=user[0])
+    # Refresh the session context
+    connection.getEventContext()
+    if group_id is not None:
+        connection.SERVICE_OPTS.setOmeroGroup(group_id)
+    return connection
+
+
+def marshal_objects(objects):
+    """Marshal objects using omero_marshal."""
+    expected = []
+    for obj in objects:
+        encoder = get_encoder(obj.__class__)
+        expected.append(encoder.encode(obj))
+    return expected
+
+
+def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
+                   group='-1'):
+    """
+    Load objects from OMERO, via conn.getObjects().
+
+    marshal with omero_marshal and compare with json_objects.
+    omero_ids_objects can be IDs or list of omero.model objects.
+    """
+    pids = []
+    for p in omero_ids_objects:
+        try:
+            pids.append(long(p))
+        except TypeError:
+            pids.append(p.id.val)
+    conn.SERVICE_OPTS.setOmeroGroup(group)
+    projects = conn.getObjects(dtype, pids, respect_order=True)
+    projects = [p._obj for p in projects]
+    expected = marshal_objects(projects)
+    assert len(json_objects) == len(expected)
+    for o1, o2 in zip(json_objects, expected):
+        assert o1 == o2
+
+
+class TestContainers(IWebTest):
+    """Tests querying & editing Datasets, Screens etc."""
+
+    # Create users in the read-only group
+    @pytest.fixture()
+    def user1(self):
+        """Return a new user in the group1 group and also add to group2."""
+        group = self.new_group(perms='rwra--')
+        user = self.new_client_and_user(group=group)
+        return user
+
+    @pytest.mark.parametrize("dtype", ['Project', 'Dataset', 'Screen'])
+    def test_container_crud(self, dtype):
+        """
+        Test create, read, update and delete of Containers.
+
+        Create with POST to /save
+        Read with GET of /m/dtype/:id/
+        Update with PUT to /m/dtype/:id/
+        Delete with DELETE to /m/dtype/:id/
+        """
+        django_client = self.django_root_client
+        group = self.ctx.groupId
+        version = settings.API_VERSIONS[-1]
+        # Need to get the Schema url to create @type
+        base_url = reverse('api_base', kwargs={'api_version': version})
+        rsp = _get_response_json(django_client, base_url, {})
+        schema_url = rsp['schema_url']
+        # specify group via query params
+        save_url = "%s?group=%s" % (rsp['save_url'], group)
+        project_name = 'test_container_create_read'
+        payload = {'Name': project_name,
+                   '@type': '%s#%s' % (schema_url, dtype)}
+        rsp = _csrf_post_json(django_client, save_url, payload,
+                              status_code=201)
+        # We get the complete new Object returned
+        assert rsp['Name'] == project_name
+        object_id = rsp['@id']
+
+        # Read Object
+        object_url = "%sm/%ss/%s/" % (base_url, dtype.lower(), object_id)
+        print object_url
+        object_json = _get_response_json(django_client, object_url, {})
+        assert object_json['@id'] == object_id
+        conn = BlitzGateway(client_obj=self.root)
+        assert_objects(conn, [object_json], [object_id], dtype=dtype)
+
+        # Update Object...
+        object_json['Name'] = 'new name'
+        rsp = _csrf_put_json(django_client, save_url, object_json)
+        # ...and read again to check
+        updated_json = _get_response_json(django_client, object_url, {})
+        assert updated_json['Name'] == 'new name'
+
+        # Delete
+        _csrf_delete_response_json(django_client, object_url, {})
+        # Get should now return 404
+        rsp = _get_response_json(django_client, object_url, {},
+                                 status_code=404)


### PR DESCRIPTION
# Support for single Dataset and Screen

This is another PR with subset of #4945.
Here, we add support for ```/api/datasets/:id``` and ```/api/screens/:id/``` using subclasses of a new View Class ```ObjectView```.
This approach allows us to further customise the handling of different objects using view subclasses.

To test:
 - Choose a valid Dataset ID and go to  ```/api/v0.1/m/datasets/:id/```
 - Choose a valid Screen ID and go to ```/api/v0.1/m/screens/:id/```

Added a test to test Create, Read, Update and Delete of Project, Dataset & Screen.