### PR TITLE
display PhysicalPixelSize value only if set

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -41,23 +41,29 @@
     </tr>
     <tr>
         {% with psX=image.getPixelSizeXWithUnits psY=image.getPixelSizeYWithUnits psZ=image.getPixelSizeZWithUnits %}
-            {% with uX=psX.1 uY=psY.1 uZ=psZ.1 %}
+            {% with vX=psX.0 vY=psY.0 vZ=psZ.0 uX=psX.1 uY=psY.1 uZ=psZ.1 %}
         <th>Pixels Size (XYZ){% if uX == uY and uX == uZ %} ({{ uX }}){% endif %}:</th>
         <td id='pixels_size'>
             <div class='tooltip'>
-                {{ psX.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
-                x {{ psY.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
-                {% if psZ.0 %}
-                    x {{ psZ.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
+                {% if vX or vY %}
+                    {{ vX|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
+                    x {{ vY|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
+                    {% if vZ %}
+                        x {{ vZ|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
+                    {% endif %}
+                {% else %}
+                not available
                 {% endif %}
             </div>
+            {% if vX or vY %}
             <span class="tooltip_html" style='display:none'>
-                {{ psX.0 }} ({{ uX }})
-                x {{ psY.0 }} ({{ uY }})
-                {% if psZ.0 %}
-                    x {{ psZ.0 }} ({{ uZ }})
+                {{ vX|default:'-' }} ({{ uX }})
+                x {{ vY|default:'-' }} ({{ uY }})
+                {% if vZ %}
+                    x {{ vZ|default:'-' }} ({{ uZ }})
                 {% endif %}
             </span>
+            {% endif %}
         </td>
             {% endwith %}
         {% endwith %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -45,25 +45,25 @@
         <th>Pixels Size (XYZ){% if uX == uY and uX == uZ %} ({{ uX }}){% endif %}:</th>
         <td id='pixels_size'>
             <div class='tooltip'>
-                {% if vX or vY %}
+                {% if vX or vY or vZ %}
                     {{ vX|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
                     x {{ vY|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
                     {% if vZ %}
                         x {{ vZ|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
                     {% endif %}
-                {% else %}
-                not available
-                {% endif %}
+                {% else %}-{% endif %}
             </div>
-            {% if vX or vY %}
             <span class="tooltip_html" style='display:none'>
-                {{ vX|default:'-' }} ({{ uX }})
-                x {{ vY|default:'-' }} ({{ uY }})
-                {% if vZ %}
-                    x {{ vZ|default:'-' }} ({{ uZ }})
+                {% if vX or vY or vZ %}
+                    {{ vX|default:'-' }} ({{ uX }})
+                    x {{ vY|default:'-' }} ({{ uY }})
+                    {% if vZ %}
+                        x {{ vZ|default:'-' }} ({{ uZ }})
+                    {% endif %}
+                {% else %}
+                Physical pixel sizes not available
                 {% endif %}
             </span>
-            {% endif %}
         </td>
             {% endwith %}
         {% endwith %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2440,7 +2440,7 @@ class ImageWrapper (OmeroWebObjectWrapper,
         convert to more appropriate units & value
         """
         if size is None:
-            return (0, "µm")
+            return (None, "µm")
         length = size.getValue()
         unit = size.getUnit()
         if unit == "MICROMETER":


### PR DESCRIPTION
# What this PR does

Fixes invalid value displayed when PhysicalPixelSize is not set
https://trello.com/c/vQ6uJKoJ/24-pixel-sizes-in-idr0009-are-all-0

# Testing this PR

1. check images with or without Pixel sizes
