### PR TITLE
display PhysicalPixelSize value only if set (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -46,8 +46,19 @@
         <td id='pixels_size'>
             <div class='tooltip'>
                 {% if vX or vY or vZ %}
-                    {{ vX|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
-                    x {{ vY|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
+                    {% with vXd=vX|floatformat:2|default:'-' %}
+                        {{ vXd }}
+                        {% if uX != uY or uX != uZ %}
+                            {% if vXd != '-' %} ({{ uX }}) {% endif %}
+                        {% endif %}
+                    {% endwith %}
+                    x 
+                    {% with vYd=vY|floatformat:2|default:'-' %}
+                        {{ vYd }}
+                        {% if uX != uY or uX != uZ %}
+                            {% if vYd != '-' %} ({{ uY }}) {% endif %}
+                        {% endif %}
+                    {% endwith %}
                     {% if vZ %}
                         x {{ vZ|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
                     {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -46,44 +46,16 @@
         <td id='pixels_size'>
             <div class='tooltip'>
                 {% if vX or vY or vZ %}
-                    {% with vXd=vX|floatformat:2|default:'-' %}
-                        {{ vXd }}
-                        {% if uX != uY or uX != uZ %}
-                            {% if vXd != '-' %} ({{ uX }}) {% endif %}
-                        {% endif %}
-                    {% endwith %}
-                    x 
-                    {% with vYd=vY|floatformat:2|default:'-' %}
-                        {{ vYd }}
-                        {% if uX != uY or uX != uZ %}
-                            {% if vYd != '-' %} ({{ uY }}) {% endif %}
-                        {% endif %}
-                    {% endwith %}
-                    x 
-                    {% with vZd=vZ|floatformat:2|default:'-' %}
-                        {{ vZd }}
-                        {% if uX != uY or uX != uZ %}
-                            {% if vZd != '-' %} ({{ uZ }}) {% endif %}
-                        {% endif %}
-                    {% endwith %}
+                    {{ vX|floatformat:2|default:'-' }} {% if vX %}{% if uX != uY or uX != uZ %}({{ uX }}){% endif %}{% endif %}
+                    x {{ vY|floatformat:2|default:'-' }} {% if vY %}{% if uX != uY or uX != uZ %}({{ uY }}){% endif %}{% endif %}
+                    x {{ vZ|floatformat:2|default:'-' }} {% if vZ %}{% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}{% endif %}
                 {% else %}-{% endif %}
             </div>
             <span class="tooltip_html" style='display:none'>
                 {% if vX or vY or vZ %}
-                    {% with vXd=vX|default:'-' %}
-                        {{ vXd }}
-                        {% if vXd != '-' %} ({{ uX }}) {% endif %}
-                    {% endwith %}
-                    x
-                    {% with vYd=vY|default:'-' %}
-                        {{ vYd }}
-                        {% if vYd != '-' %} ({{ uY }}) {% endif %}
-                    {% endwith %}
-                    x
-                    {% with vZd=vZ|default:'-' %}
-                        {{ vZd }}
-                        {% if vZd != '-' %} ({{ uZ }}) {% endif %}
-                    {% endwith %}
+                    {{ vX|default:'-' }} {% if vX %}({{ uX }}){% endif %}
+                    x {{ vY|default:'-' }} {% if vY %}({{ uY }}){% endif %}
+                    x {{ vZ|default:'-' }} {% if vZ %}({{ uZ }}){% endif %}
                 {% else %}
                 Physical pixel sizes not available
                 {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -41,23 +41,29 @@
     </tr>
     <tr>
         {% with psX=image.getPixelSizeXWithUnits psY=image.getPixelSizeYWithUnits psZ=image.getPixelSizeZWithUnits %}
-            {% with uX=psX.1 uY=psY.1 uZ=psZ.1 %}
+            {% with vX=psX.0 vY=psY.0 vZ=psZ.0 uX=psX.1 uY=psY.1 uZ=psZ.1 %}
         <th>Pixels Size (XYZ){% if uX == uY and uX == uZ %} ({{ uX }}){% endif %}:</th>
         <td id='pixels_size'>
             <div class='tooltip'>
-                {{ psX.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
-                x {{ psY.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
-                {% if psZ.0 %}
-                    x {{ psZ.0|floatformat:2 }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
+                {% if vX or vY %}
+                    {{ vX|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
+                    x {{ vY|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
+                    {% if vZ %}
+                        x {{ vZ|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
+                    {% endif %}
+                {% else %}
+                not available
                 {% endif %}
             </div>
+            {% if vX or vY %}
             <span class="tooltip_html" style='display:none'>
-                {{ psX.0 }} ({{ uX }})
-                x {{ psY.0 }} ({{ uY }})
-                {% if psZ.0 %}
-                    x {{ psZ.0 }} ({{ uZ }})
+                {{ vX|default:'-' }} ({{ uX }})
+                x {{ vY|default:'-' }} ({{ uY }})
+                {% if vZ %}
+                    x {{ vZ|default:'-' }} ({{ uZ }})
                 {% endif %}
             </span>
+            {% endif %}
         </td>
             {% endwith %}
         {% endwith %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -66,8 +66,15 @@
             </div>
             <span class="tooltip_html" style='display:none'>
                 {% if vX or vY or vZ %}
-                    {{ vX|default:'-' }} ({{ uX }})
-                    x {{ vY|default:'-' }} ({{ uY }})
+                    {% with vXd=vX|default:'-' %}
+                        {{ vXd }}
+                        {% if vXd != '-' %} ({{ uX }}) {% endif %}
+                    {% endwith %}
+                    x
+                    {% with vYd=vY|default:'-' %}
+                        {{ vYd }}
+                        {% if vYd != '-' %} ({{ uY }}) {% endif %}
+                    {% endwith %}
                     {% if vZ %}
                         x {{ vZ|default:'-' }} ({{ uZ }})
                     {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -59,9 +59,13 @@
                             {% if vYd != '-' %} ({{ uY }}) {% endif %}
                         {% endif %}
                     {% endwith %}
-                    {% if vZ %}
-                        x {{ vZ|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
-                    {% endif %}
+                    x 
+                    {% with vZd=vZ|floatformat:2|default:'-' %}
+                        {{ vZd }}
+                        {% if uX != uY or uX != uZ %}
+                            {% if vZd != '-' %} ({{ uZ }}) {% endif %}
+                        {% endif %}
+                    {% endwith %}
                 {% else %}-{% endif %}
             </div>
             <span class="tooltip_html" style='display:none'>
@@ -75,9 +79,11 @@
                         {{ vYd }}
                         {% if vYd != '-' %} ({{ uY }}) {% endif %}
                     {% endwith %}
-                    {% if vZ %}
-                        x {{ vZ|default:'-' }} ({{ uZ }})
-                    {% endif %}
+                    x
+                    {% with vZd=vZ|default:'-' %}
+                        {{ vZd }}
+                        {% if vZd != '-' %} ({{ uZ }}) {% endif %}
+                    {% endwith %}
                 {% else %}
                 Physical pixel sizes not available
                 {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/core_metadata.html
@@ -45,25 +45,25 @@
         <th>Pixels Size (XYZ){% if uX == uY and uX == uZ %} ({{ uX }}){% endif %}:</th>
         <td id='pixels_size'>
             <div class='tooltip'>
-                {% if vX or vY %}
+                {% if vX or vY or vZ %}
                     {{ vX|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uX }}){% endif %}
                     x {{ vY|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uY }}){% endif %}
                     {% if vZ %}
                         x {{ vZ|floatformat:2|default:'-' }} {% if uX != uY or uX != uZ %}({{ uZ }}){% endif %}
                     {% endif %}
-                {% else %}
-                not available
-                {% endif %}
+                {% else %}-{% endif %}
             </div>
-            {% if vX or vY %}
             <span class="tooltip_html" style='display:none'>
-                {{ vX|default:'-' }} ({{ uX }})
-                x {{ vY|default:'-' }} ({{ uY }})
-                {% if vZ %}
-                    x {{ vZ|default:'-' }} ({{ uZ }})
+                {% if vX or vY or vZ %}
+                    {{ vX|default:'-' }} ({{ uX }})
+                    x {{ vY|default:'-' }} ({{ uY }})
+                    {% if vZ %}
+                        x {{ vZ|default:'-' }} ({{ uZ }})
+                    {% endif %}
+                {% else %}
+                Physical pixel sizes not available
                 {% endif %}
             </span>
-            {% endif %}
         </td>
             {% endwith %}
         {% endwith %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2440,7 +2440,7 @@ class ImageWrapper (OmeroWebObjectWrapper,
         convert to more appropriate units & value
         """
         if size is None:
-            return (0, "µm")
+            return (None, "µm")
         length = size.getValue()
         unit = size.getUnit()
         if unit == "MICROMETER":


### PR DESCRIPTION
This is the same as gh-5007 but rebased onto develop.

----

# What this PR does

Fixes invalid value displayed when PhysicalPixelSize is not set
https://trello.com/c/vQ6uJKoJ/24-pixel-sizes-in-idr0009-are-all-0

# Testing this PR

1. check images with or without Pixel sizes

cc @will-moore 
