### PR TITLE
Bugfix: Save rendering settings

### DIFF
--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -17,6 +17,7 @@ USER_NAME=${USER_NAME:-robot_user}-$now
 USER_PASSWORD=${USER_PASSWORD:-ome}
 CONFIG_FILENAME=${CONFIG_FILENAME:-robot_ice.config}
 IMAGE_NAME=${IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00&sizeZ=3&sizeT=10.fake}
+MULTI_C_IMAGE_NAME=${MULTI_C_IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00&sizeC=3&sizeZ=3&sizeT=10.fake}
 TINY_IMAGE_NAME=${TINY_IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00.fake}
 MIF_IMAGE_NAME=${MIF_IMAGE_NAME:-test&series=3.fake}
 PLATE_NAME=${PLATE_NAME:-test&plates=1&plateAcqs=2&plateRows=2&plateCols=3&fields=5&screens=0.fake}
@@ -34,6 +35,7 @@ bin/omero logout
 
 # Create fake files
 touch $IMAGE_NAME
+touch $MULTI_C_IMAGE_NAME
 touch $TINY_IMAGE_NAME
 touch $PLATE_NAME
 touch $TINY_PLATE_NAME
@@ -87,6 +89,13 @@ mifDs=$(bin/omero obj new Dataset name='MIF Images')
 for (( k=1; k<=2; k++ ))
 do
   bin/omero import -d $mifDs $MIF_IMAGE_NAME --debug ERROR
+done
+
+# Create Dataset with multi channel images
+mcDs=$(bin/omero obj new Dataset name='MultiChannel Images')
+for (( k=1; k<=2; k++ ))
+do
+  bin/omero import -d $mcDs $MULTI_C_IMAGE_NAME --debug ERROR
 done
 
 # Import Plate and rename

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -96,63 +96,6 @@ Right Click Rendering Settings
 
 *** Test Cases ***
 
-Test Rdef Save
-    [Documentation]     Tests saving rendering settings, including inactive channels
-
-    Select Experimenter
-
-    Select And Expand Node              nodeText=${multic_dataset} 
-    ${imageId}=                         Select First Image
-
-    Click Link                          Preview
-    ${status}    ${oldId}               Wait For Preview Load       FAIL      '1'
-
-    # Undo, Redo & Save should be disabled
-    Element Should Be Disabled          id=rdef-undo-btn
-    Element Should Be Disabled          id=rdef-redo-btn
-    Element Should Be Disabled          id=rdef-setdef-btn
-
-    Edit Channel End                    0   50
-
-    # Undo & Save should be enabled now
-    Element Should Be Enabled           id=rdef-undo-btn
-    Element Should Be Enabled           id=rdef-setdef-btn
-
-    # Deactivate second and third channel
-    Toggle Channel Active               1
-    Toggle Channel Active               2
-
-    Edit Channel End                    1   50
-    Edit Channel End                    2   50
-
-    # Save rendering settings
-    ${thumbSrc}=                        Get Element Attribute      xpath=//button[@class="rdef clicked"]/img@src
-    Click Element                       id=rdef-setdef-btn
-    # Wait for response
-    Wait For BlockUI
-    Wait Until Page Contains Element    xpath=//button[@class="rdef clicked"]/img[@src!='${thumbSrc}']
-
-    # Check that 'Save' has worked by switching to the dataset and back again to the image
-    Select And Expand Node              nodeText=${multic_dataset}
-    Click Link                          General
-    Wait Until Element Is Visible       xpath=//div[@id="general_tab"]
-    Select Image By Id                  ${imageId}
-    Click Link                          Preview
-    ${status}    ${oldId}               Wait For Preview Load       FAIL      '1'
-
-    # Check that all values have been saved, including deactivated channels
-    Textfield Value Should Be           wblitz-ch0-cw-end           50
-    Textfield Value Should Be           wblitz-ch1-cw-end           50
-    Textfield Value Should Be           wblitz-ch2-cw-end           50
-    Channel Should Be Active            0
-    Channel Should Not Be Active        1
-    Channel Should Not Be Active        2
-
-    # Reset rendering settings again
-    Click Element                       id=rdef-reset-btn
-    Wait Until Element Is Enabled       id=rdef-setdef-btn
-    Click Element                       id=rdef-setdef-btn
-
 Test Rdef Copy Paste Save
     [Documentation]     Tests Copy and Paste rdef, then Save and 'Save All'
 
@@ -375,3 +318,62 @@ Test Owners Rdef
     Wait Until Page Contains Element        id=wblitz-ch0
     Click Link                              Edit
     Textfield Value Should Be               wblitz-ch0-cw-end    200
+
+
+Test Rdef Save
+    [Documentation]     Tests saving rendering settings, including inactive channels
+    
+    Go To                                   ${WELCOME URL}
+    Select Experimenter
+
+    Select And Expand Node              nodeText=${multic_dataset} 
+    ${imageId}=                         Select First Image
+
+    Click Link                          Preview
+    ${status}    ${oldId}               Wait For Preview Load       FAIL      '1'
+
+    # Undo, Redo & Save should be disabled
+    Element Should Be Disabled          id=rdef-undo-btn
+    Element Should Be Disabled          id=rdef-redo-btn
+    Element Should Be Disabled          id=rdef-setdef-btn
+
+    Edit Channel End                    0   50
+
+    # Undo & Save should be enabled now
+    Element Should Be Enabled           id=rdef-undo-btn
+    Element Should Be Enabled           id=rdef-setdef-btn
+
+    # Deactivate second and third channel
+    Toggle Channel Active               1
+    Toggle Channel Active               2
+
+    Edit Channel End                    1   50
+    Edit Channel End                    2   50
+
+    # Save rendering settings
+    ${thumbSrc}=                        Get Element Attribute      xpath=//button[@class="rdef clicked"]/img@src
+    Click Element                       id=rdef-setdef-btn
+    # Wait for response
+    Wait For BlockUI
+    Wait Until Page Contains Element    xpath=//button[@class="rdef clicked"]/img[@src!='${thumbSrc}']
+
+    # Check that 'Save' has worked by switching to the dataset and back again to the image
+    Select And Expand Node              nodeText=${multic_dataset}
+    Click Link                          General
+    Wait Until Element Is Visible       xpath=//div[@id="general_tab"]
+    Select Image By Id                  ${imageId}
+    Click Link                          Preview
+    ${status}    ${oldId}               Wait For Preview Load       FAIL      '1'
+
+    # Check that all values have been saved, including deactivated channels
+    Textfield Value Should Be           wblitz-ch0-cw-end           50
+    Textfield Value Should Be           wblitz-ch1-cw-end           50
+    Textfield Value Should Be           wblitz-ch2-cw-end           50
+    Channel Should Be Active            0
+    Channel Should Not Be Active        1
+    Channel Should Not Be Active        2
+
+    # Reset rendering settings again
+    Click Element                       id=rdef-reset-btn
+    Wait Until Element Is Enabled       id=rdef-setdef-btn
+    Click Element                       id=rdef-setdef-btn

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -132,11 +132,13 @@ Test Rdef Save
     Wait For BlockUI
     Wait Until Page Contains Element    xpath=//button[@class="rdef clicked"]/img[@src!='${thumbSrc}']
 
-    # Check that 'Save' has worked by switching to other image and back
-    Click Next Thumbnail
-    Wait For BlockUI
+    # Check that 'Save' has worked by switching to the dataset and back again to the image
+    Select And Expand Node              nodeText=${multic_dataset}
+    Click Link                          General
+    Wait Until Element Is Visible       xpath=//div[@id="general_tab"]
     Select Image By Id                  ${imageId}
-    Wait For BlockUI
+    Click Link                          Preview
+    ${status}    ${oldId}               Wait For Preview Load       FAIL      '1'
 
     # Check that all values have been saved, including deactivated channels
     Textfield Value Should Be           wblitz-ch0-cw-end           50
@@ -148,10 +150,8 @@ Test Rdef Save
 
     # Reset rendering settings again
     Click Element                       id=rdef-reset-btn
-    Wait For BlockUI
+    Wait Until Element Is Enabled       id=rdef-setdef-btn
     Click Element                       id=rdef-setdef-btn
-    Wait For BlockUI
-
 
 Test Rdef Copy Paste Save
     [Documentation]     Tests Copy and Paste rdef, then Save and 'Save All'
@@ -316,7 +316,7 @@ Test Owners Rdef
     Pick Color                              FFFFFF
     Click Element                           xpath=//button[@id='rdef-copy-btn']
     Wait For Toolbar Button Enabled         rdef-paste-btn
-    
+
     # Test 'Paste and Save' with right-click on different Image in tree
     # (check thumb refresh by change of src)
     ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/a/img@src

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -15,8 +15,30 @@ ${importedMax}                      255
 ${sizeZ}                            3
 ${defaultZ}                         2
 ${currZ}                            3
+${multic_dataset}                   MultiChannel Images
 
 *** Keywords ***
+
+Edit Channel End
+    [Arguments]                             ${index}    ${value}
+    Click Element                           xpath=//input[@id="wblitz-ch${index}-cw-end"]
+    Input Text                              wblitz-ch${index}-cw-end    ${value}
+    # Switch focus to other element to trigger a 'focus lost' event
+    Click Element                           xpath=//input[@id="wblitz-ch0-cw-start"]
+
+Toggle Channel Active
+    [Arguments]                             ${index}
+    Click Element                           xpath=//button[@id="rd-wblitz-ch${index}"]
+
+Channel Should Be Active
+    [Arguments]                             ${index}
+    ${style}=                               Get Element Attribute       xpath=//button[@id="rd-wblitz-ch${index}"]@class
+    Should Contain                          ${style}                    pressed
+
+Channel Should Not Be Active
+    [Arguments]                             ${index}
+    ${style}=                               Get Element Attribute       xpath=//button[@id="rd-wblitz-ch${index}"]@class
+    Should Not Contain                      ${style}                    pressed
 
 Pick Color
     [Arguments]                             ${hexColor}
@@ -74,9 +96,67 @@ Right Click Rendering Settings
 
 *** Test Cases ***
 
+Test Rdef Save
+    [Documentation]     Tests saving rendering settings, including inactive channels
+
+    Select Experimenter
+
+    Select And Expand Node              nodeText=${multic_dataset} 
+    ${imageId}=                         Select First Image
+
+    Click Link                          Preview
+    ${status}    ${oldId}               Wait For Preview Load       FAIL      '1'
+
+    # Undo, Redo & Save should be disabled
+    Element Should Be Disabled          id=rdef-undo-btn
+    Element Should Be Disabled          id=rdef-redo-btn
+    Element Should Be Disabled          id=rdef-setdef-btn
+
+    Edit Channel End                    0   50
+
+    # Undo & Save should be enabled now
+    Element Should Be Enabled           id=rdef-undo-btn
+    Element Should Be Enabled           id=rdef-setdef-btn
+
+    # Deactivate second and third channel
+    Toggle Channel Active               1
+    Toggle Channel Active               2
+
+    Edit Channel End                    1   50
+    Edit Channel End                    2   50
+
+    # Save rendering settings
+    ${thumbSrc}=                        Get Element Attribute      xpath=//button[@class="rdef clicked"]/img@src
+    Click Element                       id=rdef-setdef-btn
+    # Wait for response
+    Wait For BlockUI
+    Wait Until Page Contains Element    xpath=//button[@class="rdef clicked"]/img[@src!='${thumbSrc}']
+
+    # Check that 'Save' has worked by switching to other image and back
+    Click Next Thumbnail
+    Wait For BlockUI
+    Select Image By Id                  ${imageId}
+    Wait For BlockUI
+
+    # Check that all values have been saved, including deactivated channels
+    Textfield Value Should Be           wblitz-ch0-cw-end           50
+    Textfield Value Should Be           wblitz-ch1-cw-end           50
+    Textfield Value Should Be           wblitz-ch2-cw-end           50
+    Channel Should Be Active            0
+    Channel Should Not Be Active        1
+    Channel Should Not Be Active        2
+
+    # Reset rendering settings again
+    Click Element                       id=rdef-reset-btn
+    Wait For BlockUI
+    Click Element                       id=rdef-setdef-btn
+    Wait For BlockUI
+
+
 Test Rdef Copy Paste Save
     [Documentation]     Tests Copy and Paste rdef, then Save and 'Save All'
 
+    Go To                                   ${WELCOME URL}
     Select Experimenter
 
     Select First Project With Children

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -458,11 +458,18 @@
                 applyRDCW(viewport);
             };
         };
+
         var keyup_cb = function() {
             return function(event){
                 if (event.keyCode === 13){
                     applyRDCW(viewport);
                 }
+            };
+        };
+
+        var focusout_cb = function() {
+            return function(event){
+                applyRDCW(viewport);
             };
         };
 
@@ -516,8 +523,10 @@
             init_ch_slider(i, channels);
             $('#wblitz-ch'+i+'-cw-start').val(channels[i].window.start).unbind('change').bind('change', start_cb(i));
             $('#wblitz-ch'+i+'-cw-start').keyup(keyup_cb());
+            $('#wblitz-ch'+i+'-cw-start').focusout(focusout_cb());
             $('#wblitz-ch'+i+'-cw-end').val(channels[i].window.end).unbind('change').bind('change', end_cb(i));
             $('#wblitz-ch'+i+'-cw-end').keyup(keyup_cb());
+            $('#wblitz-ch'+i+'-cw-end').focusout(focusout_cb());
         }
 
         // bind clicking on channel checkboxes

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -522,11 +522,9 @@
             $('#wblitz-ch'+(i)+'-cw').append('<td width="10%"><span class="min" title="min: ' + channels[i].window.min + '"><input type="text" id="wblitz-ch' + i + '-cw-start" /></span></td><td><div class="rangeslider" id="wblitz-ch' + i + '-cwslider"></div></td> <td width="10%"><span class="max" title="max: ' + channels[i].window.max + '"><input type="text" id="wblitz-ch' + i + '-cw-end" /></span></td>');
             init_ch_slider(i, channels);
             $('#wblitz-ch'+i+'-cw-start').val(channels[i].window.start).unbind('change').bind('change', start_cb(i));
-            $('#wblitz-ch'+i+'-cw-start').keyup(keyup_cb());
-            $('#wblitz-ch'+i+'-cw-start').focusout(focusout_cb());
+            $('#wblitz-ch'+i+'-cw-start').keyup(keyup_cb()).focusout(focusout_cb());
             $('#wblitz-ch'+i+'-cw-end').val(channels[i].window.end).unbind('change').bind('change', end_cb(i));
-            $('#wblitz-ch'+i+'-cw-end').keyup(keyup_cb());
-            $('#wblitz-ch'+i+'-cw-end').focusout(focusout_cb());
+            $('#wblitz-ch'+i+'-cw-end').keyup(keyup_cb()).focusout(focusout_cb());
         }
 
         // bind clicking on channel checkboxes

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -774,8 +774,16 @@ def _get_prepared_image(request, iid, server_id=None, conn=None,
         return
     if 'c' in r:
         logger.debug("c="+r['c'])
-        channels, windows, colors, reverses = _split_channel_info(r['c'])
-        if not img.setActiveChannels(channels, windows, colors, reverses):
+        activechannels, windows, colors, reverses = _split_channel_info(r['c'])
+        allchannels = []
+        for ch in activechannels:
+            allchannels.append(abs(int(ch)))
+        # First save properties of all channels
+        if not img.setActiveChannels(allchannels, windows, colors, reverses):
+            logger.debug(
+                "Something bad happened while setting the active channels...")
+        # Save the active/inactive state of the channels
+        if not img.setActiveChannels(activechannels):
             logger.debug(
                 "Something bad happened while setting the active channels...")
     if r.get('m', None) == 'g':

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -779,11 +779,11 @@ def _get_prepared_image(request, iid, server_id=None, conn=None,
         for ch in activechannels:
             allchannels.append(abs(int(ch)))
         # First save properties of all channels
-        if not img.setActiveChannels(allchannels, windows, colors, reverses):
+        if saveDefs and not img.setActiveChannels(allchannels, windows, colors, reverses):
             logger.debug(
                 "Something bad happened while setting the active channels...")
         # Save the active/inactive state of the channels
-        if not img.setActiveChannels(activechannels):
+        if not img.setActiveChannels(activechannels, windows, colors, reverses):
             logger.debug(
                 "Something bad happened while setting the active channels...")
     if r.get('m', None) == 'g':

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -779,11 +779,13 @@ def _get_prepared_image(request, iid, server_id=None, conn=None,
         for ch in activechannels:
             allchannels.append(abs(int(ch)))
         # First save properties of all channels
-        if saveDefs and not img.setActiveChannels(allchannels, windows, colors, reverses):
+        if saveDefs and not img.setActiveChannels(allchannels, windows,
+                                                  colors, reverses):
             logger.debug(
                 "Something bad happened while setting the active channels...")
         # Save the active/inactive state of the channels
-        if not img.setActiveChannels(activechannels, windows, colors, reverses):
+        if not img.setActiveChannels(activechannels, windows, colors,
+                                     reverses):
             logger.debug(
                 "Something bad happened while setting the active channels...")
     if r.get('m', None) == 'g':


### PR DESCRIPTION
# What this PR does

Fixes two bugs with respect to saving rendering settings:
- The up/down buttons mentioned on the Trello card [web rendering details up/down buttons don't enable the save icon](https://trello.com/c/DFN0mRSf/135-web-rendering-details-up-down-buttons-don-t-enable-the-save-icon) don't exist any more, but there was still a similar issue: Changing the value in the text field and then moving the cursor somewhere else (without hitting the enter key), didn't update the preview image, respectively the save button. With this PR the preview image and save button also gets updated in these cases (ie. on focus loss of the text field).
- If an inactive channel's start and/or end value was changed, this change didn't get saved, see [Trello -  Critical: channel color change is not saved for inactive channels](https://trello.com/c/p5ujlK67/559-critical-channel-color-change-is-not-saved-for-inactive-channels)

# Testing this PR

- Change a channel's start and/or end value via the text field. Make sure the save button is enabled when the cursor is removed from the text field.
- Change an **inactive** channel's start and/or end value. Save the rendering settings. Make sure the settings really have been saved.
- Check that robot test 'Test Rdef Save' passes

# Related reading

- [Trello - web rendering details up/down buttons don't enable the save icon](https://trello.com/c/DFN0mRSf/135-web-rendering-details-up-down-buttons-don-t-enable-the-save-icon) 
- [Trello -  Critical: channel color change is not saved for inactive channels](https://trello.com/c/p5ujlK67/559-critical-channel-color-change-is-not-saved-for-inactive-channels)

/cc @will-moore 
