### PR TITLE
Channel slider background

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -197,7 +197,7 @@
             $('#wblitz-ch' + i).css('background-color', '#' + color)
                 .find('.lutBackground').css('background-position', lutBgPos);
             // Slider background
-            $('#wblitz-ch'+i+'-cwslider').addClass('lutBackground')
+            $('#wblitz-ch'+i+'-cwslider').find('.ui-slider-range').addClass('lutBackground')
                 .css({'background-position': lutBgPos, 'background-color': '#' + color});
             // Channel button beside slider
             $('#rd-wblitz-ch'+i)


### PR DESCRIPTION
# What this PR does

Same as #4919 just for Omero.Web; draw channel slider background lut/color only within the silder knobs.

# Testing this PR

See above.

# Related reading

[Trello - LUT Follow-up](https://trello.com/c/h8OylVrf/209-lut-follow-up)

Thanks @will-moore for pointing out how to do that.
