### PR TITLE
Allow non digits

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -1,5 +1,6 @@
 {% extends "webgateway/base/container3.html" %}
 {% load i18n %}
+{% load common_filters %}
 
 
 {% comment %}
@@ -178,7 +179,7 @@
         WEBCLIENT.URLS.reset_rdef_json = "{% url 'reset_rdef_json' %}";
         // jsTree code in ome.tree.js and center panel code in center_plugin.thumbs.js.html uses initially_select
         // instead of browser URL since URL may be /webclient/?path=plate.name-barcode|well.name-A1
-        WEBCLIENT.initially_select = [{% for o in initially_select %}"{{ o }}"{% if not forloop.last %},{% endif %}{% endfor %}];
+        WEBCLIENT.initially_select = {{ initially_select|json_dumps|safe }};
 
         {% ifequal menu 'usertags' %}
             WEBCLIENT.TAG_TREE = true;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -274,3 +274,9 @@ def timeformat(value):
         value = round(value)        # Avoids '1h 60min'
         return u'%d\u00A0h\u00A0%d\u00A0min' % (value / 3600,
                                                 round((value % 3600)/60))
+
+
+# taken from https://code.djangoproject.com/ticket/17419
+@register.filter
+def json_dumps(value):
+    return json.dumps(value)


### PR DESCRIPTION
# What this PR does

This PR clean up console.logs and allow non digits to be passed as initially selected tree elements. see https://github.com/ome/omero-mapr/pull/12

