### PR TITLE
Bio-Formats 5.3 fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -73,7 +73,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
         </then></if>
         <installIvy/>
         <ivy:buildlist reference="all.buildpath" settingsRef="ivy.toplevel">
-            <fileset dir="${omero.home}/components" includes="*/build.xml" excludes="**/tools/**, **/tests/**, **/bioformats/**"/>
+            <fileset dir="${omero.home}/components" includes="*/build.xml" excludes="**/tools/**, **/tests/**"/>
         </ivy:buildlist>
         <ivy:buildlist reference="blitzserver.buildpath" settingsRef="ivy.toplevel">
             <fileset dir="${omero.home}/components/blitz/" includes="build.xml"/>
@@ -315,7 +315,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
 
     <macrodef name="launchSuite">
         <attribute name="suite"/>
-        <attribute name="excludes" default="**/tools/build.xml,**/tests/build.xml,**/bioformats/**"/>
+        <attribute name="excludes" default="**/tools/build.xml,**/tests/build.xml"/>
         <sequential>
         <ivy:settings id="ivy.@{suite}"  file="${etc.dir}/ivysettings.xml"/>
         <ivy:buildlist reference="@{suite}.buildpath" settingsRef="ivy.@{suite}" ivyfilepath="test.xml">

--- a/build.xml
+++ b/build.xml
@@ -658,7 +658,7 @@ To get started using Eclipse, execute "./build.py build-dev" and import the top-
                 <link href="http://docs.oracle.com/javase/8/docs/api/"/>
                 <link href="http://docs.spring.io/spring/docs/${versions.spring}/api/"/>
                 <link href="http://aopalliance.sourceforge.net/doc/"/>
-                <link href="http://downloads.openmicroscopy.org/bio-formats/5.1.7/api/"/>
+                <link href="http://downloads.openmicroscopy.org/bio-formats/${versions.bioformats}/api/"/>
 
             </javadoc>
         </presetdef>

--- a/components/insight/build/app.xml
+++ b/components/insight/build/app.xml
@@ -53,7 +53,7 @@
     <include name="**/*.java"/>
   </patternset>
   <fileset id="app.libs" dir="${base.runtimelib.dir}" includes="*.jar"/>
-  <fileset id="app.libs.no-bioformats-no-logback" dir="${base.runtimelib.dir}" includes="*.jar" excludes="formats-api.jar,formats-bsd.jar,formats-common.jar,formats-gpl.jar,jai_imageio.jar,mdbtools-java.jar,metakit.jar,ome-xml.jar,ome-poi.jar,turbojpeg.jar, logback-classic.jar,logback-core.jar"/>
+  <fileset id="app.libs.no-bioformats-no-logback" dir="${base.runtimelib.dir}" includes="*.jar" excludes="formats-api.jar,formats-bsd.jar,formats-gpl.jar,jai_imageio.jar,jxrlib-all.jar,metakit.jar,ome-common.jar,ome-mdbtools.jar,ome-poi.jar,ome-xml.jar,specification.jar,turbojpeg.jar,logback-classic.jar,logback-core.jar"/>
   <fileset id="app.resources" dir="${base.src.dir}" excludes="**/*.java"/>
   <fileset id="app.config" dir="${base.config.dir}"/>
   <path id="app.compile.classpath">


### PR DESCRIPTION
### What this PR does

Cleans up a few places noticed while initiating the work on the next following breaking series of OMERO:

- removes obsolete `bioformats` regexp exclusion in `build.xml` - invalid since OMERO 5.1.3 where the Bio-Formats submodule got removed
- updates the Javadoc API links to use the Bio-Formats version specified in `omero.properties`
- updates the manual exclusion list for the OMERO.insight-ij plugin following the components re-architecture in Bio-Formats 5.3.0

### Testing this PR

Check all builds and integration tests are green with this set of changes.

For the OMERO.insight-ij plugin, unzip the bundle and make sure the `libs` folder does not contain any JAR that would conflict with the content of `/path/to/Fiji.app/jars/bio-formats`

For the Javadoc review, open the CI Javadoc pages for classes inheriting from Bio-Formats e.g. [ome.formats.OMEROMetadataStoreClient](https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-build/ICE=3.6,jdk=8_LATEST,label=octopus/javadoc/ome/formats/OMEROMetadataStoreClient.html) and check the links point to the correct version of the Bio-Formats API.