### PR TITLE
Api list datasets screens

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -291,7 +291,7 @@ class BlitzObjectWrapper (object):
         """
         extra_select = ""
         child_count = False
-        if opts is not None and 'child_count' in opts:
+        if opts is not None and opts.get('child_count'):
             child_count = opts['child_count']
         if child_count and cls.LINK_CLASS is not None:
             extra_select = """, (select count(id) from %s chl
@@ -5701,7 +5701,7 @@ class _DatasetWrapper (BlitzObjectWrapper):
             query += ' join obj.projectLinks plink'
             clauses.append('plink.parent.id = :pid')
             params.add('pid', rlong(opts['project']))
-        if opts is not None and 'orphaned' in opts and opts['orphaned']:
+        if opts is not None and opts.get('orphaned'):
             clauses.append(
                 """
                 not exists (
@@ -5968,7 +5968,7 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         Also handles filtering of Plates by Screens.
         Returns a tuple of (query, clauses, params).
-        Supported opts: 'plate': <screen_id> to filter by Screen
+        Supported opts: 'screen': <screen_id> to filter by Screen
                         'orphaned': <bool>. Filter by 'not in Screen'
 
         :param opts:        Dictionary of optional parameters.
@@ -5986,7 +5986,7 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if opts is not None and 'screen' in opts:
             clauses.append('spl.parent.id = :sid')
             params.add('sid', rlong(opts['screen']))
-        if opts is not None and 'orphaned' in opts and opts['orphaned']:
+        if opts is not None and opts.get('orphaned'):
             clauses.append(
                 """
                 not exists (

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5984,8 +5984,7 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         clauses = []
         params = omero.sys.ParametersI()
         if opts is not None and 'screen' in opts:
-            query += ' join obj.screenLinks slink'
-            clauses.append('slink.parent.id = :sid')
+            clauses.append('spl.parent.id = :sid')
             params.add('sid', rlong(opts['screen']))
         if opts is not None and 'orphaned' in opts and opts['orphaned']:
             clauses.append(

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5684,6 +5684,7 @@ class _DatasetWrapper (BlitzObjectWrapper):
         Extend base query to handle filtering of Datasets by Projects.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'project': <project_id> to filter by Project
+                        'orphaned': <bool>. Filter by 'not in Project'
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
@@ -5694,6 +5695,15 @@ class _DatasetWrapper (BlitzObjectWrapper):
             query += ' join obj.projectLinks plink'
             clauses.append('plink.parent.id = :pid')
             params.add('pid', rlong(opts['project']))
+        if opts is not None and 'orphaned' in opts and opts['orphaned']:
+            clauses.append(
+                """
+                not exists (
+                    select pdlink from ProjectDatasetLink as pdlink
+                    where pdlink.child = obj.id
+                )
+                """
+            )
         return (query, clauses, params)
 
     def __loadedHotSwap__(self):

--- a/components/tools/OmeroWeb/omeroweb/api/api_query.py
+++ b/components/tools/OmeroWeb/omeroweb/api/api_query.py
@@ -37,6 +37,16 @@ def query_projects(conn, child_count=False,
                          page=page, limit=limit, normalize=normalize)
 
 
+def query_datasets(conn, project=None, child_count=False,
+                   group=None, owner=None,
+                   page=1, limit=settings.PAGE,
+                   normalize=False):
+    """Query OMERO and marshal omero.model.Datasets."""
+    return query_objects(conn, 'Dataset', project=project,
+                         child_count=child_count, group=group, owner=owner,
+                         page=page, limit=limit, normalize=normalize)
+
+
 def query_objects(conn, object_type,
                   project=None,
                   child_count=False,

--- a/components/tools/OmeroWeb/omeroweb/api/api_query.py
+++ b/components/tools/OmeroWeb/omeroweb/api/api_query.py
@@ -58,7 +58,9 @@ def query_objects(conn, object_type,
         for p in result:
             obj = unwrap(p[0])
             objects.append(obj)
-            extras[obj.id.val] = {'omero:childCount': unwrap(p[1])}
+            if len(p) > 1:
+                # in case child_count not supported by conn.buildQuery()
+                extras[obj.id.val] = {'omero:childCount': unwrap(p[1])}
     else:
         extras = None
         result = qs.findAllByQuery(query, params, ctx)

--- a/components/tools/OmeroWeb/omeroweb/api/api_query.py
+++ b/components/tools/OmeroWeb/omeroweb/api/api_query.py
@@ -38,7 +38,9 @@ def query_objects(conn, object_type,
 
     @param conn:        BlitzGateway
     @param object_type: Type to query. E.g. Project
+    @param group:       Filter query by ExperimenterGroup ID
     @param opts:        Options dict for conn.buildQuery()
+    @param normalize:   If true, marshal groups and experimenters separately
     """
     # buildQuery is used by conn.getObjects()
     query, params, wrapper = conn.buildQuery(object_type, opts=opts)
@@ -53,7 +55,7 @@ def query_objects(conn, object_type,
 
     objects = []
     extras = {}
-    if opts is not None and 'child_count' in opts and opts['child_count']:
+    if opts is not None and opts.get('child_count'):
         result = qs.projection(query, params, ctx)
         for p in result:
             obj = unwrap(p[0])

--- a/components/tools/OmeroWeb/omeroweb/api/api_query.py
+++ b/components/tools/OmeroWeb/omeroweb/api/api_query.py
@@ -37,21 +37,12 @@ def query_projects(conn, child_count=False,
                          page=page, limit=limit, normalize=normalize)
 
 
-def query_datasets(conn, project=None, child_count=False,
-                   group=None, owner=None,
-                   page=1, limit=settings.PAGE,
-                   normalize=False):
-    """Query OMERO and marshal omero.model.Datasets."""
-    return query_objects(conn, 'Dataset', project=project,
-                         child_count=child_count, group=group, owner=owner,
-                         page=page, limit=limit, normalize=normalize)
-
-
 def query_objects(conn, object_type,
                   project=None,
                   child_count=False,
                   group=None, owner=None,
                   page=1, limit=settings.PAGE,
+                  orphaned=False,
                   normalize=False):
     """
     Base query method, handles different object_types.
@@ -75,6 +66,8 @@ def query_objects(conn, object_type,
             'order_by': 'name'}
     if object_type == 'Dataset' and project is not None:
         opts['project'] = project
+    if orphaned:
+        opts['orphaned'] = True
 
     # buildQuery is used by conn.getObjects()
     query, params, wrapper = conn.buildQuery(object_type, opts=opts)

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -89,6 +89,14 @@ api_datasets = url(r'^v(?P<api_version>%s)/m/datasets/$' % versions,
 GET all datasets, using omero-marshal to generate json
 """
 
+api_project_datasets = url(
+    r'^v(?P<api_version>%s)/m/projects/(?P<project_id>[0-9]+)/datasets/$' % versions,
+    views.DatasetsView.as_view(),
+    name='api_project_datasets')
+"""
+GET Datasets in Project, using omero-marshal to generate json
+"""
+
 api_dataset = url(
     r'^v(?P<api_version>%s)/m/datasets/(?P<pid>[0-9]+)/$' % versions,
     views.DatasetView.as_view(),
@@ -116,6 +124,7 @@ urlpatterns = patterns(
     api_projects,
     api_project,
     api_datasets,
+    api_project_datasets,
     api_dataset,
     api_screen,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -120,6 +120,21 @@ api_screens = url(r'^v(?P<api_version>%s)/m/screens/$' % versions,
 GET all screens, using omero-marshal to generate json
 """
 
+api_plates = url(r'^v(?P<api_version>%s)/m/plates/$' % versions,
+                   views.PlatesView.as_view(),
+                   name='api_plates')
+"""
+GET all plates, using omero-marshal to generate json
+"""
+
+api_plate = url(
+    r'^v(?P<api_version>%s)/m/plates/(?P<pid>[0-9]+)/$' % versions,
+    views.PlateView.as_view(),
+    name='api_plate')
+"""
+Plate url to GET or DELETE a single Plate
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -135,4 +150,7 @@ urlpatterns = patterns(
     api_dataset,
     api_screen,
     api_screens,
+    api_plates,
+    api_plate,
+
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -134,7 +134,7 @@ api_screen_plates = url(
     views.PlatesView.as_view(),
     name='api_screen_plates')
 """
-GET Datasets in Project, using omero-marshal to generate json
+GET Plates in Screen, using omero-marshal to generate json
 """
 
 api_plate = url(

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -128,6 +128,15 @@ api_plates = url(r'^v(?P<api_version>%s)/m/plates/$' % versions,
 GET all plates, using omero-marshal to generate json
 """
 
+api_screen_plates = url(
+    r'^v(?P<api_version>%s)/m/screens/'
+    '(?P<screen_id>[0-9]+)/plates/$' % versions,
+    views.PlatesView.as_view(),
+    name='api_screen_plates')
+"""
+GET Datasets in Project, using omero-marshal to generate json
+"""
+
 api_plate = url(
     r'^v(?P<api_version>%s)/m/plates/(?P<pid>[0-9]+)/$' % versions,
     views.PlateView.as_view(),
@@ -152,6 +161,7 @@ urlpatterns = patterns(
     api_screen,
     api_screens,
     api_plates,
+    api_screen_plates,
     api_plate,
 
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -82,6 +82,13 @@ api_project = url(
 Project url to GET or DELETE a single Project
 """
 
+api_datasets = url(r'^v(?P<api_version>%s)/m/datasets/$' % versions,
+                   views.DatasetsView.as_view(),
+                   name='api_datasets')
+"""
+GET all datasets, using omero-marshal to generate json
+"""
+
 api_dataset = url(
     r'^v(?P<api_version>%s)/m/datasets/(?P<pid>[0-9]+)/$' % versions,
     views.DatasetView.as_view(),
@@ -108,6 +115,7 @@ urlpatterns = patterns(
     api_save,
     api_projects,
     api_project,
+    api_datasets,
     api_dataset,
     api_screen,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -90,7 +90,8 @@ GET all datasets, using omero-marshal to generate json
 """
 
 api_project_datasets = url(
-    r'^v(?P<api_version>%s)/m/projects/(?P<project_id>[0-9]+)/datasets/$' % versions,
+    r'^v(?P<api_version>%s)/m/projects/'
+    '(?P<project_id>[0-9]+)/datasets/$' % versions,
     views.DatasetsView.as_view(),
     name='api_project_datasets')
 """
@@ -114,15 +115,15 @@ Screen url to GET or DELETE a single Screen
 """
 
 api_screens = url(r'^v(?P<api_version>%s)/m/screens/$' % versions,
-                   views.ScreensView.as_view(),
-                   name='api_screens')
+                  views.ScreensView.as_view(),
+                  name='api_screens')
 """
 GET all screens, using omero-marshal to generate json
 """
 
 api_plates = url(r'^v(?P<api_version>%s)/m/plates/$' % versions,
-                   views.PlatesView.as_view(),
-                   name='api_plates')
+                 views.PlatesView.as_view(),
+                 name='api_plates')
 """
 GET all plates, using omero-marshal to generate json
 """

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -113,6 +113,13 @@ api_screen = url(
 Screen url to GET or DELETE a single Screen
 """
 
+api_screens = url(r'^v(?P<api_version>%s)/m/screens/$' % versions,
+                   views.ScreensView.as_view(),
+                   name='api_screens')
+"""
+GET all screens, using omero-marshal to generate json
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -127,4 +134,5 @@ urlpatterns = patterns(
     api_project_datasets,
     api_dataset,
     api_screen,
+    api_screens,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -79,6 +79,7 @@ def api_base(request, api_version=None, **kwargs):
     rv = {'projects_url': build_url(request, 'api_projects', v),
           'datasets_url': build_url(request, 'api_datasets', v),
           'screens_url': build_url(request, 'api_screens', v),
+          'plates_url': build_url(request, 'api_plates', v),
           'token_url': build_url(request, 'api_token', v),
           'servers_url': build_url(request, 'api_servers', v),
           'login_url': build_url(request, 'api_login', v),

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -28,7 +28,7 @@ from django.conf import settings
 import traceback
 import json
 
-from api_query import query_projects, query_datasets
+from api_query import query_projects, query_objects
 from omero_marshal import get_encoder, get_decoder, OME_SCHEMA_URL
 from omero import ValidationException
 from omeroweb.connector import Server
@@ -211,6 +211,7 @@ class DatasetsView(View):
             owner = getIntOrDefault(request, 'owner', None)
             child_count = request.GET.get('child_count', False) == 'true'
             normalize = request.GET.get('normalize', False) == 'true'
+            orphaned = request.GET.get('orphaned', False) == 'true'
             # filter by ?project=pid instead of /projects/:pdi/datasets/
             if pid is None:
                 pid = getIntOrDefault(request, 'project', None)
@@ -218,14 +219,16 @@ class DatasetsView(View):
             raise BadRequestError(str(ex))
 
         # Get the datasets
-        datasets = query_datasets(conn,
-                                  project=pid,
-                                  group=group,
-                                  owner=owner,
-                                  child_count=child_count,
-                                  page=page,
-                                  limit=limit,
-                                  normalize=normalize)
+        datasets = query_objects(conn,
+                                 'Dataset',
+                                 project=pid,
+                                 group=group,
+                                 owner=owner,
+                                 child_count=child_count,
+                                 page=page,
+                                 limit=limit,
+                                 orphaned=orphaned,
+                                 normalize=normalize)
 
         return datasets
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -221,7 +221,7 @@ class DatasetsView(ObjectsView):
 
     def get_opts(self, request, **kwargs):
         """Add filtering by 'project' to the opts dict."""
-        opts = super(DatasetsView, self).get_opts(request)
+        opts = super(DatasetsView, self).get_opts(request, **kwargs)
         # at /projects/:project_id/datasets/ we have 'project_id' in kwargs
         if 'project_id' in kwargs:
             opts['project'] = long(kwargs['project_id'])
@@ -243,6 +243,15 @@ class PlatesView(ObjectsView):
     """Handles GET for /plates/ to list available Plates."""
 
     OMERO_TYPE = 'Plate'
+
+    def get_opts(self, request, **kwargs):
+        """Add filtering by 'screen' to the opts dict."""
+        opts = super(PlatesView, self).get_opts(request, **kwargs)
+        # filter by query /plates/?screen=:id
+        screen = getIntOrDefault(request, 'screen', None)
+        if screen is not None:
+            opts['screen'] = screen
+        return opts
 
 
 class SaveView(View):

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -204,9 +204,7 @@ class ObjectsView(View):
         group = getIntOrDefault(request, 'group', -1)
         normalize = request.GET.get('normalize', False) == 'true'
         # Get the data
-        marshalled = query_objects(conn, self.OMERO_TYPE,
-                                   group, opts, normalize)
-        return marshalled
+        return query_objects(conn, self.OMERO_TYPE, group, opts, normalize)
 
 
 class ProjectsView(ObjectsView):

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -78,6 +78,7 @@ def api_base(request, api_version=None, **kwargs):
     v = api_version
     rv = {'projects_url': build_url(request, 'api_projects', v),
           'datasets_url': build_url(request, 'api_datasets', v),
+          'screens_url': build_url(request, 'api_screens', v),
           'token_url': build_url(request, 'api_token', v),
           'servers_url': build_url(request, 'api_servers', v),
           'login_url': build_url(request, 'api_login', v),

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -215,10 +215,14 @@ class DatasetsView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add filtering by 'project' to the opts dict."""
         opts = super(DatasetsView, self).get_opts(request)
-        # filter by query /datasets/?project=:id
-        project = getIntOrDefault(request, 'project', None)
-        if project is not None:
-            opts['project'] = project
+        # at /projects/:project_id/datasets/ we have 'project_id' in kwargs
+        if 'project_id' in kwargs:
+            opts['project'] = long(kwargs['project_id'])
+        else:
+            # otherwise we filter by query /datasets/?project=:id
+            project = getIntOrDefault(request, 'project', None)
+            if project is not None:
+                opts['project'] = project
         return opts
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -246,10 +246,14 @@ class PlatesView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add filtering by 'screen' to the opts dict."""
         opts = super(PlatesView, self).get_opts(request, **kwargs)
-        # filter by query /plates/?screen=:id
-        screen = getIntOrDefault(request, 'screen', None)
-        if screen is not None:
-            opts['screen'] = screen
+        # at /screens/:screen_id/plates/ we have 'screen_id' in kwargs
+        if 'screen_id' in kwargs:
+            opts['screen'] = long(kwargs['screen_id'])
+        else:
+            # filter by query /plates/?screen=:id
+            screen = getIntOrDefault(request, 'screen', None)
+            if screen is not None:
+                opts['screen'] = screen
         return opts
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -77,6 +77,7 @@ def api_base(request, api_version=None, **kwargs):
     """Base url of the webgateway json api for a specified version."""
     v = api_version
     rv = {'projects_url': build_url(request, 'api_projects', v),
+          'datasets_url': build_url(request, 'api_datasets', v),
           'token_url': build_url(request, 'api_token', v),
           'servers_url': build_url(request, 'api_servers', v),
           'login_url': build_url(request, 'api_login', v),

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -161,6 +161,12 @@ class ScreenView(ObjectView):
     OMERO_TYPE = 'Screen'
 
 
+class PlateView(ObjectView):
+    """Handle access to an individual Plate to GET or DELETE it."""
+
+    OMERO_TYPE = 'Plate'
+
+
 class ObjectsView(View):
     """Base class for listing objects."""
 
@@ -231,6 +237,12 @@ class ScreensView(ObjectsView):
     """Handles GET for /screens/ to list available Screens."""
 
     OMERO_TYPE = 'Screen'
+
+
+class PlatesView(ObjectsView):
+    """Handles GET for /plates/ to list available Plates."""
+
+    OMERO_TYPE = 'Plate'
 
 
 class SaveView(View):

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -226,6 +226,12 @@ class DatasetsView(ObjectsView):
         return opts
 
 
+class ScreensView(ObjectsView):
+    """Handles GET for /screens/ to list available Screens."""
+
+    OMERO_TYPE = 'Screen'
+
+
 class SaveView(View):
     """
     This view provides 'Save' functionality for all types of objects.

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -174,8 +174,8 @@ class ProjectsView(View):
             page = getIntOrDefault(request, 'page', 1)
             limit = getIntOrDefault(request, 'limit', settings.PAGE)
             group = getIntOrDefault(request, 'group', -1)
-            owner = getIntOrDefault(request, 'owner', -1)
-            childCount = request.GET.get('childCount', False) == 'true'
+            owner = getIntOrDefault(request, 'owner', None)
+            child_count = request.GET.get('childCount', False) == 'true'
             normalize = request.GET.get('normalize', False) == 'true'
         except ValueError as ex:
             raise BadRequestError(str(ex))
@@ -184,7 +184,7 @@ class ProjectsView(View):
         projects = query_projects(conn,
                                   group=group,
                                   owner=owner,
-                                  childCount=childCount,
+                                  child_count=child_count,
                                   page=page,
                                   limit=limit,
                                   normalize=normalize)

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -68,7 +68,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     omero_ids_objects can be IDs or list of omero.model objects.
 
     @param: extra       List of dicts containing expected extra json data
-                        E.g. {'omero:childCount': 1}
+                        e.g. {'omero:childCount': 1}
     """
     pids = []
     for p in omero_ids_objects:

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -176,6 +176,12 @@ class TestDatasets(IWebTest):
         rsp = _get_response_json(django_client, request_url, {})
         assert len(rsp['data']) == 6
 
+        # Filter Datasets by Orphaned
+        dataset = project_datasets[1]
+        payload = {'orphaned': 'true'}
+        rsp = _get_response_json(django_client, request_url, payload)
+        assert_objects(conn, rsp['data'], [dataset], dtype="Dataset")
+
         # Filter Datasets by Project
         project = project_datasets[0]
         datasets = project.linkedDatasetList()

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -246,7 +246,7 @@ class TestContainers(IWebTest):
         rsp = _get_response_json(django_client, request_url, payload)
         assert len(rsp['data']) == 5
         assert_objects(conn, rsp['data'], children, dtype=dtype,
-            extra=child_counts)
+                       extra=child_counts)
 
         # Pagination
         limit = 3

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -60,6 +60,7 @@ class TestLogin(IWebTest):
         assert 'servers_url' in rsp
         assert 'login_url' in rsp
         assert 'projects_url' in rsp
+        assert 'datasets_url' in rsp
         assert 'save_url' in rsp
         assert rsp['schema_url'] == OME_SCHEMA_URL
 

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -62,6 +62,7 @@ class TestLogin(IWebTest):
         assert 'projects_url' in rsp
         assert 'datasets_url' in rsp
         assert 'screens_url' in rsp
+        assert 'plates_url' in rsp
         assert 'save_url' in rsp
         assert rsp['schema_url'] == OME_SCHEMA_URL
 

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -61,6 +61,7 @@ class TestLogin(IWebTest):
         assert 'login_url' in rsp
         assert 'projects_url' in rsp
         assert 'datasets_url' in rsp
+        assert 'screens_url' in rsp
         assert 'save_url' in rsp
         assert rsp['schema_url'] == OME_SCHEMA_URL
 

--- a/components/tools/OmeroWeb/test/integration/test_api_projects.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_projects.py
@@ -407,7 +407,7 @@ class TestProjects(IWebTest):
                                      projects_user1_group1,
                                      projects_user2_group1):
         """
-        Tests normalize, childCount and callback params of projects
+        Tests normalize and childCount params of projects
         """
         projects = projects_user1_group1 + projects_user2_group1
         projects.sort(cmp_name_insensitive)


### PR DESCRIPTION
# What this PR does

Adds support for listing Datasets, Screens & Plates.
Also adds support for showing (and updating) single Plates.

This uses subclasses of a new ```ObjectsView``` class to reduce code duplication for listing Projects, Datasets, Screens & Plates.
Processing of the ```request``` and any other ```kwargs``` into an ```opts``` dict is handled by the base class and can be extended by subclasses, E.g. to add filtering of Datasets by Project.

# Testing this PR

- Check tests are green.
- Functionality below is largely covered by tests, so just pick a few different options and check that they correspond to what you see in webclient/Insight.
- Browse to /api/ and then click on the 'base_url' and then the 'datasets_url', 'screens_url' and 'plates_url'.
- These should list datasets, screens or plates.
- Filter datasets by project ```/api/v0.1/m/datasets/?project=:project_id```
    - Also try ```/api/v0.1/m/projects/:project_id/datasets/```
- Filter plates by screen ```/api/v0.1/m/plates/?screen=:screen_id```
    - Also try ```/api/v0.1/m/screens/:screen_id/plates/```
- Filter by datasets AND plates to only show orphaned ```?orphaned=true```
- Also test paginate via ```?page=2&limit=5```.
- Can also filter by ```?owner=:expId``` and ```?group=:gid```
- Test display of single Plate via E.g. ```/api/v0.1/m/plates/:plate_id/```
- Create, Update and Delete of single Plate covered by ```test_container_crud```