### PR TITLE
Allow non digits (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -99,7 +99,7 @@ class Show(object):
         self._initially_select = list()
         # The nodes of the tree that will be initially open based on the
         # nodes that are initially selected.
-        self._initially_open = None
+        self._initially_open = list()
         # The owner of the node closest to the root of the tree from the
         # list of initially open nodes.
         self._initially_open_owner = None

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -1,5 +1,6 @@
 {% extends "webgateway/base/container3.html" %}
 {% load i18n %}
+{% load common_filters %}
 
 
 {% comment %}
@@ -184,8 +185,9 @@
         WEBCLIENT.URLS.reset_rdef_json = "{% url 'reset_rdef_json' %}";
         // jsTree code in ome.tree.js and center panel code in center_plugin.thumbs.js.html uses initially_select
         // instead of browser URL since URL may be /webclient/?path=plate.name-barcode|well.name-A1
-        WEBCLIENT.initially_select = [{% for o in initially_select %}"{{ o }}"{% if not forloop.last %},{% endif %}{% endfor %}];
-        WEBCLIENT.initially_open = [{% for o in initially_open %}"{{ o }}"{% if not forloop.last %},{% endif %}{% endfor %}];
+
+        WEBCLIENT.initially_select = {{ initially_select|json_dumps|safe }};
+        WEBCLIENT.initially_open = {{ initially_open|json_dumps|safe }};
 
         {% ifequal menu 'usertags' %}
             WEBCLIENT.TAG_TREE = true;

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templatetags/common_filters.py
@@ -274,3 +274,9 @@ def timeformat(value):
         value = round(value)        # Avoids '1h 60min'
         return u'%d\u00A0h\u00A0%d\u00A0min' % (value / 3600,
                                                 round((value % 3600)/60))
+
+
+# taken from https://code.djangoproject.com/ticket/17419
+@register.filter
+def json_dumps(value):
+    return json.dumps(value)

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -699,7 +699,7 @@ class TestShow(IWebTest):
 
     def assert_instantiation(self, show):
         assert show.conn == self.conn
-        assert show.initially_open is None
+        assert len(show.initially_open) == 0
         assert show.initially_open_owner is None
         assert show._first_selected is None
 
@@ -1085,7 +1085,7 @@ class TestShow(IWebTest):
 
         first_selected = show.first_selected
         assert first_selected is None
-        assert show.initially_open is None
+        assert len(show.initially_open) == 0
         assert show.initially_select == \
             screen_plate_run_illegal_run_request['initially_select']
 

--- a/components/tools/OmeroWeb/test/unit/test_show.py
+++ b/components/tools/OmeroWeb/test/unit/test_show.py
@@ -92,21 +92,21 @@ class TestShow(object):
 
     def test_basic_instantiation(self, empty_request):
         show = Show(None, empty_request, None)
-        assert show.initially_open is None
+        assert len(show.initially_open) == 0
         assert show.initially_open_owner is None
         assert show.initially_select == list()
         assert show._first_selected is None
 
     def test_legacy_path_instantiation(self, path_request):
         show = Show(None, path_request['request'], None)
-        assert show.initially_open is None
+        assert len(show.initially_open) == 0
         assert show.initially_open_owner is None
         assert show.initially_select == list(path_request['initially_select'])
         assert show._first_selected is None
 
     def test_show_instantiation(self, show_request):
         show = Show(None, show_request['request'], None)
-        assert show.initially_open is None
+        assert len(show.initially_open) == 0
         assert show.initially_open_owner is None
         assert show.initially_select == list(show_request['initially_select'])
         assert show._first_selected is None


### PR DESCRIPTION

This is the same as gh-5014 but rebased onto develop.

----

# What this PR does

This PR clean up console.logs and allow non digits to be passed as initially selected tree elements. see https://github.com/ome/omero-mapr/pull/12



                