### PR TITLE
trim non-existent Java packages from logback.xml

### DIFF
--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -89,8 +89,6 @@
   <logger name="omero.cmd" level="INFO"/>
   <logger name="omero.cmd.graphs" level="INFO"/>
   <logger name="ome.services.graphs" level="INFO"/>
-  <logger name="ome.services.chgrp" level="INFO"/>
-  <logger name="ome.services.chmod" level="INFO"/>
   <logger name="ome.services.delete" level="INFO"/>
   <!-- Adapters are also too so is a bit verbose -->
   <logger name="ome.adapters" level="ERROR"/>


### PR DESCRIPTION
`logback.xml` configures the logging level for various Java classes. This PR removes the `ome.services.chgrp` and `ome.services.chmod` packages from its configuration because there are no longer any classes in those packages.