### PR TITLE
fix accidental assignment in conditional

### DIFF
--- a/components/blitz/test/ome/formats/test/util/TestEngine.java
+++ b/components/blitz/test/ome/formats/test/util/TestEngine.java
@@ -145,7 +145,7 @@ public class TestEngine
 
 		String[] fileTypes = iniFile.getFileTypes();
 
-		if (populate = true && fileTypes != null)
+		if (populate == true && fileTypes != null)
 		{
 			// get all files in the directory
 			File[] datasetFiles = directory.listFiles();
@@ -163,7 +163,7 @@ public class TestEngine
 				}
 			}
 		}
-		else if (populate = true && fileTypes == null)
+		else if (populate == true && fileTypes == null)
 		{
 			log.error("No filetypes for " + iniFilePath);
 		}


### PR DESCRIPTION
This PR corrects an apparent bug in the `TestEngine` code. Anybody who knows how to use the "populate initiation files with metadata" option of the importer test engine may want to take a look as I do not know how best to test this change.