### PR TITLE
Configure session serializer

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/serializers.py
+++ b/components/tools/OmeroWeb/omeroweb/serializers.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#
+#
+# Copyright (c) 2017 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>, 2008.
+#
+# Version: 1.0
+#
+
+import jsonpickle
+
+
+class JSONPickleSerializer(object):
+    """
+    Simple wrapper around json to be used in signing.dumps and
+    signing.loads.
+    """
+    def dumps(self, obj):
+        return jsonpickle.encode(obj)
+
+    def loads(self, data):
+        return jsonpickle.decode(data)

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -208,9 +208,9 @@ SESSION_ENGINE_VALUES = ('omeroweb.filesessionstore',
                          'django.contrib.sessions.backends.cache',
                          'django.contrib.sessions.backends.cached_db')
 
-DEFAULT_SESSION_SERILIZER = \
-    'django.contrib.sessions.serializers.PickleSerializer'
+DEFAULT_SESSION_SERILIZER = 'serializers.JSONPickleSerializer'
 SESSION_SERILIZER_VALUES = (
+    'serializers.JSONPickleSerializer',
     'django.contrib.sessions.serializers.PickleSerializer',
     'django.contrib.sessions.serializers.JSONSerializer',
 )

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -247,7 +247,7 @@ def check_session_engine(s):
     return check_settings_value(s, SESSION_ENGINE_VALUES)
 
 
-def check_serilizers(s):
+def check_session_serilizers(s):
     return check_settings_value(s, SESSION_SERILIZER_VALUES)
 
 
@@ -346,7 +346,7 @@ INTERNAL_SETTINGS_MAPPING = {
     "omero.web.session_serializer":
         ["SESSION_SERIALIZER",
          DEFAULT_SESSION_SERILIZER,
-         check_serilizers,
+         check_session_serilizers,
          "Session serialization. For redis use JSONSerializer."],
 }
 

--- a/components/tools/OmeroWeb/requirements-common.txt
+++ b/components/tools/OmeroWeb/requirements-common.txt
@@ -5,5 +5,6 @@
 #
 
 Django>=1.8,<1.9
+jsonpickle
 django-pipeline==1.3.20
 omero-marshal==0.4.1


### PR DESCRIPTION
# What this PR does

Make session serializer configurable and add use jsonpickle.

As mentioned in https://docs.djangoproject.com/en/1.8/topics/http/sessions/#session-serialization the PickleSerializer is not recommended. Although default JSONserilizer is not enough as Connector object can't be encoded with json.dumps. We could add a custom serializer but jsonpickle library seems to work and is super simple.

Test:

 - default web config using filebased session store (any spider)
 - configure to store sessions in redis, for more details how to do it see https://github.com/openmicroscopy/openmicroscopy/pull/4935

and log in

--breaking