### PR TITLE
Api images

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3007,7 +3007,8 @@ class _BlitzGateway (object):
     ###########################
     # Specific Object Getters #
 
-    def getObject(self, obj_type, oid=None, params=None, attributes=None):
+    def getObject(self, obj_type, oid=None, params=None, attributes=None,
+                  opts=None):
         """
         Retrieve single Object by type E.g. "Image" or None if not found.
         If more than one object found, raises ome.conditions.ApiUsageException
@@ -3026,7 +3027,7 @@ class _BlitzGateway (object):
         """
         oids = (oid is not None) and [oid] or None
         query, params, wrapper = self.buildQuery(
-            obj_type, oids, params, attributes)
+            obj_type, oids, params, attributes, opts)
         result = self.getQueryService().findByQuery(
             query, params, self.SERVICE_OPTS)
         if result is not None:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7116,6 +7116,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Extend base query to handle filtering of Images by Datasets.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'dataset': <dataset_id> to filter by Dataset
+                        'load_pixels': <bool> to load Pixel objects.
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
@@ -7126,6 +7127,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             query += ' join obj.datasetLinks dlink'
             clauses.append('dlink.parent.id = :did')
             params.add('did', rlong(opts['dataset']))
+        if opts is not None and 'load_pixels' in opts:
+            # We use 'left outer join', since we still want images if no pixels
+            query += ' left outer join fetch obj.pixels pixels'
         return (query, clauses, params)
 
     @classmethod

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7117,10 +7117,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Extend base query to handle filtering of Images by Datasets.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'dataset': <dataset_id> to filter by Dataset
-                        'load_pixels': <bool> to load Pixel objects.
+                        'load_pixels': <bool> to load Pixel objects
                         'load_channels': <bool> to load Channels and
                                                     Logical Channels
-                        'orphaned': <bool>. Images not in Dataset or WellSample
+                        'orphaned': <bool> Images not in Dataset or WellSample
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7141,7 +7141,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if load_pixels or load_channels:
             # We use 'left outer join', since we still want images if no pixels
             query += ' left outer join fetch obj.pixels pixels' \
-                     ' join fetch pixels.pixelsType'
+                     ' left outer join fetch pixels.pixelsType'
         if load_channels:
             query += ' join fetch pixels.channels as channels' \
                      ' join fetch channels.logicalChannel as logicalChannel' \

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7117,6 +7117,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Returns a tuple of (query, clauses, params).
         Supported opts: 'dataset': <dataset_id> to filter by Dataset
                         'load_pixels': <bool> to load Pixel objects.
+                        'load_channels': <bool> to load Channels and
+                                                    Logical Channels
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
@@ -7127,9 +7129,17 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             query += ' join obj.datasetLinks dlink'
             clauses.append('dlink.parent.id = :did')
             params.add('did', rlong(opts['dataset']))
-        if opts is not None and 'load_pixels' in opts:
+        load_pixels = False
+        load_channels = False
+        if opts is not None:
+            load_pixels = 'load_pixels' in opts and opts['load_pixels']
+            load_channels = 'load_channels' in opts and opts['load_channels']
+        if load_pixels or load_channels:
             # We use 'left outer join', since we still want images if no pixels
             query += ' left outer join fetch obj.pixels pixels'
+        if load_channels:
+            query += ' join fetch pixels.channels as channels' \
+                     ' join fetch channels.logicalChannel'
         return (query, clauses, params)
 
     @classmethod

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7111,6 +7111,24 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     PLANEDEF = omero.romio.XY
 
     @classmethod
+    def _getQueryString(cls, opts=None):
+        """
+        Extend base query to handle filtering of Images by Datasets.
+        Returns a tuple of (query, clauses, params).
+        Supported opts: 'dataset': <dataset_id> to filter by Dataset
+
+        :param opts:        Dictionary of optional parameters.
+        :return:            Tuple of string, list, ParametersI
+        """
+        query, clauses, params = super(
+            _ImageWrapper, cls)._getQueryString(opts)
+        if opts is not None and 'dataset' in opts:
+            query += ' join obj.datasetLinks dlink'
+            clauses.append('dlink.parent.id = :did')
+            params.add('did', rlong(opts['dataset']))
+        return (query, clauses, params)
+
+    @classmethod
     def fromPixelsId(cls, conn, pid):
         """
         Creates a new Image wrapper with the image specified by pixels ID

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7135,15 +7135,20 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         load_channels = False
         orphaned = False
         if opts is not None:
-            load_pixels = 'load_pixels' in opts and opts['load_pixels']
-            load_channels = 'load_channels' in opts and opts['load_channels']
-            orphaned = 'orphaned' in opts and opts['orphaned']
+            load_pixels = opts.get('load_pixels')
+            load_channels = opts.get('load_channels')
+            orphaned = opts.get('orphaned')
         if load_pixels or load_channels:
             # We use 'left outer join', since we still want images if no pixels
-            query += ' left outer join fetch obj.pixels pixels'
+            query += ' left outer join fetch obj.pixels pixels' \
+                     ' join fetch pixels.pixelsType'
         if load_channels:
             query += ' join fetch pixels.channels as channels' \
-                     ' join fetch channels.logicalChannel'
+                     ' join fetch channels.logicalChannel as logicalChannel' \
+                     ' left outer join fetch logicalChannel.photometricInterpretation' \
+                     ' left outer join fetch logicalChannel.illumination' \
+                     ' left outer join fetch logicalChannel.mode' \
+                     ' left outer join fetch logicalChannel.contrastMethod'
         if orphaned:
             clauses.append(
                 """

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -403,7 +403,7 @@ class ITest(object):
         return plates
 
     def create_test_image(self, size_x=16, size_y=16, size_z=1, size_c=1,
-                          size_t=1, session=None):
+                          size_t=1, session=None, name="testImage"):
         """
         Creates a test image of the required dimensions, where each pixel
         value is set to the value of x+y.
@@ -448,7 +448,7 @@ class ITest(object):
         channel_list = range(1, size_c + 1)
         iid = pixels_service.createImage(size_x, size_y, size_z, size_t,
                                          channel_list, pixels_type,
-                                         "testImage", "description")
+                                         name, "description")
         image_id = iid.getValue()
         image = container_service.getImages("Image", [image_id], None)[0]
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -40,7 +40,7 @@ class TestDeleteObject (object):
         tagId = tag.getId()
         handle = gateway.deleteObjects("Annotation", [tagId])
         gateway._waitOnCmd(handle)
-        assert None == gateway.getObject("Annotation", tagId)
+        assert gateway.getObject("Annotation", tagId) is None
 
     def testDeleteImage(self, gatewaywrapper, author_testimg_generated):
         image = author_testimg_generated

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -650,7 +650,8 @@ class TestGetObject (object):
                 # Pagination
                 params = omero.sys.ParametersI()
                 params.page(1, 3)
-                findImagesInPage = list(conn.listOrphans("Image", eid=eid, params=params))
+                findImagesInPage = list(conn.listOrphans("Image", eid=eid,
+                                                         params=params))
                 assert len(findImagesInPage) == 3
 
                 # No pagination (all orphans)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -571,6 +571,23 @@ class TestGetObject (object):
         assert image.getOwnerOmeName == testImage.getOwnerOmeName
         assert image.getThumbVersion() is not None
 
+    def testGetImageLoadPixels(self, gatewaywrapper, author_testimg_tiny):
+        testImage = author_testimg_tiny
+        conn = gatewaywrapper.gateway
+        # By default, don't load pixels
+        image = conn.getObject("Image", testImage.id)
+        assert not image._obj.pixelsLoaded
+        # Load just the pixels
+        image = conn.getObject("Image", testImage.id,
+                               opts={'load_pixels': True})
+        assert image._obj.pixelsLoaded
+        assert not image._obj._pixelsSeq[0].channelsLoaded
+        # Load pixels and channels
+        image = conn.getObject("Image", testImage.id,
+                               opts={'load_channels': True})
+        assert image._obj.pixelsLoaded
+        assert image._obj._pixelsSeq[0].channelsLoaded
+
     def testGetProject(self, gatewaywrapper):
         gatewaywrapper.loginAsAuthor()
         testProj = gatewaywrapper.getTestProject()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -22,7 +22,12 @@ from omero.gateway.scripts import dbhelpers
 from omero.rtypes import wrap
 from omero.testlib import ITest
 from omero.gateway import BlitzGateway, KNOWN_WRAPPERS
-from omero.model import ScreenI, PlateI, WellI, WellSampleI, DatasetI, ImageI
+from omero.model import DatasetI, \
+    ImageI, \
+    PlateI, \
+    ScreenI, \
+    WellI, \
+    WellSampleI
 
 
 class TestDeleteObject (object):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -626,7 +626,7 @@ class TestGetObject (object):
     @pytest.mark.parametrize("orphaned", [True, False])
     @pytest.mark.parametrize("load_pixels", [False, False])
     def testListOrphans(self, orphaned, load_pixels, gatewaywrapper):
-        # We login as 'User', since they have no other orphan images
+        # We login as 'User', since they have no other orphaned images
         gatewaywrapper.loginAsUser()
         conn = gatewaywrapper.gateway
         eid = conn.getUserId()

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -113,6 +113,15 @@ api_images = url(r'^v(?P<api_version>%s)/m/images/$' % versions,
 GET all images, using omero-marshal to generate json
 """
 
+api_dataset_images = url(
+    r'^v(?P<api_version>%s)/m/datasets/'
+    '(?P<dataset_id>[0-9]+)/images/$' % versions,
+    views.ImagesView.as_view(),
+    name='api_dataset_imagess')
+"""
+GET Images in Dataset, using omero-marshal to generate json
+"""
+
 api_image = url(
     r'^v(?P<api_version>%s)/m/images/(?P<pid>[0-9]+)/$' % versions,
     views.ImageView.as_view(),
@@ -174,6 +183,7 @@ urlpatterns = patterns(
     api_project_datasets,
     api_dataset,
     api_images,
+    api_dataset_images,
     api_image,
     api_screen,
     api_screens,

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -145,6 +145,13 @@ api_plate = url(
 Plate url to GET or DELETE a single Plate
 """
 
+api_images = url(r'^v(?P<api_version>%s)/m/images/$' % versions,
+                 views.ImagesView.as_view(),
+                 name='api_images')
+"""
+GET all images, using omero-marshal to generate json
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -163,5 +170,5 @@ urlpatterns = patterns(
     api_plates,
     api_screen_plates,
     api_plate,
-
+    api_images,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -117,7 +117,7 @@ api_dataset_images = url(
     r'^v(?P<api_version>%s)/m/datasets/'
     '(?P<dataset_id>[0-9]+)/images/$' % versions,
     views.ImagesView.as_view(),
-    name='api_dataset_imagess')
+    name='api_dataset_images')
 """
 GET Images in Dataset, using omero-marshal to generate json
 """

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -107,8 +107,8 @@ Dataset url to GET or DELETE a single Dataset
 """
 
 api_images = url(r'^v(?P<api_version>%s)/m/images/$' % versions,
-                   views.ImagesView.as_view(),
-                   name='api_images')
+                 views.ImagesView.as_view(),
+                 name='api_images')
 """
 GET all images, using omero-marshal to generate json
 """

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -106,6 +106,21 @@ api_dataset = url(
 Dataset url to GET or DELETE a single Dataset
 """
 
+api_images = url(r'^v(?P<api_version>%s)/m/images/$' % versions,
+                   views.ImagesView.as_view(),
+                   name='api_images')
+"""
+GET all images, using omero-marshal to generate json
+"""
+
+api_image = url(
+    r'^v(?P<api_version>%s)/m/images/(?P<pid>[0-9]+)/$' % versions,
+    views.ImageView.as_view(),
+    name='api_image')
+"""
+Image url to GET or DELETE a single Image
+"""
+
 api_screen = url(
     r'^v(?P<api_version>%s)/m/screens/(?P<pid>[0-9]+)/$' % versions,
     views.ScreenView.as_view(),
@@ -145,13 +160,6 @@ api_plate = url(
 Plate url to GET or DELETE a single Plate
 """
 
-api_images = url(r'^v(?P<api_version>%s)/m/images/$' % versions,
-                 views.ImagesView.as_view(),
-                 name='api_images')
-"""
-GET all images, using omero-marshal to generate json
-"""
-
 urlpatterns = patterns(
     '',
     api_versions,
@@ -165,10 +173,11 @@ urlpatterns = patterns(
     api_datasets,
     api_project_datasets,
     api_dataset,
+    api_images,
+    api_image,
     api_screen,
     api_screens,
     api_plates,
     api_screen_plates,
     api_plate,
-    api_images,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -284,10 +284,14 @@ class ImagesView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add filtering by 'dataset' and other params to the opts dict."""
         opts = super(ImagesView, self).get_opts(request, **kwargs)
-        # filter by query /images/?dataset=:id
-        dataset = getIntOrDefault(request, 'dataset', None)
-        if dataset is not None:
-            opts['dataset'] = dataset
+        # at /datasets/:dataset_id/images/ we have 'dataset_id' in kwargs
+        if 'dataset_id' in kwargs:
+            opts['dataset'] = long(kwargs['dataset_id'])
+        else:
+            # filter by query /images/?dataset=:id
+            dataset = getIntOrDefault(request, 'dataset', None)
+            if dataset is not None:
+                opts['dataset'] = dataset
         # When listing images, always load pixels by defualt
         opts['load_pixels'] = True
         return opts

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -78,6 +78,7 @@ def api_base(request, api_version=None, **kwargs):
     v = api_version
     rv = {'projects_url': build_url(request, 'api_projects', v),
           'datasets_url': build_url(request, 'api_datasets', v),
+          'images_url': build_url(request, 'api_images', v),
           'screens_url': build_url(request, 'api_screens', v),
           'plates_url': build_url(request, 'api_plates', v),
           'token_url': build_url(request, 'api_token', v),

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -169,10 +169,9 @@ class ImageView(ObjectView):
     def get_opts(self, request):
         """Add support for load_pixels and load_channels."""
         opts = super(ImageView, self).get_opts(request)
-        for p in ['load_pixels', 'load_channels', 'orphaned']:
-            load = request.GET.get(p, False) == 'true'
-            if load:
-                opts[p] = True
+        opts['orphaned'] = request.GET.get('orphaned', False) == 'true'
+        # for single image, we always load channels
+        opts['load_channels'] = True
         return opts
 
 
@@ -289,10 +288,8 @@ class ImagesView(ObjectsView):
         dataset = getIntOrDefault(request, 'dataset', None)
         if dataset is not None:
             opts['dataset'] = dataset
-        # handle 'boolean' params
-        for param in ['load_pixels', 'load_channels']:
-            if request.GET.get(param, False) == 'true':
-                opts[param] = True
+        # When listing images, always load pixels by defualt
+        opts['load_pixels'] = True
         return opts
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -257,6 +257,12 @@ class PlatesView(ObjectsView):
         return opts
 
 
+class ImagesView(ObjectsView):
+    """Handles GET for /images/ to list available Images."""
+
+    OMERO_TYPE = 'Image'
+
+
 class SaveView(View):
     """
     This view provides 'Save' functionality for all types of objects.

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -293,7 +293,7 @@ class ImagesView(ObjectsView):
             dataset = getIntOrDefault(request, 'dataset', None)
             if dataset is not None:
                 opts['dataset'] = dataset
-        # When listing images, always load pixels by defualt
+        # When listing images, always load pixels by default
         opts['load_pixels'] = True
         return opts
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -262,6 +262,19 @@ class ImagesView(ObjectsView):
 
     OMERO_TYPE = 'Image'
 
+    def get_opts(self, request, **kwargs):
+        """Add filtering by 'dataset' and other params to the opts dict."""
+        opts = super(ImagesView, self).get_opts(request, **kwargs)
+        # filter by query /images/?dataset=:id
+        dataset = getIntOrDefault(request, 'dataset', None)
+        if dataset is not None:
+            opts['dataset'] = dataset
+        # handle 'boolean' params
+        for param in ['load_pixels', 'load_channels']:
+            if request.GET.get(param, False) == 'true':
+                opts[param] = True
+        return opts
+
 
 class SaveView(View):
     """

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -169,7 +169,7 @@ class ImageView(ObjectView):
     def get_opts(self, request):
         """Add support for load_pixels and load_channels."""
         opts = super(ImageView, self).get_opts(request)
-        for p in ['load_pixels', 'load_channels']:
+        for p in ['load_pixels', 'load_channels', 'orphaned']:
             load = request.GET.get(p, False) == 'true'
             if load:
                 opts[p] = True

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify

--- a/components/tools/OmeroWeb/test/integration/test_api_images.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_images.py
@@ -102,8 +102,7 @@ class TestImages(IWebTest):
     def user1(self):
         """Return a new user in a read-annotate group."""
         group = self.new_group(perms='rwra--')
-        user = self.new_client_and_user(group=group)
-        return user
+        return self.new_client_and_user(group=group)
 
     @pytest.fixture()
     def dataset_images(self, user1):

--- a/components/tools/OmeroWeb/test/integration/test_api_images.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_images.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests querying Images with web json api."""
+
+from omeroweb.testlib import IWebTest, _get_response_json, \
+    _csrf_post_json, _csrf_put_json, _csrf_delete_response_json
+from django.core.urlresolvers import reverse
+from django.conf import settings
+import pytest
+from omero.gateway import BlitzGateway
+from omero_marshal import get_encoder
+from omero.model import DatasetI, ProjectI, ScreenI, PlateI, ImageI
+from omero.rtypes import rstring, unwrap
+import json
+
+
+def get_update_service(user):
+    """Get the update_service for the given user's client."""
+    return user[0].getSession().getUpdateService()
+
+def get_query_service(user):
+    """Get the query_service for the given user's client."""
+    return user[0].getSession().getQueryService()
+
+
+def get_connection(user, group_id=None):
+    """Get a BlitzGateway connection for the given user's client."""
+    connection = BlitzGateway(client_obj=user[0])
+    # Refresh the session context
+    connection.getEventContext()
+    if group_id is not None:
+        connection.SERVICE_OPTS.setOmeroGroup(group_id)
+    return connection
+
+
+def cmp_name_insensitive(x, y):
+    """Case-insensitive name comparator."""
+    return cmp(unwrap(x.name).lower(), unwrap(y.name).lower())
+
+
+def marshal_objects(objects):
+    """Marshal objects using omero_marshal."""
+    expected = []
+    for obj in objects:
+        encoder = get_encoder(obj.__class__)
+        expected.append(encoder.encode(obj))
+    return expected
+
+
+def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
+                   group='-1', extra=None, opts=None):
+    """
+    Load objects from OMERO, via conn.getObjects().
+
+    marshal with omero_marshal and compare with json_objects.
+    omero_ids_objects can be IDs or list of omero.model objects.
+
+    @param: extra       List of dicts containing expected extra json data
+                        e.g. {'omero:childCount': 1}
+    """
+    pids = []
+    for p in omero_ids_objects:
+        try:
+            pids.append(long(p))
+        except TypeError:
+            pids.append(p.id.val)
+    conn.SERVICE_OPTS.setOmeroGroup(group)
+    objs = conn.getObjects(dtype, pids, respect_order=True, opts=opts)
+    objs = [p._obj for p in objs]
+    expected = marshal_objects(objs)
+    assert len(json_objects) == len(expected)
+    for i, o1, o2 in zip(range(len(expected)), json_objects, expected):
+        if extra is not None and i < len(extra):
+            o2.update(extra[i])
+        # dumping to json and loading (same as test data) means that
+        # unicode has been handled in same way, e.g. Pixel size symbols.
+        o2 = json.loads(json.dumps(o2))
+        assert o1 == o2
+
+
+class TestImages(IWebTest):
+    """Tests querying & editing Images."""
+
+    @pytest.fixture()
+    def user1(self):
+        """Return a new user in a read-annotate group."""
+        group = self.new_group(perms='rwra--')
+        user = self.new_client_and_user(group=group)
+        return user
+
+    @pytest.fixture()
+    def dataset_images(self, user1):
+        """Return Dataset with Images and an orphaned Image."""
+        query = get_query_service(user1)
+        dataset = DatasetI()
+        dataset.name = rstring('Dataset')
+
+        # Create 5 Images in Dataset
+        for i in range(5):
+            img = self.create_test_image(size_x=125, size_y=125,
+                                         session=user1[0].getSession(),
+                                         name="Image%s" % i)
+            img = ImageI(img.id.val, False)
+            dataset.linkImage(img)
+
+        # Import a single orphaned Image "tinyTest.d3d.dv" and get ImageID
+        pids = self.import_image(client=user1[0], skip=None)
+        pixels = query.get("Pixels", long(pids[0]))
+        image = query.get("Image", pixels.image.id.val)
+
+        dataset = get_update_service(user1).saveAndReturnObject(dataset)
+        return dataset, image
+
+    def test_dataset_images(self, user1, dataset_images):
+        """Test listing of Images in a Dataset."""
+        conn = get_connection(user1)
+        user_name = conn.getUser().getName()
+        django_client = self.new_django_client(user_name, user_name)
+        version = settings.API_VERSIONS[-1]
+
+        dataset = dataset_images[0]
+        images = dataset.linkedImageList()
+        orphaned = dataset_images[1]
+
+        images_url = reverse('api_images', kwargs={'api_version': version})
+
+        # List ALL Images
+        rsp = _get_response_json(django_client, images_url, {})
+        assert len(rsp['data']) == 6
+
+        # Filter Images by Orphaned
+        payload = {'orphaned': 'true'}
+        rsp = _get_response_json(django_client, images_url, payload)
+        assert_objects(conn, rsp['data'], [orphaned], dtype='Image',
+                       opts={'load_pixels': True})
+
+        # Filter Images by Dataset
+        images.sort(cmp_name_insensitive)
+        payload = {'dataset': dataset.id.val}
+        rsp = _get_response_json(django_client, images_url, payload)
+        assert len(rsp['data']) == 5
+        assert_objects(conn, rsp['data'], images, dtype='Image',
+                       opts={'load_pixels': True})
+
+        # Pagination
+        limit = 3
+        payload = {'dataset': dataset.id.val, 'limit': limit}
+        rsp = _get_response_json(django_client, images_url, payload)
+        assert_objects(conn, rsp['data'], images[0:limit], dtype='Image',
+                       opts={'load_pixels': True})
+        payload['page'] = 2
+        rsp = _get_response_json(django_client, images_url, payload)
+        assert_objects(conn, rsp['data'], images[limit:limit * 2],
+                       dtype='Image', opts={'load_pixels': True})
+
+        # Show ONLY the orphaned image (channels are loaded by default)
+        img_url = images_url + '%s/' % orphaned.id.val
+        rsp = _get_response_json(django_client, img_url, {})
+        assert_objects(conn, [rsp], [orphaned], dtype='Image',
+                       opts={'load_channels': True})

--- a/components/tools/OmeroWeb/test/integration/test_api_images.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_images.py
@@ -140,6 +140,7 @@ class TestImages(IWebTest):
         orphaned = dataset_images[1]
 
         images_url = reverse('api_images', kwargs={'api_version': version})
+        datasets_url = reverse('api_datasets', kwargs={'api_version': version})
 
         # List ALL Images
         rsp = _get_response_json(django_client, images_url, {})
@@ -160,10 +161,11 @@ class TestImages(IWebTest):
         assert_objects(conn, rsp['data'], images, dtype='Image',
                        opts={'load_pixels': True})
 
-        # Pagination
+        # Pagination, listing images via /datasets/:id/images/
         limit = 3
+        dataset_images_url = datasets_url + "%s/images/" % dataset.id.val
         payload = {'dataset': dataset.id.val, 'limit': limit}
-        rsp = _get_response_json(django_client, images_url, payload)
+        rsp = _get_response_json(django_client, dataset_images_url, payload)
         assert_objects(conn, rsp['data'], images[0:limit], dtype='Image',
                        opts={'load_pixels': True})
         payload['page'] = 2

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -61,6 +61,7 @@ class TestLogin(IWebTest):
         assert 'login_url' in rsp
         assert 'projects_url' in rsp
         assert 'datasets_url' in rsp
+        assert 'images_url' in rsp
         assert 'screens_url' in rsp
         assert 'plates_url' in rsp
         assert 'save_url' in rsp


### PR DESCRIPTION
# What this PR does

Adds support for ```/images/``` and ```/images/:image_id/```.

Added integration tests of urls below.
Also added gateway test for ```getObject()``` with 'load_pixels' and 'load_channels' and one for 'orphaned'.

# Testing this PR

- Check tests green.
- Browse from /api/ -> version -> images_url to list all images at e.g. ```/api/v0.1/m/images/```
- Filter by dataset ```/images/?dataset=:id``` or ```datasets/:dataset_id/images/```
- List orphaned images ```/images/?orphaned=true```
- For all above urls, pixels should be loaded for images. json contains "Pixels"
- Show a single image ```/images/:image-id/```
- This should also load Channels data.

# Related reading

https://github.com/openmicroscopy/design/issues/69
