### PR TITLE
Deprecate scipy usage

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -98,6 +98,8 @@ from omeroweb.webgateway.views import LoginView
 
 import tree
 
+import warnings
+
 logger = logging.getLogger(__name__)
 
 logger.info("INIT '%s'" % os.getpid())
@@ -2886,6 +2888,8 @@ def image_as_map(request, imageId, conn=None, **kwargs):
     Converts OMERO image into mrc.map file (using tiltpicker utils) and
     returns the file
     """
+    warnings.warn(
+        "This module is deprecated as of OMERO 5.3.0", DeprecationWarning)
 
     from omero_ext.tiltpicker.pyami import mrc
     from numpy import dstack, zeros, int8


### PR DESCRIPTION


# What this PR does

Deprecate method introduced to create "map" to be used with the emdatabank viewer
Support for the viewer has been removed in a previous release.

Removing the method in the next release will allow to remove the ``scipy`` dependency

# Testing this PR

No testing required, check that the message is correct

# Related reading

https://trello.com/c/BKRBO167/220-to-deprecate
