### PR TITLE
Bugfix: canExportAsJpg

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -213,12 +213,16 @@ class BaseContainer(BaseController):
         except:
             limit = 144000000
         if self.image:
-            if (self.image.getSizeX() * self.image.getSizeY()) > limit:
+            if self.image.getSizeX() is None or\
+                    self.image.getSizeY() is None or\
+                    (self.image.getSizeX() * self.image.getSizeY()) > limit:
                 can = False
         elif objDict is not None:
             if 'image' in objDict:
                 for i in objDict['image']:
-                    if (i.getSizeX() * i.getSizeY()) > limit:
+                    if i.getSizeX() is None or\
+                            i.getSizeY() is None or\
+                            (i.getSizeX() * i.getSizeY()) > limit:
                         can = False
         return can
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/container.py
@@ -213,16 +213,17 @@ class BaseContainer(BaseController):
         except:
             limit = 144000000
         if self.image:
-            if self.image.getSizeX() is None or\
-                    self.image.getSizeY() is None or\
-                    (self.image.getSizeX() * self.image.getSizeY()) > limit:
+            sizex = self.image.getSizeX()
+            sizey = self.image.getSizeY()
+            if sizex is None or sizey is None or (sizex * sizey) > limit:
                 can = False
         elif objDict is not None:
             if 'image' in objDict:
                 for i in objDict['image']:
-                    if i.getSizeX() is None or\
-                            i.getSizeY() is None or\
-                            (i.getSizeX() * i.getSizeY()) > limit:
+                    sizex = i.getSizeX()
+                    sizey = i.getSizeY()
+                    if sizex is None or sizey is None or\
+                            (sizex * sizey) > limit:
                         can = False
         return can
 


### PR DESCRIPTION
# What this PR does

Fixes a bug when image size x/y cannot be retrieved.

# Testing this PR
On webdev-merge as root, open dataset `dataset-b8bf17d5-7ceb-493d-bec8-13964a8897ed`.  Select the image. No exception should thrown.

# Related reading

https://trello.com/c/069qFkHv/257-bug-canexportasjpg