### PR TITLE
BfPixelBuffer: fix file leak (rebased onto develop)

### DIFF
--- a/components/romio/src/ome/io/bioformats/BfPixelsWrapper.java
+++ b/components/romio/src/ome/io/bioformats/BfPixelsWrapper.java
@@ -46,7 +46,14 @@ public class BfPixelsWrapper {
         this.path = path;
         this.reader = reader; // don't re-memoize
         reader.setFlattenedResolutions(false);
-        reader.setId(path);
+        try {
+            // An exception here could conceivably leave
+            // files dangling.
+            reader.setId(path);
+        } catch (RuntimeException|IOException|FormatException e) {
+            reader.close();
+            throw e;
+        }
     }
 
     public byte[] getMessageDigest() throws IOException {


### PR DESCRIPTION

This is the same as gh-5036 but rebased onto develop.

----

An exception thrown during a call to `BfPixelsBuffer.close()`
inadvertently leaked file handles. The call to `reader()` in
`close()` initiated a call to `BfPixelsWrapper.setId()`. When
this threw an exception, the files were left dangling.

# What this PR does

 * Buffer: Don't call `new BfPixelsWrapper` from `close()`
 * Buffer: Detect unused new wrappers and close them
 * Wrapper: close if an exception is called on `setId`

# Testing this PR

Testing may prove fairly difficult. What's been most prone to produce this error is re-thumbnailing Tara on IDR. If "Too many open files" is hit, then a snowball effect is produced when trying to _close_ files leading to more attempts to open files rather than closing _any_.

# Related reading

 * https://github.com/openmicroscopy/bioformats/pull/2438#r65844693
 * https://trello.com/c/AZNC7S6V/411-formatreader-auto-close-file-on-exception

                