### PR TITLE
ProjectionTest tinydv

### DIFF
--- a/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
@@ -35,7 +35,7 @@ public class ProjectionServiceTest extends AbstractServerTest
      * Creates a binary image with
      * 5 z-sections, 6 timepoints, 1 channel.
      * 
-     * @return The id of the pixels set.
+     * @return The pixels set.
      * @throws Exception Thrown if an error occurred.
      */
     private Pixels importImage() throws Exception

--- a/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
@@ -6,6 +6,7 @@ package integration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import omero.ValidationException;
@@ -45,8 +46,7 @@ public class ProjectionServiceTest extends AbstractServerTest
         int sizeC = 1;
         Image image = createBinaryImage(20, 20, sizeZ, sizeT, sizeC);
         //load the image so the pixels type is loaded
-        List<Long> ids = new ArrayList<Long>(1);
-        ids.add(image.getId().getValue());
+        List<Long> ids = Collections.singletonList(image.getId().getValue());
         List<Image> images = factory.getContainerService().getImages(
                 Image.class.getName(), ids, new ParametersI());
         image = images.get(0);

--- a/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
@@ -32,7 +32,7 @@ public class ProjectionServiceTest extends AbstractServerTest
 {
 
     /**
-     * Creates a binary image with with
+     * Creates a binary image with
      * 5 z-sections, 6 timepoints, 1 channel.
      * 
      * @return The id of the pixels set.

--- a/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
@@ -1,12 +1,9 @@
 /*
- * $Id$
- *
- * Copyright 2013 University of Dundee. All rights reserved.
+ * Copyright 2013-2017 University of Dundee. All rights reserved.
  * Use is subject to license terms supplied in LICENSE.txt
  */
 package integration;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +17,6 @@ import omero.model.PixelsType;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 
-import org.springframework.util.ResourceUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -36,22 +32,25 @@ public class ProjectionServiceTest extends AbstractServerTest
 {
 
     /**
-     * Imports the small dv.
-     * The image has 5 z-sections, 6 timepoints, 1 channel, signed 16-bit.
+     * Creates a binary image with with
+     * 5 z-sections, 6 timepoints, 1 channel.
      * 
      * @return The id of the pixels set.
      * @throws Exception Thrown if an error occurred.
      */
     private Pixels importImage() throws Exception
     {
-        File srcFile = ResourceUtils.getFile("classpath:tinyTest.d3d.dv");
-        List<Pixels> pixels = null;
-        try {
-            pixels = importFile(srcFile, "dv");
-        } catch (Throwable e) {
-            throw new Exception("cannot import image", e);
-        }
-        return pixels.get(0);
+        int sizeZ = 5;
+        int sizeT = 6;
+        int sizeC = 1;
+        Image image = createBinaryImage(20, 20, sizeZ, sizeT, sizeC);
+        //load the image so the pixels type is loaded
+        List<Long> ids = new ArrayList<Long>(1);
+        ids.add(image.getId().getValue());
+        List<Image> images = factory.getContainerService().getImages(
+                Image.class.getName(), ids, new ParametersI());
+        image = images.get(0);
+        return image.getPrimaryPixels();
     }
 
     /** 


### PR DESCRIPTION
# What this PR does

Remove usage of ``tiny.dv``
I noticed that the image was still used in this class while working on
https://github.com/openmicroscopy/openmicroscopy/pull/5042

# Testing this PR

Make sure the tests are still passing

# Related reading
See https://github.com/openmicroscopy/openmicroscopy/pull/5042