### PR TITLE
Javatests remove deprecated

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -746,7 +746,7 @@ public class AbstractServerTest extends AbstractTest {
         iUpdate = factory.getUpdateService();
         iAdmin = factory.getAdminService();
         iPix = factory.getPixelsService();
-        mmFactory = new ModelMockFactory(factory.getPixelsService());
+        mmFactory = new ModelMockFactory(factory.getTypesService());
 
         importer = new OMEROMetadataStoreClient();
         importer.initialize(factory);

--- a/components/tools/OmeroJava/test/integration/MetadataServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/MetadataServiceTest.java
@@ -1119,14 +1119,14 @@ public class MetadataServiceTest extends AbstractServerTest {
             ContrastMethod cm;
             Illumination illumination;
             AcquisitionMode mode;
-            List<IObject> types = factory.getPixelsService()
-                    .getAllEnumerations(ContrastMethod.class.getName());
+            List<IObject> types = factory.getTypesService()
+                    .allEnumerations(ContrastMethod.class.getName());
             cm = (ContrastMethod) types.get(0);
 
-            types = factory.getPixelsService().getAllEnumerations(
+            types = factory.getTypesService().allEnumerations(
                     Illumination.class.getName());
             illumination = (Illumination) types.get(0);
-            types = factory.getPixelsService().getAllEnumerations(
+            types = factory.getTypesService().allEnumerations(
                     AcquisitionMode.class.getName());
             mode = (AcquisitionMode) types.get(0);
 

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList.Builder;
 import ome.formats.model.UnitsFactory;
 import ome.units.UNITS;
 import omero.ServerError;
-import omero.api.IPixelsPrx;
+import omero.api.ITypesPrx;
 import omero.model.*;
 import omero.model.enums.UnitsLength;
 import omero.model.enums.UnitsTime;
@@ -97,8 +97,8 @@ public class ModelMockFactory {
     /** The bit pixels Type. */
     static String BIT = "bit";
 
-    /** Helper reference to the <code>IPixels</code> service. */
-    private IPixelsPrx pixelsService;
+    /** Helper reference to the <code>ITypes</code> service. */
+    private ITypesPrx typesService;
 
     /** all {@link ExperimentType}s */
     private ImmutableList<ExperimentType> experimentTypes;
@@ -118,11 +118,11 @@ public class ModelMockFactory {
     /**
      * Creates a new instance.
      *
-     * @param pixelsService
+     * @param typesService
      * @throws ServerError unexpected
      */
-    public ModelMockFactory(IPixelsPrx pixelsService) throws ServerError {
-        this.pixelsService = pixelsService;
+    public ModelMockFactory(ITypesPrx typesService) throws ServerError {
+        this.typesService = typesService;
         getExperimentTypes();
     }
 
@@ -132,7 +132,7 @@ public class ModelMockFactory {
      */
     public void getExperimentTypes() throws ServerError {
         final Builder<ExperimentType> builder = ImmutableList.builder();
-        for (final IObject experimentType : pixelsService.getAllEnumerations(ExperimentType.class.getName())) {
+        for (final IObject experimentType : typesService.allEnumerations(ExperimentType.class.getName())) {
             builder.add((ExperimentType) experimentType);
         }
         experimentTypes = builder.build();
@@ -350,8 +350,8 @@ public class ModelMockFactory {
      */
     public Detector createDetector() throws Exception {
         // already tested see PixelsService enumeration.
-        List<IObject> types = pixelsService
-                .getAllEnumerations(DetectorType.class.getName());
+        List<IObject> types = typesService
+                .allEnumerations(DetectorType.class.getName());
         Detector detector = new DetectorI();
         detector.setAmplificationGain(omero.rtypes.rdouble(0));
         detector.setGain(omero.rtypes.rdouble(1));
@@ -378,7 +378,7 @@ public class ModelMockFactory {
     public OTF createOTF(FilterSet filterSet, Objective objective)
             throws Exception {
         // already tested see PixelsService enumeration.
-        List<IObject> types = pixelsService.getAllEnumerations(PixelsType.class
+        List<IObject> types = typesService.allEnumerations(PixelsType.class
                 .getName());
         OTF otf = new OTFI();
         otf.setFilterSet(filterSet);
@@ -405,7 +405,7 @@ public class ModelMockFactory {
      */
     public Filter createFilter(int cutIn, int cutOut) throws Exception {
         // already tested see PixelsService enumeration.
-        List<IObject> types = pixelsService.getAllEnumerations(FilterType.class
+        List<IObject> types = typesService.allEnumerations(FilterType.class
                 .getName());
         Filter filter = new FilterI();
         filter.setLotNumber(omero.rtypes.rstring("lot number"));
@@ -471,11 +471,11 @@ public class ModelMockFactory {
         objective.setCalibratedMagnification(omero.rtypes.rdouble(1));
         // correction
         // already tested see PixelsService enumeration.
-        List<IObject> types = pixelsService.getAllEnumerations(Correction.class
+        List<IObject> types = typesService.allEnumerations(Correction.class
                 .getName());
         objective.setCorrection((Correction) types.get(0));
         // immersion
-        types = pixelsService.getAllEnumerations(Immersion.class.getName());
+        types = typesService.allEnumerations(Immersion.class.getName());
         objective.setImmersion((Immersion) types.get(0));
 
         objective.setIris(omero.rtypes.rbool(true));
@@ -497,7 +497,7 @@ public class ModelMockFactory {
     public ObjectiveSettings createObjectiveSettings(Objective objective)
             throws Exception {
         // already tested see PixelsService enumeration.
-        List<IObject> types = pixelsService.getAllEnumerations(Medium.class
+        List<IObject> types = typesService.allEnumerations(Medium.class
                 .getName());
         ObjectiveSettings settings = new ObjectiveSettingsI();
         settings.setCorrectionCollar(omero.rtypes.rdouble(1));
@@ -545,8 +545,8 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     DetectorSettings createDetectorSettings(Detector detector) throws Exception {
-        // already tested see PixelsService enumeration.
-        List<IObject> types = pixelsService.getAllEnumerations(Binning.class
+        // already tested see Types enumeration.
+        List<IObject> types = typesService.allEnumerations(Binning.class
                 .getName());
         DetectorSettings settings = new DetectorSettingsI();
         settings.setBinning((Binning) types.get(0));
@@ -569,9 +569,7 @@ public class ModelMockFactory {
      */
     public LightSettings createLightSettings(LightSource light)
             throws Exception {
-        // already tested see PixelsService enumeration.
-        List<IObject> types = pixelsService
-                .getAllEnumerations(MicrobeamManipulationType.class.getName());
+        List<IObject> types = typesService.allEnumerations(MicrobeamManipulationType.class.getName());
         LightSettings settings = new LightSettingsI();
         settings.setLightSource(light);
         settings.setAttenuation(omero.rtypes.rdouble(1));
@@ -611,8 +609,7 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Filament createFilament() throws Exception {
-        List<IObject> types = pixelsService
-                .getAllEnumerations(FilamentType.class.getName());
+        List<IObject> types = typesService.allEnumerations(FilamentType.class.getName());
         Filament filament = new FilamentI();
         filament.setManufacturer(omero.rtypes.rstring("manufacturer"));
         filament.setModel(omero.rtypes.rstring("model"));
@@ -632,7 +629,7 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Arc createArc() throws Exception {
-        List<IObject> types = pixelsService.getAllEnumerations(ArcType.class
+        List<IObject> types =typesService.allEnumerations(ArcType.class
                 .getName());
         Arc arc = new ArcI();
         arc.setManufacturer(omero.rtypes.rstring("manufacturer"));
@@ -677,15 +674,15 @@ public class ModelMockFactory {
         laser.setLotNumber(omero.rtypes.rstring("lot number"));
         laser.setSerialNumber(omero.rtypes.rstring("serial number"));
         // type
-        List<IObject> types = pixelsService.getAllEnumerations(LaserType.class
+        List<IObject> types = typesService.allEnumerations(LaserType.class
                 .getName());
         laser.setType((LaserType) types.get(0));
         // laser medium
-        types = pixelsService.getAllEnumerations(LaserMedium.class.getName());
+        types = typesService.allEnumerations(LaserMedium.class.getName());
         laser.setLaserMedium((LaserMedium) types.get(0));
 
         // pulse
-        types = pixelsService.getAllEnumerations(Pulse.class.getName());
+        types = typesService.allEnumerations(Pulse.class.getName());
         laser.setPulse((Pulse) types.get(0));
 
         laser.setFrequencyMultiplication(omero.rtypes.rint(1));
@@ -705,8 +702,7 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Instrument createInstrument() throws Exception {
-        List<IObject> types = pixelsService
-                .getAllEnumerations(MicroscopeType.class.getName());
+        List<IObject> types = typesService.allEnumerations(MicroscopeType.class.getName());
         Instrument instrument = new InstrumentI();
         MicroscopeI microscope = new MicroscopeI();
         microscope.setManufacturer(omero.rtypes.rstring("manufacturer"));
@@ -841,7 +837,7 @@ public class ModelMockFactory {
      */
     public Pixels createPixels(int sizeX, int sizeY, int sizeZ, int sizeT,
             int sizeC, String pxType) throws Exception {
-        List<IObject> types = pixelsService.getAllEnumerations(PixelsType.class
+        List<IObject> types = typesService.allEnumerations(PixelsType.class
                 .getName());
         Iterator<IObject> i = types.iterator();
         PixelsType object;
@@ -855,8 +851,7 @@ public class ModelMockFactory {
         }
         if (type == null)
             type = (PixelsType) types.get(0);
-        types = pixelsService
-                .getAllEnumerations(DimensionOrder.class.getName());
+        types = typesService.allEnumerations(DimensionOrder.class.getName());
         i = types.iterator();
         DimensionOrder o;
         DimensionOrder order = null;
@@ -915,13 +910,12 @@ public class ModelMockFactory {
         Channel channel = new ChannelI();
         LogicalChannel lc = new LogicalChannelI();
         lc.setEmissionWave(new LengthI(200.1, UnitsFactory.Channel_EmissionWavelength));
-        List<IObject> types = pixelsService
-                .getAllEnumerations(ContrastMethod.class.getName());
+        List<IObject> types = typesService.allEnumerations(ContrastMethod.class.getName());
         ContrastMethod cm = (ContrastMethod) types.get(0);
 
-        types = pixelsService.getAllEnumerations(Illumination.class.getName());
+        types = typesService.allEnumerations(Illumination.class.getName());
         Illumination illumination = (Illumination) types.get(0);
-        types = pixelsService.getAllEnumerations(AcquisitionMode.class
+        types = typesService.allEnumerations(AcquisitionMode.class
                 .getName());
         AcquisitionMode mode = (AcquisitionMode) types.get(0);
         lc.setContrastMethod(cm);

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -349,7 +349,6 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Detector createDetector() throws Exception {
-        // already tested see PixelsService enumeration.
         List<IObject> types = typesService
                 .allEnumerations(DetectorType.class.getName());
         Detector detector = new DetectorI();
@@ -377,7 +376,6 @@ public class ModelMockFactory {
      */
     public OTF createOTF(FilterSet filterSet, Objective objective)
             throws Exception {
-        // already tested see PixelsService enumeration.
         List<IObject> types = typesService.allEnumerations(PixelsType.class
                 .getName());
         OTF otf = new OTFI();
@@ -404,7 +402,6 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Filter createFilter(int cutIn, int cutOut) throws Exception {
-        // already tested see PixelsService enumeration.
         List<IObject> types = typesService.allEnumerations(FilterType.class
                 .getName());
         Filter filter = new FilterI();
@@ -470,7 +467,6 @@ public class ModelMockFactory {
         objective.setLotNumber(omero.rtypes.rstring("lot number"));
         objective.setCalibratedMagnification(omero.rtypes.rdouble(1));
         // correction
-        // already tested see PixelsService enumeration.
         List<IObject> types = typesService.allEnumerations(Correction.class
                 .getName());
         objective.setCorrection((Correction) types.get(0));
@@ -496,7 +492,6 @@ public class ModelMockFactory {
      */
     public ObjectiveSettings createObjectiveSettings(Objective objective)
             throws Exception {
-        // already tested see PixelsService enumeration.
         List<IObject> types = typesService.allEnumerations(Medium.class
                 .getName());
         ObjectiveSettings settings = new ObjectiveSettingsI();
@@ -545,7 +540,6 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     DetectorSettings createDetectorSettings(Detector detector) throws Exception {
-        // already tested see Types enumeration.
         List<IObject> types = typesService.allEnumerations(Binning.class
                 .getName());
         DetectorSettings settings = new DetectorSettingsI();
@@ -629,7 +623,7 @@ public class ModelMockFactory {
      *             Thrown if an error occurred.
      */
     public Arc createArc() throws Exception {
-        List<IObject> types =typesService.allEnumerations(ArcType.class
+        List<IObject> types = typesService.allEnumerations(ArcType.class
                 .getName());
         Arc arc = new ArcI();
         arc.setManufacturer(omero.rtypes.rstring("manufacturer"));

--- a/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
@@ -233,7 +233,7 @@ public class PermissionsTestAll extends AbstractServerTest {
                             false);
                     session.setSecurityContext(group);
                     iUpdate = session.getUpdateService();
-                    mmFactory = new ModelMockFactory(session.getPixelsService());
+                    mmFactory = new ModelMockFactory(session.getTypesService());
 
                     // Create new Image Objects(with pixels) and attach it to
                     // the session
@@ -274,7 +274,7 @@ public class PermissionsTestAll extends AbstractServerTest {
                     session.setSecurityContext(new ExperimenterGroupI(group.getId()
                             .getValue(), false));
                     iUpdate = session.getUpdateService();
-                    mmFactory = new ModelMockFactory(session.getPixelsService());
+                    mmFactory = new ModelMockFactory(session.getTypesService());
 
                     List<Long> annotationIds = new ArrayList<Long>();
 

--- a/components/tools/OmeroJava/test/integration/PixelsServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/PixelsServiceTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import omero.RLong;
 import omero.api.IPixelsPrx;
 import omero.api.IRenderingSettingsPrx;
+import omero.api.ITypesPrx;
 import omero.model.AcquisitionMode;
 import omero.model.ArcType;
 import omero.model.Binning;
@@ -202,8 +203,8 @@ public class PixelsServiceTest extends AbstractServerTest {
      *            The number of objects to retrieve.
      */
     private void checkEnumeration(String name, int max) throws Exception {
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> values = svc.getAllEnumerations(name);
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> values = svc.allEnumerations(name);
         Assert.assertNotNull(values);
         Assert.assertTrue(values.size() >= max);
         Iterator<IObject> i = values.iterator();
@@ -378,15 +379,15 @@ public class PixelsServiceTest extends AbstractServerTest {
      */
     @Test
     public void testCreateImage() throws Exception {
-        IPixelsPrx svc = factory.getPixelsService();
+        ITypesPrx svc = factory.getTypesService();
         List<IObject> types = svc
-                .getAllEnumerations(PixelsType.class.getName());
+                .allEnumerations(PixelsType.class.getName());
         List<Integer> channels = new ArrayList<Integer>();
         for (int i = 0; i < 3; i++) {
             channels.add(i);
         }
-        RLong id = svc.createImage(10, 10, 10, 10, channels,
-                (PixelsType) types.get(1), "test", "");
+        RLong id = factory.getPixelsService().createImage(10, 10, 10, 10,
+                channels, (PixelsType) types.get(1), "test", "");
         Assert.assertNotNull(id);
         // Retrieve the image.
         ParametersI param = new ParametersI();

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2006-2016 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package integration;
@@ -26,9 +26,9 @@ import javax.imageio.ImageIO;
 
 import ome.specification.XMLMockObjects;
 import ome.specification.XMLWriter;
-import omero.api.IPixelsPrx;
 import omero.api.IRenderingSettingsPrx;
 import omero.api.IScriptPrx;
+import omero.api.ITypesPrx;
 import omero.api.RenderingEnginePrx;
 import omero.cmd.Chgrp2;
 import omero.cmd.Delete2;
@@ -469,9 +469,9 @@ public class RenderingEngineTest extends AbstractServerTest {
         Assert.assertEquals(re.getDefaultZ(), v);
 
         // tested in PixelsService
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> families = svc.getAllEnumerations(Family.class.getName());
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> families = svc.allEnumerations(Family.class.getName());
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         RenderingModel model = def.getModel();
         Iterator<IObject> i;
@@ -668,9 +668,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         re.setCodomainInterval(new_cd_start, new_cd_end);
         //mode change
         RenderingModel model = re.getModel();
-        List<IObject> models = factory.getPixelsService().getAllEnumerations(
-                RenderingModel.class
-                .getName());
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class.getName());
         Iterator<IObject> j = models.iterator();
         RenderingModel m, new_model = null;
         // Change the color model so it is not grey scale.
@@ -802,8 +801,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         Assert.assertNotNull(buffer);
         Assert.assertEquals(p.getSizeX().getValue(), buffer.sizeX1);
         Assert.assertEquals(p.getSizeY().getValue(), buffer.sizeX2);
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         RenderingModel model = re.getModel();
         Iterator<IObject> i = models.iterator();
@@ -947,8 +946,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         pDef.region = r;
         bufferRegion = re.render(pDef);
         Assert.assertNotNull(bufferRegion);
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         RenderingModel model = re.getModel();
         Iterator<IObject> i = models.iterator();
@@ -1108,8 +1107,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         Assert.assertNotNull(image);
 
         // now change the model
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         RenderingModel model = re.getModel();
         Iterator<IObject> i = models.iterator();
@@ -1245,8 +1244,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         Assert.assertNotNull(region);
         imageRegion = createImage(region, 32, r.width, r.height);
         Assert.assertNotNull(imageRegion);
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         RenderingModel model = re.getModel();
         Iterator<IObject> i = models.iterator();
@@ -1517,8 +1516,8 @@ public class RenderingEngineTest extends AbstractServerTest {
 
         // greyscale
         RenderingModel model = re.getModel();
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         Iterator<IObject> i = models.iterator();
         RenderingModel m;
@@ -1587,8 +1586,8 @@ public class RenderingEngineTest extends AbstractServerTest {
 
         // grey scale.
         RenderingModel model = re.getModel();
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         Iterator<IObject> i = models.iterator();
         RenderingModel m;
@@ -1795,9 +1794,9 @@ public class RenderingEngineTest extends AbstractServerTest {
         re.saveCurrentSettings();
         Assert.assertEquals(re.getDefaultT(), t);
         // tested in PixelsService
-        IPixelsPrx svc = factory.getPixelsService();
-        List<IObject> families = svc.getAllEnumerations(Family.class.getName());
-        List<IObject> models = svc.getAllEnumerations(RenderingModel.class
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> families = svc.allEnumerations(Family.class.getName());
+        List<IObject> models = svc.allEnumerations(RenderingModel.class
                 .getName());
         RenderingModel rm = re.getModel();
         Iterator<IObject> i;
@@ -2200,9 +2199,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         pDef.z = re.getDefaultZ();
         pDef.slice = omero.romio.XY.value;
         RenderingModel model = re.getModel();
-        List<IObject> models = factory.getPixelsService().getAllEnumerations(
-                RenderingModel.class
-                .getName());
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class.getName());
         Iterator<IObject> j = models.iterator();
         RenderingModel m;
         // Change the color model so it is not grey scale.
@@ -2276,9 +2274,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         pDef.z = re.getDefaultZ();
         pDef.slice = omero.romio.XY.value;
         RenderingModel model = re.getModel();
-        List<IObject> models = factory.getPixelsService().getAllEnumerations(
-                RenderingModel.class
-                .getName());
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class.getName());
         Iterator<IObject> j = models.iterator();
         RenderingModel m;
         // Change the color model so it is not grey scale.
@@ -3305,7 +3302,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
         List<ChannelBinding> channels = def.copyWaveRendering();
         RenderingModel model = re.getModel();
-        List<IObject> models = factory.getPixelsService().getAllEnumerations(
+        List<IObject> models = factory.getTypesService().allEnumerations(
                 RenderingModel.class
                 .getName());
         Iterator<IObject> j = models.iterator();
@@ -3351,9 +3348,8 @@ public class RenderingEngineTest extends AbstractServerTest {
         RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
         List<ChannelBinding> channels = def.copyWaveRendering();
         RenderingModel model = re.getModel();
-        List<IObject> models = factory.getPixelsService().getAllEnumerations(
-                RenderingModel.class
-                .getName());
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class.getName());
         Iterator<IObject> j = models.iterator();
         RenderingModel m;
         // Change the color model so it is not grey scale.

--- a/components/tools/OmeroJava/test/integration/gateway/DataManagerFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/DataManagerFacilityTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -466,8 +466,8 @@ public class DataManagerFacilityTest extends GatewayTest {
     
     private long createImage(SecurityContext ctx) throws Exception {
         IPixelsPrx svc = gw.getPixelsService(ctx);
-        List<IObject> types = svc
-                .getAllEnumerations(PixelsType.class.getName());
+        List<IObject> types = gw.getTypesService(ctx)
+                .allEnumerations(PixelsType.class.getName());
         List<Integer> channels = new ArrayList<Integer>();
         for (int i = 0; i < 3; i++) {
             channels.add(i);
@@ -526,8 +526,8 @@ public class DataManagerFacilityTest extends GatewayTest {
     private long createImage() throws ServerError, DSOutOfServiceException {
         String name = UUID.randomUUID().toString();
         IPixelsPrx svc = gw.getPixelsService(rootCtx);
-        List<IObject> types = svc
-                .getAllEnumerations(PixelsType.class.getName());
+        List<IObject> types = gw.getTypesService(rootCtx)
+                .allEnumerations(PixelsType.class.getName());
         List<Integer> channels = new ArrayList<Integer>();
         for (int i = 0; i < 3; i++) {
             channels.add(i);

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
@@ -221,8 +221,8 @@ public class GatewayTest {
     private long createImage(SecurityContext ctx) throws Exception {
         String name = UUID.randomUUID().toString();
         IPixelsPrx svc = gw.getPixelsService(ctx);
-        List<IObject> types = svc
-                .getAllEnumerations(PixelsType.class.getName());
+        List<IObject> types = gw.getTypesService(ctx)
+                .allEnumerations(PixelsType.class.getName());
         List<Integer> channels = new ArrayList<Integer>();
         for (int i = 0; i < 3; i++) {
             channels.add(i);

--- a/components/tools/OmeroJava/test/integration/gateway/MetadataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/MetadataFacilityTest.java
@@ -95,8 +95,8 @@ public class MetadataFacilityTest extends GatewayTest {
     private void initData() throws Exception {
         String name = UUID.randomUUID().toString();
         IPixelsPrx svc = gw.getPixelsService(rootCtx);
-        List<IObject> types = svc
-                .getAllEnumerations(PixelsType.class.getName());
+        List<IObject> types = gw.getTypesService(rootCtx)
+                .allEnumerations(PixelsType.class.getName());
         List<Integer> channels = new ArrayList<Integer>();
         for (int i = 0; i < 3; i++) {
             channels.add(i);

--- a/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
@@ -228,8 +228,8 @@ public class ROIFacilityTest extends GatewayTest {
     private void initData() throws Exception {
         String name = UUID.randomUUID().toString();
         IPixelsPrx svc = gw.getPixelsService(rootCtx);
-        List<IObject> types = svc
-                .getAllEnumerations(PixelsType.class.getName());
+        List<IObject> types = gw.getTypesService(rootCtx)
+                .allEnumerations(PixelsType.class.getName());
         List<Integer> channels = new ArrayList<Integer>();
         for (int i = 0; i < 3; i++) {
             channels.add(i);

--- a/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
@@ -118,8 +118,8 @@ public class RawDataFacilityTest extends GatewayTest {
 
         String name = UUID.randomUUID().toString();
         IPixelsPrx svc = gw.getPixelsService(rootCtx);
-        List<IObject> types = svc
-                .getAllEnumerations(PixelsType.class.getName());
+        List<IObject> types = gw.getTypesService(rootCtx)
+                .allEnumerations(PixelsType.class.getName());
         PixelsType type = (PixelsType) types.get(2); // unit8
         List<Integer> channels = new ArrayList<Integer>();
         for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
# What this PR does

Remove the usage of deprecated method to retrieve enumerations
in the test under ``OmeroJava``
This was noticed while working on 

https://github.com/openmicroscopy/openmicroscopy/pull/5042


# Testing this PR

Check that the integration tests are still passing


# Related reading

See https://trello.com/c/BKRBO167/220-to-deprecate

