### PR TITLE
Training example remove deprecated

### DIFF
--- a/examples/Training/java/src/training/CreateImage.java
+++ b/examples/Training/java/src/training/CreateImage.java
@@ -171,7 +171,7 @@ public class CreateImage
         }
         //Now we are going to create the new image.
         IPixelsPrx proxy = gateway.getPixelsService(ctx);
-        List<IObject> l = proxy.getAllEnumerations(PixelsType.class.getName());
+        List<IObject> l = gateway.getTypesService(ctx).allEnumerations(PixelsType.class.getName());
         Iterator<IObject> i = l.iterator();
         PixelsType type = null;
         String original = pixels.getPixelType();

--- a/examples/Training/matlab/CreateImage.m
+++ b/examples/Training/matlab/CreateImage.m
@@ -41,7 +41,7 @@ try
     
     % Retrieve pixel type
     pixelsService = session.getPixelsService();
-    pixelTypes = toMatlabList(pixelsService.getAllEnumerations('omero.model.PixelsType'));
+    pixelTypes = toMatlabList(session.getTypesService().allEnumerations('omero.model.PixelsType'));
     pixelTypeValues = arrayfun(@(x) char(x.getValue().getValue()),...
         pixelTypes, 'Unif', false);
     pixelType = pixelTypes(strcmp(pixelTypeValues, type));


### PR DESCRIPTION
# What this PR does

Remove usage of deprecated method to retrieve enum
in training example

# Testing this PR
Check that the training example job remains green


# Related reading
 See also https://github.com/openmicroscopy/openmicroscopy/pull/5044
and https://trello.com/c/BKRBO167/220-to-deprecate

