### PR TITLE
Api wells

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3096,6 +3096,7 @@ class _BlitzGateway (object):
         :param opts:        Dict of additional options for filtering or
                             defining extra data to load.
                             offset, limit and owner for all objects.
+                            Also 'order_by': 'obj.name' to order results.
                             Additional opts handled by _getQueryString()
                             E.g. 'childCount', or filter Dataset by 'project'
         :return:            (query, params, wrapper)
@@ -3171,9 +3172,9 @@ class _BlitzGateway (object):
         if clauses:
             query += " where " + (" and ".join(clauses))
 
-        # Order by...
+        # Order by... e.g. 'lower(obj.name)' or 'obj.column, obj.row' for wells
         if order_by is not None:
-            query += " order by lower(obj.%s), obj.id" % order_by
+            query += " order by %s, obj.id" % order_by
 
         return (query, baseParams, wrapper)
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6080,7 +6080,8 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if load_images or load_pixels or load_channels:
             # NB: Using left outer join, we may get Wells with no Images
             query += " left outer join fetch obj.wellSamples as wellSamples"\
-                     " left outer join fetch wellSamples.image as image"
+                     " left outer join fetch wellSamples.image as image"\
+                     " join fetch wellSamples.plateAcquisition as plateAcquisition"
         if load_pixels or load_channels:
             query += ' left outer join fetch image.pixels pixels' \
                      ' left outer join fetch pixels.pixelsType'

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6081,14 +6081,16 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             # NB: Using left outer join, we may get Wells with no Images
             query += " left outer join fetch obj.wellSamples as wellSamples"\
                      " left outer join fetch wellSamples.image as image"\
-                     " join fetch wellSamples.plateAcquisition as plateAcquisition"
+                     " left outer join fetch wellSamples.plateAcquisition"\
+                     " as plateAcquisition"
         if load_pixels or load_channels:
             query += ' left outer join fetch image.pixels pixels' \
                      ' left outer join fetch pixels.pixelsType'
         if load_channels:
             query += ' join fetch pixels.channels as channels' \
                      ' join fetch channels.logicalChannel as logicalChannel' \
-                     ' left outer join fetch logicalChannel.photometricInterpretation' \
+                     ' left outer join fetch ' \
+                     ' logicalChannel.photometricInterpretation' \
                      ' left outer join fetch logicalChannel.illumination' \
                      ' left outer join fetch logicalChannel.mode' \
                      ' left outer join fetch logicalChannel.contrastMethod'

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -143,12 +143,12 @@ def fileread_gen(fin, fsize, bufsize):
 
 def getChannelsQuery():
     """Helper for building Query for Images or Wells & Images"""
-    return (' join fetch pixels.channels as channels' \
-            ' join fetch channels.logicalChannel as logicalChannel' \
-            ' left outer join fetch ' \
-            ' logicalChannel.photometricInterpretation' \
-            ' left outer join fetch logicalChannel.illumination' \
-            ' left outer join fetch logicalChannel.mode' \
+    return (' join fetch pixels.channels as channels'
+            ' join fetch channels.logicalChannel as logicalChannel'
+            ' left outer join fetch '
+            ' logicalChannel.photometricInterpretation'
+            ' left outer join fetch logicalChannel.illumination'
+            ' left outer join fetch logicalChannel.mode'
             ' left outer join fetch logicalChannel.contrastMethod')
 
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6060,6 +6060,7 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Extend base query to handle filtering of Wells by Plate.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'plate': <plate_id> to filter by Plate
+                        'load_images': <bool> to load wellSamples and images
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
@@ -6069,6 +6070,10 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if opts is not None and 'plate' in opts:
             clauses.append('obj.plate.id = :pid')
             params.add('pid', rlong(opts['plate']))
+        if opts is not None and opts.get('load_images'):
+            # NB: Using left outer join, we may get Wells with no Images
+            query += " left outer join fetch obj.wellSamples as wellSamples"\
+                     " left outer join fetch wellSamples.image as image"
         return (query, clauses, params)
 
     def __loadedHotSwap__(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -146,6 +146,7 @@ def getPixelsQuery(imageName):
     return (' left outer join fetch %s.pixels as pixels'
             ' left outer join fetch pixels.pixelsType' % imageName)
 
+
 def getChannelsQuery():
     """Helper for building Query for Images or Wells & Images"""
     return (' join fetch pixels.channels as channels'

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -141,6 +141,17 @@ def fileread_gen(fin, fsize, bufsize):
     fin.close()
 
 
+def getChannelsQuery():
+    """Helper for building Query for Images or Wells & Images"""
+    return (' join fetch pixels.channels as channels' \
+            ' join fetch channels.logicalChannel as logicalChannel' \
+            ' left outer join fetch ' \
+            ' logicalChannel.photometricInterpretation' \
+            ' left outer join fetch logicalChannel.illumination' \
+            ' left outer join fetch logicalChannel.mode' \
+            ' left outer join fetch logicalChannel.contrastMethod')
+
+
 class OmeroRestrictionWrapper (object):
 
     def canDownload(self):
@@ -6084,16 +6095,10 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                      " left outer join fetch wellSamples.plateAcquisition"\
                      " as plateAcquisition"
         if load_pixels or load_channels:
-            query += ' left outer join fetch image.pixels pixels' \
+            query += ' left outer join fetch image.pixels as pixels' \
                      ' left outer join fetch pixels.pixelsType'
         if load_channels:
-            query += ' join fetch pixels.channels as channels' \
-                     ' join fetch channels.logicalChannel as logicalChannel' \
-                     ' left outer join fetch ' \
-                     ' logicalChannel.photometricInterpretation' \
-                     ' left outer join fetch logicalChannel.illumination' \
-                     ' left outer join fetch logicalChannel.mode' \
-                     ' left outer join fetch logicalChannel.contrastMethod'
+            query += getChannelsQuery()
 
         return (query, clauses, params)
 
@@ -7187,12 +7192,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             query += ' left outer join fetch obj.pixels pixels' \
                      ' left outer join fetch pixels.pixelsType'
         if load_channels:
-            query += ' join fetch pixels.channels as channels' \
-                     ' join fetch channels.logicalChannel as logicalChannel' \
-                     ' left outer join fetch logicalChannel.photometricInterpretation' \
-                     ' left outer join fetch logicalChannel.illumination' \
-                     ' left outer join fetch logicalChannel.mode' \
-                     ' left outer join fetch logicalChannel.contrastMethod'
+            query += getChannelsQuery()
         if orphaned:
             clauses.append(
                 """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6054,6 +6054,23 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         self._childcache = None
 
+    @classmethod
+    def _getQueryString(cls, opts=None):
+        """
+        Extend base query to handle filtering of Wells by Plate.
+        Returns a tuple of (query, clauses, params).
+        Supported opts: 'plate': <plate_id> to filter by Plate
+
+        :param opts:        Dictionary of optional parameters.
+        :return:            Tuple of string, list, ParametersI
+        """
+        query, clauses, params = super(
+            _WellWrapper, cls)._getQueryString(opts)
+        if opts is not None and 'plate' in opts:
+            clauses.append('obj.plate.id = :pid')
+            params.add('pid', rlong(opts['plate']))
+        return (query, clauses, params)
+
     def __loadedHotSwap__(self):
         query = ("select well from Well as well "
                  "join fetch well.details.creationEvent "

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6070,10 +6070,28 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if opts is not None and 'plate' in opts:
             clauses.append('obj.plate.id = :pid')
             params.add('pid', rlong(opts['plate']))
-        if opts is not None and opts.get('load_images'):
+        load_images = False
+        load_pixels = False
+        load_channels = False
+        if opts is not None:
+            load_images = opts.get('load_images')
+            load_pixels = opts.get('load_pixels')
+            load_channels = opts.get('load_channels')
+        if load_images or load_pixels or load_channels:
             # NB: Using left outer join, we may get Wells with no Images
             query += " left outer join fetch obj.wellSamples as wellSamples"\
                      " left outer join fetch wellSamples.image as image"
+        if load_pixels or load_channels:
+            query += ' left outer join fetch image.pixels pixels' \
+                     ' left outer join fetch pixels.pixelsType'
+        if load_channels:
+            query += ' join fetch pixels.channels as channels' \
+                     ' join fetch channels.logicalChannel as logicalChannel' \
+                     ' left outer join fetch logicalChannel.photometricInterpretation' \
+                     ' left outer join fetch logicalChannel.illumination' \
+                     ' left outer join fetch logicalChannel.mode' \
+                     ' left outer join fetch logicalChannel.contrastMethod'
+
         return (query, clauses, params)
 
     def __loadedHotSwap__(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -141,6 +141,11 @@ def fileread_gen(fin, fsize, bufsize):
     fin.close()
 
 
+def getPixelsQuery(imageName):
+    """Helper for building Query for Images or Wells & Images"""
+    return (' left outer join fetch %s.pixels as pixels'
+            ' left outer join fetch pixels.pixelsType' % imageName)
+
 def getChannelsQuery():
     """Helper for building Query for Images or Wells & Images"""
     return (' join fetch pixels.channels as channels'
@@ -6095,8 +6100,7 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                      " left outer join fetch wellSamples.plateAcquisition"\
                      " as plateAcquisition"
         if load_pixels or load_channels:
-            query += ' left outer join fetch image.pixels as pixels' \
-                     ' left outer join fetch pixels.pixelsType'
+            query += getPixelsQuery("image")
         if load_channels:
             query += getChannelsQuery()
 
@@ -7189,8 +7193,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             orphaned = opts.get('orphaned')
         if load_pixels or load_channels:
             # We use 'left outer join', since we still want images if no pixels
-            query += ' left outer join fetch obj.pixels pixels' \
-                     ' left outer join fetch pixels.pixelsType'
+            query += getPixelsQuery("obj")
         if load_channels:
             query += getChannelsQuery()
         if orphaned:

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -176,6 +176,15 @@ api_wells = url(r'^v(?P<api_version>%s)/m/wells/$' % versions,
 GET all wells, using omero-marshal to generate json
 """
 
+api_plate_wells = url(
+    r'^v(?P<api_version>%s)/m/plates/'
+    '(?P<plate_id>[0-9]+)/wells/$' % versions,
+    views.WellsView.as_view(),
+    name='api_plate_wells')
+"""
+GET Wells in Plate, using omero-marshal to generate json
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -198,4 +207,5 @@ urlpatterns = patterns(
     api_screen_plates,
     api_plate,
     api_wells,
+    api_plate_wells,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -185,6 +185,14 @@ api_plate_wells = url(
 GET Wells in Plate, using omero-marshal to generate json
 """
 
+api_well = url(
+    r'^v(?P<api_version>%s)/m/wells/(?P<object_id>[0-9]+)/$' % versions,
+    views.WellView.as_view(),
+    name='api_well')
+"""
+Well url to GET or DELETE a single Well
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -208,4 +216,5 @@ urlpatterns = patterns(
     api_plate,
     api_wells,
     api_plate_wells,
+    api_well,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -170,8 +170,8 @@ Plate url to GET or DELETE a single Plate
 """
 
 api_wells = url(r'^v(?P<api_version>%s)/m/wells/$' % versions,
-                 views.WellsView.as_view(),
-                 name='api_wells')
+                views.WellsView.as_view(),
+                name='api_wells')
 """
 GET all wells, using omero-marshal to generate json
 """

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -169,6 +169,13 @@ api_plate = url(
 Plate url to GET or DELETE a single Plate
 """
 
+api_wells = url(r'^v(?P<api_version>%s)/m/wells/$' % versions,
+                 views.WellsView.as_view(),
+                 name='api_wells')
+"""
+GET all wells, using omero-marshal to generate json
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -190,4 +197,5 @@ urlpatterns = patterns(
     api_plates,
     api_screen_plates,
     api_plate,
+    api_wells,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -237,6 +237,12 @@ class PlateView(ObjectView):
 
     OMERO_TYPE = 'Plate'
 
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'wells_url': {'name': 'api_plate_wells',
+                      'kwargs': {'plate_id': 'OBJECT_ID'}}
+    }
+
 
 class ObjectsView(ApiView):
     """Base class for listing objects."""

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -258,7 +258,6 @@ class ObjectsView(ApiView):
                 'owner': owner,
                 'orphaned': orphaned,
                 'child_count': child_count,
-                'order_by': 'name',     # NB: will break if object has no name
                 }
         return opts
 
@@ -280,6 +279,12 @@ class ProjectsView(ObjectsView):
 
     OMERO_TYPE = 'Project'
 
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(ProjectsView, self).get_opts(request, **kwargs)
+        opts['order_by'] = 'lower(name)'
+        return opts
+
     # To add a url to marshalled object add to this dict
     # 'name' is url name, kwargs are passed to reverse()
     # If any kwargs values are 'OBJECT_ID' then this placeholder will be
@@ -298,8 +303,9 @@ class DatasetsView(ObjectsView):
     OMERO_TYPE = 'Dataset'
 
     def get_opts(self, request, **kwargs):
-        """Add filtering by 'project' to the opts dict."""
+        """Add extra parameters to the opts dict."""
         opts = super(DatasetsView, self).get_opts(request, **kwargs)
+        opts['order_by'] = 'lower(name)'
         # at /projects/:project_id/datasets/ we have 'project_id' in kwargs
         if 'project_id' in kwargs:
             opts['project'] = long(kwargs['project_id'])
@@ -324,6 +330,12 @@ class ScreensView(ObjectsView):
 
     OMERO_TYPE = 'Screen'
 
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(ScreensView, self).get_opts(request, **kwargs)
+        opts['order_by'] = 'lower(name)'
+        return opts
+
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
         'url:plates': {'name': 'api_screen_plates',
@@ -339,8 +351,9 @@ class PlatesView(ObjectsView):
     OMERO_TYPE = 'Plate'
 
     def get_opts(self, request, **kwargs):
-        """Add filtering by 'screen' to the opts dict."""
+        """Add extra parameters to the opts dict."""
         opts = super(PlatesView, self).get_opts(request, **kwargs)
+        opts['order_by'] = 'lower(name)'
         # at /screens/:screen_id/plates/ we have 'screen_id' in kwargs
         if 'screen_id' in kwargs:
             opts['screen'] = long(kwargs['screen_id'])
@@ -370,8 +383,9 @@ class ImagesView(ObjectsView):
     }
 
     def get_opts(self, request, **kwargs):
-        """Add filtering by 'dataset' and other params to the opts dict."""
+        """Add extra parameters to the opts dict."""
         opts = super(ImagesView, self).get_opts(request, **kwargs)
+        opts['order_by'] = 'lower(name)'
         # at /datasets/:dataset_id/images/ we have 'dataset_id' in kwargs
         if 'dataset_id' in kwargs:
             opts['dataset'] = long(kwargs['dataset_id'])
@@ -382,6 +396,18 @@ class ImagesView(ObjectsView):
                 opts['dataset'] = dataset
         # When listing images, always load pixels by default
         opts['load_pixels'] = True
+        return opts
+
+
+class WellsView(ObjectsView):
+    """Handles GET for /wells/ to list available Images."""
+
+    OMERO_TYPE = 'Well'
+
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(WellsView, self).get_opts(request, **kwargs)
+        opts['order_by'] = 'column, row'
         return opts
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -366,6 +366,8 @@ class PlatesView(ObjectsView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
+        'url:wells': {'name': 'api_plate_wells',
+                      'kwargs': {'plate_id': 'OBJECT_ID'}},
         'url:plate': {'name': 'api_plate',
                       'kwargs': {'object_id': 'OBJECT_ID'}}
     }
@@ -408,6 +410,14 @@ class WellsView(ObjectsView):
         """Add extra parameters to the opts dict."""
         opts = super(WellsView, self).get_opts(request, **kwargs)
         opts['order_by'] = 'obj.column, obj.row'
+        # at /plates/:plate_id/wells/ we have 'plate_id' in kwargs
+        if 'plate_id' in kwargs:
+            opts['plate'] = long(kwargs['plate_id'])
+        else:
+            # filter by query /wells/?plate=:id
+            plate = getIntOrDefault(request, 'plate', None)
+            if plate is not None:
+                opts['plate'] = plate
         return opts
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -282,7 +282,7 @@ class ProjectsView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(ProjectsView, self).get_opts(request, **kwargs)
-        opts['order_by'] = 'lower(name)'
+        opts['order_by'] = 'lower(obj.name)'
         return opts
 
     # To add a url to marshalled object add to this dict
@@ -305,7 +305,7 @@ class DatasetsView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(DatasetsView, self).get_opts(request, **kwargs)
-        opts['order_by'] = 'lower(name)'
+        opts['order_by'] = 'lower(obj.name)'
         # at /projects/:project_id/datasets/ we have 'project_id' in kwargs
         if 'project_id' in kwargs:
             opts['project'] = long(kwargs['project_id'])
@@ -333,7 +333,7 @@ class ScreensView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(ScreensView, self).get_opts(request, **kwargs)
-        opts['order_by'] = 'lower(name)'
+        opts['order_by'] = 'lower(obj.name)'
         return opts
 
     # Urls to add to marshalled object. See ProjectsView for more details
@@ -353,7 +353,7 @@ class PlatesView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(PlatesView, self).get_opts(request, **kwargs)
-        opts['order_by'] = 'lower(name)'
+        opts['order_by'] = 'lower(obj.name)'
         # at /screens/:screen_id/plates/ we have 'screen_id' in kwargs
         if 'screen_id' in kwargs:
             opts['screen'] = long(kwargs['screen_id'])
@@ -385,7 +385,7 @@ class ImagesView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(ImagesView, self).get_opts(request, **kwargs)
-        opts['order_by'] = 'lower(name)'
+        opts['order_by'] = 'lower(obj.name)'
         # at /datasets/:dataset_id/images/ we have 'dataset_id' in kwargs
         if 'dataset_id' in kwargs:
             opts['dataset'] = long(kwargs['dataset_id'])
@@ -407,7 +407,7 @@ class WellsView(ObjectsView):
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""
         opts = super(WellsView, self).get_opts(request, **kwargs)
-        opts['order_by'] = 'column, row'
+        opts['order_by'] = 'obj.column, obj.row'
         return opts
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -256,15 +256,15 @@ class WellView(ObjectView):
         return opts
 
     def add_data(self, marshalled, request, urls={}, **kwargs):
-        """Add 'image_url' to any 'Image' in 'WellSamples'."""
+        """Add 'url:image' to any 'Image' in 'WellSamples'."""
         marshalled = super(WellView, self).add_data(marshalled, request,
                                                     urls=urls, **kwargs)
         image_urls = {
-            'image_url': {'name': 'api_image',
+            'url:image': {'name': 'api_image',
                           'kwargs': {'object_id': 'OBJECT_ID'}},
         }
         if 'WellSamples' in marshalled:
-            # For each WellSample, add image_urls to Image
+            # For each WellSample, add image urls to Image
             for ws in marshalled['WellSamples']:
                 if 'Image' in ws:
                     self.add_data(ws['Image'], request, image_urls, **kwargs)
@@ -441,7 +441,7 @@ class WellsView(ObjectsView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
-        'well_url': {'name': 'api_well',
+        'url:well': {'name': 'api_well',
                      'kwargs': {'object_id': 'OBJECT_ID'}},
     }
 
@@ -460,6 +460,21 @@ class WellsView(ObjectsView):
         # Listing Wells, load Images
         opts['load_images'] = True
         return opts
+
+    def add_data(self, marshalled, request, urls={}, **kwargs):
+        """Add 'url:image' to any 'Image' in 'WellSamples'."""
+        marshalled = super(WellsView, self).add_data(marshalled, request,
+                                                     urls=urls, **kwargs)
+        image_urls = {
+            'url:image': {'name': 'api_image',
+                          'kwargs': {'object_id': 'OBJECT_ID'}},
+        }
+        if 'WellSamples' in marshalled:
+            # For each WellSample, add image urls to Image
+            for ws in marshalled['WellSamples']:
+                if 'Image' in ws:
+                    self.add_data(ws['Image'], request, image_urls, **kwargs)
+        return marshalled
 
 
 class SaveView(View):

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -251,7 +251,7 @@ class WellView(ObjectView):
     def get_opts(self, request):
         """Add support for load_images."""
         opts = super(WellView, self).get_opts(request)
-        # for single well, we always load images
+        # for single well, we load images with pixels
         opts['load_pixels'] = True
         return opts
 
@@ -457,8 +457,8 @@ class WellsView(ObjectsView):
             plate = getIntOrDefault(request, 'plate', None)
             if plate is not None:
                 opts['plate'] = plate
-        # Listing Wells, load Images with Pixels
-        opts['load_pixels'] = True
+        # Listing Wells, load Images
+        opts['load_images'] = True
         return opts
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -238,7 +238,7 @@ class PlateView(ObjectView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
-        'wells_url': {'name': 'api_plate_wells',
+        'url:wells': {'name': 'api_plate_wells',
                       'kwargs': {'plate_id': 'OBJECT_ID'}}
     }
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -123,7 +123,7 @@ class ApiView(View):
         """Wrap other methods to add decorators."""
         return super(ApiView, self).dispatch(*args, **kwargs)
 
-    def add_data(self, marshalled, request, urls={}, **kwargs):
+    def add_data(self, marshalled, request, urls=None, **kwargs):
         """
         Post-process marshalled object to add any extra data.
 
@@ -133,15 +133,16 @@ class ApiView(View):
         """
         object_id = marshalled['@id']
         version = kwargs['api_version']
-        for key, args in urls.items():
-            name = args['name']
-            kwargs = args['kwargs'].copy()
-            # If kwargs has 'OBJECT_ID' placeholder, we replace with id
-            for k, v in kwargs.items():
-                if v == 'OBJECT_ID':
-                    kwargs[k] = object_id
-            url = build_url(request, name, version, **kwargs)
-            marshalled[key] = url
+        if urls is not None:
+            for key, args in urls.items():
+                name = args['name']
+                kwargs = args['kwargs'].copy()
+                # If kwargs has 'OBJECT_ID' placeholder, we replace with id
+                for k, v in kwargs.items():
+                    if v == 'OBJECT_ID':
+                        kwargs[k] = object_id
+                url = build_url(request, name, version, **kwargs)
+                marshalled[key] = url
         return marshalled
 
 
@@ -255,7 +256,7 @@ class WellView(ObjectView):
         opts['load_pixels'] = True
         return opts
 
-    def add_data(self, marshalled, request, urls={}, **kwargs):
+    def add_data(self, marshalled, request, urls=None, **kwargs):
         """Add 'url:image' to any 'Image' in 'WellSamples'."""
         marshalled = super(WellView, self).add_data(marshalled, request,
                                                     urls=urls, **kwargs)
@@ -461,7 +462,7 @@ class WellsView(ObjectsView):
         opts['load_images'] = True
         return opts
 
-    def add_data(self, marshalled, request, urls={}, **kwargs):
+    def add_data(self, marshalled, request, urls=None, **kwargs):
         """Add 'url:image' to any 'Image' in 'WellSamples'."""
         marshalled = super(WellsView, self).add_data(marshalled, request,
                                                      urls=urls, **kwargs)

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -123,7 +123,7 @@ class ApiView(View):
         """Wrap other methods to add decorators."""
         return super(ApiView, self).dispatch(*args, **kwargs)
 
-    def add_data(self, marshalled, request, **kwargs):
+    def add_data(self, marshalled, request, urls={}, **kwargs):
         """
         Post-process marshalled object to add any extra data.
 
@@ -133,7 +133,7 @@ class ApiView(View):
         """
         object_id = marshalled['@id']
         version = kwargs['api_version']
-        for key, args in self.urls.items():
+        for key, args in urls.items():
             name = args['name']
             kwargs = args['kwargs'].copy()
             # If kwargs has 'OBJECT_ID' placeholder, we replace with id
@@ -161,7 +161,7 @@ class ObjectView(ApiView):
                                                      object_id))
         encoder = get_encoder(obj._obj.__class__)
         marshalled = encoder.encode(obj._obj)
-        self.add_data(marshalled, request, **kwargs)
+        self.add_data(marshalled, request, self.urls, **kwargs)
         return marshalled
 
     def delete(self, request, object_id, conn=None, **kwargs):
@@ -276,7 +276,7 @@ class ObjectsView(ApiView):
         marshalled = query_objects(conn, self.OMERO_TYPE, group,
                                    opts, normalize)
         for m in marshalled['data']:
-            self.add_data(m, request, **kwargs)
+            self.add_data(m, request, self.urls, **kwargs)
         return marshalled
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -242,6 +242,7 @@ class PlateView(ObjectView):
                       'kwargs': {'plate_id': 'OBJECT_ID'}}
     }
 
+
 class WellView(ObjectView):
     """Handle access to an individual Well to GET or DELETE it."""
 

--- a/components/tools/OmeroWeb/requirements-common.txt
+++ b/components/tools/OmeroWeb/requirements-common.txt
@@ -10,4 +10,4 @@ django-pipeline==1.3.20
 # Until Screens are supported in release, we need to use master branch
 # See https://github.com/openmicroscopy/openmicroscopy/pull/5006
 # omero-marshal==0.4.1
-git+git://github.com/chris-allan/omero-marshal.git@well-wellsample-image#egg=omero-marshal
+git+git://github.com/openmicroscopy/omero-marshal.git@master#egg=omero-marshal

--- a/components/tools/OmeroWeb/requirements-common.txt
+++ b/components/tools/OmeroWeb/requirements-common.txt
@@ -10,4 +10,4 @@ django-pipeline==1.3.20
 # Until Screens are supported in release, we need to use master branch
 # See https://github.com/openmicroscopy/openmicroscopy/pull/5006
 # omero-marshal==0.4.1
-git+git://github.com/openmicroscopy/omero-marshal.git@master#egg=omero-marshal
+git+git://github.com/chris-allan/omero-marshal.git@well-wellsample-image#egg=omero-marshal

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -386,12 +386,10 @@ class TestContainers(IWebTest):
         wells_json = rsp['data']
         well_id = wells_json[0]['@id']
         extra = [{'url:well': build_url(client, 'api_well',
-                                        {'api_version': version,
-                                         'object_id': well_id})
-                }]
+                  {'api_version': version, 'object_id': well_id})}
+                 ]
         assert_objects(conn, wells_json, [well_id], dtype='Well',
                        extra=extra, opts={'load_images': True}, client=client)
-
 
     def test_pdi_urls(self, user1, project_datasets):
         """Test browsing via urls in json /api/->PDI."""

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -24,31 +24,18 @@ from omeroweb.testlib import IWebTest, _get_response_json, \
 from django.core.urlresolvers import reverse
 from django.conf import settings
 import pytest
+from test_api_projects import cmp_name_insensitive, get_update_service, \
+    get_connection, marshal_objects
 from omero.gateway import BlitzGateway
-from omero_marshal import get_encoder
-from omero.model import DatasetI, ProjectI, ScreenI, PlateI, ImageI, \
-    WellSampleI, WellI
-from omero.rtypes import rstring, unwrap, rint
+from omero.model import DatasetI, \
+    ImageI, \
+    PlateI, \
+    ProjectI, \
+    ScreenI, \
+    WellI, \
+    WellSampleI
+from omero.rtypes import rstring, rint
 
-
-def get_update_service(user):
-    """Get the update_service for the given user's client."""
-    return user[0].getSession().getUpdateService()
-
-
-def get_connection(user, group_id=None):
-    """Get a BlitzGateway connection for the given user's client."""
-    connection = BlitzGateway(client_obj=user[0])
-    # Refresh the session context
-    connection.getEventContext()
-    if group_id is not None:
-        connection.SERVICE_OPTS.setOmeroGroup(group_id)
-    return connection
-
-
-def cmp_name_insensitive(x, y):
-    """Case-insensitive name comparator."""
-    return cmp(unwrap(x.name).lower(), unwrap(y.name).lower())
 
 
 def build_url(client, url_name, url_kwargs):
@@ -59,15 +46,6 @@ def build_url(client, url_name, url_kwargs):
     url = reverse(url_name, kwargs=url_kwargs)
     url = webclient_url.replace('/webclient/', url)
     return url
-
-
-def marshal_objects(objects):
-    """Marshal objects using omero_marshal."""
-    expected = []
-    for obj in objects:
-        encoder = get_encoder(obj.__class__)
-        expected.append(encoder.encode(obj))
-    return expected
 
 
 def add_image_urls(expected, client):

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -37,7 +37,6 @@ from omero.model import DatasetI, \
 from omero.rtypes import rstring, rint
 
 
-
 def build_url(client, url_name, url_kwargs):
     """Build an absolute url using client response url."""
     response = client.request()

--- a/components/tools/OmeroWeb/test/integration/test_api_errors.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_errors.py
@@ -26,22 +26,11 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from omero.gateway import BlitzGateway
 import pytest
+from test_api_projects import get_connection
 from omero.model import ProjectI
 from omero.rtypes import rstring
 from omero_marshal import get_encoder, get_decoder, OME_SCHEMA_URL
 from omero import ValidationException
-
-
-def get_connection(user, group_id=None):
-    """
-    Get a BlitzGateway connection for the given user's client
-    """
-    connection = BlitzGateway(client_obj=user[0])
-    # Refresh the session context
-    connection.getEventContext()
-    if group_id is not None:
-        connection.SERVICE_OPTS.setOmeroGroup(group_id)
-    return connection
 
 
 class TestErrors(IWebTest):

--- a/components/tools/OmeroWeb/test/integration/test_api_errors.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_errors.py
@@ -90,7 +90,7 @@ class TestErrors(IWebTest):
                 'No decoder found for type: %s' % objType)
 
     def test_marshal_validation(self):
-        """Test we get expected error with invalid @type in json."""
+        """Test that we get expected error with invalid @type in json."""
         django_client = self.django_root_client
         version = settings.API_VERSIONS[-1]
         save_url = reverse('api_save', kwargs={'api_version': version})
@@ -160,7 +160,7 @@ class TestErrors(IWebTest):
 
     def test_project_validation(self, user_A):
         """
-        Test to demonstrate details bug on encode->deconde.
+        Test to demonstrate details bug on encode->decode.
 
         Test illustrates the ValidationException we see when
         Project is encoded to dict then decoded back to Project

--- a/components/tools/OmeroWeb/test/integration/test_api_images.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_images.py
@@ -23,45 +23,16 @@ from omeroweb.testlib import IWebTest, _get_response_json
 from django.core.urlresolvers import reverse
 from django.conf import settings
 import pytest
-from omero.gateway import BlitzGateway
-from omero_marshal import get_encoder
+from test_api_projects import cmp_name_insensitive, get_update_service, \
+    get_connection, marshal_objects
 from omero.model import DatasetI, ImageI
-from omero.rtypes import rstring, unwrap
+from omero.rtypes import rstring
 import json
-
-
-def get_update_service(user):
-    """Get the update_service for the given user's client."""
-    return user[0].getSession().getUpdateService()
 
 
 def get_query_service(user):
     """Get the query_service for the given user's client."""
     return user[0].getSession().getQueryService()
-
-
-def get_connection(user, group_id=None):
-    """Get a BlitzGateway connection for the given user's client."""
-    connection = BlitzGateway(client_obj=user[0])
-    # Refresh the session context
-    connection.getEventContext()
-    if group_id is not None:
-        connection.SERVICE_OPTS.setOmeroGroup(group_id)
-    return connection
-
-
-def cmp_name_insensitive(x, y):
-    """Case-insensitive name comparator."""
-    return cmp(unwrap(x.name).lower(), unwrap(y.name).lower())
-
-
-def marshal_objects(objects):
-    """Marshal objects using omero_marshal."""
-    expected = []
-    for obj in objects:
-        encoder = get_encoder(obj.__class__)
-        expected.append(encoder.encode(obj))
-    return expected
 
 
 def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -142,7 +142,7 @@ class TestWells(IWebTest):
                         ws.posX = LengthI(i * 10, UnitsLength.REFERENCEFRAME)
                         ws.posY = LengthI(i, UnitsLength.REFERENCEFRAME)
                         ws.setPlateAcquisition(
-                                PlateAcquisitionI(plate_acq.id.val, False))
+                            PlateAcquisitionI(plate_acq.id.val, False))
                         well.addWellSample(ws)
                 updateService.saveObject(well)
         return plate

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -23,37 +23,22 @@ from omeroweb.testlib import IWebTest, _get_response_json
 from django.core.urlresolvers import reverse
 from django.conf import settings
 import pytest
-from omero.gateway import BlitzGateway
+from test_api_projects import get_update_service, \
+    get_connection, marshal_objects
 from omero_marshal import get_encoder
-from omero.model import PlateI, WellI, WellSampleI, ImageI, LengthI
+from omero.model import ImageI, \
+    LengthI, \
+    PlateI, \
+    WellI, \
+    WellSampleI
 from omero.model.enums import UnitsLength
 from omero.rtypes import rstring, rint, unwrap
 import json
 
 
-def get_update_service(user):
-    """Get the update_service for the given user's client."""
-    return user[0].getSession().getUpdateService()
-
-
 def get_query_service(user):
     """Get the query_service for the given user's client."""
     return user[0].getSession().getQueryService()
-
-
-def get_connection(user, group_id=None):
-    """Get a BlitzGateway connection for the given user's client."""
-    connection = BlitzGateway(client_obj=user[0])
-    # Refresh the session context
-    connection.getEventContext()
-    if group_id is not None:
-        connection.SERVICE_OPTS.setOmeroGroup(group_id)
-    return connection
-
-
-def cmp_name_insensitive(x, y):
-    """Case-insensitive name comparator."""
-    return cmp(unwrap(x.name).lower(), unwrap(y.name).lower())
 
 
 def cmp_column_row(x, y):
@@ -62,15 +47,6 @@ def cmp_column_row(x, y):
     if sort_by_column == 0:
         return cmp(unwrap(x.row), unwrap(y.row))
     return sort_by_column
-
-
-def marshal_objects(objects):
-    """Marshal objects using omero_marshal."""
-    expected = []
-    for obj in objects:
-        encoder = get_encoder(obj.__class__)
-        expected.append(encoder.encode(obj))
-    return expected
 
 
 def remove_urls(marshalled):
@@ -144,7 +120,7 @@ class TestWells(IWebTest):
                 well.column = rint(col)
                 well.row = rint(row)
                 well.plate = PlateI(plate.id.val, False)
-                # Only wells in first Column have well-samples etc
+                # Only wells in first Column have well-samples etc.
                 if col == 0:
                     # Have 3 images/well-samples in these wells
                     for i in range(3):

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests querying Wells with web json api."""
+
+from omeroweb.testlib import IWebTest, _get_response_json
+from django.core.urlresolvers import reverse
+from django.conf import settings
+import pytest
+from omero.gateway import BlitzGateway
+from omero_marshal import get_encoder
+from omero.model import PlateI, WellI, WellSampleI, ImageI, LengthI
+from omero.model.enums import UnitsLength
+from omero.rtypes import rstring, rint, unwrap
+import json
+
+
+def get_update_service(user):
+    """Get the update_service for the given user's client."""
+    return user[0].getSession().getUpdateService()
+
+
+def get_query_service(user):
+    """Get the query_service for the given user's client."""
+    return user[0].getSession().getQueryService()
+
+
+def get_connection(user, group_id=None):
+    """Get a BlitzGateway connection for the given user's client."""
+    connection = BlitzGateway(client_obj=user[0])
+    # Refresh the session context
+    connection.getEventContext()
+    if group_id is not None:
+        connection.SERVICE_OPTS.setOmeroGroup(group_id)
+    return connection
+
+
+def cmp_name_insensitive(x, y):
+    """Case-insensitive name comparator."""
+    return cmp(unwrap(x.name).lower(), unwrap(y.name).lower())
+
+def cmp_column_row(x, y):
+    """Sort wells by row, then column."""
+    sort_by_column = cmp(unwrap(x.column), unwrap(y.column))
+    if sort_by_column == 0:
+        return cmp(unwrap(x.row), unwrap(y.row))
+    return sort_by_column
+
+def marshal_objects(objects):
+    """Marshal objects using omero_marshal."""
+    expected = []
+    for obj in objects:
+        encoder = get_encoder(obj.__class__)
+        expected.append(encoder.encode(obj))
+    return expected
+
+
+def remove_urls(marshalled):
+    """Traverse a dict (Well) removing 'url:' values."""
+    for key, val in marshalled.items():
+        if key.startswith('url:'):
+            del(marshalled[key])
+        # We only traverse paths where we know urls are
+        elif key == 'Image':        # isinstance(val, dict):
+            remove_urls(val)
+        elif key == 'WellSamples':  # isinstance(val, list):
+            for i in val:
+                remove_urls(i)
+
+
+def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
+                   group='-1', extra=None, opts=None):
+    """
+    Load objects from OMERO, via conn.getObjects().
+
+    marshal with omero_marshal and compare with json_objects.
+    omero_ids_objects can be IDs or list of omero.model objects.
+
+    @param: extra       List of dicts containing expected extra json data
+                        e.g. {'omero:childCount': 1}
+    """
+    pids = []
+    for p in omero_ids_objects:
+        try:
+            pids.append(long(p))
+        except TypeError:
+            pids.append(p.id.val)
+    conn.SERVICE_OPTS.setOmeroGroup(group)
+    objs = conn.getObjects(dtype, pids, respect_order=True, opts=opts)
+    objs = [p._obj for p in objs]
+    expected = marshal_objects(objs)
+    assert len(json_objects) == len(expected)
+    for i, o1, o2 in zip(range(len(expected)), json_objects, expected):
+        if extra is not None and i < len(extra):
+            o2.update(extra[i])
+        # dumping to json and loading (same as test data) means that
+        # unicode has been handled in same way, e.g. Pixel size symbols.
+        o2 = json.loads(json.dumps(o2))
+        # remove any urls from json (tested elsewhere)
+        remove_urls(o1)
+        
+        assert o1 == o2
+
+
+class TestWells(IWebTest):
+    """Tests querying Wells."""
+
+    @pytest.fixture()
+    def user1(self):
+        """Return a new user in a read-annotate group."""
+        group = self.new_group(perms='rwra--')
+        return self.new_client_and_user(group=group)
+
+    def create_plate_wells(self, user1, rows, cols):
+        """Return Plate with Wells."""
+        updateService = get_update_service(user1)
+        plate = PlateI()
+        plate.name = rstring('plate')
+        plate = updateService.saveAndReturnObject(plate)
+
+        # Create Wells for plate
+        for row in range(rows):
+            for col in range(cols):
+                # create Well
+                well = WellI()
+                well.column = rint(col)
+                well.row = rint(row)
+                well.plate = PlateI(plate.id.val, False)
+                # Only wells in first Column have well-samples etc
+                if col == 0:
+                    # Have 3 images/well-samples in these wells
+                    for i in range(3):
+                        image = self.create_test_image(
+                            size_x=5, size_y=5, session=user1[0].getSession())
+                        ws = WellSampleI()
+                        ws.image = ImageI(image.id, False)
+                        ws.well = well
+                        ws.posX = LengthI(i * 10, UnitsLength.REFERENCEFRAME)
+                        ws.posY = LengthI(i, UnitsLength.REFERENCEFRAME)
+                        well.addWellSample(ws)
+                updateService.saveObject(well)
+        return plate
+
+    @pytest.fixture()
+    def small_plate(self, user1):
+        """
+        Create a small plate with 1 row and 2 columns.
+
+        Two wells are created, but only the first has any Images (3).
+        """
+        return self.create_plate_wells(user1, 1, 2)
+
+    @pytest.fixture()
+    def bigger_plate(self, user1):
+        """
+        Create a bigger plate with 2 rows and 3 columns.
+
+        Six wells are created, but only wells in the first
+        column have any Images (3 in each Well).
+        """
+        return self.create_plate_wells(user1, 2, 3)
+
+    def test_plate_wells(self, user1, small_plate, bigger_plate):
+        """Test listing of Wells in a Plate."""
+        conn = get_connection(user1)
+        user_name = conn.getUser().getName()
+        django_client = self.new_django_client(user_name, user_name)
+        version = settings.API_VERSIONS[-1]
+
+        # Use Blitz Plates for listing Wells etc.
+        bigger_plate = conn.getObject('Plate', bigger_plate.id.val)
+        wells = [w._obj for w in bigger_plate.listChildren()]
+        wells.sort(cmp_column_row)
+
+        wells_url = reverse('api_wells', kwargs={'api_version': version})
+
+        # List ALL Wells in both plates
+        rsp = _get_response_json(django_client, wells_url, {})
+        assert len(rsp['data']) == 8
+
+        # Filter Wells by Plate
+        payload = {'plate': bigger_plate.id}
+        rsp = _get_response_json(django_client, wells_url, payload)
+        # Manual check that Images are loaded but Pixels are not
+        assert 'Image' in rsp['data'][0]['WellSamples'][0]
+        assert 'Pixels' not in rsp['data'][0]['WellSamples'][0]['Image']
+        assert len(wells) == 6
+        assert_objects(conn, rsp['data'], wells, dtype='Well',
+                       opts={'load_images': True})
+
+    def test_well(self, user1, small_plate):
+        """Test loading a single Well, with or without WellSamples."""
+        conn = get_connection(user1)
+        user_name = conn.getUser().getName()
+        django_client = self.new_django_client(user_name, user_name)
+        version = settings.API_VERSIONS[-1]
+
+        small_plate = conn.getObject('Plate', small_plate.id.val)
+        wells = [w._obj for w in small_plate.listChildren()]
+        wells.sort(cmp_column_row)
+
+        # plate has 2 wells. First has WellSamples, other doesn't
+        for well, has_image in zip(wells, [True, False]):
+            well_url = reverse('api_well', kwargs={'api_version': version,
+                                                   'object_id': well.id.val})
+            rsp = _get_response_json(django_client, well_url, {})
+            # Manually check for image and Pixels loaded
+            assert ('WellSamples' in rsp) == has_image
+            if has_image:
+                assert len(rsp['WellSamples']) == 3
+                assert 'Pixels' in rsp['WellSamples'][0]['Image'] 
+            assert_objects(conn, [rsp], [well], dtype='Well',
+                           opts={'load_pixels': True})

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -55,12 +55,14 @@ def cmp_name_insensitive(x, y):
     """Case-insensitive name comparator."""
     return cmp(unwrap(x.name).lower(), unwrap(y.name).lower())
 
+
 def cmp_column_row(x, y):
     """Sort wells by row, then column."""
     sort_by_column = cmp(unwrap(x.column), unwrap(y.column))
     if sort_by_column == 0:
         return cmp(unwrap(x.row), unwrap(y.row))
     return sort_by_column
+
 
 def marshal_objects(objects):
     """Marshal objects using omero_marshal."""
@@ -114,7 +116,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
         o2 = json.loads(json.dumps(o2))
         # remove any urls from json (tested elsewhere)
         remove_urls(o1)
-        
+
         assert o1 == o2
 
 
@@ -224,6 +226,6 @@ class TestWells(IWebTest):
             assert ('WellSamples' in rsp) == has_image
             if has_image:
                 assert len(rsp['WellSamples']) == 3
-                assert 'Pixels' in rsp['WellSamples'][0]['Image'] 
+                assert 'Pixels' in rsp['WellSamples'][0]['Image']
             assert_objects(conn, [rsp], [well], dtype='Well',
                            opts={'load_pixels': True})

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -55,9 +55,9 @@ def remove_urls(marshalled):
         if key.startswith('url:'):
             del(marshalled[key])
         # We only traverse paths where we know urls are
-        elif key == 'Image':        # isinstance(val, dict):
+        elif key == 'Image':
             remove_urls(val)
-        elif key == 'WellSamples':  # isinstance(val, list):
+        elif key == 'WellSamples':
             for i in val:
                 remove_urls(i)
 
@@ -87,7 +87,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     for i, o1, o2 in zip(range(len(expected)), json_objects, expected):
         if extra is not None and i < len(extra):
             o2.update(extra[i])
-        # dumping to json and loading (same as test data) means that
+        # We dump to json and re-load (same as test data). This means that
         # unicode has been handled in same way, e.g. Pixel size symbols.
         o2 = json.loads(json.dumps(o2))
         # remove any urls from json (tested elsewhere)


### PR DESCRIPTION
# What this PR does

Adds support for Wells to web api. 
NB: Needs https://github.com/openmicroscopy/omero-marshal/pull/31. ```requirements.txt``` points to that branch of omero-marshal to allow testing of this PR. Once that is merged, we can revert requirements.txt.

# Testing this PR

1. Added tests in ```test_api_wells.py```
2. Browse to ```/plates/```
    - List of ```/plates/``` - each Plate will have link to 'url:wells': 'plates/:id/wells'
    - Single plate ```/plates/:id``` also links to 'wells'
    - Browse to plates/:id/wells (or /wells/?plate=:id ) to filter wells by Plate
    - /wells/ will be ordered by Column & Row and include WellSamples, PlateAcquisitions & Images.
    - plate/:id/wells/ will also include any Wells that have no WellSamples & Images
    - Each Well in /wells/ will link to a single /wells/:id/
    - /wells/:id shows single Well with WellSamples, Images and Pixels loaded.
    - Images listed at /wells/ and /wells/:id/ will have link to 'url:image': 'images/:id/'

# Related reading

As discussed at https://github.com/openmicroscopy/design/issues/65 Wells are the next object we need to support. This now allows browsing Screen -> Plate -> Well -> Image starting at ```/api/```.

Also tests https://github.com/openmicroscopy/omero-marshal/pull/31.

cc @chris-allan @jburel @aleksandra-tarkowska 

## To consider for follow-up:
 - Filter wells in plate by PlateAcquisition (only load images from single plateAcquisition)
 - Don't marshal separate PlateAcquisition for every WellSample. Normalize!
 - /plate/:id/ needs min/max wsIndex