### PR TITLE
doc build cleanup

### DIFF
--- a/docs/sphinx-api/rules.xml
+++ b/docs/sphinx-api/rules.xml
@@ -93,7 +93,7 @@ Type "ant -p" for a list of targets.
         <runlatex file="@{file}"/>
       </sequential>
     </for>
-    <copy file="_build/latex/Bio-Formats.pdf" tofile="${dist.dir}/docs/omero-${omero.release}.pdf"/>
+    <copy file="_build/latex/omero.pdf" tofile="${dist.dir}/docs/omero-${omero.release}.pdf"/>
   </target>
 
   <target name="pdf" depends="latexpdf"/>

--- a/docs/sphinx-api/rules.xml
+++ b/docs/sphinx-api/rules.xml
@@ -6,10 +6,13 @@ Download Apache Ant from http://ant.apache.org/.
 Type "ant -p" for a list of targets.
 -->
 
-<project name="rules" basedir=".">
+<project name="rules" default="html" basedir=".">
   <description>Common sphinx targets</description>
   <dirname property="imported.basedir" file="${ant.file.rules}"/>
   <import file="${imported.basedir}/sphinx.xml"/>
+  <property name="root.dir" location="../.."/>
+  <import file="${root.dir}/components/antlib/resources/global.xml"/>
+
 
   <!-- Ant-Contrib Tasks: http://ant-contrib.sourceforge.net/ -->
   <taskdef resource="net/sf/antcontrib/antcontrib.properties"
@@ -19,50 +22,68 @@ Type "ant -p" for a list of targets.
   <taskdef resource="net/sf/antcontrib/antlib.xml"
     classpath="${imported.basedir}/ant-contrib-1.0b3.jar"/>
 
-  <property name="omero.shortversion" value=""/>
-  <if>
-    <equals arg1="omero.shortversion" arg2=""/>
-    <then>
-      <property name="source.branch" value="v.${omero.shortversion}"/>
-    </then>
-  </if>
-  <property name="source.branch" value=""/>
-  <property name="source.user" value="openmicroscopy"/>
-  <property name="omero.release" value="${omero.shortversion}"/>
-  <property name="formats.release" value="${omero.shortversion}"/>
-  <property name="jenkins.job" value=""/>
+  <target name="init">
+    <property name="omero.shortversion" value=""/>
+    <if>
+      <equals arg1="omero.shortversion" arg2=""/>
+      <then>
+        <property name="source.branch" value="v.${omero.shortversion}"/>
+      </then>
+    </if>
+    <property name="source.branch" value="develop"/>
+    <property name="source.user" value="openmicroscopy"/>
+    <property name="omero.release" value="${omero.shortversion}"/>
+    <property name="formats.release" value="${omero.shortversion}"/>
+  </target>
 
+  <macrodef name="sphinx" description="Run sphinx-build">
+    <attribute name="buildtype" default="html"/>
+    <attribute name="srcdir" default="."/>
+    <attribute name="destdir" default=""/>
+    <attribute name="opts" default=""/>
+    <attribute name="warnopts" default=""/>
+    <sequential>
+      <exec executable="${sphinx.build}" failonerror="true">
+        <arg value="-D"/>
+        <arg value="release=${omero.release}"/>
+        <arg value="-D"/>
+        <arg value="version=${omero.shortversion}"/>
+        <arg value="-b"/>
+        <arg value="@{buildtype}"/>
+        <arg line="@{opts}"/>
+        <arg line="@{warnopts}"/>
+        <arg value="@{srcdir}"/>
+        <arg value="@{destdir}"/>
+      </exec>
+    </sequential>
+  </macrodef>
   <target name="sphinx-deps"/>
   <target name="clean-deps"/>
 
-  <target name="html" depends="sphinx-deps">
-    <exec executable="${sphinx.build}" failonerror="true">
-        <env key="SOURCE_BRANCH" value="${source.branch}"/>
-        <env key="SOURCE_USER" value="${source.user}"/>
-        <env key="OMERO_RELEASE" value="${omero.release}"/>
-        <env key="FORMATS_RELEASE" value="${formats.release}"/>
-        <env key="JENKINS_JOB" value="${jenkins.job}"/>
-        <arg value="-b"/>
-        <arg value="html"/>
-        <arg line="${sphinx.opts}"/>
-        <arg value="."/>
-        <arg value="${sphinx.builddir}/html"/>
-      </exec>
+  <target name="html" depends="sphinx-deps, init">
+        <sphinx buildtype="html"
+            srcdir="."
+            destdir="${sphinx.builddir}/html"
+            opts="${sphinx.opts}"/>
+    <delete dir="${dist.dir}/docs/omero-doc-${omero.release}"/>
+    <copy todir="${dist.dir}/docs/omero-doc-${omero.release}">
+      <!--
+        include (none) to prevent problems if component.resources-bin is empty
+      -->
+      <fileset dir="_build/html"/>
+    </copy>
+    <zip destfile="${dist.dir}/docs/omero-doc-${omero.release}.zip">
+      <zipfileset dir="_build/html" includes="**/*" prefix="omero-doc-${omero.release}"/>
+    </zip>
+    <delete dir="${dist.dir}/docs/omero-doc-${omero.release}"/>
   </target>
 
-  <target name="latexpdf" depends="sphinx-deps">
-    <exec executable="${sphinx.build}" failonerror="true">
-        <env key="SOURCE_BRANCH" value="${source.branch}"/>
-        <env key="SOURCE_USER" value="${source.user}"/>
-        <env key="OMERO_RELEASE" value="${omero.release}"/>
-        <env key="FORMATS_RELEASE" value="${formats.release}"/>
-        <env key="JENKINS_JOB" value="${jenkins.job}"/>
-        <arg value="-b"/>
-        <arg value="latex"/>
-        <arg line="${sphinx.opts}"/>
-        <arg value="."/>
-        <arg value="${sphinx.builddir}/latex"/>
-    </exec>
+  <target name="latexpdf" depends="sphinx-deps, init">
+    <sphinx buildtype="latex"
+            srcdir="."
+            destdir="${sphinx.builddir}/latex"
+            opts="${sphinx.opts}"
+            warnopts="${sphinx.warnopts}"/>
 
     <for param="file">
       <path>
@@ -72,23 +93,16 @@ Type "ant -p" for a list of targets.
         <runlatex file="@{file}"/>
       </sequential>
     </for>
+    <copy file="_build/latex/Bio-Formats.pdf" tofile="${dist.dir}/docs/omero-${omero.release}.pdf"/>
   </target>
 
   <target name="pdf" depends="latexpdf"/>
 
-  <target name="linkcheck" depends="sphinx-deps">
-    <exec executable="${sphinx.build}" failonerror="true">
-        <env key="SOURCE_BRANCH" value="${source.branch}"/>
-        <env key="SOURCE_USER" value="${source.user}"/>
-        <env key="OMERO_RELEASE" value="${omero.release}"/>
-        <env key="FORMATS_RELEASE" value="${formats.release}"/>
-        <env key="JENKINS_JOB" value="${jenkins.job}"/>
-        <arg value="-b"/>
-        <arg value="linkcheck"/>
-        <arg line="${sphinx.opts}"/>
-        <arg value="."/>
-        <arg value="${sphinx.builddir}/linkcheck"/>
-      </exec>
+  <target name="linkcheck" depends="sphinx-deps, init">
+    <sphinx buildtype="linkcheck" srcdir="."
+            destdir="${sphinx.builddir}/linkcheck"
+            opts="${sphinx.opts}"
+            warnopts="${sphinx.warnopts}"/>
   </target>
 
   <target name="clean" depends="clean-deps">

--- a/docs/sphinx-api/rules.xml
+++ b/docs/sphinx-api/rules.xml
@@ -10,9 +10,6 @@ Type "ant -p" for a list of targets.
   <description>Common sphinx targets</description>
   <dirname property="imported.basedir" file="${ant.file.rules}"/>
   <import file="${imported.basedir}/sphinx.xml"/>
-  <property name="root.dir" location="../.."/>
-  <import file="${root.dir}/components/antlib/resources/global.xml"/>
-
 
   <!-- Ant-Contrib Tasks: http://ant-contrib.sourceforge.net/ -->
   <taskdef resource="net/sf/antcontrib/antcontrib.properties"
@@ -65,17 +62,6 @@ Type "ant -p" for a list of targets.
             srcdir="."
             destdir="${sphinx.builddir}/html"
             opts="${sphinx.opts}"/>
-    <delete dir="${dist.dir}/docs/omero-doc-${omero.release}"/>
-    <copy todir="${dist.dir}/docs/omero-doc-${omero.release}">
-      <!--
-        include (none) to prevent problems if component.resources-bin is empty
-      -->
-      <fileset dir="_build/html"/>
-    </copy>
-    <zip destfile="${dist.dir}/docs/omero-doc-${omero.release}.zip">
-      <zipfileset dir="_build/html" includes="**/*" prefix="omero-doc-${omero.release}"/>
-    </zip>
-    <delete dir="${dist.dir}/docs/omero-doc-${omero.release}"/>
   </target>
 
   <target name="latexpdf" depends="sphinx-deps, init">

--- a/docs/sphinx-api/sphinx.xml
+++ b/docs/sphinx-api/sphinx.xml
@@ -11,6 +11,7 @@ Type "ant -p" for a list of targets.
 
   <property name="sphinx.build" value="sphinx-build"/>
   <property name="sphinx.opts" value=""/>
+  <property name="sphinx.warnopts" value=""/>
   <property name="sphinx.builddir" location="_build"/>
   <property name="latex.opts" value=""/>
 


### PR DESCRIPTION
# What this PR does
Clean up the ``rules.xml`` and unify with B-F sphinx command

# Testing this PR
Run the command ``ant release-docs`` or ``./build.py release-docs``
This will create a zip under ``target/docs``, unzip the result and check few files under ``api`` 

# Related reading
https://trello.com/c/SnUesylG/505-ditching-docs-pdfs