### PR TITLE
Show platename for well tags

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -1505,7 +1505,8 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
             obj.column as column,
             plate.id as plateId,
             plate.columnNamingConvention as colnames,
-            plate.rowNamingConvention as rownames)
+            plate.rowNamingConvention as rownames,
+            plate.name as platename)
         from Well obj
             join obj.annotationLinks alink
             join obj.plate plate
@@ -1524,8 +1525,9 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
              e[0]["column"],
              e[0]["plateId"],
              e[0]["rownames"],
-             e[0]["colnames"]]
-        wells.append(_marshal_well(conn, e[0:8]))
+             e[0]["colnames"],
+             e[0]["platename"]]
+        wells.append(_marshal_well(conn, e[0:9]))
     tagged['wells'] = wells
 
     return tagged
@@ -1544,7 +1546,8 @@ def _marshal_well(conn, row):
         @param row The Well row to marshal
         @type row L{list}
     '''
-    well_id, owner_id, perms, row, col, plateId, rownames, colnames = row
+    well_id, owner_id, perms, row, col, plateId, rownames, colnames,\
+        platename = row
     well = dict()
     well['id'] = unwrap(well_id)
     well['ownerId'] = unwrap(owner_id)
@@ -1553,7 +1556,7 @@ def _marshal_well(conn, row):
         parse_permissions_css(perms, unwrap(owner_id), conn)
     rowname = str(row + 1) if rownames == 'number' else _letterGridLabel(row)
     colname = _letterGridLabel(col) if colnames == 'letter' else str(col + 1)
-    well['name'] = "%s%s" % (rowname, colname)
+    well['name'] = "%s - %s%s" % (platename, rowname, colname)
     return well
 
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -243,11 +243,12 @@ def expected_wells(user, wells):
     for well in wells:
         rName = unwrap(well.plate.rowNamingConvention)
         cName = unwrap(well.plate.columnNamingConvention)
+        pName = unwrap(well.plate.name)
         row = well.row.val
         col = well.column.val
         rowname = str(row + 1) if rName == 'number' else _letterGridLabel(row)
         colname = _letterGridLabel(col) if cName == 'letter' else str(col + 1)
-        name = "%s%s" % (rowname, colname)
+        name = "%s - %s%s" % (pName, rowname, colname)
         expected.append({
             'id': well.id.val,
             'name': name,


### PR DESCRIPTION
# What this PR does

Show the plate name for tags on wells.
![screen shot 2017-01-19 at 15 43 56](https://cloud.githubusercontent.com/assets/6575139/22113477/536a73d6-de5e-11e6-8037-d804897d7f3d.png)
Without the PR the tag "WellTag" in the example screenshot will only list the well as "B6", with the PR the name additionally shows the plate name, to which the well belongs.

ToDo:
- If you click on the well, nothing is shown in the center panel. What is expected to be shown in that case?

# Testing this PR

Tag a well. Select "Tags" view in the left hand panel. Make sure you find the tagged well under the tag and that the name of the plate is indicated, too.

# Related reading

[Trello - SPW Follow up](https://trello.com/c/GxqDnD0P/211-spw-follow-up)

/cc @will-moore 


