### PR TITLE
cli: add cli_login contextmanager

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -36,6 +36,7 @@ import shlex
 import errno
 from threading import Lock
 from path import path
+from contextlib import contextmanager
 
 from omero_ext.argparse import ArgumentError
 from omero_ext.argparse import ArgumentTypeError
@@ -1407,6 +1408,36 @@ class CLI(cmd.Cmd, Context):
 
     # End Cli
     ###########################################################
+
+
+@contextmanager
+def cli_login(*args, **kwargs):
+    """
+    args will be appended to ["-q", "login"] and then
+    passed to onecmd
+
+    kwargs:
+      - keep_alive
+    """
+
+    keep_alive = kwargs.get("keep_alive", 300)
+    try:
+        cli = omero.cli.CLI()
+        cli.loadplugins()
+        login = ["-q", "login"]
+        login.extend(list(args))
+        cli.onecmd(login)
+        if keep_alive is not None:
+            client = cli.get_client()
+            if client is not None:
+                keep_alive = int(keep_alive)
+                client.enableKeepAlive(keep_alive)
+            else:
+                cli.close()
+                raise Exception("Failed to login")
+        yield cli
+    finally:
+        cli.close()
 
 
 def argv(args=sys.argv):

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1433,7 +1433,6 @@ def cli_login(*args, **kwargs):
                 keep_alive = int(keep_alive)
                 client.enableKeepAlive(keep_alive)
             else:
-                cli.close()
                 raise Exception("Failed to login")
         yield cli
     finally:


### PR DESCRIPTION
The contextmanager allows easy creation of a CLI
object for scripting bin/omero cli-like actions.

# Testing this PR
1. `bin/omero shell` (no `--login`)
2. `from omero.cli import cli_login` followed by `with cli_login() as cli:`
3. CLI-like login process should be followed: e.g. "Host:", "User:", "Password:"