### PR TITLE
Search for wells

### DIFF
--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -22,6 +22,8 @@ ${XpathPlate}           xpath=//table[@id='dataTable']//img[@alt='plate']
 ${XpathPlateThumb}      xpath=//table[@id='dataTable']//img[contains(@src,'folder_plate16.png')]
 ${XpathScreen}          xpath=//table[@id='dataTable']//img[@alt='screen']
 ${XpathScreenThumb}     xpath=//table[@id='dataTable']//img[contains(@src,'folder_screen16.png')]
+${XpathWell}            xpath=//table[@id='dataTable']//img[@alt='well']
+${XpathWellThumb}       xpath=//table[@id='dataTable']//img[contains(@src,'well16.png')]
 ${XpathTable}           xpath=//table[@id='dataTable']
 ${XpathTableColumn}     xpath=//table[@id='dataTable']//tr/td[position()=3]
 ${XPathAlertText}       xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//p
@@ -67,6 +69,7 @@ Unselect All Checkboxes
     Unselect Checkbox  projects
     Unselect Checkbox  plates
     Unselect Checkbox  screens
+    Unselect Checkbox  wells
 
 Select All Checkboxes
     
@@ -78,6 +81,7 @@ Select All Checkboxes
     Select Checkbox  projects
     Select Checkbox  plates
     Select Checkbox  screens
+    Select Checkbox  wells
 
 Omero Default Search
     
@@ -189,6 +193,8 @@ Test Check Search Results
     Run Keyword If    '${status3}' == 'True'        Page Should Contain Element     ${XpathProjectThumb}
     ${status4}   Run Keyword And Return status      Page Should Contain Element     ${XpathImage}
     Run Keyword If    '${status4}' == 'True'        Page Should Contain Element     ${XpathImageThumb}
+    ${status5}   Run Keyword And Return status      Page Should Contain Element     ${XpathWell}
+    Run Keyword If    '${status5}' == 'True'        Page Should Contain Element     ${XpathWellThumb}
 
     
 Test Default Search Selections
@@ -199,6 +205,7 @@ Test Default Search Selections
     Checkbox Should Be Selected  projects
     Checkbox Should Be Selected  plates
     Checkbox Should Be Selected  screens
+    Checkbox Should Be Selected  wells
     Checkbox Should Not Be Selected  name
     Checkbox Should Not Be Selected  description
     Checkbox Should Not Be Selected  annotation
@@ -253,7 +260,8 @@ Test Object Types and Fields
     Page Should Not Contain Element     ${XpathProject}
     Page Should Not Contain Element     ${XpathPlate}
     Page Should Not Contain Element     ${XpathScreen}
-
+    Page Should Not Contain Element     ${XpathWell}
+    
     # Select Dataset Alone
     Unselect All Checkboxes
     Select Checkbox  datasets
@@ -264,7 +272,8 @@ Test Object Types and Fields
     Page Should Not Contain Element     ${XpathProject}
     Page Should Not Contain Element     ${XpathPlate}
     Page Should Not Contain Element     ${XpathScreen}
-
+    Page Should Not Contain Element     ${XpathWell}
+    
     # Select Project Alone
     Unselect All Checkboxes
     Select Checkbox  projects
@@ -275,7 +284,8 @@ Test Object Types and Fields
     Page Should Not Contain Element     ${XpathImage}
     Page Should Not Contain Element     ${XpathPlate}
     Page Should Not Contain Element     ${XpathScreen}
-
+    Page Should Not Contain Element     ${XpathWell}
+    
     # Select Plate Alone
     Unselect All Checkboxes
     Select Checkbox  plates
@@ -284,12 +294,24 @@ Test Object Types and Fields
     Page Should Not Contain Element     ${XpathProject}
     Page Should Not Contain Element     ${XpathDataset}
     Page Should Not Contain Element     ${XpathImage}
-
+    Page Should Not Contain Element     ${XpathWell}
+    
     # Select Screen Alone
     Unselect All Checkboxes
     Select Checkbox  screens
     Click Button  id=search_button
     sleep                               ${ImplicitDELAY}
+    Page Should Not Contain Element     ${XpathProject}
+    Page Should Not Contain Element     ${XpathDataset}
+    Page Should Not Contain Element     ${XpathImage}
+    Page Should Not Contain Element     ${XpathWell}
+    
+    # Select Well Alone
+    Unselect All Checkboxes
+    Select Checkbox  wells
+    Click Button  id=search_button
+    sleep                               ${ImplicitDELAY}
+    Page Should Contain Element         ${XpathWell}
     Page Should Not Contain Element     ${XpathProject}
     Page Should Not Contain Element     ${XpathDataset}
     Page Should Not Contain Element     ${XpathImage}
@@ -349,7 +371,7 @@ Test Date Range
     Select All Checkboxes
     Click Button    id=search_button
     Click Element                   ${AlertWindow}
- 
+    
     
 Test Key Word Search
     

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -52,6 +52,7 @@ class BaseSearch(BaseController):
 
     def search(self, query, onlyTypes, fields, searchGroup, ownedBy,
                useAcquisitionDate, date=None):
+
         # If fields contains 'annotation', we really want to search files too
         fields = set(fields)
         if "annotation" in fields:
@@ -87,6 +88,7 @@ class BaseSearch(BaseController):
         def doSearch(searchType):
             """ E.g. searchType is 'images' """
             objType = searchType[0:-1]  # remove 's'
+
             obj_list = list(self.conn.searchObjects(
                 [objType],
                 query,

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -52,7 +52,6 @@ class BaseSearch(BaseController):
 
     def search(self, query, onlyTypes, fields, searchGroup, ownedBy,
                useAcquisitionDate, date=None):
-
         # If fields contains 'annotation', we really want to search files too
         fields = set(fields)
         if "annotation" in fields:
@@ -109,6 +108,11 @@ class BaseSearch(BaseController):
                 if dt in ['projects', 'datasets', 'images', 'screens',
                           'plateacquisitions', 'plates', 'wells']:
                     self.containers[dt] = doSearch(dt)
+                    if dt == "wells":
+                        for well in self.containers[dt]:
+                            well.name = "%s - %s" %\
+                                        (well.listParents()[0].name,
+                                         well.getWellPos())
                     # If we get a full page of results, we know there are more
                     if len(self.containers[dt]) == batchSize:
                         self.moreResults = True

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -88,7 +88,6 @@ class BaseSearch(BaseController):
         def doSearch(searchType):
             """ E.g. searchType is 'images' """
             objType = searchType[0:-1]  # remove 's'
-
             obj_list = list(self.conn.searchObjects(
                 [objType],
                 query,
@@ -108,7 +107,7 @@ class BaseSearch(BaseController):
             for dt in onlyTypes:
                 dt = str(dt)
                 if dt in ['projects', 'datasets', 'images', 'screens',
-                          'plateacquisitions', 'plates']:
+                          'plateacquisitions', 'plates', 'wells']:
                     self.containers[dt] = doSearch(dt)
                     # If we get a full page of results, we know there are more
                     if len(self.containers[dt]) == batchSize:

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -262,6 +262,7 @@
 	                        <li><input type="checkbox" name="datatype" value="images" CHECKED />{% trans "Images" %}</li>
 	                        <li><input type="checkbox" name="datatype" value="datasets" CHECKED />{% trans "Datasets" %}</li>
 	                        <li><input type="checkbox" name="datatype" value="projects" CHECKED />{% trans "Projects" %}</li>
+	                        <li><input type="checkbox" name="datatype" value="wells" CHECKED />{% trans "Wells" %}</li>
 	                        <li><input type="checkbox" name="datatype" value="plates" CHECKED />{% trans "Plates" %}</li>
 	                        <li><input type="checkbox" name="datatype" value="screens" CHECKED />{% trans "Screens" %}</li>
 	                    </ul>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
@@ -209,6 +209,20 @@
                     </a></td>
                 </tr>
             {% endfor %}
+            {% for c in manager.containers.wells %}
+                <tr id="well-{{ c.id }}" class="{{ c.getPermsCss }}">
+                    <td class="image">
+                        <img id="{{ c.id }}" src="{% static "webclient/image/well16.png" %}" alt="well" title="{{ c.name }}"/>
+                    </td>
+                    <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
+                    <td class="date">{{ c.getDate|date:"Y-m-d H:i:s" }}</td>
+                    <td class="date">{{ c.creationEventDate|date:"Y-m-d H:i:s" }}</td>
+                    <td class="group">{{ c.getDetails.group.name.val }}</td>
+                    <td><a href="{% url 'webindex' %}?show=well-{{ c.id }}" title="{% trans 'Show in hierarchy view' %}">
+                        {% trans "Browse" %}
+                    </a></td>
+                </tr>
+            {% endfor %}
             </tbody>
         </table>
         

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1426,7 +1426,7 @@ def load_searching(request, form=None, conn=None, **kwargs):
                     for t in onlyTypes:
                         t = t[0:-1]  # remove 's'
                         if t in ('project', 'dataset', 'image', 'screen',
-                                 'plate'):
+                                 'plate', 'well'):
                             obj = conn.getObject(t, searchById)
                             if obj is not None:
                                 foundById.append({'otype': t, 'obj': obj})

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -443,7 +443,7 @@ omero.search.max_partition_size=1000000
 # custom search bridges.
 omero.search.include_types=ome.model.core.Image,ome.model.containers.Project,\
 ome.model.containers.Dataset,ome.model.screen.Plate,ome.model.screen.Screen,\
-ome.model.screen.PlateAcquisition
+ome.model.screen.PlateAcquisition,ome.model.screen.Well
 
 # EventLog.action values which will be indexed.
 # Unless custom code is generating other action


### PR DESCRIPTION
# What this PR does

Enables the search for wells.

ToDo: 
- Add/Adjust integration (or robot?) test

# Testing this PR

- ~~Enable the indexing of wells: `./omero config set omero.search.include_types "ome.model.core.Image,ome.model.containers.Project,ome.model.containers.Dataset,ome.model.screen.Plate,ome.model.screen.Screen,ome.model.screen.PlateAcquisition,ome.model.screen.Well"`.~~ Not necessary, with 6d56fdf that's the default now anyway.
- Tag a Well.
- Search for the Tag and check that the well shows up in the search results.

# Related reading

[Trello - Critical: search on wells](https://trello.com/c/23gd5W58/120-critical-search-on-wells)

/cc @will-moore 