### PR TITLE
Map rclass (rebased onto develop)

### DIFF
--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -9,6 +9,7 @@
 package omero.util;
 
 import static omero.rtypes.rbool;
+import static omero.rtypes.rclass;
 import static omero.rtypes.rdouble;
 import static omero.rtypes.rfloat;
 import static omero.rtypes.rint;
@@ -422,6 +423,10 @@ public class IceMapper extends ome.util.ModelMapper implements
             Boolean b = (Boolean) o;
             omero.RBool bool = rbool(b.booleanValue());
             return bool;
+        } else if (o instanceof Class) {
+            Class c = (Class) o;
+            omero.RClass rc = rclass(c.getName());
+            return rc;
         } else if (o instanceof Date) {
             Date date = (Date) o;
             omero.RTime time = rtime(date.getTime());

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -167,7 +167,8 @@ class TestQuery(ITest):
         """
         params = ParametersI()
         params.addString("uuid", uuid)
-        rv = [x[0] for x in unwrap(self.query.projection(query_string, params))]
+        rv = self.query.projection(query_string, params)
+        rv = [x[0] for x in unwrap(rv)]
         assert len(rv) == 2
         assert "ome.model.annotations.CommentAnnotation" in rv
         assert "ome.model.annotations.TagAnnotation" in rv

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -150,3 +150,16 @@ class TestQuery(ITest):
         for idx in range(len(result1)-1):
             # Omit final since == isn't defined for Ice objects.
             assert result1[idx] == result2[idx]
+
+    def testClassType(self):
+        created = []
+        for x in (CommentAnnotationI, TagAnnotationI):
+            x = self.update.saveAndReturnObject(x())
+            created.append(x)
+        query_string = """
+        select type(a.class) from Annotation a
+        """
+        rv = [x[0] for x in unwrap(self.query.projection(query_string, None))]
+        assert len(rv) == 2
+        assert "ome.model.annotations.CommentAnnotation" in rv
+        assert "ome.model.annotations.TagAnnotation" in rv

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -26,6 +26,7 @@
 
 from omero.testlib import ITest
 from omero.rtypes import unwrap, wrap
+from omero.model import CommentAnnotationI
 from omero.model import TagAnnotationI, ImageI, ImageAnnotationLinkI
 from omero.model import PermissionsI
 from omero.sys import ParametersI
@@ -153,9 +154,9 @@ class TestQuery(ITest):
 
     def testClassType(self):
         created = []
-        for x in (CommentAnnotationI, TagAnnotationI):
-            x = self.update.saveAndReturnObject(x())
-            created.append(x)
+        for Ann in (CommentAnnotationI, TagAnnotationI):
+            ann = self.update.saveAndReturnObject(Ann())
+            created.append(ann)
         query_string = """
         select type(a.class) from Annotation a
         """

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -25,6 +25,7 @@
 """
 
 from omero.testlib import ITest
+from omero.rtypes import rstring
 from omero.rtypes import unwrap, wrap
 from omero.model import CommentAnnotationI
 from omero.model import TagAnnotationI, ImageI, ImageAnnotationLinkI
@@ -153,14 +154,20 @@ class TestQuery(ITest):
             assert result1[idx] == result2[idx]
 
     def testClassType(self):
+        uuid = self.uuid()
         created = []
         for Ann in (CommentAnnotationI, TagAnnotationI):
-            ann = self.update.saveAndReturnObject(Ann())
+            ann = Ann()
+            ann.setNs(rstring(uuid))
+            ann = self.update.saveAndReturnObject(ann)
             created.append(ann)
         query_string = """
         select type(a.class) from Annotation a
+        where a.ns = :uuid
         """
-        rv = [x[0] for x in unwrap(self.query.projection(query_string, None))]
+        params = ParametersI()
+        params.addString("uuid", uuid)
+        rv = [x[0] for x in unwrap(self.query.projection(query_string, params))]
         assert len(rv) == 2
         assert "ome.model.annotations.CommentAnnotation" in rv
         assert "ome.model.annotations.TagAnnotation" in rv


### PR DESCRIPTION

This is the same as gh-5051 but rebased onto develop.

----

# What this PR does

Make it possible to retrieve the `ome.model` class name for a Hibernate subclass, e.g. `select type(a.class) from Annotation a` might return `ome.model.annotations.CommentAnnotation`. Note: Most HQL functions return the discriminator, including: `a.class` and `type(a)`


# Testing this PR

1. have a database with at least one annotation (`bin/omero obj new CommentAnnotation`)
2. query without this PR: `bin/omero hql -q 'select type(a.class) from Annotation a'`
3. This will fail with an exception from IceMapper

cc: @aleksandra-tarkowska 

                