### PR TITLE
deprecate IAdmin.moveToCommonSpace

### DIFF
--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010-2014 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -461,6 +459,7 @@ module omero {
                  *
                  * @param objects
                  */
+                ["deprecated:moveToCommonSpace() is deprecated. use omero::cmd::Chgrp2() instead to move to 'user' group."]
                 idempotent void moveToCommonSpace(IObjectList objects) throws ServerError;
 
                 // UAuth

--- a/components/common/src/ome/api/IAdmin.java
+++ b/components/common/src/ome/api/IAdmin.java
@@ -486,6 +486,7 @@ public interface IAdmin extends ServiceInterface {
      *            The user name who should gain ownership of this entity. Not
      *            null.
      */
+    @Deprecated
     void changeOwner(@NotNull
     IObject iObject, @NotNull
     String omeName);
@@ -503,6 +504,7 @@ public interface IAdmin extends ServiceInterface {
      *            The group name who should gain ownership of this entity. Not
      *            null.
      */
+    @Deprecated
     void changeGroup(@NotNull
     IObject iObject, @NotNull
     String groupName);
@@ -519,6 +521,7 @@ public interface IAdmin extends ServiceInterface {
      * @param perms
      *            The permissions value for this entity. Not null.
      */
+    @Deprecated
     void changePermissions(@NotNull
     IObject iObject, @NotNull
     Permissions perms);
@@ -530,6 +533,7 @@ public interface IAdmin extends ServiceInterface {
      * @param iObjects
      * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1794">ticket 1794</a>
      */
+    @Deprecated
     void moveToCommonSpace(IObject... iObjects);
 
     // ~ Authentication and Authorization


### PR DESCRIPTION
# What this PR does

Deprecates `IAdmin.moveToCommonSpace` following the pattern of deprecating the other synchronous methods that can now be done otherwise. Also propagates those deprecations to Java annotations.

Will look at reducing internal usage of such once code churn in related classes subsides so as to avoid conflicts.

--exclude because it may not be desirable

# Testing this PR

CI should remain green.