### PR TITLE
if user not in group then reload session to be sure

### DIFF
--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -395,9 +395,9 @@ public class BasicSecuritySystem implements SecuritySystem,
             // tickets:2950, 1940, 3529
             if (!isAdmin && !ec.getMemberOfGroupsList().contains(groupId)) {
                 if (!callPerms.isGranted(Role.WORLD, Right.READ)) {
-                    /* reload to address problems with PR 4957: user wrongly thought not to be in group */
-                    ec = sessionManager.reload(ec.getCurrentSessionUuid());
-                    if (!ec.getMemberOfGroupsList().contains(groupId)) {
+                    /* recheck memberships to address problems with PR 4957: user wrongly thought not to be in group */
+                    final Experimenter currentUser = new Experimenter(ec.getCurrentUserId(), false);
+                    if (!sf.getAdminService().getMemberOfGroupIds(currentUser).contains(groupId)) {
                         throw new SecurityViolation(String.format(
                                 "User %s is not a member of group %s and cannot login",
                                 ec.getCurrentUserId(), groupId));

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -395,9 +395,13 @@ public class BasicSecuritySystem implements SecuritySystem,
             // tickets:2950, 1940, 3529
             if (!isAdmin && !ec.getMemberOfGroupsList().contains(groupId)) {
                 if (!callPerms.isGranted(Role.WORLD, Right.READ)) {
-                    throw new SecurityViolation(String.format(
-                        "User %s is not a member of group %s and cannot login",
+                    /* reload to address problems with PR 4957: user wrongly thought not to be in group */
+                    ec = sessionManager.reload(ec.getCurrentSessionUuid());
+                    if (!ec.getMemberOfGroupsList().contains(groupId)) {
+                        throw new SecurityViolation(String.format(
+                                "User %s is not a member of group %s and cannot login",
                                 ec.getCurrentUserId(), groupId));
+                    }
                 }
             }
 

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -397,10 +397,13 @@ public class BasicSecuritySystem implements SecuritySystem,
                 if (!callPerms.isGranted(Role.WORLD, Right.READ)) {
                     /* recheck memberships to address problems with PR 4957: user wrongly thought not to be in group */
                     final Experimenter currentUser = new Experimenter(ec.getCurrentUserId(), false);
-                    if (!sf.getAdminService().getMemberOfGroupIds(currentUser).contains(groupId)) {
+                    final List<Long> groupIds = sf.getAdminService().getMemberOfGroupIds(currentUser);
+                    if (!groupIds.contains(groupId)) {
                         throw new SecurityViolation(String.format(
                                 "User %s is not a member of group %s and cannot login",
                                 ec.getCurrentUserId(), groupId));
+                    } else if (ec instanceof BasicEventContext) {
+                        ((BasicEventContext) ec).setMemberOfGroups(groupIds);
                     }
                 }
             }


### PR DESCRIPTION
This PR is just an experiment to see if it stabilizes the intermittent integration test errors caused by some commits from #4957 being included in #5048 and #5054.

--exclude