### PR TITLE
Omero properties cleanup

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1492,6 +1492,8 @@ class _BlitzGateway (object):
         self._defaultOmeroUser = None
         self._maxPlaneSize = None
 
+        self._defaultThumbnailSize = None
+
         self._connected = False
         self._user = None
         self._userid = None
@@ -1547,9 +1549,21 @@ class _BlitzGateway (object):
         if self._maxPlaneSize is None:
             c = self.getConfigService()
             self._maxPlaneSize = (
-                int(c.getConfigValue('omero.pixeldata.max_plane_width')),
-                int(c.getConfigValue('omero.pixeldata.max_plane_height')))
+                int(c.getConfigValue('omero.client.pixeldata.max_plane_width')),
+                int(c.getConfigValue('omero.client.pixeldata.max_plane_height')))
         return self._maxPlaneSize
+
+    def getDefaultThumbnailSize(self):
+        """
+        Returns the default thumbnail size
+        """
+        if self._defaultThumbnailSize is None:
+            try:
+                c = self.getConfigService()
+                self._defaultThumbnailSize = int(c.getConfigValue('omero.client.browser.thumb_default_size'))
+            except:
+                self._defaultThumbnailSize = 96
+        return self._defaultThumbnailSize
 
     def getClientSettings(self):
         """

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -244,29 +244,6 @@ class login_required(object):
             return self.allowPublic
         return False
 
-    def _cleanup_deprecated(self, s):
-        # TODO: remove in 5.3, cleanup deprecated
-        if 'omero.client.ui.tree.orphans.enabled' not in s:
-            s['omero.client.ui.tree.orphans.enabled'] = True
-
-        if 'omero.client.ui.menu.dropdown.everyone.label' not in s:
-            s['omero.client.ui.menu.dropdown.everyone.label'] = \
-                s['omero.client.ui.menu.dropdown.everyone']
-        if 'omero.client.ui.menu.dropdown.leaders.label' not in s:
-            s['omero.client.ui.menu.dropdown.leaders.label'] = \
-                s['omero.client.ui.menu.dropdown.leaders']
-        if 'omero.client.ui.menu.dropdown.colleagues.label' not in s:
-            s['omero.client.ui.menu.dropdown.colleagues.label'] = \
-                s['omero.client.ui.menu.dropdown.colleagues']
-
-        if 'omero.client.ui.menu.dropdown.everyone' in s:
-            del s['omero.client.ui.menu.dropdown.everyone']
-        if 'omero.client.ui.menu.dropdown.leaders' in s:
-            del s['omero.client.ui.menu.dropdown.leaders']
-        if 'omero.client.ui.menu.dropdown.colleagues' in s:
-            del s['omero.client.ui.menu.dropdown.colleagues']
-        return s
-
     def load_server_settings(self, conn, request):
         """Loads Client preferences from the server."""
         try:
@@ -275,7 +252,7 @@ class login_required(object):
             request.session.modified = True
             request.session['server_settings'] = {}
             try:
-                s = self._cleanup_deprecated(conn.getClientSettings())
+                s = conn.getClientSettings()
                 request.session['server_settings'] = \
                     propertiesToDict(s, prefix="omero.client.")
             except:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -331,14 +331,16 @@ def render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
     """
     server_id = request.session['connector'].server_id
     direct = True
+    defaultSize = conn.getDefaultThumbnailSize()
+
     if w is None:
-        size = (96,)
+        size = (defaultSize,)
     else:
         if h is None:
             size = (int(w),)
         else:
             size = (int(w), int(h))
-    if size == (96,):
+    if size == (defaultSize,):
         direct = False
     user_id = conn.getUserId()
     z = getIntOrDefault(request, 'z', None)
@@ -554,8 +556,8 @@ def get_shape_thumbnail(request, conn, image, s, compress_quality):
             logger.warn("webgateway: get_shape_thumbnail() could not get"
                         " Config-Value for %s" % key)
             pass
-    max_plane_width = getConfigValue("omero.pixeldata.max_plane_width")
-    max_plane_height = getConfigValue("omero.pixeldata.max_plane_height")
+    max_plane_width = getConfigValue("omero.client.pixeldata.max_plane_width")
+    max_plane_height = getConfigValue("omero.client.pixeldata.max_plane_height")
     if (max_plane_width is None or max_plane_height is None or
             (newW > int(max_plane_width)) or (newH > int(max_plane_height))):
         # generate dummy image to return

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -829,24 +829,18 @@ omero.client.ui.tree.orphans.name=Orphaned Images
 # Description of the "Orphaned images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
-# DEVELOPMENT: Deprecated use label. Removed in 5.3
-omero.client.ui.menu.dropdown.leaders=Owners
 # Client dropdown menu leader label.
-omero.client.ui.menu.dropdown.leaders.label=${omero.client.ui.menu.dropdown.leaders}
+omero.client.ui.menu.dropdown.leaders.label=Owners
 # Flag to show/hide leader.
 omero.client.ui.menu.dropdown.leaders.enabled=true
 
-# DEVELOPMENT: Deprecated use label. Removed in 5.3
-omero.client.ui.menu.dropdown.colleagues=Members
 # Client dropdown menu colleagues label.
-omero.client.ui.menu.dropdown.colleagues.label=${omero.client.ui.menu.dropdown.colleagues}
+omero.client.ui.menu.dropdown.colleagues.label=Members
 # Flag to show/hide colleagues
 omero.client.ui.menu.dropdown.colleagues.enabled=true
 
-# DEVELOPMENT: Deprecated use label. Removed in 5.3
-omero.client.ui.menu.dropdown.everyone=All Members
 # Client dropdown menu all users label.
-omero.client.ui.menu.dropdown.everyone.label=${omero.client.ui.menu.dropdown.everyone}
+omero.client.ui.menu.dropdown.everyone.label=All Members
 # Flag to show/hide all users.
 omero.client.ui.menu.dropdown.everyone.enabled=true
 
@@ -867,6 +861,9 @@ omero.client.viewer.roi_limit=2000
 # if set to 'false' empty list allows mixing all types and
 # sorting them by default client ordering strategy
 omero.client.ui.tree.type_order=tagset,tag,project,dataset,screen,plate,acquisition,image
+
+# The default thumbnail size
+omero.client.browser.thumb_default_size=96
 
 #############################################
 ## Ice overrides


### PR DESCRIPTION
# What this PR does

- Removes deprecated properties  `omero.client.ui.menu.dropdown.leaders` `omero.client.ui.menu.dropdown.everyone` and `omero.client.ui.menu.dropdown.colleagues `
- Add default thumbnail size as client property `omero.client.browser.thumb_default_size`

# Testing this PR

Check that integration test `test_thumbnails.py` still passes.

# Related reading

[Trello - omero properties](https://trello.com/c/Ib4Rk0bw/25-omero-properties)
