### PR TITLE
ROI tool NPE

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
@@ -298,19 +298,23 @@ public class FigureTableModel
 		}
 		else if (MeasurementAttributes.START_DECORATION.equals(key)) {
             LineDecoration dec = null;
-            Cap c = Cap.findByValue(value.toString());
-            if (c != null) {
-                dec = c.newLineDecorationInstance();
+            if (value != null) {
+                Cap c = Cap.findByValue(value.toString());
+                if (c != null) {
+                    dec = c.newLineDecorationInstance();
+                }
+                figure.setAttribute(key, dec);
             }
-            figure.setAttribute(key, dec);
 		}
 		else if (MeasurementAttributes.END_DECORATION.equals(key)) {
 		    LineDecoration dec = null;
-            Cap c = Cap.findByValue(value.toString());
-            if (c != null) {
-                dec = c.newLineDecorationInstance();
-            }
-            figure.setAttribute(key, dec);
+		    if (value != null) {
+		        Cap c = Cap.findByValue(value.toString());
+	            if (c != null) {
+	                dec = c.newLineDecorationInstance();
+	            }
+	            figure.setAttribute(key, dec);
+		    }
         }
 		else  
 			figure.setAttribute(key, value);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/measurement/util/model/FigureTableModel.java
@@ -307,14 +307,14 @@ public class FigureTableModel
             }
 		}
 		else if (MeasurementAttributes.END_DECORATION.equals(key)) {
-		    LineDecoration dec = null;
-		    if (value != null) {
-		        Cap c = Cap.findByValue(value.toString());
-	            if (c != null) {
-	                dec = c.newLineDecorationInstance();
-	            }
-	            figure.setAttribute(key, dec);
-		    }
+            LineDecoration dec = null;
+            if (value != null) {
+                Cap c = Cap.findByValue(value.toString());
+                if (c != null) {
+                    dec = c.newLineDecorationInstance();
+                }
+                figure.setAttribute(key, dec);
+            }
         }
 		else  
 			figure.setAttribute(key, value);


### PR DESCRIPTION
# What this PR does
Fix NPE when no selection set for start/end decoration

# Testing this PR
 * Open an image without ROI
 * Open the measurement tool.
 * Draw a rectangle. 
 * Go to the ``inspector`` tab
 * Click on the combo box in front of ``Start Decoration`` (resp. ``End decoration``)
 * Do no select anything, click outside the combox box e.g. on the label
 * Without this PR, this leads to a NPE. 

# Related reading
Problem noticed while preparing data for https://github.com/ome/omero-iviewer/pull/26 review

cc @dominikl 
