### PR TITLE
Omero properties cleanup

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -259,6 +259,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.browser.thumb_default_size">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -184,11 +184,6 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
-    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.leaders">
-       <property name="db" value="false"/>
-       <property name="mutable" value="false"/>
-       <property name="visibility" value="all"/>
-    </bean>
     <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.leaders.label">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>
@@ -199,22 +194,12 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
-    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.colleagues">
-       <property name="db" value="false"/>
-       <property name="mutable" value="false"/>
-       <property name="visibility" value="all"/>
-    </bean>
     <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.colleagues.label">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
     <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.colleagues.enabled">
-       <property name="db" value="false"/>
-       <property name="mutable" value="false"/>
-       <property name="visibility" value="all"/>
-    </bean>
-    <bean class="ome.system.Preference" id="omero.client.ui.menu.dropdown.everyone">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>

--- a/components/tools/OmeroPy/test/integration/test_iconfig.py
+++ b/components/tools/OmeroPy/test/integration/test_iconfig.py
@@ -63,7 +63,7 @@ class TestConfig(ITest):
     def testClientDefaults(self):
         cfg = self.sf.getConfigService()
         defs = cfg.getClientConfigDefaults()
-        assert "omero.client.ui.menu.dropdown.colleagues" in defs
+        assert "omero.client.ui.menu.dropdown.colleagues.label" in defs
 
     def testClientValues(self):
         # Not sure what's in this so just calling

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -244,29 +244,6 @@ class login_required(object):
             return self.allowPublic
         return False
 
-    def _cleanup_deprecated(self, s):
-        # TODO: remove in 5.3, cleanup deprecated
-        if 'omero.client.ui.tree.orphans.enabled' not in s:
-            s['omero.client.ui.tree.orphans.enabled'] = True
-
-        if 'omero.client.ui.menu.dropdown.everyone.label' not in s:
-            s['omero.client.ui.menu.dropdown.everyone.label'] = \
-                s['omero.client.ui.menu.dropdown.everyone']
-        if 'omero.client.ui.menu.dropdown.leaders.label' not in s:
-            s['omero.client.ui.menu.dropdown.leaders.label'] = \
-                s['omero.client.ui.menu.dropdown.leaders']
-        if 'omero.client.ui.menu.dropdown.colleagues.label' not in s:
-            s['omero.client.ui.menu.dropdown.colleagues.label'] = \
-                s['omero.client.ui.menu.dropdown.colleagues']
-
-        if 'omero.client.ui.menu.dropdown.everyone' in s:
-            del s['omero.client.ui.menu.dropdown.everyone']
-        if 'omero.client.ui.menu.dropdown.leaders' in s:
-            del s['omero.client.ui.menu.dropdown.leaders']
-        if 'omero.client.ui.menu.dropdown.colleagues' in s:
-            del s['omero.client.ui.menu.dropdown.colleagues']
-        return s
-
     def load_server_settings(self, conn, request):
         """Loads Client preferences from the server."""
         try:
@@ -275,9 +252,9 @@ class login_required(object):
             request.session.modified = True
             request.session['server_settings'] = {}
             try:
-                s = self._cleanup_deprecated(conn.getClientSettings())
                 request.session['server_settings'] = \
-                    propertiesToDict(s, prefix="omero.client.")
+                    propertiesToDict(conn.getClientSettings(),
+                                     prefix="omero.client.")
             except:
                 logger.error(traceback.format_exc())
             # make extra call for omero.mail, not a part of omero.client

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -330,15 +330,20 @@ def render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
     @return:            http response containing jpeg
     """
     server_id = request.session['connector'].server_id
+
+    server_settings = request.session.get('server_settings', {}) \
+                                     .get('browser', {})
+    defaultSize = server_settings.get('thumb_default_size', 96)
+
     direct = True
     if w is None:
-        size = (96,)
+        size = (defaultSize,)
     else:
         if h is None:
             size = (int(w),)
         else:
             size = (int(w), int(h))
-    if size == (96,):
+    if size == (defaultSize,):
         direct = False
     user_id = conn.getUserId()
     z = getIntOrDefault(request, 'z', None)

--- a/components/tools/OmeroWeb/test/integration/test_config.py
+++ b/components/tools/OmeroWeb/test/integration/test_config.py
@@ -131,7 +131,6 @@ class TestConfig(ITest):
         key = "omero.client.ui.menu.dropdown.%s" % prop
         try:
             self.rs.setConfigValue(key, label)
-            print "set %s to %s " % (key, label)
             # test load_server_settings directly
             login_required(default_view).load_server_settings(
                 self.conn, self.r)

--- a/components/tools/OmeroWeb/test/integration/test_config.py
+++ b/components/tools/OmeroWeb/test/integration/test_config.py
@@ -25,18 +25,13 @@ import json
 
 from omero.testlib import ITest
 
-import omero
-import omero.clients
-
 from django.test import RequestFactory
 from django.contrib.sessions.middleware import SessionMiddleware
-
 
 from omeroweb.webclient import webclient_gateway  # NOQA
 from omero.gateway import BlitzGateway
 from omeroweb.decorators import login_required
 
-import pytest
 from omero.gateway.utils import propertiesToDict
 
 
@@ -89,30 +84,14 @@ class TestConfig(ITest):
 
     def testDefaultConfig(self):
         """ Test loading default config """
-        deprecated = [
-            'omero.client.ui.menu.dropdown.everyone',
-            'omero.client.ui.menu.dropdown.leaders',
-            'omero.client.ui.menu.dropdown.colleagues'
-        ]
         default = self.rs.getClientConfigDefaults()
         login_required(default_view).load_server_settings(self.conn, self.r)
         s = {"omero": {"client": self.r.session.get('server_settings', {})}}
-        ss = self.r.session['server_settings']
-        # assert if alias gives the same value as deprecated
-        # rather then ${property}
-        for d in deprecated:
-            ds = d.split(".")
-            assert ss['ui']['menu']['dropdown'][ds[-1]]['label'] == default[d]
-            # workaround for alias as getClientConfigDefaults returns
-            # ${property} rather then value
-            assert ss['ui']['menu']['dropdown'][ds[-1]]['label'] == \
-                self.conn.getConfigService().getConfigValue(
-                    default['%s.label' % d][2:-1])
-
         # compare keys in default and config loaded by decorator
         a = filter(lambda x: x not in (
-            set(default.keys()) - set(deprecated)),
-            set(flattenProperties(s).keys()))
+            set(default.keys())),
+            set(flattenProperties(s).keys())
+            )
         assert a == ['omero.client.email']
 
     def testDefaultConfigConversion(self):
@@ -140,72 +119,3 @@ class TestConfig(ITest):
 
         assert isinstance(ss['viewer']['roi_limit'], int)
         assert ss['viewer']['roi_limit'] == json.loads(default[key2])
-
-    @pytest.mark.parametrize("prop", ["colleagues", "leaders", "everyone",
-                                      "colleagues.label", "leaders.label",
-                                      "everyone.label"])
-    @pytest.mark.parametrize("label", ["foo"])
-    def testUpgradeDropdownMenuConfig(self, prop, label):
-        """ Test if alias loads deprecated property value """
-        d = self.rs.getClientConfigDefaults()
-        key = "omero.client.ui.menu.dropdown.%s" % prop
-        try:
-            self.rs.setConfigValue(key, label)
-            # test load_server_settings directly
-            login_required(default_view).load_server_settings(
-                self.conn, self.r)
-            s = self.r.session.get('server_settings', {})
-            prop = prop.replace(".label", "")
-            assert s['ui']['menu']['dropdown'][prop]['label'] == label
-        finally:
-            self.rs.setConfigValue(key, d[key])
-
-    def mock_getClientSettings(self, monkeypatch, default):
-        def get_clientSettings(*args, **kwargs):
-            not_exist = [
-                'omero.client.ui.menu.dropdown.everyone.label',
-                'omero.client.ui.menu.dropdown.leaders.label',
-                'omero.client.ui.menu.dropdown.colleagues.label',
-                'omero.client.ui.tree.orphans.enabled',
-                'omero.client.viewer.initial_zoom_level'
-            ]
-            for n in not_exist:
-                if n in default:
-                    del default[n]
-            return default
-        monkeypatch.setattr(omero.gateway.BlitzGateway,
-                            'getClientSettings',
-                            get_clientSettings)
-
-    @pytest.mark.parametrize("prop", ["colleagues", "leaders", "everyone"])
-    @pytest.mark.parametrize("label", ["foo"])
-    def testOldDropdownMenuConfig(self, monkeypatch, prop, label):
-        """ Test against older server with monkeypatch """
-        d = self.rs.getClientConfigDefaults()
-        key = "omero.client.ui.menu.dropdown.%s" % prop
-        try:
-            if label is not None:
-                self.rs.setConfigValue(key, label)
-            self.mock_getClientSettings(monkeypatch,
-                                        self.rs.getClientConfigValues())
-            # validate old config
-            ocs = self.conn.getClientSettings()
-            not_exist = [
-                'omero.client.ui.menu.dropdown.everyone.label',
-                'omero.client.ui.menu.dropdown.leaders.label',
-                'omero.client.ui.menu.dropdown.colleagues.label',
-                'omero.client.ui.tree.orphans.enabled',
-                'omero.client.viewer.initial_zoom_level'
-            ]
-            for n in not_exist:
-                assert n not in ocs
-            # test load_server_settings directly
-            login_required(default_view).load_server_settings(
-                self.conn, self.r)
-            s = self.r.session.get('server_settings', {})
-            if label is not None:
-                assert s['ui']['menu']['dropdown'][prop]['label'] == label
-            else:
-                assert s['ui']['menu']['dropdown'][prop]['label'] == d[key]
-        finally:
-            self.rs.setConfigValue(key, d[key])

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -829,24 +829,18 @@ omero.client.ui.tree.orphans.name=Orphaned Images
 # Description of the "Orphaned images" container.
 omero.client.ui.tree.orphans.description=This is a virtual container with orphaned images. These images are not linked anywhere. Just drag them to the selected container.
 
-# DEVELOPMENT: Deprecated use label. Removed in 5.3
-omero.client.ui.menu.dropdown.leaders=Owners
 # Client dropdown menu leader label.
-omero.client.ui.menu.dropdown.leaders.label=${omero.client.ui.menu.dropdown.leaders}
+omero.client.ui.menu.dropdown.leaders.label=Owners
 # Flag to show/hide leader.
 omero.client.ui.menu.dropdown.leaders.enabled=true
 
-# DEVELOPMENT: Deprecated use label. Removed in 5.3
-omero.client.ui.menu.dropdown.colleagues=Members
 # Client dropdown menu colleagues label.
-omero.client.ui.menu.dropdown.colleagues.label=${omero.client.ui.menu.dropdown.colleagues}
+omero.client.ui.menu.dropdown.colleagues.label=Members
 # Flag to show/hide colleagues
 omero.client.ui.menu.dropdown.colleagues.enabled=true
 
-# DEVELOPMENT: Deprecated use label. Removed in 5.3
-omero.client.ui.menu.dropdown.everyone=All Members
 # Client dropdown menu all users label.
-omero.client.ui.menu.dropdown.everyone.label=${omero.client.ui.menu.dropdown.everyone}
+omero.client.ui.menu.dropdown.everyone.label=All Members
 # Flag to show/hide all users.
 omero.client.ui.menu.dropdown.everyone.enabled=true
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -862,6 +862,9 @@ omero.client.viewer.roi_limit=2000
 # sorting them by default client ordering strategy
 omero.client.ui.tree.type_order=tagset,tag,project,dataset,screen,plate,acquisition,image
 
+# The default thumbnail size
+omero.client.browser.thumb_default_size=96
+
 #############################################
 ## Ice overrides
 ##


### PR DESCRIPTION
# What this PR does
(Replaces  closed PR #5063 )

- Removes deprecated properties  `omero.client.ui.menu.dropdown.leaders` `omero.client.ui.menu.dropdown.everyone` and `omero.client.ui.menu.dropdown.colleagues `
- Add default thumbnail size as client property `omero.client.browser.thumb_default_size`

# Testing this PR

Check that integration test `test_thumbnails.py` still passes.

# Related reading

[Trello - omero properties](https://trello.com/c/Ib4Rk0bw/25-omero-properties)
