### PR TITLE
Rgba fixes

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6462,7 +6462,10 @@ class ColorHolder (object):
         g = self.getGreen() << 16
         b = self.getBlue() << 8
         a = self.getAlpha() << 0
-        return r+g+b+a
+        rgba_int = r+g+b+a
+        if (rgba_int > (2**31-1)):       # convert to signed 32-bit int
+            rgba_int = rgba_int - 2**32
+        return int(rgba_int)
 
 
 class _LogicalChannelWrapper (BlitzObjectWrapper):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6458,10 +6458,10 @@ class ColorHolder (object):
         :rtype:     int
         """
 
-        a = self.getAlpha() << 24
-        r = self.getRed() << 16
-        g = self.getGreen() << 8
-        b = self.getBlue() << 0
+        r = self.getRed() << 24
+        g = self.getGreen() << 16
+        b = self.getBlue() << 8
+        a = self.getAlpha() << 0
         return r+g+b+a
 
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6461,7 +6461,7 @@ class ColorHolder (object):
         r = self.getRed() << 24
         g = self.getGreen() << 16
         b = self.getBlue() << 8
-        a = self.getAlpha() << 0
+        a = self.getAlpha()
         rgba_int = r+g+b+a
         if (rgba_int > (2**31-1)):       # convert to signed 32-bit int
             rgba_int = rgba_int - 2**32

--- a/components/tools/OmeroPy/test/integration/test_rois.py
+++ b/components/tools/OmeroPy/test/integration/test_rois.py
@@ -10,6 +10,9 @@
 """
 from omero.testlib import ITest
 import omero
+from omero.rtypes import rdouble, rstring, rint
+import pytest
+from omero.gateway import ColorHolder
 
 
 class TestRois(ITest):
@@ -173,3 +176,90 @@ class TestRois(ITest):
         for x in (fix1, fix2):
             assertRois(x, None,     0, 0,   4, 4, 2)
             assertRois(x, None,     0, 1,   4, 4, 0)  # DNE
+
+    @pytest.mark.parametrize("color", [
+        (255, 0, 0, 255, -16776961),     # Red
+        (0, 255, 0, 255, 16711935),      # Green
+        (0, 0, 255, 255, 65535),         # Blue
+        (0, 255, 255, 255, 16777215),    # Cyan
+        (255, 0, 255, 255, -16711681),   # Magenta
+        (255, 255, 0, 255, -65281),      # Yellow
+        (0, 0, 0, 255, 255),             # Black
+        (255, 255, 255, 255, -1),        # White
+        (0, 0, 0, 127, 127),             # Transparent black
+        (127, 127, 127, 127, 2139062143)])  # Grey
+    def testShapeColors(self, color):
+        """Test create an ROI with various shapes & colors set."""
+
+        color_holder = ColorHolder()
+        color_holder.setRed(color[0])
+        color_holder.setGreen(color[1])
+        color_holder.setBlue(color[2])
+        color_holder.setAlpha(color[3])
+        colorInt = color_holder.getInt()
+        assert colorInt == color[4]
+
+        img = self.new_image("testCreateRois")
+        img = self.update.saveAndReturnObject(img)
+
+        roi = omero.model.RoiI()
+        roi.setImage(img)
+
+        rect = omero.model.RectangleI()
+        rect.x = rdouble(5)
+        rect.y = rdouble(5)
+        rect.width = rdouble(100)
+        rect.height = rdouble(100)
+        rect.fillColor = rint(colorInt)
+        rect.strokeColor = rint(colorInt)
+        rect.theZ = rint(0)
+        rect.theT = rint(0)
+        rect.textValue = rstring("test-Rectangle")
+        roi.addShape(rect)
+
+        ellipse = omero.model.EllipseI()
+        ellipse.x = rdouble(50.0)
+        ellipse.y = rdouble(35.5)
+        ellipse.radiusX = rdouble(2000)
+        ellipse.radiusY = rdouble(300.04)
+        ellipse.fillColor = rint(colorInt)
+        ellipse.strokeColor = rint(colorInt)
+        ellipse.theZ = rint(1)
+        ellipse.theT = rint(2)
+        ellipse.textValue = rstring("test-Ellipse")
+        roi.addShape(ellipse)
+
+        line = omero.model.LineI()
+        line.x1 = rdouble(0)
+        line.x2 = rdouble(500.9)
+        line.y1 = rdouble(-100)
+        line.y2 = rdouble(201.0)
+        line.theZ = rint(-1)
+        line.theT = rint(1)
+        line.strokeColor = rint(colorInt)
+        line.fillColor = rint(colorInt)
+        line.textValue = rstring("test-Line")
+        roi.addShape(line)
+
+        point = omero.model.PointI()
+        point.x = rdouble(1000)
+        point.y = rdouble(0)
+        point.strokeColor = rint(colorInt)
+        point.fillColor = rint(colorInt)
+        point.textValue = rstring("test-Point")
+        roi.addShape(point)
+
+        new_roi = self.update.saveAndReturnObject(roi)
+
+        roi_service = self.client.sf.getRoiService()
+        result = roi_service.findByImage(img.id.val, None)
+        assert result is not None
+        shapeCount = 0
+        for roi in result.rois:
+            assert roi.id.val == new_roi.id.val
+            for s in roi.copyShapes():
+                assert s.getFillColor().val == colorInt
+                assert s.getStrokeColor().val == colorInt
+                shapeCount += 1
+        # Check we fount 4 shapes
+        assert shapeCount == 4

--- a/components/tools/OmeroPy/test/integration/test_rois.py
+++ b/components/tools/OmeroPy/test/integration/test_rois.py
@@ -261,5 +261,5 @@ class TestRois(ITest):
                 assert s.getFillColor().val == colorInt
                 assert s.getStrokeColor().val == colorInt
                 shapeCount += 1
-        # Check we fount 4 shapes
+        # Check we found 4 shapes
         assert shapeCount == 4

--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -65,7 +65,7 @@ def create_roi(img, shapes):
 # Another helper for generating the color integers for shapes
 def rgba_to_int(red, green, blue, alpha=255):
     """ Convert an R,G,B,A value to an int """
-    rgba_int = (alpha << 24) + (red << 16) + (green << 8) + blue
+    rgba_int = (red << 24) + (green << 16) + (blue << 8) + alpha
     if (rgba_int > (2**31-1)):       # convert to signed 32-bit int
         rgba_int = rgba_int - 2**32
     return int(rgba_int)
@@ -82,6 +82,8 @@ rect.height = rdouble(height)
 rect.theZ = rint(z)
 rect.theT = rint(t)
 rect.textValue = rstring("test-Rectangle")
+rect.fillColor = rint(rgba_to_int(255, 255, 255, 255))
+rect.strokeColor = rint(rgba_to_int(255, 255, 0, 255))
 
 # create an Ellipse shape (added to ROI below)
 ellipse = omero.model.EllipseI()


### PR DESCRIPTION
# What this PR does

I noticed that Blitz Gateway ColorHolder.getInt() didn't use RGBA encoding. On fixing that (in https://github.com/openmicroscopy/openmicroscopy/pull/5058), training tests failed:
https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-training/510/console
which revealed other places where we haven't fixed this, so I've moved that commit to a new PR.

# Testing this PR

1. Test above should pass
1. Manually run ROIs.py and check in webclient / Insight that the shapes created are the expected colors.

# Related reading

See previous PRs from @dominikl 
cc @jburel.
