### PR TITLE
Romio unit test

### DIFF
--- a/components/romio/test/ome/io/nio/utests/BfPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/BfPixelBufferUnitTest.java
@@ -1,12 +1,9 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +15,7 @@ import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 
 import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -73,7 +71,7 @@ public class BfPixelBufferUnitTest {
     public void testRomioPixelBufferCreation() {
         service = new PixelsService(root);
         pixelBuffer = service._getPixelBuffer(pixels, true);
-        assertTrue(pixelBuffer instanceof RomioPixelBuffer);
+        Assert.assertTrue(pixelBuffer instanceof RomioPixelBuffer);
     }
 
 }

--- a/components/romio/test/ome/io/nio/utests/HelperUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/HelperUnitTest.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,10 +7,10 @@ package ome.io.nio.utests;
 import java.io.File;
 import java.io.IOException;
 
-import static org.testng.AssertJUnit.*;
-
 import org.apache.commons.io.FileUtils;
-import org.testng.annotations.*;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
 import ome.io.nio.PixelsService;
 
 public class HelperUnitTest {
@@ -39,7 +37,7 @@ public class HelperUnitTest {
     @Test
     public void testMissingTrailingSlash() {
         String path = new PixelsService(ROOT).getPixelsPath(new Long(1));
-        assertEquals(p(ROOT) + p("Pixels/1"), path);
+        Assert.assertEquals(p(ROOT) + p("Pixels/1"), path);
     }
 
     //
@@ -48,25 +46,25 @@ public class HelperUnitTest {
     @Test
     public void testPixelsSingleDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT).getPixelsPath(new Long(1));
-        assertEquals(p(ROOT) + p("Pixels/1"), path);
+        Assert.assertEquals(p(ROOT) + p("Pixels/1"), path);
     }
 
     @Test
     public void testFilesSingleDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT).getFilesPath(new Long(1));
-        assertEquals(p(ROOT) + p("Files/1"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/1"), path);
     }
 
     @Test
     public void testPixelsSingleDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT).getPixelsPath(new Long(999));
-        assertEquals(p(ROOT) + p("Pixels/999"), path);
+        Assert.assertEquals(p(ROOT) + p("Pixels/999"), path);
     }
 
     @Test
     public void testFilesSingleDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT).getFilesPath(new Long(999));
-        assertEquals(p(ROOT) + p("Files/999"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/999"), path);
     }
 
     //
@@ -75,25 +73,25 @@ public class HelperUnitTest {
     @Test
     public void testPixelsTwoDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT).getPixelsPath(new Long(1001));
-        assertEquals(p(ROOT) + p("Pixels/Dir-001/1001"), path);
+        Assert.assertEquals(p(ROOT) + p("Pixels/Dir-001/1001"), path);
     }
 
     @Test
     public void testFilesTwoDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT).getFilesPath(new Long(1001));
-        assertEquals(p(ROOT) + p("Files/Dir-001/1001"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/Dir-001/1001"), path);
     }
 
     @Test
     public void testPixelsTwoDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT).getPixelsPath(new Long(999999));
-        assertEquals(p(ROOT) + p("Pixels/Dir-999/999999"), path);
+        Assert.assertEquals(p(ROOT) + p("Pixels/Dir-999/999999"), path);
     }
 
     @Test
     public void testFilesTwoDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT).getFilesPath(new Long(999999));
-        assertEquals(p(ROOT) + p("Files/Dir-999/999999"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/Dir-999/999999"), path);
     }
 
     //
@@ -102,26 +100,26 @@ public class HelperUnitTest {
     @Test
     public void testPixelsThreeDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT).getPixelsPath(new Long(1000001));
-        assertEquals(p(ROOT) + p("Pixels/Dir-001/Dir-000/1000001"), path);
+        Assert.assertEquals(p(ROOT) + p("Pixels/Dir-001/Dir-000/1000001"), path);
     }
 
     @Test
     public void testFilesThreeDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT).getFilesPath(new Long(1000001));
-        assertEquals(p(ROOT) + p("Files/Dir-001/Dir-000/1000001"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/Dir-001/Dir-000/1000001"), path);
     }
 
     @Test
     public void testPixelsThreeDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT)
                 .getPixelsPath(new Long(999999999));
-        assertEquals(p(ROOT) + p("Pixels/Dir-999/Dir-999/999999999"), path);
+        Assert.assertEquals(p(ROOT) + p("Pixels/Dir-999/Dir-999/999999999"), path);
     }
 
     @Test
     public void testFilesThreeDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT).getFilesPath(new Long(999999999));
-        assertEquals(p(ROOT) + p("Files/Dir-999/Dir-999/999999999"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/Dir-999/Dir-999/999999999"), path);
     }
 
     //
@@ -131,7 +129,7 @@ public class HelperUnitTest {
     public void testPixelsFourDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT)
                 .getPixelsPath(new Long(1000000001));
-        assertEquals(p(ROOT) + p("Pixels/Dir-001/Dir-000/Dir-000/1000000001"),
+        Assert.assertEquals(p(ROOT) + p("Pixels/Dir-001/Dir-000/Dir-000/1000000001"),
                 path);
     }
 
@@ -139,14 +137,14 @@ public class HelperUnitTest {
     public void testFilesFourDirectoryLowerBoundsPath() {
         String path = new PixelsService(ROOT)
                 .getFilesPath(new Long(1000000001));
-        assertEquals(p(ROOT) + p("Files/Dir-001/Dir-000/Dir-000/1000000001"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/Dir-001/Dir-000/Dir-000/1000000001"), path);
     }
 
     @Test
     public void testPixelsFourDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT)
                 .getPixelsPath((long) Integer.MAX_VALUE);
-        assertEquals(p(ROOT) + p("Pixels/Dir-002/Dir-147/Dir-483/2147483647"),
+        Assert.assertEquals(p(ROOT) + p("Pixels/Dir-002/Dir-147/Dir-483/2147483647"),
                 path);
     }
 
@@ -154,6 +152,6 @@ public class HelperUnitTest {
     public void testFilesFourDirectoryUpperBoundsPath() {
         String path = new PixelsService(ROOT)
                 .getFilesPath((long) Integer.MAX_VALUE);
-        assertEquals(p(ROOT) + p("Files/Dir-002/Dir-147/Dir-483/2147483647"), path);
+        Assert.assertEquals(p(ROOT) + p("Files/Dir-002/Dir-147/Dir-483/2147483647"), path);
     }
 }

--- a/components/romio/test/ome/io/nio/utests/HugePixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/HugePixelBufferUnitTest.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -9,10 +7,12 @@ package ome.io.nio.utests;
 import java.io.File;
 import java.io.IOException;
 
-import static org.testng.AssertJUnit.*;
 
 import org.apache.commons.io.FileUtils;
-import org.testng.annotations.*;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -62,35 +62,35 @@ public class HugePixelBufferUnitTest {
 
     @Test
     public void testGetPlaneSize() {
-        assertEquals(pixelBuffer.getPlaneSize().intValue(), planeSize);
+        Assert.assertEquals(pixelBuffer.getPlaneSize().intValue(), planeSize);
     }
 
     @Test
     public void testGetStackSize() {
-        assertEquals(pixelBuffer.getStackSize().intValue(), stackSize);
+        Assert.assertEquals(pixelBuffer.getStackSize().intValue(), stackSize);
     }
 
     @Test
     public void testGetTimepointSize() {
-        assertEquals(pixelBuffer.getTimepointSize().intValue(), timepointSize);
+        Assert.assertEquals(pixelBuffer.getTimepointSize().intValue(), timepointSize);
     }
 
     @Test
     public void testGetInitialPlaneOffset()
             throws DimensionsOutOfBoundsException {
-        assertEquals(pixelBuffer.getPlaneOffset(0, 0, 0).longValue(), 0L);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(0, 0, 0).longValue(), 0L);
     }
 
     @Test
     public void testGetPlaneOffset1() throws DimensionsOutOfBoundsException {
         long offset = (long) timepointSize * 25 + (long) planeSize * 25;
-        assertEquals(pixelBuffer.getPlaneOffset(25, 0, 25).longValue(), offset);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(25, 0, 25).longValue(), offset);
     }
 
     @Test
     public void testGetPlaneOffset2() throws DimensionsOutOfBoundsException {
         long offset = (long) timepointSize * 25 + (long) stackSize * 1
                 + (long) planeSize * 25;
-        assertEquals(pixelBuffer.getPlaneOffset(25, 1, 25).longValue(), offset);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(25, 1, 25).longValue(), offset);
     }
 }

--- a/components/romio/test/ome/io/nio/utests/LargePixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/LargePixelBufferUnitTest.java
@@ -1,18 +1,18 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import static org.testng.AssertJUnit.*;
 
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.testng.annotations.*;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -60,35 +60,35 @@ public class LargePixelBufferUnitTest {
 
     @Test
     public void testGetPlaneSize() {
-        assertEquals(pixelBuffer.getPlaneSize().intValue(), planeSize);
+        Assert.assertEquals(pixelBuffer.getPlaneSize().intValue(), planeSize);
     }
 
     @Test
     public void testGetStackSize() {
-        assertEquals(pixelBuffer.getStackSize().intValue(), stackSize);
+        Assert.assertEquals(pixelBuffer.getStackSize().intValue(), stackSize);
     }
 
     @Test
     public void testGetTimepointSize() {
-        assertEquals(pixelBuffer.getTimepointSize().intValue(), timepointSize);
+        Assert.assertEquals(pixelBuffer.getTimepointSize().intValue(), timepointSize);
     }
 
     @Test
     public void testGetInitialPlaneOffset()
             throws DimensionsOutOfBoundsException {
-        assertEquals(pixelBuffer.getPlaneOffset(0, 0, 0).longValue(), 0L);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(0, 0, 0).longValue(), 0L);
     }
 
     @Test
     public void testGetPlaneOffset1() throws DimensionsOutOfBoundsException {
         long offset = (long) timepointSize * 25 + (long) planeSize * 25;
-        assertEquals(pixelBuffer.getPlaneOffset(25, 0, 25).longValue(), offset);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(25, 0, 25).longValue(), offset);
     }
 
     @Test
     public void testGetPlaneOffset2() throws DimensionsOutOfBoundsException {
         long offset = (long) timepointSize * 25 + (long) stackSize * 1
                 + (long) planeSize * 25;
-        assertEquals(pixelBuffer.getPlaneOffset(25, 1, 25).longValue(), offset);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(25, 1, 25).longValue(), offset);
     }
 }

--- a/components/romio/test/ome/io/nio/utests/NormalPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/NormalPixelBufferUnitTest.java
@@ -1,18 +1,18 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import static org.testng.AssertJUnit.*;
 
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.testng.annotations.*;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
@@ -60,35 +60,35 @@ public class NormalPixelBufferUnitTest {
 
     @Test
     public void testGetPlaneSize() {
-        assertEquals(pixelBuffer.getPlaneSize().intValue(), planeSize);
+        Assert.assertEquals(pixelBuffer.getPlaneSize().intValue(), planeSize);
     }
 
     @Test
     public void testGetStackSize() {
-        assertEquals(pixelBuffer.getStackSize().intValue(), stackSize);
+        Assert.assertEquals(pixelBuffer.getStackSize().intValue(), stackSize);
     }
 
     @Test
     public void testGetTimepointSize() {
-        assertEquals(pixelBuffer.getTimepointSize().intValue(), timepointSize);
+        Assert.assertEquals(pixelBuffer.getTimepointSize().intValue(), timepointSize);
     }
 
     @Test
     public void testGetInitialPlaneOffset()
             throws DimensionsOutOfBoundsException {
-        assertEquals(pixelBuffer.getPlaneOffset(0, 0, 0).longValue(), 0L);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(0, 0, 0).longValue(), 0L);
     }
 
     @Test
     public void testGetPlaneOffset1() throws DimensionsOutOfBoundsException {
         long offset = (long) timepointSize * 25 + (long) planeSize * 25;
-        assertEquals(pixelBuffer.getPlaneOffset(25, 0, 25).longValue(), offset);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(25, 0, 25).longValue(), offset);
     }
 
     @Test
     public void testGetPlaneOffset2() throws DimensionsOutOfBoundsException {
         long offset = (long) timepointSize * 25 + (long) stackSize * 1
                 + (long) planeSize * 25;
-        assertEquals(pixelBuffer.getPlaneOffset(25, 1, 25).longValue(), offset);
+        Assert.assertEquals(pixelBuffer.getPlaneOffset(25, 1, 25).longValue(), offset);
     }
 }

--- a/components/romio/test/ome/io/nio/utests/OutOfBoundsUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/OutOfBoundsUnitTest.java
@@ -1,12 +1,9 @@
 /*
- * ome.io.nio.utests.OutOfBoundsUnitTest
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import static org.testng.AssertJUnit.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,6 +15,7 @@ import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 
 import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -65,7 +63,7 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 
     @Test
@@ -76,7 +74,7 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 
     @Test
@@ -87,7 +85,7 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 
     @Test
@@ -98,7 +96,7 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 
     @Test
@@ -109,7 +107,7 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 
     @Test
@@ -120,7 +118,7 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 
     @Test
@@ -131,7 +129,7 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 
     @Test
@@ -142,6 +140,6 @@ public class OutOfBoundsUnitTest {
             return;
         }
 
-        fail("Out of bounds dimension was not caught.");
+        Assert.fail("Out of bounds dimension was not caught.");
     }
 }

--- a/components/romio/test/ome/io/nio/utests/OutOfBoundsUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/OutOfBoundsUnitTest.java
@@ -38,7 +38,7 @@ public class OutOfBoundsUnitTest {
     }
 
     @BeforeMethod
-    public void setUp() {
+    public void setUp() throws IOException {
         pixels = new Pixels();
 
         pixels.setId(1L);
@@ -52,7 +52,7 @@ public class OutOfBoundsUnitTest {
         pixels.setPixelsType(type); // FIXME
 
         PixelsService service = new PixelsService(ROOT);
-        pixelBuffer = service.getPixelBuffer(pixels);
+        pixelBuffer = service.createPixelBuffer(pixels);
     }
 
     @Test

--- a/components/romio/test/ome/io/nio/utests/OutOfBoundsUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/OutOfBoundsUnitTest.java
@@ -49,7 +49,8 @@ public class OutOfBoundsUnitTest {
         pixels.setSizeT(50);
 
         PixelsType type = new PixelsType();
-        pixels.setPixelsType(type); // FIXME
+        type.setValue("int8");
+        pixels.setPixelsType(type);
 
         PixelsService service = new PixelsService(ROOT);
         pixelBuffer = service.createPixelBuffer(pixels);

--- a/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
@@ -28,42 +28,42 @@ public class PixelDataBitTest
  
     public void testGetBits()
     {
-        Assert.assertEquals(data.getPixelValue(0), 1.0);  // Start byte 1
-        Assert.assertEquals(data.getPixelValue(1), 1.0);
-        Assert.assertEquals(1.0, data.getPixelValue(2), 1.0);
-        Assert.assertEquals(1.0, data.getPixelValue(3), 1.0);
-        Assert.assertEquals(1.0, data.getPixelValue(4), 1.0);
-        Assert.assertEquals(1.0, data.getPixelValue(5), 1.0);
-        Assert.assertEquals(1.0, data.getPixelValue(6), 1.0);
-        Assert.assertEquals(1.0, data.getPixelValue(7), 1.0);
-        Assert.assertEquals(1.0, data.getPixelValue(8), 1.0);  // Start byte 2 
-        Assert.assertEquals(1.0, data.getPixelValue(9), 1.0);
-        Assert.assertEquals(0.0, data.getPixelValue(10), 0.0);
-        Assert.assertEquals(0.0, data.getPixelValue(11), 0.0);
-        Assert.assertEquals(0.0, data.getPixelValue(12), 0.0);
-        Assert.assertEquals(0.0, data.getPixelValue(13), 0.0);
-        Assert.assertEquals(0.0, data.getPixelValue(14), 0.0);
-        Assert.assertEquals(1.0, data.getPixelValue(15), 1.0);
+        Assert.assertEquals(data.getPixelValue(0), 1.0, 0.0);  // Start byte 1
+        Assert.assertEquals(data.getPixelValue(1), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(2), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(3), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(4), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(5), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(6), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(7), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(8), 1.0, 0.0);  // Start byte 2 
+        Assert.assertEquals(data.getPixelValue(9), 1.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(10), 0.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(11), 0.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(12), 0.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(13), 0.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(14), 0.0, 0.0);
+        Assert.assertEquals(data.getPixelValue(15), 1.0, 0.0);
     }
     
     public void testSetAndGetBits()
     {
     	// 0
-        Assert.assertEquals(data.getPixelValue(0), 1.0);
+        Assert.assertEquals(data.getPixelValue(0), 1.0, 0.0);
     	data.setPixelValue(0, 0.0);
-    	Assert.assertEquals(data.getPixelValue(0), 0.0);
+    	Assert.assertEquals(data.getPixelValue(0), 0.0, 0.0);
     	// 7
-    	Assert.assertEquals(data.getPixelValue(7), 1.0);
+    	Assert.assertEquals(data.getPixelValue(7), 1.0, 0.0);
     	data.setPixelValue(7, 0.0);
-    	Assert.assertEquals(data.getPixelValue(7), 0.0);
+    	Assert.assertEquals(data.getPixelValue(7), 0.0, 0.0);
     	// 8
-    	Assert.assertEquals(data.getPixelValue(8), 1.0);
+    	Assert.assertEquals(data.getPixelValue(8), 1.0, 0.0);
     	data.setPixelValue(8, 1.0);
-    	Assert.assertEquals(data.getPixelValue(8), 1.0);
+    	Assert.assertEquals(data.getPixelValue(8), 1.0, 0.0);
     	// 14
-    	Assert.assertEquals(data.getPixelValue(14), 0.0);
+    	Assert.assertEquals(data.getPixelValue(14), 0.0, 0.0);
     	data.setPixelValue(14, 1.0);
-    	Assert.assertEquals(data.getPixelValue(14), 1.0);
+    	Assert.assertEquals(data.getPixelValue(14), 1.0, 0.0);
     }
     
     public void testSize()

--- a/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
@@ -19,12 +19,12 @@ import ome.util.PixelData;
  */
 public class PixelDataBitTest
 {
-	private PixelData data;
+    private PixelData data;
 
     public void setUp()
     {
-    	byte[] byteArray = new byte[] { (byte) 0xFF, (byte) 193 }; 
-	data = new PixelData("bit", ByteBuffer.wrap(byteArray));
+        byte[] byteArray = new byte[] { (byte) 0xFF, (byte) 193 };
+        data = new PixelData("bit", ByteBuffer.wrap(byteArray));
     }
 
     @Test
@@ -51,22 +51,22 @@ public class PixelDataBitTest
     @Test
     public void testSetAndGetBits()
     {
-    	// 0
+        // 0
         Assert.assertEquals(data.getPixelValue(0), 1.0, 0.0);
-    	data.setPixelValue(0, 0.0);
-    	Assert.assertEquals(data.getPixelValue(0), 0.0, 0.0);
-    	// 7
-    	Assert.assertEquals(data.getPixelValue(7), 1.0, 0.0);
-    	data.setPixelValue(7, 0.0);
-    	Assert.assertEquals(data.getPixelValue(7), 0.0, 0.0);
-    	// 8
-    	Assert.assertEquals(data.getPixelValue(8), 1.0, 0.0);
-    	data.setPixelValue(8, 1.0);
-    	Assert.assertEquals(data.getPixelValue(8), 1.0, 0.0);
-    	// 14
-    	Assert.assertEquals(data.getPixelValue(14), 0.0, 0.0);
-    	data.setPixelValue(14, 1.0);
-    	Assert.assertEquals(data.getPixelValue(14), 1.0, 0.0);
+        data.setPixelValue(0, 0.0);
+        Assert.assertEquals(data.getPixelValue(0), 0.0, 0.0);
+        // 7
+        Assert.assertEquals(data.getPixelValue(7), 1.0, 0.0);
+        data.setPixelValue(7, 0.0);
+        Assert.assertEquals(data.getPixelValue(7), 0.0, 0.0);
+        // 8
+        Assert.assertEquals(data.getPixelValue(8), 1.0, 0.0);
+        data.setPixelValue(8, 1.0);
+        Assert.assertEquals(data.getPixelValue(8), 1.0, 0.0);
+        // 14
+        Assert.assertEquals(data.getPixelValue(14), 0.0, 0.0);
+        data.setPixelValue(14, 1.0);
+        Assert.assertEquals(data.getPixelValue(14), 1.0, 0.0);
     }
 
     @Test

--- a/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
@@ -7,6 +7,7 @@
 package ome.io.nio.utests;
 
 import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 
@@ -25,7 +26,8 @@ public class PixelDataBitTest
     	byte[] byteArray = new byte[] { (byte) 0xFF, (byte) 193 }; 
 	data = new PixelData("bit", ByteBuffer.wrap(byteArray));
     }
- 
+
+    @Test
     public void testGetBits()
     {
         Assert.assertEquals(data.getPixelValue(0), 1.0, 0.0);  // Start byte 1
@@ -45,7 +47,8 @@ public class PixelDataBitTest
         Assert.assertEquals(data.getPixelValue(14), 0.0, 0.0);
         Assert.assertEquals(data.getPixelValue(15), 1.0, 0.0);
     }
-    
+
+    @Test
     public void testSetAndGetBits()
     {
     	// 0
@@ -65,7 +68,8 @@ public class PixelDataBitTest
     	data.setPixelValue(14, 1.0);
     	Assert.assertEquals(data.getPixelValue(14), 1.0, 0.0);
     }
-    
+
+    @Test
     public void testSize()
     {
         Assert.assertEquals(data.size(), 2);

--- a/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
@@ -7,6 +7,7 @@
 package ome.io.nio.utests;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
@@ -21,6 +22,7 @@ public class PixelDataBitTest
 {
     private PixelData data;
 
+    @BeforeMethod
     public void setUp()
     {
         byte[] byteArray = new byte[] { (byte) 0xFF, (byte) 193 };

--- a/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelDataBitTest.java
@@ -6,7 +6,7 @@
  */
 package ome.io.nio.utests;
 
-import static org.testng.AssertJUnit.*;
+import org.testng.Assert;
 
 import java.nio.ByteBuffer;
 
@@ -28,46 +28,46 @@ public class PixelDataBitTest
  
     public void testGetBits()
     {
-    	assertEquals(1.0, data.getPixelValue(0));  // Start byte 1
-    	assertEquals(1.0, data.getPixelValue(1));
-    	assertEquals(1.0, data.getPixelValue(2));
-    	assertEquals(1.0, data.getPixelValue(3));
-    	assertEquals(1.0, data.getPixelValue(4));
-    	assertEquals(1.0, data.getPixelValue(5));
-    	assertEquals(1.0, data.getPixelValue(6));
-    	assertEquals(1.0, data.getPixelValue(7));
-    	assertEquals(1.0, data.getPixelValue(8));  // Start byte 2 
-    	assertEquals(1.0, data.getPixelValue(9));
-    	assertEquals(0.0, data.getPixelValue(10));
-    	assertEquals(0.0, data.getPixelValue(11));
-    	assertEquals(0.0, data.getPixelValue(12));
-    	assertEquals(0.0, data.getPixelValue(13));
-    	assertEquals(0.0, data.getPixelValue(14));
-    	assertEquals(1.0, data.getPixelValue(15));
+        Assert.assertEquals(data.getPixelValue(0), 1.0);  // Start byte 1
+        Assert.assertEquals(data.getPixelValue(1), 1.0);
+        Assert.assertEquals(1.0, data.getPixelValue(2), 1.0);
+        Assert.assertEquals(1.0, data.getPixelValue(3), 1.0);
+        Assert.assertEquals(1.0, data.getPixelValue(4), 1.0);
+        Assert.assertEquals(1.0, data.getPixelValue(5), 1.0);
+        Assert.assertEquals(1.0, data.getPixelValue(6), 1.0);
+        Assert.assertEquals(1.0, data.getPixelValue(7), 1.0);
+        Assert.assertEquals(1.0, data.getPixelValue(8), 1.0);  // Start byte 2 
+        Assert.assertEquals(1.0, data.getPixelValue(9), 1.0);
+        Assert.assertEquals(0.0, data.getPixelValue(10), 0.0);
+        Assert.assertEquals(0.0, data.getPixelValue(11), 0.0);
+        Assert.assertEquals(0.0, data.getPixelValue(12), 0.0);
+        Assert.assertEquals(0.0, data.getPixelValue(13), 0.0);
+        Assert.assertEquals(0.0, data.getPixelValue(14), 0.0);
+        Assert.assertEquals(1.0, data.getPixelValue(15), 1.0);
     }
     
     public void testSetAndGetBits()
     {
     	// 0
-    	assertEquals(1.0, data.getPixelValue(0));
+        Assert.assertEquals(data.getPixelValue(0), 1.0);
     	data.setPixelValue(0, 0.0);
-    	assertEquals(0.0, data.getPixelValue(0));
+    	Assert.assertEquals(data.getPixelValue(0), 0.0);
     	// 7
-    	assertEquals(1.0, data.getPixelValue(7));
+    	Assert.assertEquals(data.getPixelValue(7), 1.0);
     	data.setPixelValue(7, 0.0);
-    	assertEquals(0.0, data.getPixelValue(7));
+    	Assert.assertEquals(data.getPixelValue(7), 0.0);
     	// 8
-    	assertEquals(1.0, data.getPixelValue(8));
+    	Assert.assertEquals(data.getPixelValue(8), 1.0);
     	data.setPixelValue(8, 1.0);
-    	assertEquals(1.0, data.getPixelValue(8));
+    	Assert.assertEquals(data.getPixelValue(8), 1.0);
     	// 14
-    	assertEquals(0.0, data.getPixelValue(14));
+    	Assert.assertEquals(data.getPixelValue(14), 0.0);
     	data.setPixelValue(14, 1.0);
-    	assertEquals(1.0, data.getPixelValue(14));
+    	Assert.assertEquals(data.getPixelValue(14), 1.0);
     }
     
     public void testSize()
     {
-    	assertEquals(2, data.size());
+        Assert.assertEquals(data.size(), 2);
     }
 }

--- a/components/romio/test/ome/io/nio/utests/PixelServiceCreatesDirectoryUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelServiceCreatesDirectoryUnitTest.java
@@ -1,12 +1,10 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import static org.testng.AssertJUnit.*;
+
 
 import java.io.File;
 import java.io.IOException;
@@ -17,6 +15,7 @@ import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 
 import org.apache.commons.io.FileUtils;
+import org.testng.AssertJUnit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -53,7 +52,7 @@ public class PixelServiceCreatesDirectoryUnitTest {
     @Test
     public void testLargeId() throws Exception {
         PixelBuffer pixelBuffer = service.createPixelBuffer(pixels);
-        assertNotNull(pixelBuffer);
+        AssertJUnit.assertNotNull(pixelBuffer);
     }
 
 }

--- a/components/romio/test/ome/io/nio/utests/PixelServiceCreatesDirectoryUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PixelServiceCreatesDirectoryUnitTest.java
@@ -15,7 +15,7 @@ import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 
 import org.apache.commons.io.FileUtils;
-import org.testng.AssertJUnit;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -52,7 +52,7 @@ public class PixelServiceCreatesDirectoryUnitTest {
     @Test
     public void testLargeId() throws Exception {
         PixelBuffer pixelBuffer = service.createPixelBuffer(pixels);
-        AssertJUnit.assertNotNull(pixelBuffer);
+        Assert.assertNotNull(pixelBuffer);
     }
 
 }

--- a/components/romio/test/ome/io/nio/utests/PlanarDataTest.java
+++ b/components/romio/test/ome/io/nio/utests/PlanarDataTest.java
@@ -1,16 +1,14 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import static org.testng.AssertJUnit.*;
 
 import java.nio.ByteBuffer;
 
-import org.testng.annotations.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import ome.io.nio.RomioPixelBuffer;
 import ome.model.core.Pixels;
@@ -63,7 +61,7 @@ public class PlanarDataTest
     	RomioPixelBuffer buffer = getRomioPixelBuffer();
     	ByteBuffer buf = buffer.getPlane(0, 0, 1).getData();
     	String md = cpf.getProvider(ChecksumType.MD5).putBytes(buf).checksumAsString();
-    	assertEquals("2d1c16c02bece26920ff04ff08985f5e", md);
+    	Assert.assertEquals(md, "2d1c16c02bece26920ff04ff08985f5e");
     }
 
 	@Test(groups={"manual"})
@@ -74,7 +72,7 @@ public class PlanarDataTest
     	byte[] buf = new byte[16];
     	buffer.getPlaneRegionDirect(0, 0, 1, 8, 0, buf);
     	String md = cpf.getProvider(ChecksumType.MD5).putBytes(buf).checksumAsString();
-    	assertEquals("505c12f3149129adf250ae96af159ea1", md);
+    	Assert.assertEquals(md, "505c12f3149129adf250ae96af159ea1");
     }
 
 	@Test(groups={"manual"})
@@ -85,7 +83,7 @@ public class PlanarDataTest
     	byte[] buf = new byte[16];
     	buffer.getPlaneRegionDirect(0, 0, 1, 8, 8, buf);
     	String md = cpf.getProvider(ChecksumType.MD5).putBytes(buf).checksumAsString();
-    	assertEquals("ed6a8ba38c61808d5790419c7a33839c", md);
+    	Assert.assertEquals(md, "ed6a8ba38c61808d5790419c7a33839c");
     }
 
 	@Test(groups={"manual"})
@@ -96,6 +94,6 @@ public class PlanarDataTest
     	byte[] buf = new byte[16];
     	buffer.getPlaneRegionDirect(0, 0, 1, 8, 392, buf);
     	String md = cpf.getProvider(ChecksumType.MD5).putBytes(buf).checksumAsString();
-    	assertEquals("ab1786af4395c09f52de23d710e37a7f", md);
+    	Assert.assertEquals(md, "ab1786af4395c09f52de23d710e37a7f");
     }
 }

--- a/components/romio/test/ome/io/nio/utests/PyramidPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PyramidPixelBufferUnitTest.java
@@ -1,13 +1,10 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,6 +18,7 @@ import ome.util.checksum.ChecksumProviderFactory;
 import ome.util.checksum.ChecksumProviderFactoryImpl;
 import ome.util.checksum.ChecksumType;
 
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -55,7 +53,7 @@ public class PyramidPixelBufferUnitTest extends AbstractPyramidPixelBufferUnitTe
     @Test(dependsOnMethods={"testTruePyramidCreation"}, enabled=true)
     public void testPyramidWriteTiles() throws Exception {
         short tileCount = writeTiles(hashDigests);
-        assertEquals(tileCount, 768);
+        Assert.assertEquals(tileCount, 768);
         pixelBuffer.close();
         // close now nulls the reader to free file descriptors
         pixelBuffer = service._getPixelBuffer(pixels, true);
@@ -77,7 +75,7 @@ public class PyramidPixelBufferUnitTest extends AbstractPyramidPixelBufferUnitTe
                     String writtenDigest = hashDigests.get(tileCount);
                     if (!writtenDigest.equals(readDigest))
                     {
-                        fail(String.format(
+                        Assert.fail(String.format(
                                 "Hash digest mismatch z:%d c:%d t:%d " +
                                 "x:%d y:%d -- %s != %s",
                                 z, c, t, x, y,
@@ -90,30 +88,30 @@ public class PyramidPixelBufferUnitTest extends AbstractPyramidPixelBufferUnitTe
                 }
             }
         }, pixelBuffer, tileWidth, tileHeight);
-        assertEquals(tileCount, 768);
+        Assert.assertEquals(tileCount, 768);
     }
 
     @Test(dependsOnMethods={"testPyramidWriteTiles"}, enabled=true)
     public void testGetPixelBufferResolutionLevels() {
-        assertEquals(pixelBuffer.getResolutionLevels(), 6);
+        Assert.assertEquals(pixelBuffer.getResolutionLevels(), 6);
     }
 
     @Test(dependsOnMethods={"testPyramidWriteTiles"}, enabled=true)
     public void testGetPixelBufferResolutionLevel() {
-        assertEquals(pixelBuffer.getResolutionLevel(), 5);
+        Assert.assertEquals(pixelBuffer.getResolutionLevel(), 5);
     }
 
     @Test(dependsOnMethods={"testPyramidWriteTiles"}, enabled=true)
     public void testSetPixelBufferResolutionLevel() {
         pixelBuffer.setResolutionLevel(0);
-        assertEquals(pixelBuffer.getResolutionLevel(), 0);
+        Assert.assertEquals(pixelBuffer.getResolutionLevel(), 0);
     }
 
     @Test(dependsOnMethods={"testPyramidWriteTiles"}, enabled=true)
     public void testSetPixelBufferResolutionLevelChangeOfDimensions() {
         pixelBuffer.setResolutionLevel(pixelBuffer.getResolutionLevels() - 2);
-        assertEquals(pixelBuffer.getSizeX(), sizeX / 2);
-        assertEquals(pixelBuffer.getSizeY(), sizeY / 2);
+        Assert.assertEquals(pixelBuffer.getSizeX(), sizeX / 2);
+        Assert.assertEquals(pixelBuffer.getSizeY(), sizeY / 2);
     }
 
     @Test(dependsOnMethods={"testPyramidWriteTiles"}, enabled=true)
@@ -126,7 +124,7 @@ public class PyramidPixelBufferUnitTest extends AbstractPyramidPixelBufferUnitTe
                 {
                     final PixelData tile = pixelBuffer.getTile(z, c, t, x, y,
                             tileWidth, tileHeight);
-                    assertEquals(tile.size(), tileWidth * tileHeight);
+                    Assert.assertEquals(tile.size(), tileWidth * tileHeight);
                 }
                 catch (IOException e)
                 {
@@ -134,7 +132,7 @@ public class PyramidPixelBufferUnitTest extends AbstractPyramidPixelBufferUnitTe
                 }
             }
         }, pixelBuffer, tileWidth, tileHeight);
-        assertEquals(tileCount, 192);
+        Assert.assertEquals(tileCount, 192);
     }
 
 }

--- a/components/romio/test/ome/io/nio/utests/SimpleBackOffUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/SimpleBackOffUnitTest.java
@@ -1,15 +1,13 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.io.nio.utests;
 
-import junit.framework.TestCase;
 import ome.io.bioformats.BfPyramidPixelBuffer;
 import ome.io.nio.SimpleBackOff;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -19,7 +17,7 @@ import org.testng.annotations.Test;
  * @since Beta4.3.1
  */
 @Test(groups = "ticket:5910")
-public class SimpleBackOffUnitTest extends TestCase {
+public class SimpleBackOffUnitTest {
 
     public void testSimple() {
         long start = System.currentTimeMillis();
@@ -31,6 +29,6 @@ public class SimpleBackOffUnitTest extends TestCase {
         double actual = ((double) stop - start);
         double expected = factor + warmup;
         double delta = 1000.0; // one sec.
-        assertEquals(expected, actual, delta);
+        Assert.assertEquals(expected, actual, delta);
     }
 }


### PR DESCRIPTION
# What this PR does

 * Remove the usage of "import static`` and be more explicit in the import  in the unit tests
 * Fix failing unit test
 * Replace usage of Junit by testng

# Testing this PR

Run the unit test, they should all be green now

# Related reading

https://trello.com/c/9nZfJ6Pi/132-import-static-cleanup