### PR TITLE
Codomain maps render url

### DIFF
--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -416,8 +416,8 @@ Test Rdef Save
 
 
 Test LUTs Reverse Intensity
-    [Documentation]     Tests LUTs and Reverse
-    # Go To                                   ${WELCOME URL}
+    [Documentation]     Tests LUTs and Reverse, Copying and Pasting.
+    Go To                                   ${WELCOME URL}
     Select Experimenter
     Select And Expand Node                  ${multic_dataset}
     ${nodeId}                               Wait For Dataset Node Text      ${multic_dataset}

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -33,6 +33,39 @@ Wait For Channel Color
     # Wait Until Element Is Visible           xpath=//button[@id="rd-wblitz-ch0"][contains(@style, "background-color: ${rgbColor}")]      ${WAIT}
     Wait Until Element Is Visible           xpath=//button[@id="wblitz-ch0-color"][@data-color="${hexColor}"]
 
+Pick Lut
+    [Arguments]                             ${lutName}
+    Click Element                           xpath=//button[@id="wblitz-ch0-color"]
+    Wait Until Element Is Visible           id=cbpicker-box
+    Click Element                           xpath=//div[contains(@class, 'lutpicker')]//label[contains(text(), '${lutName}')]
+    Wait For Image Src                      ${lutName}
+    Element Should Not Be Visible           id=cbpicker-box
+
+Check Image Src
+    [Arguments]                             ${findInImgSrc}
+    ${imageSrc}=                            Get Element Attribute       xpath=//img[@id='viewport-img']@src
+    Should Contain                          ${imageSrc}                 ${findInImgSrc}
+
+Wait For Image Src
+    [Arguments]                             ${findInImgSrc}
+    Wait Until Keyword Succeeds             ${TIMEOUT}   ${INTERVAL}    Check Image Src         ${findInImgSrc}
+
+Check Reverse Intensity
+    [Arguments]                             ${channelIdx}               ${checked}
+    Click Element                           xpath=//button[@id="wblitz-ch${channelIdx}-color"]
+    Wait Until Element Is Visible           id=cbpicker-box
+    Run Keyword If      ${checked}          Checkbox Should Be Selected                 id=reverseIntensity
+    ...                 ELSE                Checkbox Should Not Be Selected             id=reverseIntensity
+    Click Element                           xpath=//div[contains(@class, 'cbpicker')]//div[contains(@class, 'postit-close-btn')]
+    Element Should Not Be Visible           id=cbpicker-box
+
+Toggle Reverse Intensity
+    [Arguments]                             ${channelIdx}
+    Click Element                           xpath=//button[@id="wblitz-ch${channelIdx}-color"]
+    Wait Until Element Is Visible           id=cbpicker-box
+    Select Checkbox                         id=reverseIntensity
+    Element Should Not Be Visible           id=cbpicker-box
+
 Wait For BlockUI
     # Wait Until Element Is Visible           xpath=//div[contains(@class, 'blockOverlay')]
     Wait For Condition                      return ($("div.blockOverlay").length == 0)
@@ -69,10 +102,85 @@ Right Click Rendering Settings
     [Arguments]            ${treeId}       ${optionText}
     Open Context Menu                       xpath=//li[@id='${treeId}']/a
     Mouse Over                              xpath=//ul[contains(@class, 'jstree-contextmenu')]//a[contains(text(), 'Rendering Settings...')]
-    Click Element                           xpath=//ul[contains(@class, 'jstree-contextmenu')]//a[contains(text(), "${optionText}")]
-    Click Dialog Button                     OK
+    Click Element                           xpath=//ul[contains(@class, 'jstree-contextmenu')]//li[descendant::a[contains(text(), 'Rendering Settings')]]//a[contains(text(), "${optionText}")]
+    # E.g. 'Copy' option won't have 'OK' dialog
+    Run Keyword And Ignore Error            Click Dialog Button                     OK
 
 *** Test Cases ***
+
+
+Test LUTs Reverse Intensity
+    [Documentation]     Tests LUTs and Reverse
+    # Go To                                   ${WELCOME URL}
+    Select Experimenter
+    Select And Expand Node                  MultiChannel Images
+    ${nodeId}                               Wait For Dataset Node Text      MultiChannel Images
+    Right Click Rendering Settings          ${nodeId}                       Set Imported and Save
+    Select First Image
+    ${imageId}=                             Wait For General Panel And Return Id    Image
+    Click Link                              Preview
+    ${status}   ${oldId}                    Wait For Preview Load                   FAIL      '1'
+
+    Pick Lut                                16_colors
+
+    # Reverse Intensity of first channel
+    Toggle Reverse Intensity                0
+    Wait For Image Src                      maps=[{%22reverse%22:{%22enabled%22:true}
+    # Check the Intensity checkbox resets when dialog launched for different channels
+    Check Reverse Intensity                 1                           ${False}
+    Check Reverse Intensity                 0                           ${True}
+
+    # Copy Settings, refresh...
+    Click Element                           id=rdef-copy-btn
+    Click Element                           id=refreshButton
+    ${status}    ${oldId}                   Wait For Preview Load       ${status}   ${oldId}
+    # Check changes above weren't saved (first channel Red)
+    Wait For Image Src                      FF0000
+    Check Reverse Intensity                 0                           ${False}
+    Wait For Image Src                      maps=[{%22reverse%22:{%22enabled%22:false}
+
+    # ...and paste (to same image)
+    Click Element                           id=rdef-paste-btn
+    Check Reverse Intensity                 0                           ${True}
+    Check Reverse Intensity                 1                           ${False}
+    Wait For Image Src                      maps=[{%22reverse%22:{%22enabled%22:true}
+    Wait For Image Src                      16_colors
+
+    # Paste and Save by right-click on next Image in Tree
+    Click Next Thumbnail
+    Wait For Image Src                      FF0000
+    ${imageId2}=                            Get Selected Id From Tree
+    ${imgNodeId2}=                          Wait For Image Node         ${imageId2}
+    Right Click Rendering Settings          ${imgNodeId2}               Paste and Save
+    Wait For Image Src                      16_colors
+    Check Reverse Intensity                 0                           ${True}
+
+    # Pick a different LUT and Save
+    Pick Lut                                5_ramps
+    Click Element                           id=rdef-setdef-btn
+    Wait For BlockUI
+
+    # Copy in Tree (copies the 'fromid' to session instead of rdef json)
+    Right Click Rendering Settings          ${imgNodeId2}               Copy
+    # Return to first Image and check nothing seved yet
+    Click Thumbnail                         ${imageId}
+    Wait For Image Src                      FF0000
+    Check Reverse Intensity                 0                           ${False}
+
+    # Paste settings 'fromid' in Preview Panel...
+    Click Element                           id=rdef-paste-btn
+    Wait For Image Src                      5_ramps
+    Check Reverse Intensity                 0                           ${True}
+    # Refresh
+    Click Element                           id=refreshButton
+    Wait For Image Src                      FF0000
+
+    # Paste settings 'fromid' in Tree
+    ${imgNodeId}=                           Wait For Image Node         ${imageId}
+    Right Click Rendering Settings          ${imgNodeId}                Paste and Save
+    Wait For Image Src                      5_ramps
+    Check Reverse Intensity                 0                           ${True}
+
 
 Test Rdef Copy Paste Save
     [Documentation]     Tests Copy and Paste rdef, then Save and 'Save All'
@@ -236,7 +344,7 @@ Test Owners Rdef
     Pick Color                              FFFFFF
     Click Element                           xpath=//button[@id='rdef-copy-btn']
     Wait For Toolbar Button Enabled         rdef-paste-btn
-    
+
     # Test 'Paste and Save' with right-click on different Image in tree
     # (check thumb refresh by change of src)
     ${thumbSrc}=                            Get Element Attribute      xpath=//li[@id="image_icon-${imageId_2}"]/div[@class="image"]/a/img@src

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -511,4 +511,4 @@ Test Launch Full Viewer
     Wait Until Page Contains Element        id=wblitz-ch0
     # Check various channel settings and reverse map are applied
     Wait For Image Src                      c=1|0:255$FFFF00,2|0:255$16_colors.lut,-3|0:255$0000FF
-    Wait For Image Src                      maps=[{%22reverse%22:{%22enabled%22:false}
+    Wait For Image Src                      maps=[{%22reverse%22:{%22enabled%22:true}

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -409,11 +409,6 @@ Test Rdef Save
     Channel Should Not Be Active        1
     Channel Should Not Be Active        2
 
-    # Reset rendering settings again
-    Click Element                       id=rdef-reset-btn
-    Wait Until Element Is Enabled       id=rdef-setdef-btn
-    Click Element                       id=rdef-setdef-btn
-
 
 Test LUTs Reverse Intensity
     [Documentation]     Tests LUTs and Reverse, Copying and Pasting.

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -56,8 +56,8 @@ Wait For Channel Color
     Wait Until Element Is Visible           xpath=//button[@id="wblitz-ch0-color"][@data-color="${hexColor}"]
 
 Pick Lut
-    [Arguments]                             ${lutName}
-    Click Element                           xpath=//button[@id="wblitz-ch0-color"]
+    [Arguments]                             ${lutName}      ${channelIdx}
+    Click Element                           xpath=//button[@id="wblitz-ch${channelIdx}-color"]
     Wait Until Element Is Visible           id=cbpicker-box
     Click Element                           xpath=//div[contains(@class, 'lutpicker')]//label[contains(text(), '${lutName}')]
     Wait For Image Src                      ${lutName}
@@ -65,7 +65,7 @@ Pick Lut
 
 Check Image Src
     [Arguments]                             ${findInImgSrc}
-    ${imageSrc}=                            Get Element Attribute       xpath=//img[@id='viewport-img']@src
+    ${imageSrc}=                            Get Element Attribute       xpath=//img[contains(@class, 'weblitz-viewport-img')]@src
     Should Contain                          ${imageSrc}                 ${findInImgSrc}
 
 Wait For Image Src
@@ -427,7 +427,7 @@ Test LUTs Reverse Intensity
     Click Link                              Preview
     ${status}   ${oldId}                    Wait For Preview Load                   FAIL      '1'
 
-    Pick Lut                                16_colors
+    Pick Lut                                16_colors                       0
 
     # Reverse Intensity of first channel
     Toggle Reverse Intensity                0
@@ -462,7 +462,7 @@ Test LUTs Reverse Intensity
     Check Reverse Intensity                 0                           ${True}
 
     # Pick a different LUT and Save
-    Pick Lut                                5_ramps
+    Pick Lut                                5_ramps                     0
     Click Element                           id=rdef-setdef-btn
     Wait For BlockUI
 
@@ -486,3 +486,29 @@ Test LUTs Reverse Intensity
     Right Click Rendering Settings          ${imgNodeId}                Paste and Save
     Wait For Image Src                      5_ramps
     Check Reverse Intensity                 0                           ${True}
+
+
+Test Launch Full Viewer
+    [Documentation]     Tests viewer launched from Preview panel with current settings
+    Go To                                   ${WELCOME URL}
+    Select Experimenter
+    Select And Expand Node                  ${multic_dataset}
+    ${nodeId}                               Wait For Dataset Node Text      ${multic_dataset}
+    Right Click Rendering Settings          ${nodeId}                       Set Imported and Save
+    Select First Image
+    ${imageName}=                           Wait For General Panel And Return Name              Image
+    Click Link                              Preview
+    Wait For Preview Load                   FAIL      '1'
+
+    # Change settings
+    Pick Lut                                16_colors       1
+    Toggle Reverse Intensity                0
+    Pick Color                              FFFF00
+    Toggle Channel Active                   2
+
+    Click Link                              id=preview_open_viewer
+    Wait Until Keyword Succeeds             ${TIMEOUT}     ${INTERVAL}     Select Window     title=${imageName}
+    Wait Until Page Contains Element        id=wblitz-ch0
+    # Check various channel settings and reverse map are applied
+    Wait For Image Src                      c=1|0:255$FFFF00,2|0:255$16_colors.lut,-3|0:255$0000FF
+    Wait For Image Src                      maps=[{%22reverse%22:{%22enabled%22:false}

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -419,8 +419,8 @@ Test LUTs Reverse Intensity
     [Documentation]     Tests LUTs and Reverse
     # Go To                                   ${WELCOME URL}
     Select Experimenter
-    Select And Expand Node                  MultiChannel Images
-    ${nodeId}                               Wait For Dataset Node Text      MultiChannel Images
+    Select And Expand Node                  ${multic_dataset}
+    ${nodeId}                               Wait For Dataset Node Text      ${multic_dataset}
     Right Click Rendering Settings          ${nodeId}                       Set Imported and Save
     Select First Image
     ${imageId}=                             Wait For General Panel And Return Id    Image

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.gs_utils.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.gs_utils.js
@@ -166,7 +166,7 @@ function gs_json (url, data, callback) {
   var cb = function (result) {
     return function (data, textStatus, errorThrown) {
       if (callback) {
-        callback (result, result ? data:errorThrown || textStatus);
+        callback (result, result ? data : errorThrown || textStatus);
       }
     }
   }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -322,7 +322,12 @@ jQuery._WeblitzViewport = function (container, server, options) {
     _this.loadedImg._load(data);
     _this.loadedImg_def = jQuery.extend(true, {}, _this.loadedImg);
     if (_this.loadedImg.current.query) {
-      _this.setQuery(_this.loadedImg.current.query);
+      // setQuery expects 'maps' to be json
+      var query_rdef = $.extend({}, _this.loadedImg.current.query);
+      if (query_rdef.maps) {
+        query_rdef.maps = JSON.parse(query_rdef.maps);
+      }
+      _this.setQuery(query_rdef);
     }
     // refresh allow_resize = true, seems to *prevent* resize (good) but don't fully understand
     _this.refresh(true);

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -1092,14 +1092,16 @@ jQuery._WeblitzViewport = function (container, server, options) {
     /* Channels (verbose as IE7 does not support Array.filter */
     var chs = [];
     var channels = this.loadedImg.channels;
+    var maps_json = [];
     for (var i=0; i<channels.length; i++) {
       var ch = channels[i].active ? '' : '-';
       ch += parseInt(i, 10)+1;
       ch += '|' + channels[i].window.start + ':' + channels[i].window.end;
-      ch += channels[i].reverseIntensity ? 'r' : '-r';
       ch += '$' + OME.rgbToHex(channels[i].color);
       chs.push(ch);
+      maps_json.push({'reverse': {'enabled': channels[i].reverseIntensity}});
     }
+    query.push('maps=' + JSON.stringify(maps_json));
     query.push('c=' + chs.join(','));
     /* Rendering Model */
     query.push('m=' + this.loadedImg.rdefs.model.toLowerCase().substring(0,1));

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -1184,6 +1184,13 @@ jQuery._WeblitzViewport = function (container, server, options) {
         }
       }
     }
+    if (query.maps) {
+      query.maps.map(function(m, idx){
+        if (m.reverse) {
+          this.setChannelReverseIntensity(idx, m.reverse.enabled, true);
+        }
+      }.bind(this));
+    }
     if (query.q) this.setQuality(query.q, true);
     if (query.p) this.setProjection(query.p, true);
     if (query.p) this.setInvertedAxis(query.ia, true);

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -325,7 +325,12 @@ jQuery._WeblitzViewport = function (container, server, options) {
       // setQuery expects 'maps' to be json
       var query_rdef = $.extend({}, _this.loadedImg.current.query);
       if (query_rdef.maps) {
-        query_rdef.maps = JSON.parse(query_rdef.maps);
+        try {
+          query_rdef.maps = JSON.parse(query_rdef.maps);
+        } catch(err) {
+          alert('maps query string is not valid json: ' + query_rdef.maps);
+          query_rdef.maps = [];
+        }
       }
       _this.setQuery(query_rdef);
     }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -1106,8 +1106,6 @@ jQuery._WeblitzViewport = function (container, server, options) {
       chs.push(ch);
       maps_json.push({'reverse': {'enabled': channels[i].reverseIntensity}});
     }
-    // We can 'stringify' json for url. Nicer if we remove all spaces
-    query.push('maps=' + JSON.stringify(maps_json).replace(/ /g, ""));
     query.push('c=' + chs.join(','));
     /* Rendering Model */
     query.push('m=' + this.loadedImg.rdefs.model.toLowerCase().substring(0,1));
@@ -1154,6 +1152,8 @@ jQuery._WeblitzViewport = function (container, server, options) {
     if (this.loadedImg.current.query.debug !== undefined) {
       query.push('debug='+this.loadedImg.current.query.debug);
     }
+    // We can 'stringify' json for url. Nicer if we remove all spaces
+    query.push('maps=' + JSON.stringify(maps_json).replace(/ /g, ""));
     return query.join('&');
   };
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.viewport.js
@@ -1101,7 +1101,8 @@ jQuery._WeblitzViewport = function (container, server, options) {
       chs.push(ch);
       maps_json.push({'reverse': {'enabled': channels[i].reverseIntensity}});
     }
-    query.push('maps=' + JSON.stringify(maps_json));
+    // We can 'stringify' json for url. Nicer if we remove all spaces
+    query.push('maps=' + JSON.stringify(maps_json).replace(/ /g, ""));
     query.push('c=' + chs.join(','));
     /* Rendering Model */
     query.push('m=' + this.loadedImg.rdefs.model.toLowerCase().substring(0,1));

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -99,7 +99,7 @@
             function(success, rv) {
                 $(obj).html(old).prop('disabled', false);
                 if (!(success && rv)) {
-                    alert('Setting image defaults failed.');
+                    alert('Setting image defaults failed.' + success + " " + rv);
                 }
                 if (callback) {
                     callback();

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -99,7 +99,7 @@
             function(success, rv) {
                 $(obj).html(old).prop('disabled', false);
                 if (!(success && rv)) {
-                    alert('Setting image defaults failed.' + success + " " + rv);
+                    alert('Setting image defaults failed. Success: ' + success + ' Response: ' + rv);
                 }
                 if (callback) {
                     callback();

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -46,7 +46,8 @@
             }
             // only pick what we need
             var pasteData = {'c': data.c,
-                'm': data.m};
+                'm': data.m,
+                'maps': data.maps};
             viewport.setQuery(pasteData);
             viewport.doload();        // loads image
             syncRDCW(viewport);       // update rdef table

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2063,8 +2063,9 @@ def get_image_rdef_json(request, conn=None, **kwargs):
             maps = []
             for i, ch in enumerate(rv['channels']):
                 act = ch['active'] and str(i+1) or "-%s" % (i+1)
+                color = ch.get('lut') or ch['color']
                 chs.append("%s|%s:%s$%s" % (act, ch['window']['start'],
-                                            ch['window']['end'], ch['color']))
+                                            ch['window']['end'], color))
                 maps.append({'reverse':{'enabled': ch['reverseIntensity']}})
             rdef = {'c': (",".join(chs)),
                     'm': rv['rdefs']['model'],

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2059,16 +2059,18 @@ def get_image_rdef_json(request, conn=None, **kwargs):
             image = conn.getObject("Image", fromid)
         if image is not None:
             rv = imageMarshal(image, request=request)
-            # return rv
             chs = []
+            maps = []
             for i, ch in enumerate(rv['channels']):
                 act = ch['active'] and str(i+1) or "-%s" % (i+1)
                 chs.append("%s|%s:%s$%s" % (act, ch['window']['start'],
                                             ch['window']['end'], ch['color']))
+                maps.append({'reverse':{'enabled': ch['reverseIntensity']}})
             rdef = {'c': (",".join(chs)),
                     'm': rv['rdefs']['model'],
                     'pixel_range': "%s:%s" % (rv['pixel_range'][0],
-                                              rv['pixel_range'][1])}
+                                              rv['pixel_range'][1]),
+                    'maps': maps}
 
     return {'rdef': rdef}
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -762,7 +762,7 @@ def _get_maps_enabled(request, name, sizeC=0):
                         enabled = m.get('enabled') in (True, 'true')
                 codomains.append(enabled)
         except:
-            logger.debug('Invalid json for query ?maps=%s' % mapping)
+            logger.debug('Invalid json for query ?maps=%s' % map_json)
             codomains = None
     return codomains
 
@@ -1979,7 +1979,7 @@ def copy_image_rdef_json(request, conn=None, **kwargs):
             start = ch.getWindowStart()
             end = ch.getWindowEnd()
             color = ch.getLut()
-            maps.append({'reverse':{'enabled': ch.isReverseIntensity()}})
+            maps.append({'reverse': {'enabled': ch.isReverseIntensity()}})
             if not color or len(color) == 0:
                 color = ch.getColor().getHtml()
             chs.append("%s%s|%s:%s$%s" % (act, i+1, start, end, color))
@@ -2074,7 +2074,7 @@ def get_image_rdef_json(request, conn=None, **kwargs):
                 color = ch.get('lut') or ch['color']
                 chs.append("%s|%s:%s$%s" % (act, ch['window']['start'],
                                             ch['window']['end'], color))
-                maps.append({'reverse':{'enabled': ch['reverseIntensity']}})
+                maps.append({'reverse': {'enabled': ch['reverseIntensity']}})
             rdef = {'c': (",".join(chs)),
                     'm': rv['rdefs']['model'],
                     'pixel_range': "%s:%s" % (rv['pixel_range'][0],

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -211,7 +211,6 @@ def _split_channel_info(rchannels):
     channels = []
     windows = []
     colors = []
-    reverses = []
     for chan in rchannels.split(','):
         # chan  1|12:1386r$0000FF
         chan = chan.split('|', 1)
@@ -219,7 +218,6 @@ def _split_channel_info(rchannels):
         t = chan[0].strip()
         # t = '1'
         color = None
-        rev = None
         # Not normally used...
         if t.find('$') >= 0:
             t, color = t.split('$')
@@ -232,14 +230,7 @@ def _split_channel_info(rchannels):
                 if t.find('$') >= 0:
                     t, color = t.split('$', 1)
                     # color = '0000FF'
-                    # t = 12:1386r
-                # Optional flag to enable reverse codomain
-                if t.endswith('-r'):
-                    rev = False
-                    t = t[:-2]
-                elif t.endswith('r'):
-                    rev = True
-                    t = t[:-1]
+                    # t = 12:1386
                 t = t.split(':')
                 if len(t) == 2:
                     try:
@@ -248,11 +239,10 @@ def _split_channel_info(rchannels):
                         pass
             windows.append(ch_window)
             colors.append(color)
-            reverses.append(rev)
         except ValueError:
             pass
     logger.debug(str(channels)+","+str(windows)+","+str(colors))
-    return channels, windows, colors, reverses
+    return channels, windows, colors
 
 
 def getImgDetailsFromReq(request, as_string=False):
@@ -750,6 +740,31 @@ def _get_signature_from_request(request):
     return rv
 
 
+def _get_maps_enabled(request, name, sizeC=0):
+    """
+    Parses 'maps' query string from request
+    """
+    codomains = None
+    if 'maps' in request:
+        mapping = request['maps']
+        codomains = []
+        try:
+            map_json = json.loads(mapping)
+            sizeC = max(len(map_json), sizeC)
+            for c in range(sizeC):
+                enabled = None
+                if len(map_json) > c:
+                    m = map_json[c].get(name)
+                    # If None, no change to saved status
+                    if m is not None:
+                        enabled = m.get('enabled') in (True, 'true')
+                codomains.append(enabled)
+        except:
+            logger.debug('Invalid json for query ?maps=%s' % mapping)
+            codomains = None
+    return codomains
+
+
 def _get_prepared_image(request, iid, server_id=None, conn=None,
                         saveDefs=False, retry=True):
     """
@@ -772,9 +787,10 @@ def _get_prepared_image(request, iid, server_id=None, conn=None,
     img = conn.getObject("Image", iid)
     if img is None:
         return
+    reverses = _get_maps_enabled(r, 'reverse', img.getSizeC())
     if 'c' in r:
         logger.debug("c="+r['c'])
-        channels, windows, colors, reverses = _split_channel_info(r['c'])
+        channels, windows, colors = _split_channel_info(r['c'])
         if not img.setActiveChannels(channels, windows, colors, reverses):
             logger.debug(
                 "Something bad happened while setting the active channels...")
@@ -1958,7 +1974,8 @@ def copy_image_rdef_json(request, conn=None, **kwargs):
         return rv
 
     def applyRenderingSettings(image, rdef):
-        channels, windows, colors, reverse = _split_channel_info(rdef['c'])
+        reverse = None
+        channels, windows, colors = _split_channel_info(rdef['c'])
         # also prepares _re
         image.setActiveChannels(channels, windows, colors, reverse)
         if rdef['m'] == 'g':


### PR DESCRIPTION
# What this PR does

Updates the url query string for encoding codomain 'maps'.
See https://trello.com/c/PzMTIpY2/266-rendering-settings-in-url and original PR: https://github.com/openmicroscopy/openmicroscopy/pull/4839

This makes the encoding of 'maps' more extensible for addition of more maps in the future.
We now encode maps as a list of dictionaries. Each dictionary applies to a channel and each dictionary has a key that is an identifier for the map, and the value is another dictionary.
```"reverse"``` codomain only has an "enabled" boolean. For a 2-channel image this looks like:
```
?maps=[{"reverse":{"enabled":true}},{"reverse":{"enabled":false}}
```

# Testing this PR

1. Test rendering of images in Preview and Full viewer. Turn on/off reverse intensity and check that this is rendered correctly.

2. Copy & paste settings with Reverse-Intensity in various combinations of 
     - Copy via 'Copy' button in Preview panel OR via right-click menu on jsTree OR in full viewer
     - Paste via 'Paste' button in Preview panel OR via 'Paste and Save' on jsTree OR in full viewer

# Related reading

Link to cards, tickets, other PRs:

1. https://trello.com/c/PzMTIpY2/266-rendering-settings-in-url

2. Discussion at https://github.com/openmicroscopy/openmicroscopy/pull/4839

cc @chris-allan @waxenegger 