### PR TITLE
Rename javadoc zip bundle

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -453,8 +453,8 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     </target>
 
     <target name="release-docs" depends="release-javadoc,release-sphinx-api,release-slice2html" description="Generate Docs for all components under dist/docs/api">
-        <zip destfile="${omero.home}/target/OMERO.javadoc-${omero.version}.zip">
-            <zipfileset dir="${dist.dir}/docs" prefix="OMERO.javadoc-${omero.version}"/>
+        <zip destfile="${omero.home}/target/OMERO.apidoc-${omero.version}.zip">
+            <zipfileset dir="${dist.dir}/docs" prefix="OMERO.apidoc-${omero.version}"/>
         </zip>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -454,7 +454,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
 
     <target name="release-docs" depends="release-javadoc,release-sphinx-api,release-slice2html" description="Generate Docs for all components under dist/docs/api">
         <zip destfile="${omero.home}/target/OMERO.javadoc-${omero.version}.zip">
-            <zipfileset dir="${dist.dir}/docs" prefix="OMERO.docs-${omero.version}"/>
+            <zipfileset dir="${dist.dir}/docs" prefix="OMERO.javadoc-${omero.version}"/>
         </zip>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -453,7 +453,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     </target>
 
     <target name="release-docs" depends="release-javadoc,release-sphinx-api,release-slice2html" description="Generate Docs for all components under dist/docs/api">
-        <zip destfile="${omero.home}/target/OMERO.docs-${omero.version}.zip">
+        <zip destfile="${omero.home}/target/OMERO.javadoc-${omero.version}.zip">
             <zipfileset dir="${dist.dir}/docs" prefix="OMERO.docs-${omero.version}"/>
         </zip>
     </target>


### PR DESCRIPTION
# What this PR does

Renames the zip bundle from 'OMERO-docs-version.zip' to 'OMERO-javadoc-version.zip' to avoid confusion with the new documentation bundle and match the approach used in BF. 

# Testing this PR

Ask @jburel if you're not sure, I assume something along the lines of `ant release-docs -Domero.release="5.3.0-m6"` works but I can't test locally as I don't have ice etc installed.


# Related reading

See https://trello.com/c/SnUesylG/505-ditching-docs-pdfs

Will need edits made to the downloads page which could be added to https://github.com/openmicroscopy/ome-release/pull/211