### PR TITLE
Api filter by children

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5725,6 +5725,7 @@ class _DatasetWrapper (BlitzObjectWrapper):
         Extend base query to handle filtering of Datasets by Projects.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'project': <project_id> to filter by Project
+                        'image': <image_id> to filter by child Image
                         'orphaned': <bool>. Filter by 'not in Project'
 
         :param opts:        Dictionary of optional parameters.
@@ -5779,6 +5780,26 @@ class _ProjectWrapper (BlitzObjectWrapper):
     LINK_CLASS = "ProjectDatasetLink"
     CHILD_WRAPPER_CLASS = 'DatasetWrapper'
     PARENT_WRAPPER_CLASS = None
+
+    @classmethod
+    def _getQueryString(cls, opts=None):
+        """
+        Extend base query to handle filtering of Projects by Datasets.
+        Returns a tuple of (query, clauses, params).
+        Supported opts: 'dataset': <dataset_id> to filter by Dataset
+
+        :param opts:        Dictionary of optional parameters.
+        :return:            Tuple of string, list, ParametersI
+        """
+        query, clauses, params = super(
+            _ProjectWrapper, cls)._getQueryString(opts)
+        if opts is None:
+            opts = {}
+        if 'dataset' in opts:
+            query += ' join obj.datasetLinks datasetLinks'
+            clauses.append('datasetLinks.child.id = :dataset_id')
+            params.add('dataset_id', rlong(opts['dataset']))
+        return (query, clauses, params)
 
 ProjectWrapper = _ProjectWrapper
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6071,10 +6071,16 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         # NB: we don't use base _getQueryString.
         clauses = []
         params = omero.sys.ParametersI()
-        if opts is not None and 'screen' in opts:
+        if opts is None:
+            opts = {}
+        if 'screen' in opts:
             clauses.append('spl.parent.id = :sid')
             params.add('sid', rlong(opts['screen']))
-        if opts is not None and opts.get('orphaned'):
+        if 'well' in opts:
+            query += ' join obj.wells wells'
+            clauses.append('wells.id = :well_id')
+            params.add('well_id', rlong(opts['well']))
+        if opts.get('orphaned'):
             clauses.append(
                 """
                 not exists (

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5814,6 +5814,26 @@ class _ScreenWrapper (BlitzObjectWrapper):
     CHILD_WRAPPER_CLASS = 'PlateWrapper'
     PARENT_WRAPPER_CLASS = None
 
+    @classmethod
+    def _getQueryString(cls, opts=None):
+        """
+        Extend base query to handle filtering of Screens by Plate.
+        Returns a tuple of (query, clauses, params).
+        Supported opts: 'plate': <plate_id> to filter by Plate
+
+        :param opts:        Dictionary of optional parameters.
+        :return:            Tuple of string, list, ParametersI
+        """
+        query, clauses, params = super(
+            _ScreenWrapper, cls)._getQueryString(opts)
+        if opts is None:
+            opts = {}
+        if 'plate' in opts:
+            query += ' join obj.plateLinks plateLinks'
+            clauses.append('plateLinks.child.id = :plate_id')
+            params.add('plate_id', rlong(opts['plate']))
+        return (query, clauses, params)
+
 ScreenWrapper = _ScreenWrapper
 
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6058,6 +6058,7 @@ class _PlateWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Also handles filtering of Plates by Screens.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'screen': <screen_id> to filter by Screen
+                        'well': <well_id> to filter by Well
                         'orphaned': <bool>. Filter by 'not in Screen'
 
         :param opts:        Dictionary of optional parameters.

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5743,8 +5743,8 @@ class _DatasetWrapper (BlitzObjectWrapper):
         if opts is None:
             opts = {}
         if 'project' in opts:
-            query += ' join obj.projectLinks plink'
-            clauses.append('plink.parent.id = :pid')
+            query += ' join obj.projectLinks projectLinks'
+            clauses.append('projectLinks.parent.id = :pid')
             params.add('pid', rlong(opts['project']))
         if 'image' in opts:
             query += ' join obj.imageLinks imagelinks'

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5732,11 +5732,17 @@ class _DatasetWrapper (BlitzObjectWrapper):
         """
         query, clauses, params = super(
             _DatasetWrapper, cls)._getQueryString(opts)
-        if opts is not None and 'project' in opts:
+        if opts is None:
+            opts = {}
+        if 'project' in opts:
             query += ' join obj.projectLinks plink'
             clauses.append('plink.parent.id = :pid')
             params.add('pid', rlong(opts['project']))
-        if opts is not None and opts.get('orphaned'):
+        if 'image' in opts:
+            query += ' join obj.imageLinks imagelinks'
+            clauses.append('imagelinks.child.id = :iid')
+            params.add('iid', rlong(opts['image']))
+        if opts.get('orphaned'):
             clauses.append(
                 """
                 not exists (

--- a/components/tools/OmeroWeb/omeroweb/api/api_settings.py
+++ b/components/tools/OmeroWeb/omeroweb/api/api_settings.py
@@ -55,3 +55,5 @@ report_settings(sys.modules[__name__])
 # E.g. /api/v0/
 # TODO - need to decide how this is configured, strategy for extending etc.
 API_VERSIONS = ('0',)
+
+API_VERSION = '0.0'

--- a/components/tools/OmeroWeb/omeroweb/api/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/api/decorators.py
@@ -27,6 +27,7 @@ import logging
 import traceback
 from django.http import JsonResponse
 from functools import update_wrapper
+from . import api_settings
 from api_exceptions import BadRequestError, \
     CreatedObject, \
     MethodNotSupportedError, \
@@ -58,6 +59,12 @@ class json_response(object):
         """Initialise the decorator."""
         pass
 
+    def create_response(self, response, status=200):
+        """Create the Json response and set global headers."""
+        response = JsonResponse(response, status=status)
+        response['X-OMERO-ApiVersion'] = api_settings.API_VERSION
+        return response
+
     def handle_success(self, rv):
         """
         Handle successful response from wrapped function.
@@ -65,7 +72,7 @@ class json_response(object):
         By default, we simply return a JsonResponse() but this can be
         overwritten by subclasses if needed.
         """
-        return JsonResponse(rv)
+        return self.create_response(rv)
 
     def handle_error(self, ex, trace):
         """
@@ -96,7 +103,7 @@ class json_response(object):
         if isinstance(ex, CreatedObject):
             status = ex.status
             rsp_json = ex.response
-        return JsonResponse(rsp_json, status=status)
+        return self.create_response(rsp_json, status=status)
 
     def __call__(self, f):
         """

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -211,6 +211,15 @@ api_well = url(
 Well url to GET or DELETE a single Well
 """
 
+api_plate_screens = url(
+    r'^v(?P<api_version>%s)/m/plates/'
+    '(?P<plate_id>[0-9]+)/screens/$' % versions,
+    views.ScreensView.as_view(),
+    name='api_plate_screens')
+"""
+GET Screens for child Plate, using omero-marshal to generate json
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -237,4 +246,5 @@ urlpatterns = patterns(
     api_wells,
     api_plate_wells,
     api_well,
+    api_plate_screens,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -122,12 +122,30 @@ api_dataset_images = url(
 GET Images in Dataset, using omero-marshal to generate json
 """
 
+api_dataset_projects = url(
+    r'^v(?P<api_version>%s)/m/datasets/'
+    '(?P<dataset_id>[0-9]+)/projects/$' % versions,
+    views.ProjectsView.as_view(),
+    name='api_dataset_projects')
+"""
+GET Projects in Dataset, using omero-marshal to generate json
+"""
+
 api_image = url(
     r'^v(?P<api_version>%s)/m/images/(?P<object_id>[0-9]+)/$' % versions,
     views.ImageView.as_view(),
     name='api_image')
 """
 Image url to GET or DELETE a single Image
+"""
+
+api_image_datasets = url(
+    r'^v(?P<api_version>%s)/m/images/'
+    '(?P<image_id>[0-9]+)/datasets/$' % versions,
+    views.DatasetsView.as_view(),
+    name='api_image_datasets')
+"""
+GET Datasets parents of Image, using omero-marshal to generate json
 """
 
 api_screen = url(
@@ -208,7 +226,9 @@ urlpatterns = patterns(
     api_dataset,
     api_images,
     api_dataset_images,
+    api_dataset_projects,
     api_image,
+    api_image_datasets,
     api_screen,
     api_screens,
     api_plates,

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -273,7 +273,7 @@ api_plate_screens = url(
     views.ScreensView.as_view(),
     name='api_plate_screens')
 """
-GET Screens for child Plate, using omero-marshal to generate json
+GET Screens that contain a Plate, using omero-marshal to generate json
 """
 
 urlpatterns = patterns(

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -128,7 +128,7 @@ api_dataset_projects = url(
     views.ProjectsView.as_view(),
     name='api_dataset_projects')
 """
-GET Projects in Dataset, using omero-marshal to generate json
+GET Projects that contain a Dataset, using omero-marshal to generate json
 """
 
 api_image = url(
@@ -145,7 +145,7 @@ api_image_datasets = url(
     views.DatasetsView.as_view(),
     name='api_image_datasets')
 """
-GET Datasets parents of Image, using omero-marshal to generate json
+GET Datasets that contain an Image, using omero-marshal to generate json
 """
 
 api_screen = url(
@@ -177,6 +177,15 @@ api_screen_plates = url(
     name='api_screen_plates')
 """
 GET Plates in Screen, using omero-marshal to generate json
+"""
+
+api_well_plates = url(
+    r'^v(?P<api_version>%s)/m/wells/'
+    '(?P<well_id>[0-9]+)/plates/$' % versions,
+    views.PlatesView.as_view(),
+    name='api_well_plates')
+"""
+GET Plates that contain a Well, using omero-marshal to generate json
 """
 
 api_plate = url(
@@ -289,6 +298,7 @@ urlpatterns = patterns(
     api_screens,
     api_plates,
     api_screen_plates,
+    api_well_plates,
     api_plate,
     api_wells,
     api_plate_plateacquisitions,

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -271,10 +271,10 @@ class PlateView(ObjectView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
-        'url:wells': {'name': 'api_plate_wells',
-                      'kwargs': {'plate_id': 'OBJECT_ID'}},
         'url:screens': {'name': 'api_plate_screens',
                         'kwargs': {'plate_id': 'OBJECT_ID'}},
+        'url:wells': {'name': 'api_plate_wells',
+                      'kwargs': {'plate_id': 'OBJECT_ID'}},
     }
 
 
@@ -461,12 +461,12 @@ class PlatesView(ObjectsView):
 
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
+        'url:screens': {'name': 'api_plate_screens',
+                        'kwargs': {'plate_id': 'OBJECT_ID'}},
         'url:wells': {'name': 'api_plate_wells',
                       'kwargs': {'plate_id': 'OBJECT_ID'}},
         'url:plate': {'name': 'api_plate',
                       'kwargs': {'object_id': 'OBJECT_ID'}},
-        'url:screens': {'name': 'api_plate_screens',
-                        'kwargs': {'plate_id': 'OBJECT_ID'}},
     }
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -335,6 +335,12 @@ class WellView(ObjectView):
 
     CAN_DELETE = False
 
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:plates': {'name': 'api_well_plates',
+                       'kwargs': {'well_id': 'OBJECT_ID'}},
+    }
+
     def get_opts(self, request):
         """Add support for load_images."""
         opts = super(WellView, self).get_opts(request)
@@ -508,6 +514,14 @@ class PlatesView(ObjectsView):
             screen = getIntOrDefault(request, 'screen', None)
             if screen is not None:
                 opts['screen'] = screen
+        # Filter Plates by Well
+        if 'well_id' in kwargs:
+            opts['well'] = long(kwargs['well_id'])
+        else:
+            # filter by query /plates/?well=:id
+            well = getIntOrDefault(request, 'well', None)
+            if well is not None:
+                opts['well'] = well
         return opts
 
     # Urls to add to marshalled object. See ProjectsView for more details
@@ -605,6 +619,8 @@ class WellsView(ObjectsView):
     urls = {
         'url:well': {'name': 'api_well',
                      'kwargs': {'object_id': 'OBJECT_ID'}},
+        'url:plates': {'name': 'api_well_plates',
+                       'kwargs': {'well_id': 'OBJECT_ID'}},
     }
 
     def get_opts(self, request, **kwargs):

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -429,6 +429,19 @@ class ScreensView(ObjectsView):
                        'kwargs': {'object_id': 'OBJECT_ID'}}
     }
 
+    def get_opts(self, request, **kwargs):
+        """Add filtering by 'plate' to the opts dict."""
+        opts = super(ScreensView, self).get_opts(request, **kwargs)
+        # at /plate/:plate_id/screens/ we have 'plate_id' in kwargs
+        if 'plate_id' in kwargs:
+            opts['plate'] = long(kwargs['plate_id'])
+        else:
+            # filter by query /screens/?plate=:id
+            plate = getIntOrDefault(request, 'plate', None)
+            if plate is not None:
+                opts['plate'] = plate
+        return opts
+
 
 class PlatesView(ObjectsView):
     """Handles GET for /plates/ to list available Plates."""

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -374,6 +374,10 @@ class DatasetsView(ObjectsView):
             project = getIntOrDefault(request, 'project', None)
             if project is not None:
                 opts['project'] = project
+        # Filter Datasets by child 'image'
+        image = getIntOrDefault(request, 'image', None)
+        if image is not None:
+            opts['image'] = image
         return opts
 
     # Urls to add to marshalled object. See ProjectsView for more details

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -272,7 +272,9 @@ class PlateView(ObjectView):
     # Urls to add to marshalled object. See ProjectsView for more details
     urls = {
         'url:wells': {'name': 'api_plate_wells',
-                      'kwargs': {'plate_id': 'OBJECT_ID'}}
+                      'kwargs': {'plate_id': 'OBJECT_ID'}},
+        'url:screens': {'name': 'api_plate_screens',
+                        'kwargs': {'plate_id': 'OBJECT_ID'}},
     }
 
 
@@ -419,19 +421,6 @@ class ScreensView(ObjectsView):
         """Add extra parameters to the opts dict."""
         opts = super(ScreensView, self).get_opts(request, **kwargs)
         opts['order_by'] = 'lower(obj.name)'
-        return opts
-
-    # Urls to add to marshalled object. See ProjectsView for more details
-    urls = {
-        'url:plates': {'name': 'api_screen_plates',
-                       'kwargs': {'screen_id': 'OBJECT_ID'}},
-        'url:screen': {'name': 'api_screen',
-                       'kwargs': {'object_id': 'OBJECT_ID'}}
-    }
-
-    def get_opts(self, request, **kwargs):
-        """Add filtering by 'plate' to the opts dict."""
-        opts = super(ScreensView, self).get_opts(request, **kwargs)
         # at /plate/:plate_id/screens/ we have 'plate_id' in kwargs
         if 'plate_id' in kwargs:
             opts['plate'] = long(kwargs['plate_id'])
@@ -441,6 +430,14 @@ class ScreensView(ObjectsView):
             if plate is not None:
                 opts['plate'] = plate
         return opts
+
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:plates': {'name': 'api_screen_plates',
+                       'kwargs': {'screen_id': 'OBJECT_ID'}},
+        'url:screen': {'name': 'api_screen',
+                       'kwargs': {'object_id': 'OBJECT_ID'}}
+    }
 
 
 class PlatesView(ObjectsView):
@@ -467,7 +464,9 @@ class PlatesView(ObjectsView):
         'url:wells': {'name': 'api_plate_wells',
                       'kwargs': {'plate_id': 'OBJECT_ID'}},
         'url:plate': {'name': 'api_plate',
-                      'kwargs': {'object_id': 'OBJECT_ID'}}
+                      'kwargs': {'object_id': 'OBJECT_ID'}},
+        'url:screens': {'name': 'api_plate_screens',
+                        'kwargs': {'plate_id': 'OBJECT_ID'}},
     }
 
 

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -343,6 +343,10 @@ class ProjectsView(ObjectsView):
         """Add extra parameters to the opts dict."""
         opts = super(ProjectsView, self).get_opts(request, **kwargs)
         opts['order_by'] = 'lower(obj.name)'
+        # Filter Projects by child 'dataset'
+        dataset = getIntOrDefault(request, 'dataset', None)
+        if dataset is not None:
+            opts['dataset'] = dataset
         return opts
 
     # To add a url to marshalled object add to this dict

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -224,6 +224,8 @@ class DatasetView(ObjectView):
     urls = {
         'url:images': {'name': 'api_dataset_images',
                        'kwargs': {'dataset_id': 'OBJECT_ID'}},
+        'url:projects': {'name': 'api_dataset_projects',
+                         'kwargs': {'dataset_id': 'OBJECT_ID'}},
     }
 
 
@@ -233,6 +235,12 @@ class ImageView(ObjectView):
     OMERO_TYPE = 'Image'
 
     CAN_DELETE = False
+
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:datasets': {'name': 'api_image_datasets',
+                         'kwargs': {'image_id': 'OBJECT_ID'}},
+    }
 
     def get_opts(self, request):
         """Add support for load_pixels and load_channels."""
@@ -343,10 +351,14 @@ class ProjectsView(ObjectsView):
         """Add extra parameters to the opts dict."""
         opts = super(ProjectsView, self).get_opts(request, **kwargs)
         opts['order_by'] = 'lower(obj.name)'
-        # Filter Projects by child 'dataset'
-        dataset = getIntOrDefault(request, 'dataset', None)
-        if dataset is not None:
-            opts['dataset'] = dataset
+        # at /datasets/:dataset_id/projects/ we have 'dataset_id' in kwargs
+        if 'dataset_id' in kwargs:
+            opts['dataset'] = long(kwargs['dataset_id'])
+        else:
+            # Filter Projects by child 'dataset'
+            dataset = getIntOrDefault(request, 'dataset', None)
+            if dataset is not None:
+                opts['dataset'] = dataset
         return opts
 
     # To add a url to marshalled object add to this dict
@@ -379,9 +391,12 @@ class DatasetsView(ObjectsView):
             if project is not None:
                 opts['project'] = project
         # Filter Datasets by child 'image'
-        image = getIntOrDefault(request, 'image', None)
-        if image is not None:
-            opts['image'] = image
+        if 'image_id' in kwargs:
+            opts['image'] = long(kwargs['image_id'])
+        else:
+            image = getIntOrDefault(request, 'image', None)
+            if image is not None:
+                opts['image'] = image
         return opts
 
     # Urls to add to marshalled object. See ProjectsView for more details
@@ -390,6 +405,8 @@ class DatasetsView(ObjectsView):
                        'kwargs': {'dataset_id': 'OBJECT_ID'}},
         'url:dataset': {'name': 'api_dataset',
                         'kwargs': {'object_id': 'OBJECT_ID'}},
+        'url:projects': {'name': 'api_dataset_projects',
+                         'kwargs': {'dataset_id': 'OBJECT_ID'}},
     }
 
 
@@ -450,6 +467,8 @@ class ImagesView(ObjectsView):
     urls = {
         'url:image': {'name': 'api_image',
                       'kwargs': {'object_id': 'OBJECT_ID'}},
+        'url:datasets': {'name': 'api_image_datasets',
+                         'kwargs': {'image_id': 'OBJECT_ID'}},
     }
 
     def get_opts(self, request, **kwargs):

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -532,7 +532,6 @@ class TestContainers(IWebTest):
         rsp = _get_response_json(client, screens_url, {})
         assert_objects(conn, rsp['data'], [screen], dtype='Screen')
 
-
     def test_pdi_urls(self, user1, project_datasets):
         """Test browsing via urls in json /api/->PDI."""
         conn = get_connection(user1)

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -581,7 +581,7 @@ class TestContainers(IWebTest):
         # Single Image has link to parents...
         img_url = imgs_url + '%s/' % images[0].id.val
         rsp = _get_response_json(client, img_url, {})
-        img_json = rsp
+        img_json = rsp['data']
         image_datasets_url = build_url(client, 'api_image_datasets',
                                        {'api_version': version,
                                         'image_id': images[0].id.val})
@@ -604,7 +604,7 @@ class TestContainers(IWebTest):
         # Single Dataset has link to parents...
         dataset_url = datasets_url + '%s/' % dataset_id
         rsp = _get_response_json(client, dataset_url, {})
-        dataset_json = rsp
+        dataset_json = rsp['data']
         dataset_projects_url = build_url(client, 'api_dataset_projects',
                                          {'api_version': version,
                                           'dataset_id': dataset_id})

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -559,7 +559,7 @@ class TestContainers(IWebTest):
         conn = get_connection(user1)
         user_name = conn.getUser().getName()
         client = self.new_django_client(user_name, user_name)
-        version = settings.API_VERSIONS[-1]
+        version = api_settings.API_VERSIONS[-1]
 
         # Get image...
         project, dataset = project_datasets

--- a/examples/Training/python/Json_Api/Login.py
+++ b/examples/Training/python/Json_Api/Login.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
 #                    All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
@@ -10,6 +10,7 @@
 import requests
 
 from Parse_OMERO_Properties import USERNAME, PASSWORD, OMERO_WEB_HOST
+SERVER_NAME = 'omero'
 
 session = requests.Session()
 
@@ -22,18 +23,18 @@ print 'Versions', versions
 # use most recent version...
 version = versions[-1]
 # get the 'base' url
-base_url = version['base_url']
+base_url = version['url:base']
 r = session.get(base_url)
 # which lists a bunch of urls as starting points
 urls = r.json()
-servers_url = urls['servers_url']
-login_url = urls['login_url']
-projects_url = urls['projects_url']
-save_url = urls['save_url']
-schema_url = urls['schema_url']
+servers_url = urls['url:servers']
+login_url = urls['url:login']
+projects_url = urls['url:projects']
+save_url = urls['url:save']
+schema_url = urls['url:schema']
 
 # To login we need to get CSRF token
-token_url = urls['token_url']
+token_url = urls['url:token']
 token = session.get(token_url).json()['data']
 print 'CSRF token', token
 # We add this to our session header
@@ -49,10 +50,10 @@ for s in servers:
     print ' name:', s['server']
     print ' host:', s['host']
     print ' port:', s['port']
-# find one called 'omero'
-servers = [s for s in servers if s['server'] == 'omero']
+# find one called SERVER_NAME
+servers = [s for s in servers if s['server'] == SERVER_NAME]
 if len(servers) < 1:
-    print "Found no server called 'omero'"
+    print "Found no server called '%s'" % SERVER_NAME
 server = servers[0]
 
 # Login with username, password and token
@@ -89,7 +90,8 @@ projType = schema_url + '#Project'
 url = save_url + '?group=' + str(groupId)
 r = session.post(url, json={'Name': 'API TEST foo', '@type': projType})
 assert r.status_code == 201
-project = r.json()
+project = r.json()['data']
+print project
 project_id = project['@id']
 print 'Created Project:', project_id, project['Name']
 

--- a/examples/Training/python/Json_Api/Login.py
+++ b/examples/Training/python/Json_Api/Login.py
@@ -91,7 +91,6 @@ url = save_url + '?group=' + str(groupId)
 r = session.post(url, json={'Name': 'API TEST foo', '@type': projType})
 assert r.status_code == 201
 project = r.json()['data']
-print project
 project_id = project['@id']
 print 'Created Project:', project_id, project['Name']
 

--- a/examples/Training/python/__main__.py
+++ b/examples/Training/python/__main__.py
@@ -33,3 +33,4 @@ if __name__ == "__main__":
         execfile(os.path.join(training_dir, 'Task_Scripts/Raw_Data_Task.py'))
         execfile(os.path.join(training_dir, 'Task_Scripts/Write_Data_4.py'))
         execfile(os.path.join(training_dir, 'Task_Scripts/Write_Data_3.py'))
+        execfile(os.path.join(training_dir, 'Json_Api/Login.py'))


### PR DESCRIPTION
# What this PR does

Supports filtering of Projects by Datasets and filtering of Datasets by Image.
This allows users to find the parents of a given Image or Dataset and
so browse Image -> Dataset -> Project.
Also, we now add the version number in the header of every request:
```
X-OMERO-ApiVersion: 0.0
```
Also I've updated the example at ```examples/Training/python/Json_Api/Login.py``` to work with recent changes to the API.

# Testing this PR

1. Filter Projects by Dataset ```/projects/?dataset=:id``` or via ```/datasets/:id/projects/```
2. Filter Datasets by Image ```/datasets/?image=:id``` or via ```/images/:id/datasets/```
3. Datasets listed at ```/datasets/``` or single object at ```/datasets/:id/``` have ```'url: projects``` to browse to parents.
4. Images listed at ```/images/``` or single object at ```/images/:id/``` have ```'url: datasets``` to browse to parents.
5. Browse from /wells/ -> ```url:plates``` -> Plate -> ```url:Screens``` -> Screen.
5. Check header in browser dev tools for ```X-OMERO-ApiVersion: 0.0```
6. I've added ```examples/Training/python/Json_Api/Login.py``` to the Training test suite, so it should be tested by ci job now.

TODO:
 - [x] Write Tests
 - [x] When Wells PR is merged, support /wells/:id/plates/ etc.

# Related reading
