### PR TITLE
html logo in docs

### DIFF
--- a/docs/sphinx-api/conf.py
+++ b/docs/sphinx-api/conf.py
@@ -48,10 +48,6 @@ release = os.environ.get('OMERO_RELEASE', 'UNKNOWN')
 
 html_theme = 'api_theme'
 
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-html_logo = '../sphinx/common/images/ome-tight.svg'
-
 # The suffix of source filenames.
 source_suffix = '.rst'
 


### PR DESCRIPTION

# What this PR does

Remove html_logo
It points to a non existing svg image
Noticed while reviewing https://github.com/openmicroscopy/openmicroscopy/pull/5086

# Testing this PR

Check that the "warning" is no longer displayed when building the sphinx doc

cc @hflynn 
