### PR TITLE
CLI: hide password config fix

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -288,7 +288,8 @@ class PrefsControl(WriteableConfigControl):
                 k in keys and keys.remove(k)
 
         hide_password = 'hide_password' in args and args.hide_password
-        is_password = lambda x: x.endswith('.pass') or x.endswith('.password')
+        is_password = (lambda x: x.lower().endswith('pass') or
+                       x.lower().endswith('password'))
         for k in keys:
             if k not in orig:
                 continue

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -95,22 +95,44 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys)
 
     def testGetHidePassword(self, capsys):
-        self.invoke("set omero.X.pass shortpass")
-        self.cli.invoke(self.args + ["set", "omero.Y.pass", ""], strict=True)
-        self.invoke("set omero.Y.password long_password")
-        self.invoke("set omero.Z val")
+        config = {
+            "omero.X.mypassword": "long_password",
+            "omero.X.pass": "shortpass",
+            "omero.X.password": "medium_password",
+            "omero.X.regular": "value",
+            "omero.Y.MyPassword": "long_password",
+            "omero.Y.Pass": "shortpass",
+            "omero.Y.Password": "medium_password",
+            "omero.Z.mypassword": "",
+            "omero.Z.pass": "",
+            "omero.Z.password": ""}
+
+        for k, v in config.iteritems():
+            self.cli.invoke(self.args + ["set", k, v], strict=True)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out=(
+            'omero.X.mypassword=long_password\n'
             'omero.X.pass=shortpass\n'
-            'omero.Y.pass=\n'
-            'omero.Y.password=long_password\n'
-            'omero.Z=val'))
+            'omero.X.password=medium_password\n'
+            'omero.X.regular=value\n'
+            'omero.Y.MyPassword=long_password\n'
+            'omero.Y.Pass=shortpass\n'
+            'omero.Y.Password=medium_password\n'
+            'omero.Z.mypassword=\n'
+            'omero.Z.pass=\n'
+            'omero.Z.password='))
         self.invoke("get --hide-password")
         self.assertStdoutStderr(capsys, out=(
+            'omero.X.mypassword=********\n'
             'omero.X.pass=********\n'
-            'omero.Y.pass=\n'
-            'omero.Y.password=********\n'
-            'omero.Z=val'))
+            'omero.X.password=********\n'
+            'omero.X.regular=value\n'
+            'omero.Y.MyPassword=********\n'
+            'omero.Y.Pass=********\n'
+            'omero.Y.Password=********\n'
+            'omero.Z.mypassword=\n'
+            'omero.Z.pass=\n'
+            'omero.Z.password='))
 
     @pytest.mark.parametrize('argument', ['A=B', 'A= B'])
     def testSetFails(self, capsys, argument):


### PR DESCRIPTION
Fixes https://github.com/openmicroscopy/openmicroscopy/issues/5096

The introduction of the `--hide-password` options was done as a best effort to provide a safe output of the OMERO configuration while troubleshooting problems in the community (see https://github.com/openmicroscopy/openmicroscopy/pull/3376).

The initial implementation was limited to hiding properties ending with `.pass` and `.password`.  As reported by @hajaalin, this does not cover existing properties such as `omero.security.trustStorePassword`.

This PR increases the scope of `--hide-password` to replace the content of any property ending with `pass` or `password` (in a non case-sensitive manner). The unit tests have been adjusted to cover the new use cases and should be tested by the CI builds (Travis).

In terms of functional testing, it should be possible to download a server (or even OMERO.py), set up a local configuration with various properties ending with `[Pp]ass[word] using `omero config set` and check that `omero config get --hide-password` hides the expected values.