### PR TITLE
noise reduction

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/DomainPane.java
@@ -183,9 +183,6 @@ public class DomainPane
     /** Field displaying the <code>Bit Depth</code> value. */
     private JTextField bitDepthLabel;
 
-    /** Box to select the mapping algorithm. */
-    private JCheckBox noiseReduction;
-
     /** Button to bring up the histogram widget on screen. */
     private JButton histogramButton;
 
@@ -357,11 +354,6 @@ public class DomainPane
         bitDepthLabel.setBackground(UIUtilities.BACKGROUND_COLOR);
         bitDepthLabel.setEnabled(false);
         bitDepthLabel.setEditable(false);
-        noiseReduction = new JCheckBox();
-        noiseReduction.setBackground(UIUtilities.BACKGROUND_COLOR);
-        noiseReduction.setSelected(model.isNoiseReduction());
-        noiseReduction.setAction(
-                controller.getAction(RendererControl.NOISE_REDUCTION));
         histogramButton = new JButton(
                 controller.getAction(RendererControl.HISTOGRAM));
         
@@ -650,8 +642,6 @@ public class DomainPane
 		comp = buildSliderPane(bitDepthSlider, bitDepthLabel);
 		comp.setBackground(UIUtilities.BACKGROUND_COLOR);
 		addComponent(c, "Bit Depth", comp, p);
-		c.gridy++;
-		addComponent(c, "", noiseReduction, p);
 		c.gridx = 0;
 		c.gridy++;
 		comp = new SeparatorPane();
@@ -851,7 +841,6 @@ public class DomainPane
 			gammaLabel.setEnabled(enabled);
 		}
 		if (bitDepthSlider != null) bitDepthSlider.setEnabled(b);
-		if (noiseReduction != null) noiseReduction.setEnabled(b);
 		if (channelList != null) {
 			Iterator<ChannelButton> i = channelList.iterator();
 			while (i.hasNext()) 


### PR DESCRIPTION
# What this PR does

Remove noise reduction from the UI
This option is not available in the web viewer
This is still available in the rendering engine and DB


# Testing this PR

Check that the control is no longer available
see screenshots

before:


<img width="1090" alt="noise_reduction_before" src="https://cloud.githubusercontent.com/assets/1022396/22882591/d6cef7ae-f1e3-11e6-99cd-c512b778db90.png">

after
<img width="1094" alt="noise_reduction_after" src="https://cloud.githubusercontent.com/assets/1022396/22882597/de7081f8-f1e3-11e6-856f-9aca2a35d3ee.png">



# Related reading

https://trello.com/c/0WcOqsgf/131-clarify-noise-reduction

This is a legacy of the "pretty good image"
cc @pwalczysko @hflynn 

Some screenshots in help might have to be retaken