### PR TITLE
PixelsService: use Memoizer.failIfMissing (rebased onto develop)

### DIFF
--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -764,6 +764,7 @@ public class PixelsService extends AbstractFileSystemService
      * @param filePath Non-null.
      * @param series series to use
      * @param store Min/max store to use with the min/max calculator.
+     * @param raise an exception if no cache file is available
      */
     protected BfPixelBuffer createMinMaxBfPixelBuffer(final String filePath,
                                                       final int series,
@@ -799,6 +800,8 @@ public class PixelsService extends AbstractFileSystemService
      * Short-cut in the FS case where we know that we are dealing with a FS-lite
      * file, and want to retrieve the actual file as opposed to a pyramid or anything
      * else. This may be used to access the original metadata.
+     * @param model object which should be read
+     * @param raise an exception if no cache file is available
      * @throws FormatException
      * @throws IOException
      */

--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -90,6 +90,9 @@ public class PixelsService extends AbstractFileSystemService
 	 */
 	protected final long memoizerWait;
 
+	/** Whether or not Memoizer should fail if a cache file is not found */
+	private boolean failIfMissing = false;
+
 	private Timer tileTimes;
 
 	private Timer minmaxTimes;
@@ -181,6 +184,10 @@ public class PixelsService extends AbstractFileSystemService
                      ", sizes=" + sizes + ")");
         }
         this.iQuery = iQuery;
+    }
+
+    public void setMemoizerFailIfMissing(boolean failIfMissing) {
+        this.failIfMissing = failIfMissing;
     }
 
     public void setMetrics(Metrics metrics) {
@@ -787,7 +794,9 @@ public class PixelsService extends AbstractFileSystemService
         IFormatReader reader = new ImageReader();
         reader = new ChannelFiller(reader);
         reader = new ChannelSeparator(reader);
-        reader = new Memoizer(reader, getMemoizerWait(), getMemoizerDirectory());
+        Memoizer memoizer = new Memoizer(reader, getMemoizerWait(), getMemoizerDirectory());
+        memoizer.setFailIfMissing(failIfMissing);
+        reader = memoizer;
         reader.setFlattenedResolutions(false);
         reader.setMetadataFiltered(true);
         return reader;

--- a/components/server/resources/ome/services/service-ome.io.nio.PixelsService.xml
+++ b/components/server/resources/ome/services/service-ome.io.nio.PixelsService.xml
@@ -38,6 +38,7 @@
     <constructor-arg ref="tileSizes"/>
     <constructor-arg ref="internal-ome.api.IQuery"/>
     <property name="metrics" ref="metrics"/>
+    <property name="memoizerFailIfMissing" value="${omero.pixeldata.fail_if_missing}"/>
   </bean>
 
   <bean id="backOff" class="${omero.pixeldata.backoff}">

--- a/components/server/src/ome/security/SecuritySystem.java
+++ b/components/server/src/ome/security/SecuritySystem.java
@@ -7,11 +7,6 @@
 
 package ome.security;
 
-// Java imports
-
-// Third-party libraries
-
-// Application-internal dependencies
 import java.util.Map;
 
 import ome.conditions.ApiUsageException;

--- a/components/server/src/ome/security/SecuritySystem.java
+++ b/components/server/src/ome/security/SecuritySystem.java
@@ -12,6 +12,8 @@ package ome.security;
 // Third-party libraries
 
 // Application-internal dependencies
+import java.util.Map;
+
 import ome.conditions.ApiUsageException;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
@@ -336,5 +338,13 @@ public interface SecuritySystem {
     // ~ Configured Elements
     // =========================================================================
     Roles getSecurityRoles();
+
+    /**
+     * Provide access to the underlying call context, key-value pairs provided
+     * by remote callers.
+     *
+     * @return never null
+     */
+    Map<String, String> getCallContext();
 
 }

--- a/components/server/src/ome/security/SecuritySystemHolder.java
+++ b/components/server/src/ome/security/SecuritySystemHolder.java
@@ -5,6 +5,8 @@
 
 package ome.security;
 
+import java.util.Map;
+
 import ome.conditions.ApiUsageException;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
@@ -76,6 +78,10 @@ public class SecuritySystemHolder implements SecuritySystem {
 
     public void enable(String... ids) {
         choose().enable(ids);
+    }
+
+    public Map<String, String> getCallContext() {
+        return choose().getCallContext();
     }
 
     public EventContext getEventContext() {

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -10,6 +10,7 @@ package ome.security.basic;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import ome.api.local.LocalAdmin;
 import ome.api.local.LocalQuery;
@@ -672,6 +673,10 @@ public class BasicSecuritySystem implements SecuritySystem,
 
     public EventContext getEventContext() {
         return getEventContext(false);
+    }
+
+    public Map<String, String> getCallContext() {
+        return cd.getContext();
     }
 
     /**

--- a/components/server/src/ome/security/sharing/SharingSecuritySystem.java
+++ b/components/server/src/ome/security/sharing/SharingSecuritySystem.java
@@ -7,6 +7,9 @@
 
 package ome.security.sharing;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import ome.conditions.ApiUsageException;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
@@ -64,6 +67,10 @@ public class SharingSecuritySystem implements SecuritySystem {
     public void enable(String... ids) {
         // TODO Auto-generated method stub
 
+    }
+
+    public Map<String, String> getCallContext() {
+        return new HashMap<String, String>();
     }
 
     public EventContext getEventContext() {

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -281,7 +281,15 @@ public class RawPixelsBean extends AbstractStatefulBean implements
             }
 
             try {
-                buffer = dataService.getPixelBuffer(pixelsInstance, true);
+                Map<String, String> ctx = this.sec.getCallContext();
+                if (ctx.containsKey("omero.pixeldata.fail_if_missing")) {
+                    boolean failIfMissing = Boolean.valueOf(ctx.get(
+                        "omero.pixeldata.fail_if_missing"));
+                    buffer = dataService.getPixelBuffer(pixelsInstance, true, failIfMissing);
+                } else {
+                    // Use the default
+                    buffer = dataService.getPixelBuffer(pixelsInstance, true);
+                }
             } catch (RuntimeException re) {
                 // Rolling back to let the next setPixelsId try again
                 // since this is most likely our MissingPyramidException.

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -390,6 +390,12 @@ omero.pixeldata.backoff=ome.io.nio.SimpleBackOff
 # cached to BioFormatsCache.
 omero.pixeldata.memoizer_wait=0
 
+# Whether or not to raise an exception if no
+# cached file is present. This tends to be most
+# useful in a static, public-repository where
+# all the data should be pre-computed.
+omero.pixeldata.fail_if_missing=false
+
 # Whether the PixelData.dispose() method should
 # try to clean up ByteBuffer instances which may
 # lead to memory exceptions. See ticket #11675


### PR DESCRIPTION
This is the same as gh-4684 but rebased onto develop.

----

To prevent DoS'ing a server, this flag can be set which
requires that all files have a valid cached Memoizer. A
next step will be to allow selectively permitting access
based on some flag.

See https://github.com/openmicroscopy/bioformats/pull/2435

NB: The boolean added to PixelsService should likely be refactored
    into a more general "options" class to reduce future method
    clutter.


This prevent the server from being taken down by missing bfmemo files. Note: if `fail_if_missing` is set to true, then sysadmins will need to run a bfmemo generation script after upgrade
cc @hflynn 

Ref https://trello.com/c/cKEf9iDK/240-other-metadata52-rebases
                