### PR TITLE
Open viewer new tab

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -556,8 +556,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "Selected objects are added to the url as ?image=:1&image=2"
           "Objects supported must be specified in options with"
           "E.g. ``{\"supported_objects\":[\"images\"]}`` "
-          "to enable viewer for one or more images, "
-          "``{\"target\":\"_blank\"}`` to open in new tab.")],
+          "to enable viewer for one or more images.")],
 
     # PIPELINE 1.3.20
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -251,7 +251,7 @@ $(function() {
         if (node) {
             if (node.type === 'image') {
                 //Open the image viewer for this image
-                OME.openPopup(WEBCLIENT.URLS.webindex + "img_detail/" + node.data.obj.id);
+                window.open(WEBCLIENT.URLS.webindex + "img_detail/" + node.data.obj.id, '_blank');
             }
         }
     })
@@ -1041,12 +1041,7 @@ $(function() {
                                     url = v.getUrl(selJson, v.url);
                                 }
                                 // ...otherwise we use default handling...
-                                if (v.target) {
-                                    // E.g. target '_blank' tries to open in a new tab
-                                    window.open(url, v.target);
-                                } else {
-                                    OME.openPopup(url);
-                                }
+                                window.open(url, '_blank');
                             },
                             "_disabled": function() {
                                 var sel = $.jstree.reference('#dataTree').get_selected(true),

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
@@ -270,7 +270,8 @@
                                                     {% ifequal v.type "Image" %}
                                                         <!-- View Image -->
                                                         <li class="btn_view">
-                                                            <a href="#" onClick="return OME.openPopup('{% url 'webgateway.views.full_viewer' v.id %}');" title="Open Image in Viewer">View Image</a>
+                                                            <a href="#" onClick="return window.open('{% url 'webgateway.views.full_viewer' v.id %}', '_blank');"
+                                                            title="Open Image in Viewer">View Image</a>
                                                         </li>
                                                     {% endifequal %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -268,12 +268,11 @@
 
     {% if image %}
     <a class="btn silver btn_text" style="position: absolute; left: 0; height: 20px"
+            target="_blank"
             {% if share and not share.share.isOwned %}
                 href="{% url 'web_image_viewer' share.share.id image.id %}"
-                onclick="return OME.openPopup('{% url 'web_image_viewer' share.share.id image.id %}')"
             {% else %}
                 href="{% url 'web_image_viewer' image.id %}"
-                onclick="return OME.openPopup('{% url 'web_image_viewer' image.id %}')"
             {% endif %}
             title="Open full image viewer in new window">
         <span>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -337,7 +337,7 @@
               // remove &zm=50
               vpQuery = vpQuery.replace("&zm=" + OME.preview_viewport.getZoom(), "");
 
-              OME.openPopup(url + "?" + vpQuery);
+              window.open(url + "?" + vpQuery, '_blank');
               return false;
             });
         });

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -96,7 +96,7 @@ $(document).ready(function() {
             url = "{% url 'web_image_viewer' 0 %}";
         }
         url = url.replace('/0/', "/" + iid + "/" );
-        OME.openPopup(url);
+        window.open(url, '_blank');
     });
 
     // Set up the centre panel header.

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -146,7 +146,8 @@
                 showImagesInWell();
             });
             $( '#spw' ).on( "dblclick", "td.well img", function(event) {
-                OME.openPopup("{% url 'web_image_viewer' 0 %}".replace('/0/', "/"+$(this).attr('id').split("-")[1]+"/" ));
+                var url = "{% url 'web_image_viewer' 0 %}".replace('/0/', "/"+$(this).attr('id').split("-")[1]+"/" );
+                window.open(url, '_blank');
             });
 
             wpv.self.selectable({

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/public/public.html
@@ -156,7 +156,7 @@
                             popup_url += "img_detail/" + node.data.obj.id ;
                         }
                         //Open the image viewer for this image
-                        OME.openPopup(popup_url);
+                        window.open(popup_url, '_blank');
                     }
                 }
             })

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/base_custom_dialog.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/base_custom_dialog.html
@@ -198,7 +198,7 @@
             <a href="#" onClick="self.close()">Cancel</a>
             <input id="submit" type="submit" value="{% block submit_text %}Create Figure{% endblock %}" />
         </div>
-        <a href="#" onClick="return OME.openPopup('{% url 'get_original_file' scriptId %}');">View Script</a>
+        <a href="{% url 'get_original_file' scriptId %}" target="_blank">View Script</a>
 
         <div id="img_size_slider" title="Zoom Preview Figure"></div>
     </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/script_ui.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/script_ui.html
@@ -216,7 +216,7 @@
                 <a href="#" tabIndex="3" onClick="self.close()">Cancel</a>
                 <input id="submit" tabIndex="2" type="submit" value="Run Script" />
             </div>
-            <a href="#" tabIndex="0" onClick="return OME.openPopup('{% url 'get_original_file' scriptId %}');">
+            <a href="{% url 'get_original_file' scriptId %}" tabIndex="0" target="_blank">
                 View Script
             </a>
         </div>


### PR DESCRIPTION
# What this PR does

This changes the default behaviour when opening images in viewer to open images in a new Tab instead of a popup window.
See https://trello.com/c/KPGIBH9i/270-open-popup-window-url-editable

# Testing this PR

Behaviour has changed in a number of places. Each of these should open a new Tab:

- Double-click on image in jsTree.
- Open with... from jsTree
- Open new image created from script in "Activities" panel
- "Full Viewer" buttons in General and Preview tabs
- Double-click on thumbnail in Dataset
- Double-click on Well in Plate
- Public page: double click in jsTree and thumbnails
- In "Run Script" dialog, click on "Show Script" in footer.

# Related reading

See [Usability Issues](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Usability_issues) with opening new windows. "Generally speaking, it is preferable to avoid resorting to window.open() for several reasons:.."

Previously users have asked to be able to open image viewer in new Tab:
https://github.com/openmicroscopy/openmicroscopy/pull/4563 from https://github.com/openmicroscopy/openmicroscopy/issues/4558

We've also noticed that popup window is too small for iViewer.

cc @waxenegger 