### PR TITLE
Load thumbnails

### DIFF
--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1008,7 +1008,7 @@ public class ThumbnailBean extends AbstractLevel2Service
                 pixelsId = pixels.getId();
                 settings = ctx.getSettings(pixelsId);
                 thumbnailMetadata = ctx.getMetadata(pixelsId);
-                if (!PROGRESS_VERSION.equals(thumbnailMetadata.getVersion())) {
+                if (inProgress && !PROGRESS_VERSION.equals(thumbnailMetadata.getVersion())) {
                     thumbnailMetadata.setVersion(PROGRESS_VERSION);
                     dirtyMetadata = true;
                 }

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4296,10 +4296,9 @@ class _BlitzGateway (object):
             tb = self.createThumbnailStore()
             p = omero.sys.ParametersI().addIds(image_ids)
             sql = """select new map(
-                        i.id as im_id, r.pixels.id as pix_id
+                        i.id as im_id, p.id as pix_id
                      )
-                     from RenderingDef as r
-                         join r.pixels.image as i
+                     from Pixels as p join p.image as i
                      where i.id in (:ids) """
 
             img_pixel_ids = self.getQueryService().projection(

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4289,6 +4289,41 @@ class _BlitzGateway (object):
             search.close()
         return rv
 
+    def getThumbnailSet(self, image_ids, max_size=64):
+        tb = None
+        _resp = dict()
+        try:
+            tb = self.createThumbnailStore()
+            p = omero.sys.ParametersI().addIds(image_ids)
+            sql = """select new map(
+                        i.id as im_id, r.pixels.id as pix_id, r.id as rdef_id
+                     )
+                     from RenderingDef as r
+                         join r.pixels.image as i
+                     where i.id in (:ids) """
+
+            rdefs_ids = self.getQueryService().projection(
+                sql, p, self.SERVICE_OPTS)
+            pixrdef = dict()
+            _temp = dict()
+            for e in rdefs_ids:
+                e = unwrap(e)
+                _temp[e[0]['pix_id']] = e[0]['im_id']
+                pixrdef[e[0]['pix_id']] = e[0]['rdef_id']
+
+            # thumb = tb.getThumbnailByLongestSideSet(
+            #    rint(max_size), image_ids)
+            thumbs_map = tb.getThumbnailByLongestSideSetAndRdef(
+                size=rint(max_size), pixelsRdefMap=pixrdef)
+            for (pix, thumb) in thumbs_map.items():
+                _resp[_temp[pix]] = thumb
+        except Exception:
+            logger.error(traceback.format_exc())
+        finally:  # pragma: no cover
+            if tb is not None:
+                tb.close()
+        return _resp
+
 
 class OmeroGatewaySafeCallWrapper(object):  # pragma: no cover
     """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4296,25 +4296,21 @@ class _BlitzGateway (object):
             tb = self.createThumbnailStore()
             p = omero.sys.ParametersI().addIds(image_ids)
             sql = """select new map(
-                        i.id as im_id, r.pixels.id as pix_id, r.id as rdef_id
+                        i.id as im_id, r.pixels.id as pix_id
                      )
                      from RenderingDef as r
                          join r.pixels.image as i
                      where i.id in (:ids) """
 
-            rdefs_ids = self.getQueryService().projection(
+            img_pixel_ids = self.getQueryService().projection(
                 sql, p, self.SERVICE_OPTS)
-            pixrdef = dict()
             _temp = dict()
-            for e in rdefs_ids:
+            for e in img_pixel_ids:
                 e = unwrap(e)
                 _temp[e[0]['pix_id']] = e[0]['im_id']
-                pixrdef[e[0]['pix_id']] = e[0]['rdef_id']
 
-            # thumb = tb.getThumbnailByLongestSideSet(
-            #    rint(max_size), image_ids)
-            thumbs_map = tb.getThumbnailByLongestSideSetAndRdef(
-                size=rint(max_size), pixelsRdefMap=pixrdef)
+            thumbs_map = tb.getThumbnailByLongestSideSet(
+                rint(max_size), list(_temp))
             for (pix, thumb) in thumbs_map.items():
                 _resp[_temp[pix]] = thumb
         except Exception:

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -66,6 +66,31 @@ class TestImage (object):
         pthumb = Image.open(ptfile)  # Raises if invalid
         pthumb.verify()  # Raises if invalid
 
+    def testThumbnailSet(self, author_testimg_bad, author_testimg_big):
+        # ordynary and big image (4k x 4k and up)
+        img_ids = [self.image.id, author_testimg_big.id]
+        conn = self.image._conn
+        for (img_id, thumb) in conn.getThumbnailSet(image_ids=img_ids).items():
+            assert img_id in img_ids
+            tfile = StringIO(thumb)
+            thumb = Image.open(tfile)  # Raises if invalid
+            thumb.verify()  # Raises if invalid
+            assert thumb.format == 'JPEG'
+            assert thumb.size == (64, 64)
+
+        thumb = conn.getThumbnailSet(
+            image_ids=[self.image.id], max_size=96)[self.image.id]
+        tfile = StringIO(thumb)
+        thumb = Image.open(tfile)  # Raises if invalid
+        thumb.verify()  # Raises if invalid
+        assert thumb.size == (96, 96)
+
+        badimg_id = author_testimg_bad.id  # no pixels
+        with pytest.raises(KeyError):
+            thumb = conn.getThumbnailSet(
+                image_ids=[badimg_id])[badimg_id]
+        # Big image (4k x 4k and up) thumb
+
     def testRenderingModels(self):
         # default is color model
         cimg = self.image.renderJpeg(0, 0)

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -638,7 +638,10 @@ CUSTOM_SETTINGS_MAPPINGS = {
          50,
          int,
          ("Number of thumbnails retrieved to prevent from loading them"
-          " all at once.")],
+          " all at once. Make sure the size is not too big, otherwise"
+          " you may excede limit request line, see"
+          " http://docs.gunicorn.org/en/latest/settings.html"
+          "?highlight=limit_request_line")],
     "omero.web.ui.top_links":
         ["TOP_LINKS",
          ('['

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -633,6 +633,12 @@ CUSTOM_SETTINGS_MAPPINGS = {
          int,
          ("Number of images displayed within a dataset or 'orphaned'"
           " container to prevent from loading them all at once.")],
+    "omero.web.thumbnails_batch":
+        ["THUMBNAILS_BATCH",
+         50,
+         int,
+         ("Number of thumbnails retrieved to prevent from loading them"
+          " all at once.")],
     "omero.web.ui.top_links":
         ["TOP_LINKS",
          ('['

--- a/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
+++ b/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
@@ -191,7 +191,7 @@ def _csrf_delete_response_json(django_client, request_url,
 
 # GET
 def _get_response(django_client, request_url, query_string, status_code=405):
-    query_string = urlencode(query_string.items())
+    query_string = urlencode(query_string.items(), doseq=True)
     response = django_client.get('%s?%s' % (request_url, query_string))
     assert response.status_code == status_code
     return response

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -103,6 +103,7 @@ class BaseSearch(BaseController):
         self.containers = {}
         resultCount = 0
         self.searchError = None
+        self.iids = []
 
         try:
             for dt in onlyTypes:
@@ -110,6 +111,8 @@ class BaseSearch(BaseController):
                 if dt in ['projects', 'datasets', 'images', 'screens',
                           'plateacquisitions', 'plates']:
                     self.containers[dt] = doSearch(dt)
+                    if dt == 'images':
+                        self.iids = [i.id for i in self.containers[dt]]
                     # If we get a full page of results, we know there are more
                     if len(self.containers[dt]) == batchSize:
                         self.moreResults = True

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -474,10 +474,10 @@ $(function() {
                 // Extra data needed for showing thumbs in centre panel
                 if (node.type === 'dataset' || node.type === 'orphaned' || node.type === 'tag') {
                     payload['sizeXYZ'] = true;
-                    payload['date'] = true;
-                    if (node.type !== 'tag') {
-                        payload['thumbVersion'] = true;
-                    }
+                    //payload['date'] = true;
+                    //if (node.type !== 'tag') {
+                    //    payload['thumbVersion'] = true;
+                    //}
                 }
 
                 // Always add the group_id from the current context

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -421,9 +421,9 @@ OME.load_thumbnails = function(thumbnails_url, input, batch, dthumb) {
                 success: function(data){
                     $.each(data, function(key, value) {
                         if (value !== null) {
-                            $("li#image_icon-"+key+ " img").attr("src", value);
+                            $("#image_icon-"+key+ " img").attr("src", value);
                         } else {
-                            $("li#image_icon-"+key+ " img").attr("src", dthumb);
+                            $("#image_icon-"+key+ " img").attr("src", dthumb);
                         }
                     });
                 }

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -408,7 +408,7 @@ OME.refreshThumbnails = function(options) {
     }
 };
 
-OME.load_thumbnails = function(thumbnails_url, input, batch) {
+OME.load_thumbnails = function(thumbnails_url, input, batch, dthumb) {
     // load thumbnails in a batches
     if (input.length > 0 && batch > 0) {
         var iids = input.slice(0 , batch)
@@ -417,17 +417,21 @@ OME.load_thumbnails = function(thumbnails_url, input, batch) {
                 type: "GET",
                 url: thumbnails_url,
                 data: $.param( { id: iids }, true),
-                dataType:'json',
+                dataType: 'json',
                 success: function(data){
                     $.each(data, function(key, value) {
-                        $("li#image_icon-"+key+ " img").attr("src", value);
+                        if (value !== null) {
+                            $("li#image_icon-"+key+ " img").attr("src", value);
+                        } else {
+                            $("li#image_icon-"+key+ " img").attr("src", dthumb);
+                        }
                     });
                 }
             });
             input = input.filter(function(x) {
                 return iids.indexOf(x) < 0;
             });
-            OME.load_thumbnails(thumbnails_url, input, batch);
+            OME.load_thumbnails(thumbnails_url, input, batch, dthumb);
         }
     }
 }

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -179,7 +179,12 @@
             // Save settings
             $("#rdef-setdef-btn").click(function(){
               setImageDefaults(OME.preview_viewport, this, function() {
-                OME.refreshThumbnails({'imageId':{{ manager.image.id }}, 'ignorePreview': true});
+                OME.refreshThumbnails(
+                    {'imageId':{{ manager.image.id }},
+                     'ignorePreview': true,
+                     'thumbnail_url': "{% url 'get_thumbnail_json' manager.image.id %}"
+                    }
+                );
                 updateMyRdef(OME.preview_viewport.getQuery());
               });
             });

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_thumbnails_underscore.html
@@ -24,11 +24,10 @@
             data-owned="">
 
             <div class="image">
-                <!-- we wrap img with <a> so you can right-click -> open link in new tab -->
+                <!-- we wrap img with <a> so you can right-click -> open link in new tab
+                src="<%= webindex %>render_thumbnail/<%= img.id %>/<% if(img.shareId) {print( img.shareId + '/')} %><% if (img.thumbVersion) { print ('?version=' + img.thumbVersion)}%>" -->
                 <a href="<%= webindex %><% if(img.shareId) {print( img.shareId + '/')} %>img_detail/<%= img.id %>/">
-                    <img alt="image"
-                         src="<%= webindex %>render_thumbnail/<%= img.id %>/<% if(img.shareId) {print( img.shareId + '/')} %><% if (img.thumbVersion) { print ('?version=' + img.thumbVersion)}%>"
-                         title="<%= img.name %>"/>
+                    <img/>
                 </a>
             </div>
             <!-- NB: '#image_icon-123 div.desc' etc is used to update name when changed in right panel via "editinplace" -->

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -1,3 +1,5 @@
+{% load common_filters %}
+
 {% comment %}
 /**
   Copyright (C) 2012-2016 University of Dundee & Open Microscopy Environment.
@@ -308,7 +310,7 @@ $(document).ready(function() {
                 }
             }
         }
-        batch = 50;
+        batch = {{ thumbnails_batch|default:50|json_dumps|safe }};
         load_thumbnails(iids, batch);
 
         // populate arrays etc for speedy icon zooming

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -283,7 +283,11 @@ $(document).ready(function() {
         iids = $.map(imgJson, function(img){
             return img.id;
         });
-        OME.load_thumbnails("{% url 'get_thumbnails_json' %}", iids, batch);
+        OME.load_thumbnails(
+            "{% url 'get_thumbnails_json' %}",
+            iids, batch,
+            "{% static 'webgateway/img/image128.png' %}"
+        );
 
         // populate arrays etc for speedy icon zooming
         setupIconZooming();

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -195,6 +195,17 @@ $(document).ready(function() {
 
             return;
         }
+        // update single thumbnail, see OME.refreshThumbnails
+        if (event.type === "refreshThumb") {
+            OME.load_thumbnail(
+                data.imageId,
+                "{% url 'webindex' %}get_thumbnail/"+data.imageId+"/",
+                function(thumb) {
+                    $("li#image_icon-"+data.imageId+ " img").attr("src", thumb);
+                }
+            );
+            return;
+        }
 
         parentId = newParentId;
 
@@ -229,21 +240,6 @@ $(document).ready(function() {
                 if (fsId) {
                     selFileSets.push(fsId);
                 }
-            }
-            // Thumb version: random to break cache if thumbnails are -1 'in progress'
-            // or we're refresing 1 or all thumbnails
-            if (node.data.obj.thumbVersion != undefined ||
-                    event.type === "refreshThumbnails" ||
-                    event.type === "refreshThumb") {
-                var thumbVersion = node.data.obj.thumbVersion;
-                if (thumbVersion === -1 || event.type === "refreshThumbnails" || (
-                        event.type === "refreshThumb" && data.imageId === iData.id)) {
-                    thumbVersion = getRandom();
-                    // We cache this to prevent new thumbnails requested on every
-                    // selection change. Refreshing of tree will reset thumbVersion.
-                    node.data.obj.thumbVersion = thumbVersion;
-                }
-                iData.thumbVersion = thumbVersion;
             }
             // If image is in share and share is not owned by user...
             if (node.data.obj.shareId && !parentNode.data.obj.isOwned) {
@@ -282,36 +278,12 @@ $(document).ready(function() {
         var html = iconTmpl(json);
         $("#icon_table").html(html);
 
+        // load thumbnails in a batches
+        batch = {{ thumbnails_batch|default:50|json_dumps|safe }};
         iids = $.map(imgJson, function(img){
             return img.id;
         });
-
-        // load thumbnails in a batches
-        var load_thumbnails = function(input, batch) {
-            if (input.length > 0 && batch > 0) {
-                var iids = input.slice(0 , batch)
-                if (iids.length > 0) {
-                    var thumbnails_url = "{% url 'get_thumbnails_json' %}";
-                    $.ajax({
-                        type: "GET",
-                        url: thumbnails_url,
-                        data: $.param( { id: iids }, true),
-                        dataType:'json',
-                        success: function(data){
-                            $.each(data, function(key, value) {
-                                $("li#image_icon-"+key+ " img").attr("src", value);
-                            });
-                        }
-                    });
-                    input = input.filter(function(x) {
-                        return iids.indexOf(x) < 0;
-                    });
-                    load_thumbnails(input, batch);
-                }
-            }
-        }
-        batch = {{ thumbnails_batch|default:50|json_dumps|safe }};
-        load_thumbnails(iids, batch);
+        OME.load_thumbnails("{% url 'get_thumbnails_json' %}", iids, batch);
 
         // populate arrays etc for speedy icon zooming
         setupIconZooming();

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -279,13 +279,13 @@ $(document).ready(function() {
         $("#icon_table").html(html);
 
         // load thumbnails in a batches
-        batch = {{ thumbnails_batch|default:50|json_dumps|safe }};
+        thumbnailsBatch = {{ thumbnails_batch|default:50|json_dumps|safe }};
         iids = $.map(imgJson, function(img){
             return img.id;
         });
         OME.load_thumbnails(
             "{% url 'get_thumbnails_json' %}",
-            iids, batch,
+            iids, thumbnailsBatch,
             "{% static 'webgateway/img/image128.png' %}"
         );
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -280,6 +280,37 @@ $(document).ready(function() {
         var html = iconTmpl(json);
         $("#icon_table").html(html);
 
+        iids = $.map(imgJson, function(img){
+            return img.id;
+        });
+
+        // load thumbnails in a batches
+        var load_thumbnails = function(input, batch) {
+            if (input.length > 0 && batch > 0) {
+                var iids = input.slice(0 , batch)
+                if (iids.length > 0) {
+                    var thumbnails_url = "{% url 'get_thumbnails_json' %}";
+                    $.ajax({
+                        type: "GET",
+                        url: thumbnails_url,
+                        data: $.param( { id: iids }, true),
+                        dataType:'json',
+                        success: function(data){
+                            $.each(data, function(key, value) {
+                                $("li#image_icon-"+key+ " img").attr("src", value);
+                            });
+                        }
+                    });
+                    input = input.filter(function(x) {
+                        return iids.indexOf(x) < 0;
+                    });
+                    load_thumbnails(input, batch);
+                }
+            }
+        }
+        batch = 50;
+        load_thumbnails(iids, batch);
+
         // populate arrays etc for speedy icon zooming
         setupIconZooming();
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -138,7 +138,7 @@
                   width: spw_thumb_size,
                   staticurl: staticurl,
                   useParentPrefix: false,
-                  thumbnails_batch: {{ thumbnails_batch|default:50|json_dumps|safe }},
+                  thumbnailsBatch: {{ thumbnails_batch|default:50|json_dumps|safe }},
                   defaultThumb: "{% static 'webgateway/img/image128.png' %}"
                 });
             var $selected;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-
+{% load common_filters %}
 
 
 {% comment %}
@@ -133,10 +133,13 @@
             };
 
             var staticurl = WEBCLIENT.URLS.static_webgateway;
-            var wpv = $.WeblitzPlateview($('#spw'), {baseurl: '{{ baseurl }}',
-                                                     width: spw_thumb_size,
-                                                     staticurl: staticurl,
-                                                     useParentPrefix: false});
+            var wpv = $.WeblitzPlateview($('#spw'),
+                { baseurl: '{{ baseurl }}',
+                  width: spw_thumb_size,
+                  staticurl: staticurl,
+                  useParentPrefix: false,
+                  thumbnails_batch: {{ thumbnails_batch|default:50|json_dumps|safe }}
+                });
             var $selected;
             // delegated click and dblclick handlers for wells
             $( '#spw' ).on( "click", "td.well img", function(event) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -138,7 +138,8 @@
                   width: spw_thumb_size,
                   staticurl: staticurl,
                   useParentPrefix: false,
-                  thumbnails_batch: {{ thumbnails_batch|default:50|json_dumps|safe }}
+                  thumbnails_batch: {{ thumbnails_batch|default:50|json_dumps|safe }},
+                  defaultThumb: "{% static 'webgateway/img/image128.png' %}"
                 });
             var $selected;
             // delegated click and dblclick handlers for wells

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
@@ -26,11 +26,11 @@
         $(document).ready(function(){
 
             var iids = {{ manager.iids|json_dumps|safe }};
-            var batch = {{ thumbnails_batch|default:50|json_dumps|safe }};
+            var thumbnailsBatch = {{ thumbnails_batch|default:50|json_dumps|safe }};
 
             OME.load_thumbnails(
                 "{% url 'get_thumbnails_json' %}",
-                iids, batch,
+                iids, thumbnailsBatch,
                 "{% static 'webgateway/img/image128.png' %}"
             );
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
@@ -24,7 +24,16 @@
 
     <script type="text/javascript">
         $(document).ready(function(){
-            
+
+            var iids = {{ manager.iids|json_dumps|safe }};
+            var batch = {{ thumbnails_batch|default:50|json_dumps|safe }};
+
+            OME.load_thumbnails(
+                "{% url 'get_thumbnails_json' %}",
+                iids, batch,
+                "{% static 'webgateway/img/image128.png' %}"
+            );
+
             // double-click handler on image - launches image viewer
             //$("table#dataTable tbody tr").dblclick(function(event) {
                 // TODO: path to the object should be rendered on the server side
@@ -64,9 +73,6 @@
         }
     </style>
 
-	
-    
-
     <div>
     {% block search_results %}
 
@@ -95,9 +101,9 @@
             {% for byId in foundById %}
                 {% with c=byId.obj %}
                 <tr id="{{ byId.otype }}-{{ c.id }}" class="{{ c.getPermsCss }}">
-                    <td class="image">
+                    <td class="image" {% if byId.otype == 'image' %}id="image_icon-{{ c.id }}"{% endif %}>
                         {% if byId.otype == 'image' %}
-                            <img class="search_thumb" id="{{ c.id }}" src="{% url 'render_thumbnail' c.id  %}" alt="image" title="{{ c.name }}"/>
+                            <img class="search_thumb" id="{{ c.id }}" alt="image" title="{{ c.name }}"/>
                         {% elif byId.otype == 'project' %}
                             <img src="{% static "webgateway/img/folder16.png" %}" alt="{{ byId.otype }}" title="{{ c.name }}"/>
                         {% elif byId.otype == 'dataset' %}
@@ -197,8 +203,8 @@
             {% endfor %}
             {% for c in manager.containers.images %}
                 <tr id="image-{{ c.id }}" class="{{ c.getPermsCss }}">
-                    <td class="image">
-                        <img class="search_thumb" id="{{ c.id }}" src="{% url 'render_thumbnail' c.id  %}" alt="image" title="{{ c.name }}"/>
+                    <td class="image" id="image_icon-{{ c.id }}">
+                        <img class="search_thumb" id="{{ c.id }}" alt="image" title="{{ c.name }}"/>
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
                     <td class="date">{{ c.getDate|date:"Y-m-d H:i:s" }}</td>

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -113,6 +113,9 @@ urlpatterns = patterns(
         views.load_metadata_hierarchy,
         name="load_metadata_hierarchy"),
 
+    url(r'^get_thumbnails/(?:(?P<share_id>[0-9]+)/)?$',
+        webgateway.get_thumbnails_json,
+        name="get_thumbnails_json"),
     url(r'^render_thumbnail/(?P<iid>[0-9]+)/'
         r'(?:(?P<share_id>[0-9]+)/)?$',
         webgateway.render_thumbnail,

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -116,6 +116,11 @@ urlpatterns = patterns(
     url(r'^get_thumbnails/(?:(?P<share_id>[0-9]+)/)?$',
         webgateway.get_thumbnails_json,
         name="get_thumbnails_json"),
+    url(r'^get_thumbnail/(?P<iid>[0-9]+)/'
+        r'(?:(?P<share_id>[0-9]+)/)?$',
+        webgateway.get_thumbnail_json,
+        {'_defcb': defaultThumbnail},
+        name="get_thumbnail_json"),
     url(r'^render_thumbnail/(?P<iid>[0-9]+)/'
         r'(?:(?P<share_id>[0-9]+)/)?$',
         webgateway.render_thumbnail,

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -100,8 +100,6 @@ from omeroweb.webgateway.views import LoginView
 
 import tree
 
-import warnings
-
 logger = logging.getLogger(__name__)
 
 logger.info("INIT '%s'" % os.getpid())

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -32,6 +32,7 @@ import traceback
 import json
 import re
 import sys
+import warnings
 
 from time import time
 
@@ -78,6 +79,7 @@ from omeroweb.webadmin.forms import LoginForm
 
 from omeroweb.webgateway import views as webgateway_views
 from omeroweb.webgateway.marshal import chgrpMarshal
+from omeroweb.webgateway.util import get_longs as webgateway_get_longs
 
 from omeroweb.feedback.views import handlerInternalError
 
@@ -121,18 +123,10 @@ def get_long_or_default(request, name, default):
 
 
 def get_longs(request, name):
-    """
-    Retrieves parameters from the request. If the parameters are not present
-    an empty list is returned
-
-    This does not catch exceptions as it makes sense to throw exceptions if
-    the arguments provided do not pass basic type validation
-    """
-    vals = []
-    vals_raw = request.GET.getlist(name)
-    for val_raw in vals_raw:
-        vals.append(long(val_raw))
-    return vals
+    warnings.warn(
+        "Deprecated. Use omeroweb.webgateway.util.get_longs()",
+        DeprecationWarning)
+    return webgateway_get_longs(request, name)
 
 
 def get_bool_or_default(request, name, default):

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1438,6 +1438,7 @@ def load_searching(request, form=None, conn=None, **kwargs):
         'foundById': foundById,
         'resultCount': manager.c_size + len(foundById)}
     context['template'] = template
+    context['thumbnails_batch'] = settings.THUMBNAILS_BATCH
     return context
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -453,6 +453,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     context['current_url'] = url
     context['page_size'] = settings.PAGE
     context['template'] = template
+    context['thumbnails_batch'] = settings.THUMBNAILS_BATCH
 
     return context
 
@@ -1264,6 +1265,7 @@ def load_plate(request, o1_type=None, o1_id=None, conn=None, **kwargs):
         context['baseurl'] = reverse('webgateway').rstrip('/')
         context['form_well_index'] = form_well_index
         context['index'] = index
+        context['thumbnails_batch'] = settings.THUMBNAILS_BATCH
         template = "webclient/data/plate.html"
         if o1_type == 'acquisition':
             context['acquisition'] = o1_id

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -87,13 +87,12 @@ class PlateGrid(object):
             thumbnails = self._conn.getThumbnailSet(image_ids, 96)
             for row in grid:
                 for col in row:
-                    thumbnails[col['id']]
                     try:
                         t = thumbnails[col['id']]
                         col['thumb_url'] = \
-                            ("data:image/jpeg;base64, "
+                            ("data:image/jpeg;base64,"
                              "%s" % base64.b64encode(t))
-                    except KeyError:
+                    except Exception:  # TypeError, KeyError
                         pass
 
             self._metadata = {'grid': grid,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+import base64
 
 import omero.sys
 from omero.rtypes import rint
@@ -54,9 +55,11 @@ class PlateGrid(object):
                     "where well.plate.id = :id "\
                     "and index(ws) = :wsidx"
 
+            image_ids = []
             for res in q.projection(query, params, self._conn.SERVICE_OPTS):
                 row, col, img_id, img_name, author, well_id, acq_date, \
                     create_date, description = res
+                image_ids.append(img_id)
 
                 if acq_date is not None and acq_date.val > 0:
                     date = acq_date.val / 1000
@@ -79,6 +82,19 @@ class PlateGrid(object):
                     wellmeta['thumb_url'] = self._thumbprefix + str(img_id.val)
 
                 grid[row.val][col.val] = wellmeta
+
+            # replace thumbnail urls by base64 encoded image
+            thumbnails = self._conn.getThumbnailSet(image_ids, 96)
+            for row in grid:
+                for col in row:
+                    thumbnails[col['id']]
+                    try:
+                        t = thumbnails[col['id']]
+                        col['thumb_url'] =
+                            ("data:image/jpeg;base64, "
+                             "%s" % base64.b64encode(t))
+                    except KeyError:
+                        pass
 
             self._metadata = {'grid': grid,
                               'collabels': self.plate.getColumnLabels(),

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -11,7 +11,6 @@
 """
 
 import logging
-import base64
 
 import omero.sys
 from omero.rtypes import rint
@@ -55,11 +54,9 @@ class PlateGrid(object):
                     "where well.plate.id = :id "\
                     "and index(ws) = :wsidx"
 
-            image_ids = []
             for res in q.projection(query, params, self._conn.SERVICE_OPTS):
                 row, col, img_id, img_name, author, well_id, acq_date, \
                     create_date, description = res
-                image_ids.append(img_id)
 
                 if acq_date is not None and acq_date.val > 0:
                     date = acq_date.val / 1000
@@ -82,18 +79,6 @@ class PlateGrid(object):
                     wellmeta['thumb_url'] = self._thumbprefix + str(img_id.val)
 
                 grid[row.val][col.val] = wellmeta
-
-            # replace thumbnail urls by base64 encoded image
-            thumbnails = self._conn.getThumbnailSet(image_ids, 96)
-            for row in grid:
-                for col in row:
-                    try:
-                        t = thumbnails[col['id']]
-                        col['thumb_url'] = \
-                            ("data:image/jpeg;base64,"
-                             "%s" % base64.b64encode(t))
-                    except Exception:  # TypeError, KeyError
-                        pass
 
             self._metadata = {'grid': grid,
                               'collabels': self.plate.getColumnLabels(),

--- a/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/plategrid.py
@@ -90,7 +90,7 @@ class PlateGrid(object):
                     thumbnails[col['id']]
                     try:
                         t = thumbnails[col['id']]
-                        col['thumb_url'] =
+                        col['thumb_url'] = \
                             ("data:image/jpeg;base64, "
                              "%s" % base64.b64encode(t))
                     except KeyError:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.plateview.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.plateview.css
@@ -24,7 +24,11 @@
 }
 
 .weblitz-plateview .waiting {
-  background:url(../img/spinner.gif) #eee 50% center no-repeat;
+  background:url(../img/spinner.gif);
+  background-color: #eee;
+  background-repeat: no-repeat;
+  background-position: center;
+  opacity: 0.5;
 }
 
 .weblitz-plateview .loading {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.plateview.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.plateview.css
@@ -24,7 +24,7 @@
 }
 
 .weblitz-plateview .waiting {
-  background-color: #eee;
+  background:url(../img/spinner.gif) #eee 50% center no-repeat;
 }
 
 .weblitz-plateview .loading {

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -105,6 +105,7 @@ jQuery._WeblitzPlateview = function (container, options) {
       height: 48,
       useParentPrefix: true,
       thumbnails_batch: 50,
+      defaultThumb: ''
     }, options);
 
   // if options.size is set, it will be used below, otherwise thumbs will be default size
@@ -173,6 +174,9 @@ jQuery._WeblitzPlateview = function (container, options) {
           thumbnails_url += '?' + $.param( { id: iids }, true);
           var _load_thumbnails = function (result, data) {
             $.each(data, function(key, value) {
+              if (value === null) {
+                value = opts.defaultThumb;
+              }
               $("img#"+parentPrefix+"image-"+key).attr("src", value);
             });
           }
@@ -185,7 +189,7 @@ jQuery._WeblitzPlateview = function (container, options) {
       }
     }
 
-    batch = parseInt(opts.thumbnails_batch);
+    batch = parseInt(opts.thumbnailsBatch);
     load_thumbnails(imgIds, batch);
     _this.self.trigger('_resetLoaded');
   };

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -104,7 +104,7 @@ jQuery._WeblitzPlateview = function (container, options) {
       width: 64,
       height: 48,
       useParentPrefix: true,
-      thumbnails_batch: 50,
+      thumbnailsBatch: 50,
       defaultThumb: ''
     }, options);
 
@@ -189,8 +189,8 @@ jQuery._WeblitzPlateview = function (container, options) {
       }
     }
 
-    batch = parseInt(opts.thumbnailsBatch);
-    load_thumbnails(imgIds, batch);
+    thumbnailsBatch = parseInt(opts.thumbnailsBatch);
+    load_thumbnails(imgIds, thumbnailsBatch);
     _this.self.trigger('_resetLoaded');
   };
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -133,12 +133,22 @@ jQuery._WeblitzPlateview = function (container, options) {
     table.addClass('showWellLabel wellSize' + opts.width);
 
     for (i=0; i < data.rowlabels.length; i++) {
+      for (var j=0; j<data.grid[i].length; j++) {
+        if (data.grid[i][j] !== null) {
+            //console.log(data.grid[i][j].id)
+        }
+      }
+    }
+
+    var imgIds = new Array();
+    for (i=0; i < data.rowlabels.length; i++) {
       tr = $('<tr></tr>').appendTo(table);
       tr.append('<th>'+data.rowlabels[i]+'</th>');
       for (var j=0; j<data.grid[i].length; j++) {
         if (data.grid[i][j] === null) {
         tr.append('<td class="placeholder"><img src="' + '' + '/static/webgateway/img/spacer.gif" /></td>');
         } else {
+          imgIds.push(data.grid[i][j].id);
           data.grid[i][j]._wellpos = data.rowlabels[i]+data.collabels[j];
           var parentPrefix = '';
           if (opts.useParentPrefix) {
@@ -147,7 +157,7 @@ jQuery._WeblitzPlateview = function (container, options) {
           var td = $('<td class="well" id="'+parentPrefix+'well-'+data.grid[i][j].wellId+'">' +
             '<img class="waiting" src="/static/webgateway/img/spacer.gif" />' +
             '<div class="wellLabel">' + data.rowlabels[i] + data.collabels[j] + '</div>' +
-            '<img id="'+parentPrefix+'image-'+data.grid[i][j].id+'" class="loading" src="'+ data.grid[i][j].thumb_url+'" name="'+(data.rowlabels[i] + data.collabels[j])+'"></td>');
+            '<img id="'+parentPrefix+'image-'+data.grid[i][j].id+'" class="loading" name="'+(data.rowlabels[i] + data.collabels[j])+'"></td>');
           $('img', td)
             .click(tclick(data.grid[i][j]))
             .load(function() {
@@ -160,6 +170,15 @@ jQuery._WeblitzPlateview = function (container, options) {
         }
       }
     }
+
+    // load thumbnails to the grid
+    var thumbnails_url = opts.baseurl+'/get_thumbnails/?' + $.param( { id: imgIds }, true);
+    var _load_thumbnails = function (result, data) {
+      $.each(data, function(key, value) {
+        $("img#"+parentPrefix+"image-"+key).attr("src", value);
+      });
+    }
+    gs_json(thumbnails_url, null, _load_thumbnails);
     _this.self.trigger('_resetLoaded');
   };
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -104,6 +104,7 @@ jQuery._WeblitzPlateview = function (container, options) {
       width: 64,
       height: 48,
       useParentPrefix: true,
+      thumbnails_batch: 50,
     }, options);
 
   // if options.size is set, it will be used below, otherwise thumbs will be default size
@@ -133,7 +134,6 @@ jQuery._WeblitzPlateview = function (container, options) {
     table.addClass('showWellLabel wellSize' + opts.width);
 
     var imgIds = new Array();
-    var dim = 0;
     for (i=0; i < data.rowlabels.length; i++) {
       tr = $('<tr></tr>').appendTo(table);
       tr.append('<th>'+data.rowlabels[i]+'</th>');
@@ -141,7 +141,6 @@ jQuery._WeblitzPlateview = function (container, options) {
         if (data.grid[i][j] === null) {
         tr.append('<td class="placeholder"><img src="' + '' + '/static/webgateway/img/spacer.gif" /></td>');
         } else {
-          dim++
           imgIds.push(data.grid[i][j].id);
           data.grid[i][j]._wellpos = data.rowlabels[i]+data.collabels[j];
           var parentPrefix = '';
@@ -186,7 +185,7 @@ jQuery._WeblitzPlateview = function (container, options) {
       }
     }
 
-    batch = 50; //dim > 100 ? Math.ceil(dim / 5) : 100;
+    batch = parseInt(opts.thumbnails_batch);
     load_thumbnails(imgIds, batch);
     _this.self.trigger('_resetLoaded');
   };

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -132,15 +132,8 @@ jQuery._WeblitzPlateview = function (container, options) {
     // NB: don't add other classes here - will get removed on slider change.
     table.addClass('showWellLabel wellSize' + opts.width);
 
-    for (i=0; i < data.rowlabels.length; i++) {
-      for (var j=0; j<data.grid[i].length; j++) {
-        if (data.grid[i][j] !== null) {
-            //console.log(data.grid[i][j].id)
-        }
-      }
-    }
-
     var imgIds = new Array();
+    var dim = 0;
     for (i=0; i < data.rowlabels.length; i++) {
       tr = $('<tr></tr>').appendTo(table);
       tr.append('<th>'+data.rowlabels[i]+'</th>');
@@ -148,6 +141,7 @@ jQuery._WeblitzPlateview = function (container, options) {
         if (data.grid[i][j] === null) {
         tr.append('<td class="placeholder"><img src="' + '' + '/static/webgateway/img/spacer.gif" /></td>');
         } else {
+          dim++
           imgIds.push(data.grid[i][j].id);
           data.grid[i][j]._wellpos = data.rowlabels[i]+data.collabels[j];
           var parentPrefix = '';
@@ -171,14 +165,29 @@ jQuery._WeblitzPlateview = function (container, options) {
       }
     }
 
-    // load thumbnails to the grid
-    var thumbnails_url = opts.baseurl+'/get_thumbnails/?' + $.param( { id: imgIds }, true);
-    var _load_thumbnails = function (result, data) {
-      $.each(data, function(key, value) {
-        $("img#"+parentPrefix+"image-"+key).attr("src", value);
-      });
+    // load thumbnails in a batches
+    var load_thumbnails = function(input, batch) {
+      if (input.length > 0 && batch > 0) {
+        var iids = input.slice(0 , batch)
+        if (iids.length > 0) {
+          var thumbnails_url = opts.baseurl+'/get_thumbnails/';
+          thumbnails_url += '?' + $.param( { id: iids }, true);
+          var _load_thumbnails = function (result, data) {
+            $.each(data, function(key, value) {
+              $("img#"+parentPrefix+"image-"+key).attr("src", value);
+            });
+          }
+          gs_json(thumbnails_url, null, _load_thumbnails);
+          input = input.filter(function(x) {
+              return iids.indexOf(x) < 0;
+          });
+          load_thumbnails(input, batch);
+        }
+      }
     }
-    gs_json(thumbnails_url, null, _load_thumbnails);
+
+    batch = 50; //dim > 100 ? Math.ceil(dim / 5) : 100;
+    load_thumbnails(imgIds, batch);
     _this.self.trigger('_resetLoaded');
   };
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1485,7 +1485,8 @@
     $("#rdef-setdef-btn").click(function(){
       setImageDefaults(viewport, this, function() {
         if (window.opener && window.opener.OME.refreshThumbnails) {
-            window.opener.OME.refreshThumbnails({'imageId':{{ image.id }} });
+            window.opener.OME.refreshThumbnails({'imageId':{{ image.id }},
+            'thumbnail_url': "{% url 'webgateway_get_thumbnail_json' manager.image.id %}" });
         }
       });
     });

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1486,7 +1486,7 @@
       setImageDefaults(viewport, this, function() {
         if (window.opener && window.opener.OME.refreshThumbnails) {
             window.opener.OME.refreshThumbnails({'imageId':{{ image.id }},
-            'thumbnail_url': "{% url 'webgateway_get_thumbnail_json' manager.image.id %}" });
+            'thumbnail_url': "{% url 'get_thumbnail_json' image.id %}" });
         }
       });
     });

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -263,6 +263,7 @@ L{views.listWellImages_json}. Returns E.g list of
     - did:  Well ID
 """
 
+
 webgateway_plategrid_json = url(
     r'^plate/(?P<pid>[0-9]+)/(?:(?P<field>[0-9]+)/)?$',
     'webgateway.views.plateGrid_json', name="webgateway_plategrid_json")
@@ -273,7 +274,8 @@ webgateway_get_thumbnails_json = url(
     r'^get_thumbnails/(?:(?P<w>[0-9]+)/)?$',
     'webgateway.views.get_thumbnails_json')
 """
-Returns a set of thumbnail base64 encoded of the OMERO Images, optionally scaled to max-width and max-height.
+Returns a set of thumbnail base64 encoded of the OMERO Images,
+optionally scaled to max-width and max-height.
 Params in get_thumbnails/<w>/ are:
     - iid:  Image ID
     - w:    Optional max width

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -263,7 +263,6 @@ L{views.listWellImages_json}. Returns E.g list of
     - did:  Well ID
 """
 
-
 webgateway_plategrid_json = url(
     r'^plate/(?P<pid>[0-9]+)/(?:(?P<field>[0-9]+)/)?$',
     'webgateway.views.plateGrid_json', name="webgateway_plategrid_json")
@@ -281,6 +280,20 @@ Params in get_thumbnails/<w>/ are:
     - w:    Optional max width
 """
 
+webgateway_get_thumbnail_json = url(
+    r'^get_thumbnail/(?P<iid>[0-9]+)'
+    '/(?:(?P<w>[0-9]+)/)?(?:(?P<h>[0-9]+)/)?$',
+    'webgateway.views.get_thumbnail_json')
+"""
+Returns a thumbnail jpeg of the OMERO Image, optionally scaled to max-width
+and max-height.
+See L{views.render_thumbnail}. Uses current rendering settings.
+Query string can be used to specify Z or T section. E.g. ?z=10.
+Params in render_thumbnail/<iid>/<w>/<h> are:
+    - iid:  Image ID
+    - w:    Optional max width
+    - h:    Optional max height
+"""
 
 imageData_json = (r'^imgData/(?P<iid>[0-9]+)/(?:(?P<key>[^/]+)/)?$',
                   'webgateway.views.imageData_json')
@@ -466,6 +479,7 @@ urlpatterns = patterns(
     render_ome_tiff,
     render_movie,
     webgateway_get_thumbnails_json,
+    webgateway_get_thumbnail_json,
     # Template views
     # JSON methods
     listProjects_json,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -285,8 +285,8 @@ webgateway_get_thumbnail_json = url(
     '/(?:(?P<w>[0-9]+)/)?(?:(?P<h>[0-9]+)/)?$',
     'webgateway.views.get_thumbnail_json')
 """
-Returns a thumbnail jpeg of the OMERO Image, optionally scaled to max-width
-and max-height.
+Returns a thumbnail base64 encoded of the OMERO Images,
+optionally scaled to max-width and max-height.
 See L{views.render_thumbnail}. Uses current rendering settings.
 Query string can be used to specify Z or T section. E.g. ?z=10.
 Params in render_thumbnail/<iid>/<w>/<h> are:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -269,6 +269,17 @@ webgateway_plategrid_json = url(
 """
 """
 
+webgateway_get_thumbnails_json = url(
+    r'^get_thumbnails/(?:(?P<w>[0-9]+)/)?$',
+    'webgateway.views.get_thumbnails_json')
+"""
+Returns a set of thumbnail base64 encoded of the OMERO Images, optionally scaled to max-width and max-height.
+Params in get_thumbnails/<w>/ are:
+    - iid:  Image ID
+    - w:    Optional max width
+"""
+
+
 imageData_json = (r'^imgData/(?P<iid>[0-9]+)/(?:(?P<key>[^/]+)/)?$',
                   'webgateway.views.imageData_json')
 """
@@ -452,6 +463,7 @@ urlpatterns = patterns(
     render_birds_eye_view,
     render_ome_tiff,
     render_movie,
+    webgateway_get_thumbnails_json,
     # Template views
     # JSON methods
     listProjects_json,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/util.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/util.py
@@ -34,6 +34,15 @@ def getIntOrDefault(request, name, default):
     return index
 
 
+def get_longs(request, name):
+
+    vals = []
+    vals_raw = request.GET.getlist(name)
+    for val_raw in vals_raw:
+        vals.append(long(val_raw))
+    return vals
+
+
 def zip_archived_files(images, temp, zipName, buf=2621440):
     """
     Util function to download original files from a list of images

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -15,6 +15,7 @@
 
 import re
 import json
+import base64
 import omero
 import omero.clients
 
@@ -68,7 +69,8 @@ import shutil
 
 from omeroweb.decorators import login_required, ConnCleaningHttpResponse
 from omeroweb.connector import Connector
-from omeroweb.webgateway.util import zip_archived_files, getIntOrDefault
+from omeroweb.webgateway.util import zip_archived_files
+from omeroweb.webgateway.util import get_longs, getIntOrDefault
 
 cache = CacheBase()
 logger = logging.getLogger(__name__)
@@ -1444,6 +1446,36 @@ def plateGrid_json(request, pid, field=0, conn=None, **kwargs):
         rv = json.loads(rv)
     return rv
 
+
+@login_required()
+@jsonp
+def get_thumbnails_json(request, w=None, conn=None, **kwargs):
+    """
+    Returns base64 encoded jpeg with the rendered thumbnail for images
+    'id'
+
+    @param request:     http request
+    @param w:           Thumbnail max width. 96 by default
+    @return:            http response containing jpeg
+    """
+    if w is None:
+        w = 96
+    image_ids = get_longs(request, 'id')
+    thumbnails = conn.getThumbnailSet(
+        [rlong(i) for i in image_ids], w)
+
+    rv = dict()
+    for i in image_ids:
+        try:
+            t = thumbnails[i]
+            # replace thumbnail urls by base64 encoded image
+            rv['id']= \
+                ("data:image/jpeg;base64,"
+                 "%s" % base64.b64encode(t))
+        except Exception:  # TypeError, KeyError
+            logger.error(traceback.format_exc())
+
+    return rv
 
 @login_required()
 @jsonp

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1469,9 +1469,7 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
         try:
             t = thumbnails[i]
             # replace thumbnail urls by base64 encoded image
-            rv['id']= \
-                ("data:image/jpeg;base64,"
-                 "%s" % base64.b64encode(t))
+            rv['id']= ("data:image/jpeg;base64,%s" % base64.b64encode(t))
         except Exception:  # TypeError, KeyError
             logger.error(traceback.format_exc())
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -357,7 +357,7 @@ def _render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
                 jpeg_data = _defcb(size=size)
                 prevent_cache = True
             else:
-                raise Http404
+                raise Http404('Failed to render thumbnail')
         else:
             jpeg_data = img.getThumbnail(
                 size=size, direct=direct, rdefId=rdefId, z=z, t=t)
@@ -367,8 +367,7 @@ def _render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
                     jpeg_data = _defcb(size=size)
                     prevent_cache = True
                 else:
-                    raise HttpResponseServerError(
-                        'Failed to render thumbnail')
+                    raise Http404('Failed to render thumbnail')
             else:
                 prevent_cache = img._thumbInProgress
         if not prevent_cache:
@@ -1466,7 +1465,7 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
 
     @param request:     http request
     @param w:           Thumbnail max width. 96 by default
-    @return:            http response containing jpeg
+    @return:            http response containing base64 encoded thumbnails
     """
     if w is None:
         w = 96
@@ -1474,7 +1473,7 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
     logger.debug("Image ids: %r" % image_ids)
     if len(image_ids) > settings.THUMBNAILS_BATCH:
         return HttpJavascriptResponseServerError(
-            'Max 50 thumbnails at a time.')
+            'Max %s thumbnails at a time.' % settings.THUMBNAILS_BATCH)
     thumbnails = conn.getThumbnailSet([rlong(i) for i in image_ids], w)
     rv = dict()
     for i in image_ids:
@@ -1502,7 +1501,7 @@ def get_thumbnail_json(request, iid, w=None, h=None, conn=None, _defcb=None,
     @param iid:         Image ID
     @param w:           Thumbnail max width. 96 by default
     @param h:           Thumbnail max height
-    @return:            http response containing jpeg
+    @return:            http response containing base64 encoded thumbnail
     """
     jpeg_data = _render_thumbnail(
         request=request, iid=iid, w=w, h=h,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -318,9 +318,8 @@ def render_birds_eye_view(request, iid, size=None,
     return render_thumbnail(request, iid, w=size, **kwargs)
 
 
-@login_required()
-def render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
-                     **kwargs):
+def _render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
+                      **kwargs):
     """
     Returns an HttpResponse wrapped jpeg with the rendered thumbnail for image
     'iid'
@@ -368,7 +367,7 @@ def render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
                     jpeg_data = _defcb(size=size)
                     prevent_cache = True
                 else:
-                    return HttpResponseServerError(
+                    raise HttpResponseServerError(
                         'Failed to render thumbnail')
             else:
                 prevent_cache = img._thumbInProgress
@@ -377,6 +376,24 @@ def render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
                                       jpeg_data, size)
     else:
         pass
+    return jpeg_data
+
+
+@login_required()
+def render_thumbnail(request, iid, w=None, h=None, conn=None, _defcb=None,
+                     **kwargs):
+    """
+    Returns an HttpResponse wrapped jpeg with the rendered thumbnail for image
+    'iid'
+
+    @param request:     http request
+    @param iid:         Image ID
+    @param w:           Thumbnail max width. 96 by default
+    @param h:           Thumbnail max height
+    @return:            http response containing jpeg
+    """
+    jpeg_data = _render_thumbnail(request=request, iid=iid, w=w, h=h,
+                                  conn=conn, _defcb=_defcb, **kwargs)
     rsp = HttpResponse(jpeg_data, content_type='image/jpeg')
     return rsp
 
@@ -1467,6 +1484,27 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
             rv[i] = ("data:image/jpeg;base64,%s" % base64.b64encode(t))
         except Exception:  # TypeError, KeyError
             logger.error(traceback.format_exc())
+    return rv
+
+
+@login_required()
+@jsonp
+def get_thumbnail_json(request, iid, w=None, h=None, conn=None, _defcb=None,
+                       **kwargs):
+    """
+    Returns an HttpResponse wrapped jpeg with the rendered thumbnail for image
+    'iid'
+
+    @param request:     http request
+    @param iid:         Image ID
+    @param w:           Thumbnail max width. 96 by default
+    @param h:           Thumbnail max height
+    @return:            http response containing jpeg
+    """
+    jpeg_data = _render_thumbnail(
+        request=request, iid=iid, w=w, h=h,
+        conn=conn, _defcb=_defcb, **kwargs)
+    rv = "data:image/jpeg;base64,%s" % base64.b64encode(jpeg_data)
     return rv
 
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1469,11 +1469,11 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
         try:
             t = thumbnails[i]
             # replace thumbnail urls by base64 encoded image
-            rv['id']= ("data:image/jpeg;base64,%s" % base64.b64encode(t))
+            rv['id'] = ("data:image/jpeg;base64,%s" % base64.b64encode(t))
         except Exception:  # TypeError, KeyError
             logger.error(traceback.format_exc())
-
     return rv
+
 
 @login_required()
 @jsonp

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1455,8 +1455,10 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
         w = 96
     image_ids = get_longs(request, 'id')
     logger.debug("Image ids: %r" % image_ids)
-    thumbnails = conn.getThumbnailSet(
-        [rlong(i) for i in image_ids], w)
+    if len(image_ids) > settings.THUMBNAILS_BATCH:
+        return HttpJavascriptResponseServerError(
+            'Max 50 thumbnails at a time.')
+    thumbnails = conn.getThumbnailSet([rlong(i) for i in image_ids], w)
     rv = dict()
     for i in image_ids:
         try:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1480,8 +1480,11 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
     for i in image_ids:
         try:
             t = thumbnails[i]
-            # replace thumbnail urls by base64 encoded image
-            rv[i] = ("data:image/jpeg;base64,%s" % base64.b64encode(t))
+            if len(t) > 0:
+                # replace thumbnail urls by base64 encoded image
+                rv[i] = ("data:image/jpeg;base64,%s" % base64.b64encode(t))
+            else:
+                rv[i] = None
         except Exception:  # TypeError, KeyError
             logger.error(traceback.format_exc())
     return rv

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1419,18 +1419,11 @@ def plateGrid_json(request, pid, field=0, conn=None, **kwargs):
         field = long(field or 0)
     except ValueError:
         field = 0
-    prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
     thumbsize = getIntOrDefault(request, 'size', None)
     logger.debug(thumbsize)
     server_id = kwargs['server_id']
 
-    def get_thumb_url(iid):
-        if thumbsize is not None:
-            return reverse(prefix, args=(iid, thumbsize))
-        return reverse(prefix, args=(iid,))
-
-    plateGrid = PlateGrid(conn, pid, field,
-                          kwargs.get('urlprefix', get_thumb_url))
+    plateGrid = PlateGrid(conn, pid, field, kwargs.get('urlprefix', ''))
     plate = plateGrid.plate
     if plate is None:
         return Http404
@@ -1461,15 +1454,15 @@ def get_thumbnails_json(request, w=None, conn=None, **kwargs):
     if w is None:
         w = 96
     image_ids = get_longs(request, 'id')
+    logger.debug("Image ids: %r" % image_ids)
     thumbnails = conn.getThumbnailSet(
         [rlong(i) for i in image_ids], w)
-
     rv = dict()
     for i in image_ids:
         try:
             t = thumbnails[i]
             # replace thumbnail urls by base64 encoded image
-            rv['id'] = ("data:image/jpeg;base64,%s" % base64.b64encode(t))
+            rv[i] = ("data:image/jpeg;base64,%s" % base64.b64encode(t))
         except Exception:  # TypeError, KeyError
             logger.error(traceback.format_exc())
     return rv

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -298,10 +298,9 @@ class TestPlateGrid(object):
                 if len(well_samples) > field:
                     img = well_samples[field].getImage()
                     assert well_metadata['name'] == img.name.val
-                    # expect default thumbnail (no size specified)
-                    assert well_metadata['thumb_url'] ==\
-                        reverse('webgateway.views.render_thumbnail',
-                                args=[img.id.val])
+                    # by default thumbprefix is not set,
+                    # thumbnail url is not restored
+                    assert well_metadata['thumb_url'] == img.id.val
 
     def test_well_images(self, django_client, plate_wells, conn):
         """

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -19,6 +19,8 @@
 
 """Tests rendering of thumbnails."""
 
+import base64
+import json
 from omeroweb.testlib import IWebTest
 from omeroweb.testlib import _get_response
 
@@ -57,3 +59,56 @@ class TestThumbnails(IWebTest):
             assert thumb.size == (96, 96)
         else:
             assert thumb.size == (size, size)
+
+    @pytest.mark.parametrize("size", [None, 100])
+    def test_base64_thumb(self, size):
+        """
+        Test base64 encoded retrival of single thumbnail
+        """
+        # Create a square image
+        iid = self.createTestImage(sizeX=256, sizeY=256,
+                                   session=self.sf).id.val
+        args = [iid]
+        if size is not None:
+            args.append(size)
+        request_url = reverse('webgateway.views.render_thumbnail', args=args)
+        rsp = _get_response(self.django_client, request_url, {},
+                            status_code=200)
+        thumb = json.dumps(
+            "data:image/jpeg;base64,%s" % base64.b64encode(rsp.content))
+
+        request_url = reverse('webgateway.views.get_thumbnail_json',
+                              args=args)
+        b64rsp = _get_response(self.django_client, request_url, {},
+                               status_code=200).content
+        assert thumb == b64rsp
+
+    def test_base64_thumb_set(self):
+        """
+        Test base64 encoded retrival of thumbnails in a batch
+        """
+        # Create a square image
+        images = []
+        for i in range(2, 5):
+            iid = self.createTestImage(sizeX=64*i, sizeY=64*i,
+                                       session=self.sf).id.val
+            images.append(iid)
+
+        expected_thumbs = {}
+        for i in images:
+            request_url = reverse('webgateway.views.render_thumbnail',
+                                  args=[i])
+            rsp = _get_response(self.django_client, request_url, {},
+                                status_code=200)
+
+            expected_thumbs[i] = \
+                "data:image/jpeg;base64,%s" % base64.b64encode(rsp.content)
+
+        iids = {'id': images}
+        request_url = reverse('webgateway.views.get_thumbnails_json')
+        b64rsp = _get_response(self.django_client, request_url, iids,
+                               status_code=200).content
+
+        assert cmp(json.loads(b64rsp),
+                   json.loads(json.dumps(expected_thumbs))) == 0
+        assert json.dumps(expected_thumbs) == b64rsp

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -1783,9 +1783,9 @@ class TestTree(ITest):
         Test marshalling image, loading thumbnail version
         """
         conn = get_connection(userA)
-        # Thumbnail not yet created: version will be -1
+        # Thumbnail is created, see testlib.ITest.createTestImage
         expected = expected_images(userA, [image_pixels_userA],
-                                   extraValues={'thumbVersion': -1})
+                                   extraValues={'thumbVersion': 0})
         marshaled = marshal_images(conn=conn,
                                    thumb_version=True,
                                    experimenter_id=userA[1].id.val)


### PR DESCRIPTION
manual rebase of https://github.com/openmicroscopy/openmicroscopy/pull/5062

--------------

# What this PR does

- https://github.com/openmicroscopy/openmicroscopy/pull/5081 fix getThumbnailsByLongestSideSet in readonly group https://trello.com/c/3eEBEPG4/7-retrieving-multiple-thumbnails 
- allow loading thumbnails in a batches

# Testing this PR

- test thumbnail version like in https://github.com/openmicroscopy/openmicroscopy/pull/3713#issuecomment-95146309
- load plate, all thumbnail should be loaded in a batches
- log in and test if updating rendeting update thumbnail:
  - test centre panel, search and plate grid
- consider any usecases I could miss! :)

- [ ] **performance testing** That should happen on real production deployment (with and without nginx micro cache turned on)

cc @pwalczysko 

--thumbnails
--exclude