### PR TITLE
Copy rnd between users

### DIFF
--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.logic;
@@ -397,57 +397,50 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
 
     /**
      * Retrieves all rendering settings associated with a given set of Pixels.
-     * @param pixels List of Pixels to retrieve settings for.
-     * @param userId User ID of the owner of the settings to query for.
+     * 
+     * @param pixels
+     *            List of Pixels to retrieve settings for.
+     * @param ownerId
+     *            User ID of the owner of the settings to query for. Pass
+     *            <code>-1</code> to load the rendering settings of the Pixels
+     *            owner instead.
      * @return A map of &lt;Pixels.Id,RenderingDef&gt; for the list of Pixels
-     * given. 
+     *         given.
      */
     private Map<Long, RenderingDef> loadRenderingSettings(List<Pixels> pixels,
-                                                          Long ownerId)
-    {
-        StopWatch s1 = new Slf4JStopWatch(
-                "omero.loadRenderingSettingsByUser");
+            Long ownerId) {
+        StopWatch s1 = new Slf4JStopWatch("omero.loadRenderingSettingsByUser");
         Set<Long> pixelsIds = new HashSet<Long>();
-        for (Pixels p : pixels)
-        {
+        for (Pixels p : pixels) {
             pixelsIds.add(p.getId());
         }
-        Parameters p = new Parameters();
-        p.addIds(pixelsIds);
-        p.addId(ownerId);
-        String sql = PixelsImpl.RENDERING_DEF_QUERY_PREFIX +
-            "rdef.pixels.id in (:ids) and " +
-            "rdef.details.owner.id = :id";
-        Map<Long, RenderingDef> settingsMap = new HashMap<Long, RenderingDef>();
-        List<RenderingDef> settingsList = iQuery.findAllByQuery(sql, p);
-        for (RenderingDef settings : settingsList)
-        {
-            settingsMap.put(settings.getPixels().getId(), settings);
-            pixelsIds.remove(settings.getPixels().getId());
-        }
-        
-        if (!pixelsIds.isEmpty()) {
-            // if the user doesn't have own rendering settings
-            // load the rendering settings of the pixels owner
+
+        Parameters p;
+        String sql;
+        if (ownerId >= 0) {
+            // Load the rendering settings of the specified owner
+            p = new Parameters();
+            p.addIds(pixelsIds);
+            p.addId(ownerId);
+            sql = PixelsImpl.RENDERING_DEF_QUERY_PREFIX
+                    + "rdef.pixels.id in (:ids) and "
+                    + "rdef.details.owner.id = :id";
+        } else {
+            // Load the rendering settings of the pixels owner
             p = new Parameters();
             p.addIds(pixelsIds);
 
             sql = PixelsImpl.RENDERING_DEF_QUERY_PREFIX
                     + "rdef.pixels.id in (:ids) and "
                     + "rdef.details.owner.id = rdef.pixels.details.owner.id";
-
-            settingsMap = new HashMap<Long, RenderingDef>();
-            settingsList = iQuery.findAllByQuery(sql, p);
-            for (RenderingDef settings : settingsList) {
-                settingsMap.put(settings.getPixels().getId(), settings);
-                pixelsIds.remove(settings.getPixels().getId());
-            }
-
-            if (!pixelsIds.isEmpty())
-                log.debug("Could not find rendering settings for all pixel ids (missing: "
-                        + pixelsIds + ")");
         }
-        
+
+        Map<Long, RenderingDef> settingsMap = new HashMap<Long, RenderingDef>();
+        List<RenderingDef> settingsList = iQuery.findAllByQuery(sql, p);
+        for (RenderingDef settings : settingsList) {
+            settingsMap.put(settings.getPixels().getId(), settings);
+        }
+
         s1.stop();
         return settingsMap;
     }
@@ -1235,6 +1228,11 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     			List<Pixels> list = new ArrayList<Pixels>(1);
     			list.add(pixelsFrom);
     			Map<Long, RenderingDef> map = loadRenderingSettings(list);
+    			if (!map.containsKey(from)) {
+    			    // user doens't have own rendering settings, load the rendering
+    			    // settings of the image owner instead
+    			    map = loadRenderingSettings(list, -1l);
+    			}
             	settingsFrom = map.get(from);
     		}
     	}

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -1229,7 +1229,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     			list.add(pixelsFrom);
     			Map<Long, RenderingDef> map = loadRenderingSettings(list);
     			if (!map.containsKey(from)) {
-    			    // user doens't have own rendering settings, load the rendering
+    			    // user doesn't have own rendering settings, load the rendering
     			    // settings of the image owner instead
     			    map = loadRenderingSettings(list, -1l);
     			}

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -1330,9 +1330,11 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     {
         Set<Long> nodeIds = new HashSet<Long>();
         nodeIds.add(to);
-        Map<Boolean, List<Long>> returnValue = 
+        List<Pixels> pixels = loadPixels(nodeIds);
+        Long imageID = pixels.get(0).getImage().getId();
+        Map<Boolean, List<Long>> returnValue =
             applySettingsToSet(from, Pixels.class, nodeIds);
-        if (returnValue.get(Boolean.TRUE).contains(to))
+        if (returnValue.get(Boolean.TRUE).contains(imageID))
         {
             return true;
         }

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -1328,22 +1328,15 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     @RolesAllowed("user")
     public boolean applySettingsToPixels(long from, long to)
     {
-        Pixels pixelsFrom = pixelsMetadata.retrievePixDescription(from);
-        Pixels pixelsTo = pixelsMetadata.retrievePixDescription(to);
-        List<Pixels> pixelsList = new ArrayList<Pixels>(2);
-        pixelsList.add(pixelsFrom);
-        pixelsList.add(pixelsTo);
-        Map<Long, RenderingDef> settingsMap = loadRenderingSettings(pixelsList);
-        RenderingDef settingsFrom = settingsMap.get(from);
-        RenderingDef settingsTo = settingsMap.get(to);
-        settingsTo = applySettings(pixelsFrom, pixelsTo,
-        		                   settingsFrom, settingsTo);
-        if (settingsTo == null)
+        Set<Long> nodeIds = new HashSet<Long>();
+        nodeIds.add(to);
+        Map<Boolean, List<Long>> returnValue = 
+            applySettingsToSet(from, Pixels.class, nodeIds);
+        if (returnValue.get(Boolean.TRUE).contains(to))
         {
-        	return false;
+            return true;
         }
-        iUpdate.saveObject(settingsTo);
-        return true;
+        return false;
     }
 
     /**

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -423,7 +423,31 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         for (RenderingDef settings : settingsList)
         {
             settingsMap.put(settings.getPixels().getId(), settings);
+            pixelsIds.remove(settings.getPixels().getId());
         }
+        
+        if (!pixelsIds.isEmpty()) {
+            // if the user doesn't have own rendering settings
+            // load the rendering settings of the pixels owner
+            p = new Parameters();
+            p.addIds(pixelsIds);
+
+            sql = PixelsImpl.RENDERING_DEF_QUERY_PREFIX
+                    + "rdef.pixels.id in (:ids) and "
+                    + "rdef.details.owner.id = rdef.pixels.details.owner.id";
+
+            settingsMap = new HashMap<Long, RenderingDef>();
+            settingsList = iQuery.findAllByQuery(sql, p);
+            for (RenderingDef settings : settingsList) {
+                settingsMap.put(settings.getPixels().getId(), settings);
+                pixelsIds.remove(settings.getPixels().getId());
+            }
+
+            if (!pixelsIds.isEmpty())
+                log.debug("Could not find rendering settings for all pixel ids (missing: "
+                        + pixelsIds + ")");
+        }
+        
         s1.stop();
         return settingsMap;
     }

--- a/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
@@ -1418,4 +1418,37 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         long ownerId = def.getDetails().getOwner().getId().getValue();
         Assert.assertEquals(ownerId, ctx.userId);
     }
+
+    /**
+     * Test the copying of rendering settings by a user who do not have rendering
+     * settings for that image.
+     * The source image does not have any settings.
+     * No copy occurs
+     * Use the applySettingsToImage
+     * @throws Exception
+     */
+    @Test
+    public void testCopyPasteNoSettingsUsingApplySettingsToImage() throws Exception {
+        EventContext ctx = newUserAndGroup("rwra--");
+        Image image = createBinaryImage();
+        Image image2 = createBinaryImage();
+        Pixels pixels = image.getPrimaryPixels();
+        IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
+        //Image has no settings
+        disconnect();
+        //Add log in as a new user
+        newUserInGroup(ctx);
+        // Same image
+        prx = factory.getRenderingSettingsService();
+        boolean v = prx.applySettingsToImage(pixels.getId().getValue(), image2.getId().getValue());
+
+        Assert.assertFalse(v);
+        ParametersI param = new ParametersI();
+        param.addLong("pid", pixels.getId().getValue());
+        String sql = "select rdef from RenderingDef as rdef "
+                + "where rdef.pixels.id = :pid";
+        List<IObject> values = iQuery.findAllByQuery(sql, param);
+        Assert.assertNotNull(values);
+        Assert.assertEquals(values.size(), 0);
+    }
 }

--- a/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingSettingsServicePermissionsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2006-2016 University of Dundee & Open Microscopy Environment.
+ *  Copyright 2006-2017 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -7,7 +7,6 @@ package integration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 import omero.api.IRenderingSettingsPrx;
@@ -315,7 +314,7 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         prx.setOriginalSettingsInSet(Image.class.getName(), ids);
 
         disconnect();
-        EventContext ctx2 = newUserInGroup(ctx);
+        newUserInGroup(ctx);
         prx = factory.getRenderingSettingsService();
         prx.setOriginalSettingsInSet(Image.class.getName(), Arrays.asList(id));
         disconnect();
@@ -1085,7 +1084,7 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
     @Test
     public void testApplySettingsToSetTargetImageNoSettingsAndBinary()
             throws Exception {
-        EventContext ctx = newUserAndGroup("rw----");
+        newUserAndGroup("rw----");
         IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
         Image image = createBinaryImage();
         Image image2 = mmFactory.createImage();
@@ -1125,7 +1124,7 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
     @Test
     public void testApplySettingsToSetForImageModifyIntensity()
             throws Exception {
-        EventContext ctx = newUserAndGroup("rw----");
+        newUserAndGroup("rw----");
         IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
         Image image = createBinaryImage();
         Image image2 = createBinaryImage();
@@ -1440,7 +1439,8 @@ public class RenderingSettingsServicePermissionsTest extends AbstractServerTest 
         newUserInGroup(ctx);
         // Same image
         prx = factory.getRenderingSettingsService();
-        boolean v = prx.applySettingsToImage(pixels.getId().getValue(), image2.getId().getValue());
+        boolean v = prx.applySettingsToImage(pixels.getId().getValue(),
+                image2.getId().getValue());
 
         Assert.assertFalse(v);
         ParametersI param = new ParametersI();


### PR DESCRIPTION
# What this PR does
This PR replaces the original gh-5073
This PR adds tests and fixes another bug
All changes are supported by integration tests now

@dominikl  being off.

Original description
Bugfix: Copy/Paste of another user's rendering setting doesn't work like expected, if the user doesn't already have own rendering settings for the image. This PR fixes the problem.

Serverside bugfix, i.e. should fix the bug for OMERO.Web and Insight.

# Testing this PR

UI testing: Check the workflow mentioned by @pwalczysko on the Trello card - Copy Rnd settings between users

Integration tests have been added. Check that they are green


# Related reading

[Trello card - Copy Rnd settings between users](https://trello.com/c/k9T9WgUW/214-copy-rnd-settings-between-users)