### PR TITLE
Filter by crash

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/BrowserModel.java
@@ -696,7 +696,7 @@ class BrowserModel
 	 */
 	public void setNodesSelection(Collection<ImageDisplay> nodes)
 	{
-		if (nodes == null) return;
+		if (CollectionUtils.isEmpty(nodes)) return;
 		setNodesColor(nodes, getSelectedDisplays());
 		final HashSet<ImageDisplay> previouslySelectedDisplays =
 		        new HashSet<ImageDisplay>(this.selectedDisplays);


### PR DESCRIPTION
# What this PR does

Fix crash if no node found when trying to filter by

# Testing this PR

 * Log as root
 * Select a dataset with images w/o any rating e.g. see screenshot below
 * Select for example ``* or better``
 * The application should no longer crash

<img width="1292" alt="selectionforpr" src="https://cloud.githubusercontent.com/assets/1022396/23260401/9603d36e-f9c9-11e6-9b96-c57f4079c6c7.png">

# Related reading

Problem noticed while reviewing gh-4694

cc @dominikl 