### PR TITLE
Python testlib

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -440,8 +440,8 @@ class ITest(object):
                     for the_t in range(size_t):
                         plane_2d = fromfunction(f, (size_y, size_x),
                                                 dtype=int16)
-                        script_utils.uploadPlane(raw_pixel_store, plane_2d,
-                                                 the_z, the_c, the_t)
+                        script_utils.upload_plane(raw_pixel_store, plane_2d,
+                                                  the_z, the_c, the_t)
                         min_value = min(min_value, plane_2d.min())
                         max_value = max(max_value, plane_2d.max())
                 pixels_service.setChannelGlobalMinMax(pixels_id, the_c,
@@ -450,10 +450,10 @@ class ITest(object):
                 rgba = None
                 if the_c in colour_map:
                     rgba = colour_map[the_c]
-                script_utils.resetRenderingSettings(rendering_engine,
-                                                    pixels_id, the_c,
-                                                    min_value, max_value,
-                                                    rgba)
+                script_utils.reset_rendering_settings(rendering_engine,
+                                                      pixels_id, the_c,
+                                                      min_value, max_value,
+                                                      rgba)
         finally:
             rendering_engine.close()
             raw_pixel_store.close()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -691,7 +691,7 @@ class ITest(object):
         image = update.saveAndReturnObject(image)
         return image.getPrimaryPixels()
 
-    def write(self, pix, rps):
+    def write(self, pixels, rps):
         """
         Writes byte arrays consisting of [5] to as
         either planes or tiles depending on the pixel
@@ -699,27 +699,27 @@ class ITest(object):
         """
         if not rps.requiresPixelsPyramid():
             # By plane
-            bytes_per_plane = pix.sizeX.val * pix.sizeY.val  # Assuming int8
-            for z in range(pix.sizeZ.val):
-                for c in range(pix.sizeC.val):
-                    for t in range(pix.sizeT.val):
+            bytes_per_plane = pixels.sizeX.val * pixels.sizeY.val  # Assuming int8
+            for z in range(pixels.sizeZ.val):
+                for c in range(pixels.sizeC.val):
+                    for t in range(pixels.sizeT.val):
                         rps.setPlane([5] * bytes_per_plane, z, c, t)
         else:
             # By tile
             w, h = rps.getTileSize()
             bytes_per_tile = w * h  # Assuming int8
-            for z in range(pix.sizeZ.val):
-                for c in range(pix.sizeC.val):
-                    for t in range(pix.sizeT.val):
-                        for x in range(0, pix.sizeX.val, w):
-                            for y in range(0, pix.sizeY.val, h):
+            for z in range(pixels.sizeZ.val):
+                for c in range(pixels.sizeC.val):
+                    for t in range(pixels.sizeT.val):
+                        for x in range(0, pixels.sizeX.val, w):
+                            for y in range(0, pixels.sizeY.val, h):
 
                                 changed = False
-                                if x + w > pix.sizeX.val:
+                                if x + w > pixels.sizeX.val:
                                     w = pix.sizeX.val - x
                                     changed = True
-                                if y + h > pix.sizeY.val:
-                                    h = pix.sizeY.val - y
+                                if y + h > pixels.sizeY.val:
+                                    h = pixels.sizeY.val - y
                                     changed = True
                                 if changed:
                                     # Again assuming int8

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -296,18 +296,17 @@ class ITest(object):
                     pass
         return pix_ids
 
-    """
-    Creates a fake file with a seriesCount of images, imports
-    the file and then return the list of images.
-    To import a single image, pass a images_count value of 1.
-    """
-
-    def import_mif(self, images_count=0, name=None, client=None,
+    def import_fake_file(self, images_count=1, name=None, client=None,
                    with_companion=False, skip="all", **kwargs):
+        """
+        Creates a fake file with a seriesCount of images, imports
+        the file and then return the list of images.
+        By default a single image is imported.
+        """
         if client is None:
             client = self.client
         if name is None:
-            name = "import_mif_%s" % images_count
+            name = "import_fake_file_%s" % images_count
 
         try:
             global_metadata = kwargs.pop("GlobalMetadata")
@@ -318,7 +317,7 @@ class ITest(object):
 
         append = ""
 
-        # Only include series count if enabled; in the case of plates,
+        # Only include images count if enabled; in the case of plates,
         # this will be unused
         if images_count >= 1:
             append = "series=%d%s" % (images_count, append)
@@ -348,12 +347,11 @@ class ITest(object):
             images.append(pixels.getImage())
         return images
 
-    def import_plates(
-        self, client=None,
-        plates=1, plate_acqs=1,
-        plate_cols=1, plate_rows=1,
-        fields=1, **kwargs
-    ):
+    def import_plates(self, client=None, plates=1, plate_acqs=1, plate_cols=1,
+                      plate_rows=1, fields=1, **kwargs):
+        """
+        Creates fake plates and imports them.
+        """
 
         if client is None:
             client = self.client
@@ -363,7 +361,7 @@ class ITest(object):
         kwargs["plateCols"] = plate_cols
         kwargs["plateRows"] = plate_rows
         kwargs["fields"] = fields
-        images = self.import_mif(client=client, **kwargs)
+        images = self.import_fake_file(images_count=0, client=client, **kwargs)
         images = [x.id.val for x in images]
 
         query = client.sf.getQueryService()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -744,19 +744,6 @@ class ITest(object):
                                         z, c, t, x, y, w, h)
                                 rps.setTile(*args)
 
-    def open_jpeg_buffer(self, buf):
-        try:
-            from PIL import Image
-        except ImportError:
-            try:
-                import Image
-            except ImportError:
-                assert False, "Pillow not installed"
-        from io import BytesIO
-        tfile = BytesIO(buf)
-        jpeg = Image.open(tfile)  # Raises if invalid
-        return jpeg
-
     def login_attempt(self, name, t, pw="BAD", less=False):
         """
         Checks that login happens in less than or greater than

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -412,7 +412,6 @@ class ITest(object):
             pixels_type = query_service.findByQuery(
                 "from PixelsType as p where p.value='%s'" % "float", None)
         if pixels_type is None:
-            print "Unknown pixels type for: " % p_type
             raise Exception("Unknown pixels type for: " % p_type)
 
         # code below here is very similar to combineImages.py

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -297,7 +297,7 @@ class ITest(object):
         return pix_ids
 
     def import_fake_file(self, images_count=1, name=None, client=None,
-                   with_companion=False, skip="all", **kwargs):
+                         with_companion=False, skip="all", **kwargs):
         """
         Creates a fake file with a seriesCount of images, imports
         the file and then return the list of images.
@@ -664,7 +664,8 @@ class ITest(object):
                                       skip="all")
         return pixels_id[0]
 
-    def create_pixels(self, x=10, y=10, z=10, c=3, t=50, pixels_type="int8", client=None):
+    def create_pixels(self, x=10, y=10, z=10, c=3, t=50, pixels_type="int8",
+                      client=None):
         """
         Creates an int8 pixel of the given size in the database.
         No data is written.
@@ -697,7 +698,8 @@ class ITest(object):
         """
         if not rps.requiresPixelsPyramid():
             # By plane
-            bytes_per_plane = pixels.sizeX.val * pixels.sizeY.val  # Assuming int8
+            # Assuming int8
+            bytes_per_plane = pixels.sizeX.val * pixels.sizeY.val
             for z in range(pixels.sizeZ.val):
                 for c in range(pixels.sizeC.val):
                     for t in range(pixels.sizeT.val):
@@ -714,7 +716,7 @@ class ITest(object):
 
                                 changed = False
                                 if x + w > pixels.sizeX.val:
-                                    w = pix.sizeX.val - x
+                                    w = pixels.sizeX.val - x
                                     changed = True
                                 if y + h > pixels.sizeY.val:
                                     h = pixels.sizeY.val - y

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -301,7 +301,7 @@ class ITest(object):
     def import_fake_file(self, images_count=1, name=None, client=None,
                          with_companion=False, skip="all", **kwargs):
         """
-        Creates a fake file with a seriesCount of images, imports
+        Creates a fake file with an images_count of images, imports
         the file and then return the list of images.
         By default a single image is imported.
         """

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -1341,20 +1341,20 @@ class AbstractRepoTest(ITest):
         # Fill version info
         system, node, release, version, machine, processor = platform.uname()
 
-        clientVersionInfo = [
+        client_version_info = [
             NV('omero.version', omero_version),
             NV('os.name', system),
             NV('os.version', release),
             NV('os.architecture', machine)
         ]
         try:
-            clientVersionInfo.append(
+            client_version_info.append(
                 NV('locale', locale.getdefaultlocale()[0]))
         except:
             pass
 
         upload = omero.model.UploadJobI()
-        upload.setVersionInfo(clientVersionInfo)
+        upload.setVersionInfo(client_version_info)
         fileset.linkJob(upload)
         return fileset
 

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -297,40 +297,9 @@ class ITest(object):
         return pix_ids
 
     """
-    Creates a fake file with one image, imports
-    the file and then return the image.
-    """
-
-    def import_single_image(self, name=None, client=None,
-                            with_companion=False, **kwargs):
-        if client is None:
-            client = self.client
-        if name is None:
-            name = "import_single_image"
-
-        images = self.import_mif(1, name=name, client=client,
-                                 with_companion=with_companion,
-                                 **kwargs)
-        return images[0]
-
-    """
-    Creates a fake file with one image and a companion file, imports
-    the file and then return the image..
-    """
-
-    def import_single_image_with_companion(self, name=None, client=None):
-        if client is None:
-            client = self.client
-        if name is None:
-            name = "import_single_image_with_companion"
-
-        images = self.import_mif(1, name=name, client=client,
-                                 with_companion=True)
-        return images[0]
-
-    """
     Creates a fake file with a seriesCount of images, imports
     the file and then return the list of images.
+    To import a single image, pass a series_count value of 1.
     """
 
     def import_mif(self, series_count=0, name=None, client=None,
@@ -338,7 +307,7 @@ class ITest(object):
         if client is None:
             client = self.client
         if name is None:
-            name = "import_mif"
+            name = "import_mif_%s" % series_count
 
         try:
             global_metadata = kwargs.pop("GlobalMetadata")

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -299,15 +299,15 @@ class ITest(object):
     """
     Creates a fake file with a seriesCount of images, imports
     the file and then return the list of images.
-    To import a single image, pass a series_count value of 1.
+    To import a single image, pass a images_count value of 1.
     """
 
-    def import_mif(self, series_count=0, name=None, client=None,
+    def import_mif(self, images_count=0, name=None, client=None,
                    with_companion=False, skip="all", **kwargs):
         if client is None:
             client = self.client
         if name is None:
-            name = "import_mif_%s" % series_count
+            name = "import_mif_%s" % images_count
 
         try:
             global_metadata = kwargs.pop("GlobalMetadata")
@@ -320,8 +320,8 @@ class ITest(object):
 
         # Only include series count if enabled; in the case of plates,
         # this will be unused
-        if series_count >= 1:
-            append = "series=%d%s" % (series_count, append)
+        if images_count >= 1:
+            append = "series=%d%s" % (images_count, append)
 
         if kwargs:
             for k, v in kwargs.items():
@@ -339,8 +339,8 @@ class ITest(object):
         pixel_ids = self.import_image(
             filename=fake.abspath(), client=client, skip=skip, **kwargs)
 
-        if series_count >= 1:
-            assert series_count == len(pixel_ids)
+        if images_count >= 1:
+            assert images_count == len(pixel_ids)
 
         images = []
         for pix_id_str in pixel_ids:

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -259,8 +259,7 @@ class ITest(object):
         Imports the specified file.
         """
         if filename is None:
-            filename = self.omero_dist / ".." / \
-                "components" / "common" / "test" / "tinyTest.d3d.dv"
+            raise Exception("No file specified")
         if client is None:
             client = self.client
 

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -666,7 +666,7 @@ class ITest(object):
                                       skip="all")
         return pixels_id[0]
 
-    def pix(self, x=10, y=10, z=10, c=3, t=50, client=None):
+    def create_pixels(self, x=10, y=10, z=10, c=3, t=50, pixels_type="int8", client=None):
         """
         Creates an int8 pixel of the given size in the database.
         No data is written.
@@ -680,7 +680,7 @@ class ITest(object):
         pixels.sizeT = rint(t)
         pixels.sha1 = rstring("")
         pixels.pixelsType = PixelsTypeI()
-        pixels.pixelsType.value = rstring("int8")
+        pixels.pixelsType.value = rstring(pixels_type)
         pixels.dimensionOrder = DimensionOrderI()
         pixels.dimensionOrder.value = rstring("XYZCT")
         image.addPixels(pixels)
@@ -689,8 +689,7 @@ class ITest(object):
             client = self.client
         update = client.sf.getUpdateService()
         image = update.saveAndReturnObject(image)
-        pixels = image.getPrimaryPixels()
-        return pixels
+        return image.getPrimaryPixels()
 
     def write(self, pix, rps):
         """

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -57,8 +57,6 @@ from omero.rtypes import rbool, rstring, rlong, rtime, rint, unwrap
 from omero.util.temp_files import create_path
 from path import path
 
-import warnings
-
 
 class Clients(object):
 
@@ -1083,26 +1081,6 @@ class ITest(object):
             targetObjects={'ExperimenterGroup': [gid]}, permissions=perms)
 
         self.do_submit(command, client)
-
-    def create_share(self, description="", timeout=None,
-                     objects=[], experimenters=[], guests=[],
-                     enabled=True, client=None):
-        warnings.warn(
-            "This method is deprecated.", DeprecationWarning)
-        """
-        Create share object
-
-        :param objects: a list of objects to include in the share
-        :param description: a string containing the description of the share
-        :param timeout: the timeout of the share
-        :param experimenters: a list of users associated with the share
-        :param client: The client to use to create the share
-        """
-        if client is None:
-            client = self.client
-        share = client.sf.getShareService()
-        return share.createShare(description, timeout, objects,
-                                 experimenters, guests, enabled)
 
 
 class ProjectionFixture(object):

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2008-2014 Glencoe Software, Inc. All Rights Reserved.
+# Copyright (C) 2008-2017 Glencoe Software, Inc. All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 # This program is free software; you can redistribute it and/or modify
@@ -1195,7 +1195,7 @@ class AbstractRepoTest(ITest):
     def test_dir(self, client=None):
         if client is None:
             client = self.client
-        mrepo = self.getManagedRepo(client=client)
+        mrepo = self.get_managed_repo(client=client)
         user_dir = self.user_dir(client=client)
         unique_dir = user_dir + "/" + self.uuid()  # ok
         mrepo.makeDir(unique_dir, True)
@@ -1212,14 +1212,14 @@ class AbstractRepoTest(ITest):
         ctx["omero.group"] = "-1"
         return ctx
 
-    def getManagedRepo(self, client=None):
+    def get_managed_repo(self, client=None):
         if client is None:
             client = self.client
         mrepo = client.getManagedRepository()
         assert mrepo
         return mrepo
 
-    def createFile(self, mrepo1, filename):
+    def create_file(self, mrepo1, filename):
         rfs = mrepo1.file(filename, "rw")
         try:
             rfs.write("hi", 0, 2)
@@ -1267,13 +1267,13 @@ class AbstractRepoTest(ITest):
                       mrepo2.file, filename, "rw")
 
     def assertDirWrite(self, mrepo2, dirname):
-        self.createFile(mrepo2, dirname + "/file2.txt")
+        self.create_file(mrepo2, dirname + "/file2.txt")
 
     def assertNoDirWrite(self, mrepo2, dirname):
         # Also check that it's not possible to write
         # in someone else's directory.
         pytest.raises(omero.SecurityViolation,
-                      self.createFile, mrepo2, dirname + "/file2.txt")
+                      self.create_file, mrepo2, dirname + "/file2.txt")
 
     def assertNoRead(self, mrepo2, filename, ofile):
         pytest.raises(omero.SecurityViolation,
@@ -1303,7 +1303,7 @@ class AbstractRepoTest(ITest):
     def raw(self, command, args, client=None):
         if client is None:
             client = self.client
-        mrepo = self.getManagedRepo(self.client)
+        mrepo = self.get_managed_repo(self.client)
         obj = mrepo.root()
         sha = obj.hash.val
         raw_access = omero.grid.RawAccessRequest()
@@ -1394,11 +1394,11 @@ class AbstractRepoTest(ITest):
                 rfs.close()
         return ret_val
 
-    def fullImport(self, client):
+    def full_import(self, client):
         """
         Re-usable method for a basic import
         """
-        mrepo = self.getManagedRepo(client)
+        mrepo = self.get_managed_repo(client)
         folder = self.create_test_dir()
         fileset = self.create_fileset(folder)
         settings = self.create_settings()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -693,13 +693,15 @@ class ITest(object):
 
     @classmethod
     def get_pixels_type(cls, pixels_type):
+        if pixels_type in ["int8", "uint8"]:
+            return 1
         if pixels_type in ["int16", "uint16"]:
             return 2
         if pixels_type in ["int32", "uint132", "float"]:
             return 4
         if pixels_type in ["double"]:
             return 8
-        return 1
+        raise Exception("Pixels Type %s not supported" % pixels_type)
 
     def write(self, pixels, rps, pixels_type="int8"):
         """
@@ -707,7 +709,7 @@ class ITest(object):
         either planes or tiles depending on the pixel
         size.
         """
-        p_type = self.get_pixels_type(unwrap(pixels.pixelsType))
+        p_type = self.get_pixels_type(pixels.pixelsType.getValue().getValue())
         if not rps.requiresPixelsPyramid():
             # By plane
             bytes_per_plane = pixels.sizeX.val * pixels.sizeY.val * p_type

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -693,15 +693,13 @@ class ITest(object):
 
     @classmethod
     def get_pixels_type(cls, pixels_type):
-        if pixels_type in ["int8", "uint8"]:
-            return 1
         if pixels_type in ["int16", "uint16"]:
             return 2
         if pixels_type in ["int32", "uint132", "float"]:
             return 4
         if pixels_type in ["double"]:
             return 8
-        return -1
+        return 1
 
     def write(self, pixels, rps, pixels_type="int8"):
         """

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -692,16 +692,28 @@ class ITest(object):
         image = update.saveAndReturnObject(image)
         return image.getPrimaryPixels()
 
-    def write(self, pixels, rps):
+    @classmethod
+    def get_pixels_type(cls, pixels_type):
+        if pixels_type in ["int8", "uint8"]:
+            return 1
+        if pixels_type in ["int16", "uint16"]:
+            return 2
+        if pixels_type in ["int32", "uint132", "float"]:
+            return 4
+        if pixels_type in ["double"]:
+            return 8
+        return -1
+
+    def write(self, pixels, rps, pixels_type="int8"):
         """
         Writes byte arrays consisting of [5] to as
         either planes or tiles depending on the pixel
         size.
         """
+        p_type = self.get_pixels_type(unwrap(pixels.pixelsType))
         if not rps.requiresPixelsPyramid():
             # By plane
-            # Assuming int8
-            bytes_per_plane = pixels.sizeX.val * pixels.sizeY.val
+            bytes_per_plane = pixels.sizeX.val * pixels.sizeY.val * p_type
             for z in range(pixels.sizeZ.val):
                 for c in range(pixels.sizeC.val):
                     for t in range(pixels.sizeT.val):
@@ -709,7 +721,7 @@ class ITest(object):
         else:
             # By tile
             w, h = rps.getTileSize()
-            bytes_per_tile = w * h  # Assuming int8
+            bytes_per_tile = w * h * p_type
             for z in range(pixels.sizeZ.val):
                 for c in range(pixels.sizeC.val):
                     for t in range(pixels.sizeT.val):

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -426,33 +426,37 @@ class ITest(object):
         image = container_service.getImages("Image", [image_id], None)[0]
 
         pixels_id = image.getPrimaryPixels().getId().getValue()
-        raw_pixel_store.setPixelsId(pixels_id, True)
 
         colour_map = {0: (0, 0, 255, 255), 1: (0, 255, 0, 255),
                       2: (255, 0, 0, 255), 3: (255, 0, 255, 255)}
         f_list = [f1, f2, f3]
-        for the_c in range(size_c):
-            min_value = 0
-            max_value = 0
-            f = f_list[the_c % len(f_list)]
-            for the_z in range(size_z):
-                for the_t in range(size_t):
-                    plane_2d = fromfunction(f, (size_y, size_x), dtype=int16)
-                    script_utils.uploadPlane(
-                        raw_pixel_store, plane_2d, the_z, the_c, the_t)
-                    min_value = min(min_value, plane_2d.min())
-                    max_value = max(max_value, plane_2d.max())
-            pixels_service.setChannelGlobalMinMax(
-                pixels_id, the_c, float(min_value), float(max_value))
-            rgba = None
-            if the_c in colour_map:
-                rgba = colour_map[the_c]
-        for the_c in range(size_c):
-            script_utils.resetRenderingSettings(
-                rendering_engine, pixels_id, the_c, min_value, max_value, rgba)
-
-        rendering_engine.close()
-        raw_pixel_store.close()
+        try:
+            raw_pixel_store.setPixelsId(pixels_id, True)
+            for the_c in range(size_c):
+                min_value = 0
+                max_value = 0
+                f = f_list[the_c % len(f_list)]
+                for the_z in range(size_z):
+                    for the_t in range(size_t):
+                        plane_2d = fromfunction(f, (size_y, size_x),
+                                                dtype=int16)
+                        script_utils.uploadPlane(raw_pixel_store, plane_2d,
+                                                 the_z, the_c, the_t)
+                        min_value = min(min_value, plane_2d.min())
+                        max_value = max(max_value, plane_2d.max())
+                pixels_service.setChannelGlobalMinMax(pixels_id, the_c,
+                                                      float(min_value),
+                                                      float(max_value))
+                rgba = None
+                if the_c in colour_map:
+                    rgba = colour_map[the_c]
+                script_utils.resetRenderingSettings(rendering_engine,
+                                                    pixels_id, the_c,
+                                                    min_value, max_value,
+                                                    rgba)
+        finally:
+            rendering_engine.close()
+            raw_pixel_store.close()
 
         # See #9070. Forcing a thumbnail creation
         tb = session.createThumbnailStore()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -57,6 +57,8 @@ from omero.rtypes import rbool, rstring, rlong, rtime, rint, unwrap
 from omero.util.temp_files import create_path
 from path import path
 
+import warnings
+
 
 class Clients(object):
 
@@ -1098,6 +1100,8 @@ class ITest(object):
     def create_share(self, description="", timeout=None,
                      objects=[], experimenters=[], guests=[],
                      enabled=True, client=None):
+        warnings.warn(
+            "This method is deprecated.", DeprecationWarning)
         """
         Create share object
 

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -52,7 +52,7 @@ from omero.model import ExperimenterGroup, ExperimenterGroupI
 from omero.model import ProjectDatasetLinkI, ImageAnnotationLinkI
 from omero.model import PermissionsI
 from omero.model import ChecksumAlgorithmI
-from omero.model import NamedValue as NV
+from omero.model import NamedValue
 from omero.rtypes import rbool, rstring, rlong, rtime, rint, unwrap
 from omero.util.temp_files import create_path
 from path import path
@@ -1237,14 +1237,14 @@ class AbstractRepoTest(ITest):
         system, node, release, version, machine, processor = platform.uname()
 
         client_version_info = [
-            NV('omero.version', omero_version),
-            NV('os.name', system),
-            NV('os.version', release),
-            NV('os.architecture', machine)
+            NamedValue('omero.version', omero_version),
+            NamedValue('os.name', system),
+            NamedValue('os.version', release),
+            NamedValue('os.architecture', machine)
         ]
         try:
             client_version_info.append(
-                NV('locale', locale.getdefaultlocale()[0]))
+                NamedValue('locale', locale.getdefaultlocale()[0]))
         except:
             pass
 
@@ -1300,20 +1300,20 @@ class AbstractRepoTest(ITest):
 
         proc = mrepo.importFileset(fileset, settings)
         try:
-            return self.assertImport(client, proc, folder)
+            return self.assert_import(client, proc, folder)
         finally:
             proc.close()
 
     # Assert methods
-    def assertImport(self, client, proc, folder):
+    def assert_import(self, client, proc, folder):
         hashes = self.upload_folder(proc, folder)
         handle = proc.verifyUpload(hashes)
         cb = CmdCallbackI(client, handle)
-        rsp = self.assertPasses(cb)
+        rsp = self.assert_passes(cb)
         assert 1 == len(rsp.pixels)
         return rsp
 
-    def assertWrite(self, mrepo2, filename, ofile):
+    def assert_write(self, mrepo2, filename, ofile):
         def _write(rfs):
             try:
                 rfs.write("bye", 0, 3)
@@ -1332,7 +1332,7 @@ class AbstractRepoTest(ITest):
         rfs = mrepo2.file(filename, "rw")
         _write(rfs)
 
-    def assertNoWrite(self, mrepo2, filename, ofile):
+    def assert_no_write(self, mrepo2, filename, ofile):
         def _nowrite(rfs):
             try:
                 pytest.raises(omero.SecurityViolation,
@@ -1351,22 +1351,22 @@ class AbstractRepoTest(ITest):
         pytest.raises(omero.SecurityViolation,
                       mrepo2.file, filename, "rw")
 
-    def assertDirWrite(self, mrepo2, dirname):
+    def assert_dir_write(self, mrepo2, dirname):
         self.create_file(mrepo2, dirname + "/file2.txt")
 
-    def assertNoDirWrite(self, mrepo2, dirname):
+    def assert_no_dir_write(self, mrepo2, dirname):
         # Also check that it's not possible to write
         # in someone else's directory.
         pytest.raises(omero.SecurityViolation,
                       self.create_file, mrepo2, dirname + "/file2.txt")
 
-    def assertNoRead(self, mrepo2, filename, ofile):
+    def assert_no_read(self, mrepo2, filename, ofile):
         pytest.raises(omero.SecurityViolation,
                       mrepo2.fileById, ofile.id.val)
         pytest.raises(omero.SecurityViolation,
                       mrepo2.file, filename, "r")
 
-    def assertRead(self, mrepo2, filename, ofile, ctx=None):
+    def assert_read(self, mrepo2, filename, ofile, ctx=None):
         def _read(rfs):
             try:
                 assert "hi" == rfs.read(0, 2)
@@ -1379,20 +1379,20 @@ class AbstractRepoTest(ITest):
         rfs = mrepo2.file(filename, "r", ctx)
         _read(rfs)
 
-    def assertListings(self, mrepo1, unique_dir):
+    def assert_listings(self, mrepo1, unique_dir):
         assert [unique_dir + "/b"] == mrepo1.list(unique_dir + "/")
         assert [unique_dir + "/b/c"] == mrepo1.list(unique_dir + "/b/")
         assert [
             unique_dir + "/b/c/file.txt"] == mrepo1.list(unique_dir + "/b/c/")
 
-    def assertPasses(self, cb, loops=10, wait=500):
+    def assert_passes(self, cb, loops=10, wait=500):
         cb.loop(loops, wait)
         rsp = cb.getResponse()
         if isinstance(rsp, omero.cmd.ERR):
             raise Exception(rsp)
         return rsp
 
-    def assertError(self, cb, loops=10, wait=500):
+    def assert_error(self, cb, loops=10, wait=500):
         cb.loop(loops, wait)
         rsp = cb.getResponse()
         assert isinstance(rsp, omero.cmd.ERR)

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -255,6 +255,9 @@ class ITest(object):
     # Import methods
     def import_image(self, filename=None, client=None, extra_args=None,
                      skip="all", **kwargs):
+        """
+        Imports the specified file.
+        """
         if filename is None:
             filename = self.omero_dist / ".." / \
                 "components" / "common" / "test" / "tinyTest.d3d.dv"

--- a/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
@@ -89,7 +89,7 @@ class TestChgrp(CLITest):
 
     def testFileset(self):
         # 2 images sharing a fileset
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         img = self.query.get('Image', images[0].id.val)
         filesetId = img.fileset.id.val
         fileset = self.query.get('Fileset', filesetId)
@@ -107,7 +107,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == target_group.id.val
 
     def testFilesetPartialFailing(self):
-        images = self.import_mif(2)  # 2 images sharing a fileset
+        images = self.import_fake_file(2)  # 2 images sharing a fileset
 
         # try to move only one image to the new group
         target_group = self.target_groups['rw----']
@@ -123,7 +123,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == gid
 
     def testFilesetOneImage(self):
-        images = self.import_mif(1)  # One image in a fileset
+        images = self.import_fake_file()  # One image in a fileset
 
         # try to move only one image to the new group
         target_group = self.target_groups['rw----']
@@ -138,7 +138,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == target_group.id.val
 
     def testFilesetAllImagesMoveImages(self):
-        images = self.import_mif(2)  # 2 images sharing a fileset
+        images = self.import_fake_file(2)  # 2 images sharing a fileset
 
         # try to move both the images to the new group
         target_group = self.target_groups['rw----']
@@ -153,7 +153,7 @@ class TestChgrp(CLITest):
             assert img.details.group.id.val == target_group.id.val
 
     def testFilesetAllImagesMoveDataset(self):
-        images = self.import_mif(2)  # 2 images sharing a fileset
+        images = self.import_fake_file(2)  # 2 images sharing a fileset
         dataset_id = self.create_object('Dataset')  # ... in a dataset
 
         # put the images into the dataset

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -93,7 +93,7 @@ class TestChown(CLITest):
     @pytest.mark.parametrize('arguments', ['image', 'fileset'])
     def testFileset(self, nimages, arguments):
         # 2 images sharing a fileset
-        images = self.import_mif(nimages)
+        images = self.import_fake_file(nimages)
         img = self.query.get('Image', images[0].id.val)
         filesetId = img.fileset.id.val
         fileset = self.query.get('Fileset', filesetId)
@@ -119,7 +119,7 @@ class TestChown(CLITest):
             assert obj.details.owner.id.val == user.id.val
 
     def testFilesetPartialFailing(self):
-        images = self.import_mif(2)  # 2 images sharing a fileset
+        images = self.import_fake_file(2)  # 2 images sharing a fileset
 
         # Create user and try to transfer only one image to the user
         client, user = self.new_client_and_user(group=self.group)
@@ -134,7 +134,7 @@ class TestChown(CLITest):
             assert obj.details.owner.id.val == self.user.id.val
 
     def testFilesetAllImagesChownDataset(self):
-        images = self.import_mif(2)  # 2 images sharing a fileset
+        images = self.import_fake_file(2)  # 2 images sharing a fileset
         dataset_id = self.create_object('Dataset')  # ... in a dataset
 
         # put the images into the dataset

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -53,7 +53,7 @@ class TestDelete(CLITest):
     @pytest.mark.parametrize('arguments', ['image', 'fileset'])
     def testFileset(self, nimages, arguments):
         # 2 images sharing a fileset
-        images = self.import_mif(nimages)
+        images = self.import_fake_file(nimages)
         img = self.query.get('Image', images[0].id.val)
         filesetId = img.fileset.id.val
         fileset = self.query.get('Fileset', filesetId)
@@ -73,7 +73,7 @@ class TestDelete(CLITest):
             assert not self.query.find('Image', i.id.val)
 
     def testFilesetPartialFailing(self):
-        images = self.import_mif(2)  # 2 images sharing a fileset
+        images = self.import_fake_file(2)  # 2 images sharing a fileset
 
         # try to delete only one image
         self.args += ['/Image:%s' % images[0].id.val]
@@ -84,7 +84,7 @@ class TestDelete(CLITest):
             assert self.query.get('Image', i.id.val) is not None
 
     def testFilesetAllImagesDeleteDataset(self):
-        images = self.import_mif(2)  # 2 images sharing a fileset
+        images = self.import_fake_file(2)  # 2 images sharing a fileset
         dataset_id = self.create_object('Dataset')  # ... in a dataset
 
         # put the images into the dataset
@@ -517,7 +517,7 @@ class TestDelete(CLITest):
         # Import several images
         ids = []
         for i in range(IMAGES):
-            images = self.import_mif(1)
+            images = self.import_fake_file()
             image = images[0]
             ids.append(image.getId().getValue())
         ids = sorted(ids)

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -517,7 +517,9 @@ class TestDelete(CLITest):
         # Import several images
         ids = []
         for i in range(IMAGES):
-            ids.append(self.import_single_image().getId().getValue())
+            images = self.import_mif(1)
+            image = images[0]
+            ids.append(image.getId().getValue())
         ids = sorted(ids)
         assert len(ids) == IMAGES
         assert ids[-1] - ids[0] + 1 == IMAGES

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -157,7 +157,8 @@ class TestDownload(CLITest):
     # Image tests
     # ========================================================================
     def testNonExistingImage(self, tmpdir):
-        image = self.import_single_image_with_companion()
+        images = self.import_mif(1, with_companion=True)
+        image = images[0]
         self.args += ["Image:%s" % str(image.id.val + 1), '-']
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
@@ -179,7 +180,8 @@ class TestDownload(CLITest):
         f.close()
 
     def testSingleImageWithCompanion(self, tmpdir):
-        image = self.import_single_image_with_companion()
+        images = self.import_mif(1, with_companion=True)
+        image = images[0]
         tmpfile = tmpdir.join('test')
         self.args += ["Image:%s" % image.id.val, str(tmpfile)]
         with pytest.raises(NonZeroReturnCode):
@@ -291,10 +293,11 @@ class TestDownload(CLITest):
         upper = self.new_client(group=group)
         upper_q = upper.sf.getQueryService()
 
-        pimage = self.import_single_image(client=upper,
+        images = self.import_mif(1, client=upper,
                                           plates=1, plateRows=1,
                                           plateCols=1, fields=1,
                                           plateAcqs=1)
+        pimage = images[0]
 
         pfile = upper_q.findByQuery((
             "select f from OriginalFile f join f.filesetEntries fe "
@@ -306,7 +309,8 @@ class TestDownload(CLITest):
             "join w.wellSamples ws join ws.image img "
             "where img.id = %s") % pimage.id.val, None)
 
-        image = self.import_single_image(client=upper)
+        images = self.import_mif(1, client=upper)
+        image = images[0]
 
         ofile = self.create_original_file("test", upper)
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -157,7 +157,7 @@ class TestDownload(CLITest):
     # Image tests
     # ========================================================================
     def testNonExistingImage(self, tmpdir):
-        images = self.import_mif(1, with_companion=True)
+        images = self.import_fake_file(with_companion=True)
         image = images[0]
         self.args += ["Image:%s" % str(image.id.val + 1), '-']
         with pytest.raises(NonZeroReturnCode):
@@ -180,7 +180,7 @@ class TestDownload(CLITest):
         f.close()
 
     def testSingleImageWithCompanion(self, tmpdir):
-        images = self.import_mif(1, with_companion=True)
+        images = self.import_fake_file(with_companion=True)
         image = images[0]
         tmpfile = tmpdir.join('test')
         self.args += ["Image:%s" % image.id.val, str(tmpfile)]
@@ -188,7 +188,7 @@ class TestDownload(CLITest):
             self.cli.invoke(self.args, strict=True)
 
     def testMIF(self, tmpdir):
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         tmpfile = tmpdir.join('test')
         self.args += ["Image:%s" % images[0].id.val, str(tmpfile)]
         self.cli.invoke(self.args, strict=True)
@@ -293,7 +293,7 @@ class TestDownload(CLITest):
         upper = self.new_client(group=group)
         upper_q = upper.sf.getQueryService()
 
-        images = self.import_mif(1, client=upper,
+        images = self.import_fake_file(0, client=upper,
                                  plates=1, plateRows=1,
                                  plateCols=1, fields=1,
                                  plateAcqs=1)
@@ -309,7 +309,7 @@ class TestDownload(CLITest):
             "join w.wellSamples ws join ws.image img "
             "where img.id = %s") % pimage.id.val, None)
 
-        images = self.import_mif(1, client=upper)
+        images = self.import_fake_file(client=upper)
         image = images[0]
 
         ofile = self.create_original_file("test", upper)

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -197,7 +197,7 @@ class TestDownload(CLITest):
         assert not bytes
 
     def testImageNoFileset(self, tmpdir):
-        pixels = self.pix()
+        pixels = self.create_pixels()
         tmpfile = tmpdir.join('test')
         self.args += ["Image:%s" % pixels.getImage().id.val, str(tmpfile)]
         with pytest.raises(NonZeroReturnCode):

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -293,10 +293,8 @@ class TestDownload(CLITest):
         upper = self.new_client(group=group)
         upper_q = upper.sf.getQueryService()
 
-        images = self.import_fake_file(0, client=upper,
-                                 plates=1, plateRows=1,
-                                 plateCols=1, fields=1,
-                                 plateAcqs=1)
+        images = self.import_fake_file(0, client=upper, plates=1, plateRows=1,
+                                       plateCols=1, fields=1, plateAcqs=1)
         pimage = images[0]
 
         pfile = upper_q.findByQuery((

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -294,9 +294,9 @@ class TestDownload(CLITest):
         upper_q = upper.sf.getQueryService()
 
         images = self.import_mif(1, client=upper,
-                                          plates=1, plateRows=1,
-                                          plateCols=1, fields=1,
-                                          plateAcqs=1)
+                                 plates=1, plateRows=1,
+                                 plateCols=1, fields=1,
+                                 plateAcqs=1)
         pimage = images[0]
 
         pfile = upper_q.findByQuery((

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -74,11 +74,11 @@ class TestFS(CLITest):
         """Test --with-transfer option of fs sets subcommand"""
 
         f = {}
-        i0 = self.import_mif(1)
+        i0 = self.import_fake_file()
         f[None] = self.get_fileset(i0)
 
         for transfer in transfers:
-            i = self.import_mif(1, extra_args=['--transfer=%s' % transfer])
+            i = self.import_fake_file(extra_args=['--transfer=%s' % transfer])
             f[transfer] = self.get_fileset(i)
 
         self.args += ["sets", "--style=plain"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -35,9 +35,8 @@ class MetadataTestBase(CLITest):
     def setup_method(self, method):
         super(MetadataTestBase, self).setup_method(method)
         self.name = self.uuid()
-        images = self.import_mif(1,
-                                 GlobalMetadata={'gmd-' + self.name:
-                                                 'gmd-' + self.name})
+        images = self.import_fake_file(GlobalMetadata={'gmd-' + self.name:
+                                                       'gmd-' + self.name})
         self.image = images[0]
 
         conn = BlitzGateway(client_obj=self.client)

--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -48,9 +48,11 @@ class MetadataTestBase(CLITest):
     def create_annotations(self, obj):
         tag = self.new_tag('tag-' + self.name)
         fab = self.make_file_annotation(
-            'fileb-' + self.name, format="OMERO.tables", ns=NSBULKANNOTATIONS)
+            'fileb-' + self.name, mimetype="OMERO.tables",
+            namespace=NSBULKANNOTATIONS)
         fam = self.make_file_annotation(
-            'filem-' + self.name, format="OMERO.tables", ns=NSMEASUREMENT)
+            'filem-' + self.name, mimetype="OMERO.tables",
+            namespace=NSMEASUREMENT)
         ma = omero.model.MapAnnotationI()
         ma.setMapValue([omero.model.NamedValue(
             'key-' + self.name, 'value-' + self.name)])

--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -35,8 +35,9 @@ class MetadataTestBase(CLITest):
     def setup_method(self, method):
         super(MetadataTestBase, self).setup_method(method)
         self.name = self.uuid()
-        self.image = self.import_single_image(
+        images = self.import_mif(1,
             GlobalMetadata={'gmd-' + self.name: 'gmd-' + self.name})
+        self.image = images[0]
 
         conn = BlitzGateway(client_obj=self.client)
         self.imageid = unwrap(self.image.getId())

--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -36,7 +36,8 @@ class MetadataTestBase(CLITest):
         super(MetadataTestBase, self).setup_method(method)
         self.name = self.uuid()
         images = self.import_mif(1,
-            GlobalMetadata={'gmd-' + self.name: 'gmd-' + self.name})
+                                 GlobalMetadata={'gmd-' + self.name:
+                                                 'gmd-' + self.name})
         self.image = images[0]
 
         conn = BlitzGateway(client_obj=self.client)

--- a/components/tools/OmeroPy/test/integration/clitest/test_search.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_search.py
@@ -39,10 +39,10 @@ class TestSearch(CLITest):
         self._uuid = self.uuid().replace("-", "")
         if with_acquisitionDate:
             filename_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            self._image = self.import_mif(
+            self._image = self.import_fake_file(
                 name=self._uuid, acquisitionDate=filename_date)[0]
         else:
-            self._image = self.import_mif(name=self._uuid)[0]
+            self._image = self.import_fake_file(name=self._uuid)[0]
         self.root.sf.getUpdateService().indexObject(self._image)
 
     def mkdataset(self):

--- a/components/tools/OmeroPy/test/integration/fstest/test_rename.py
+++ b/components/tools/OmeroPy/test/integration/fstest/test_rename.py
@@ -98,10 +98,10 @@ class TestRename(AbstractRepoTest):
             "user2": self.new_client(group=group),
             "root": self.root,
         }
-        orig_img = self.import_mif(name="rename",
-                                   sizeX=16, sizeY=16,
-                                   with_companion=True,
-                                   client=clients[owner])[0]
+        orig_img = self.import_fake_file(name="rename",
+                                         sizeX=16, sizeY=16,
+                                         with_companion=True,
+                                         client=clients[owner])[0]
         orig_fs = self.get_fileset([orig_img], clients[owner])
 
         uid = orig_fs.details.owner.id.val
@@ -127,7 +127,7 @@ class TestRename(AbstractRepoTest):
     def test_rename_annotation(self):
         ns = NSFSRENAME
         mrepo = self.client.getManagedRepository()
-        orig_img = self.import_mif(with_companion=True)
+        orig_img = self.import_fake_file(with_companion=True)
         orig_fs = self.get_fileset(orig_img)
         new_dir = prep_directory(self.client, mrepo)
         self.assert_rename(orig_fs, new_dir)

--- a/components/tools/OmeroPy/test/integration/fstest/test_rename.py
+++ b/components/tools/OmeroPy/test/integration/fstest/test_rename.py
@@ -81,7 +81,7 @@ class TestRename(AbstractRepoTest):
         """
         for source, target in tomove:
             cb = self.raw("mv", [source, target], client=self.root)
-            self.assertPasses(cb)
+            self.assert_passes(cb)
 
     @pytest.mark.parametrize("data", (
         ("user1", "user1", "rw----", True),

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
@@ -75,7 +75,7 @@ def image_channel_factory(itest, gatewaywrapper):
         gatewaywrapper.loginAsAuthor()
         gw = gatewaywrapper.gateway
         update_service = gw.getUpdateService()
-        pixels = itest.pix(client=gw.c)
+        pixels = itest.create_pixels(client=gw.c)
         for channel in channels:
             pixels.addChannel(channel)
         pixels = update_service.saveAndReturnObject(pixels)

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
@@ -42,11 +42,12 @@ except:  # pragma: nocover
 class TestScriptUtils(ITest):
 
     def test_split_image(self):
-        imported_pix = ",".join(self.import_image())
+        image = self.create_test_image(100, 100, 2, 3, 4)
+        pixels_id = image.getPrimaryPixels().getId()
         dir = tempfile.mkdtemp()
         params = omero.sys.Parameters()
         params.map = {}
-        params.map["id"] = omero.rtypes.rlong(imported_pix)
+        params.map["id"] = pixels_id
 
         query_string = "select p from Pixels p where p.id=:id"
         pixels = self.query.findByQuery(query_string, params)
@@ -66,10 +67,11 @@ class TestScriptUtils(ITest):
 
     def test_numpy_to_image(self):
         client = self.new_client()
-        imported_pix = ",".join(self.import_image(client=client))
+        image = self.create_test_image(100, 100, 2, 3, 4, client.getSession())
+        pixels_id = image.getPrimaryPixels().getId()
         params = omero.sys.Parameters()
         params.map = {}
-        params.map["id"] = omero.rtypes.rlong(imported_pix)
+        params.map["id"] = pixels_id
         imported_img = client.getSession().getQueryService().findByQuery(
             "select i from Image i join fetch i.pixels pixels\
             where pixels.id=:id", params)
@@ -102,10 +104,11 @@ class TestScriptUtils(ITest):
 
     def test_convert_numpy_array(self):
         client = self.new_client()
-        imported_pix = ",".join(self.import_image(client=client))
+        image = self.create_test_image(100, 100, 2, 3, 4, client.getSession())
+        pixels_id = image.getPrimaryPixels().getId()
         params = omero.sys.Parameters()
         params.map = {}
-        params.map["id"] = omero.rtypes.rlong(imported_pix)
+        params.map["id"] = pixels_id
 
         imported_img = client.getSession().getQueryService().findByQuery(
             "select i from Image i join fetch i.pixels pixels\
@@ -135,10 +138,11 @@ class TestScriptUtils(ITest):
     @pytest.mark.parametrize('is_file', [True, False])
     def test_numpy_save_as_image(self, format, is_file):
         client = self.new_client()
-        imported_pix = ",".join(self.import_image(client=client))
+        image = self.create_test_image(100, 100, 2, 3, 4, client.getSession())
+        pixels_id = image.getPrimaryPixels().getId()
         params = omero.sys.Parameters()
         params.map = {}
-        params.map["id"] = omero.rtypes.rlong(imported_pix)
+        params.map["id"] = pixels_id
 
         imported_img = client.getSession().getQueryService().findByQuery(
             "select i from Image i join fetch i.pixels pixels\

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -660,10 +660,10 @@ class TestTables(ITest):
         self.testBlankTable()  # ofile
 
         filename = self.unique_dir + "/file.txt"
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
 
         assert not mrepo.fileExists(filename)
-        self.createFile(mrepo, filename)
+        self.create_file(mrepo, filename)
         assert mrepo.fileExists(filename)
         assert "file.txt" in mrepo.list(self.unique_dir)[0]
 

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -57,7 +57,7 @@ class TestChgrp(ITest):
 
         # Import an image into the client context
         images = self.import_fake_file(name="testChgrpImportedImage",
-                                 client=client)
+                                       client=client)
         image = images[0]
 
         # Chgrp
@@ -239,10 +239,10 @@ class TestChgrp(ITest):
         self.do_submit(chgrp, client)
 
         # Check both Images moved
-        queryService = client.sf.getQueryService()
+        query_service = client.sf.getQueryService()
         ctx = {'omero.group': '-1'}      # query across groups
         for i in images:
-            image = queryService.get('Image', i.id.val, ctx)
+            image = query_service.get('Image', i.id.val, ctx)
             img_gid = image.details.group.id.val
             assert target_gid == img_gid,\
                 "Image should be in group: %s, NOT %s" % (target_gid,  img_gid)
@@ -292,23 +292,23 @@ class TestChgrp(ITest):
             groupId=target_gid)
         self.do_submit(chgrp, client)
 
-        queryService = client.sf.getQueryService()
+        query_service = client.sf.getQueryService()
 
         # Check Images not moved
         for i in range(2):
-            image = queryService.get('Image', images[i].id.val)
+            image = query_service.get('Image', images[i].id.val)
             assert target_gid != image.details.group.id.val,\
                 "Image should not be in group: %s" % target_gid
 
         # Check second Dataset not moved
-        dataset = queryService.get('Dataset', datasets[1].id.val)
+        dataset = query_service.get('Dataset', datasets[1].id.val)
         assert target_gid != dataset.details.group.id.val,\
             "Dataset should not be in group: %s" % target_gid
 
         ctx = {'omero.group': str(target_gid)}  # query in the target group
 
         # Check first Dataset moved
-        dataset = queryService.get('Dataset', datasets[0].id.val, ctx)
+        dataset = query_service.get('Dataset', datasets[0].id.val, ctx)
         assert target_gid == dataset.details.group.id.val,\
             "Dataset should be in group: %s" % target_gid
 
@@ -335,11 +335,11 @@ class TestChgrp(ITest):
         self.do_submit(chgrp, client)
 
         # Check both Datasets and Images moved
-        queryService = client.sf.getQueryService()
+        query_service = client.sf.getQueryService()
         ctx = {'omero.group': str(target_gid)}  # query in the target group
         for i in range(2):
-            dataset = queryService.get('Dataset', datasets[i].id.val, ctx)
-            image = queryService.get('Image', images[i].id.val, ctx)
+            dataset = query_service.get('Dataset', datasets[i].id.val, ctx)
+            image = query_service.get('Image', images[i].id.val, ctx)
             assert target_gid == dataset.details.group.id.val,\
                 "Dataset should be in group: %s" % target_gid
             assert target_gid == image.details.group.id.val,\
@@ -368,13 +368,13 @@ class TestChgrp(ITest):
         self.do_submit(chgrp, client)
 
         # Check Dataset and both Images moved
-        queryService = client.sf.getQueryService()
+        query_service = client.sf.getQueryService()
         ctx = {'omero.group': '-1'}  # query across groups
-        dataset = queryService.get('Dataset', ds.id.val, ctx)
+        dataset = query_service.get('Dataset', ds.id.val, ctx)
         assert target_gid == dataset.details.group.id.val,\
             "Dataset should be in group: %s" % target_gid
         for i in range(2):
-            image = queryService.get('Image', images[i].id.val, ctx)
+            image = query_service.get('Image', images[i].id.val, ctx)
             img_gid = image.details.group.id.val
             assert target_gid == img_gid,\
                 "Image should be in group: %s, NOT %s" % (target_gid,  img_gid)
@@ -389,11 +389,11 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        imagesFsOne = self.import_fake_file(2, client=client)
-        imagesFsTwo = self.import_fake_file(2, client=client)
+        images_fs_one = self.import_fake_file(2, client=client)
+        images_fs_two = self.import_fake_file(2, client=client)
 
         # chgrp should fail...
-        ids = [imagesFsOne[0].id.val, imagesFsTwo[0].id.val]
+        ids = [images_fs_one[0].id.val, images_fs_two[0].id.val]
         chgrp = Chgrp2(targetObjects={"Image": ids}, groupId=target_gid)
         self.do_submit(chgrp, client, test_should_pass=False)
 
@@ -407,13 +407,13 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        imagesFsOne = self.import_fake_file(2, client=client)
-        imagesFsTwo = self.import_fake_file(2, client=client)
+        images_fs_one = self.import_fake_file(2, client=client)
+        images_fs_two = self.import_fake_file(2, client=client)
 
         ds = self.make_dataset(name="testChgrpDatasetTwoFilesetsErr",
                                client=client)
         self.import_fake_file(2, client=client)
-        for i in (imagesFsOne, imagesFsTwo):
+        for i in (images_fs_one, images_fs_two):
             self.link(ds, i[0], client=client)
 
         # chgrp should succeed with the Dataset only
@@ -421,18 +421,18 @@ class TestChgrp(ITest):
             targetObjects={"Dataset": [ds.id.val]}, groupId=target_gid)
         self.do_submit(chgrp, client)
 
-        queryService = client.sf.getQueryService()
+        query_service = client.sf.getQueryService()
 
         # Check Images not moved
-        for i in (imagesFsOne[0], imagesFsTwo[0]):
-            image = queryService.get('Image', i.id.val)
+        for i in (images_fs_one[0], images_fs_two[0]):
+            image = query_service.get('Image', i.id.val)
             assert target_gid != image.details.group.id.val,\
                 "Image should not be in group: %s" % target_gid
 
         ctx = {'omero.group': str(target_gid)}  # query in the target group
 
         # Check Dataset moved
-        dataset = queryService.get('Dataset', ds.id.val, ctx)
+        dataset = query_service.get('Dataset', ds.id.val, ctx)
         assert target_gid == dataset.details.group.id.val,\
             "Dataset should be in group: %s" % target_gid
 
@@ -463,9 +463,9 @@ class TestChgrp(ITest):
         ctx = {'omero.group': '-1'}
         qs = client.sf.getQueryService()
         image1 = qs.get("Image", images[0].id.val, ctx)
-        fsId = image1.fileset.id.val
+        fs_id = image1.fileset.id.val
         image_gid = image1.details.group.id.val
-        fileset_gid = qs.get("Fileset", fsId, ctx).details.group.id.val
+        fileset_gid = qs.get("Fileset", fs_id, ctx).details.group.id.val
         assert image_gid == fileset_gid,\
             "Image group: %s and Fileset group: %s don't match" %\
             (image_gid, fileset_gid)
@@ -482,16 +482,16 @@ class TestChgrp(ITest):
         target_gid = target_grp.id.val
 
         images = self.import_fake_file(2, client=client)
-        fsId = query.get("Image", images[0].id.val).fileset.id.val
+        fs_id = query.get("Image", images[0].id.val).fileset.id.val
 
         # Now chgrp, should succeed
-        chgrp = Chgrp2(targetObjects={"Fileset": [fsId]}, groupId=target_gid)
+        chgrp = Chgrp2(targetObjects={"Fileset": [fs_id]}, groupId=target_gid)
         self.do_submit(chgrp, client)
 
         # Check Fileset and both Images moved and
         # thus the Fileset is in sync with Images.
         ctx = {'omero.group': '-1'}  # query across groups
-        fileset = query.get('Fileset', fsId, ctx)
+        fileset = query.get('Fileset', fs_id, ctx)
         assert target_gid == fileset.details.group.id.val,\
             "Fileset should be in group: %s" % target_gid
         for i in range(2):
@@ -1042,7 +1042,7 @@ class TestChgrpTarget(ITest):
         ds = self.new_dataset(name)
         return update.saveAndReturnObject(ds, ctx)
 
-    def chgrpImagesToTargetDataset(self, imgCount):
+    def chgrpImagesToTargetDataset(self, img_count):
         """
         Helper method to test chgrp of image(s) to target Dataset
         """
@@ -1052,7 +1052,7 @@ class TestChgrpTarget(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.import_fake_file(imgCount, client=client)
+        images = self.import_fake_file(img_count, client=client)
         ds = self.createDSInGroup(target_gid, client=client)
 
         # each chgrp includes a 'save' link to target dataset
@@ -1073,17 +1073,17 @@ class TestChgrpTarget(ITest):
         self.do_submit(requests, client, omero_group=target_gid)
 
         # Check Images moved to correct group
-        queryService = client.sf.getQueryService()
+        query_service = client.sf.getQueryService()
         ctx = {'omero.group': '-1'}  # query across groups
         for i in images:
-            image = queryService.get('Image', i.id.val, ctx)
+            image = query_service.get('Image', i.id.val, ctx)
             img_gid = image.details.group.id.val
             assert target_gid == img_gid,\
                 "Image should be in group: %s, NOT %s" % (target_gid,  img_gid)
         # Check Dataset has images linked
-        dsImgs = client.sf.getContainerService().getImages(
+        ds_imgs = client.sf.getContainerService().getImages(
             'Dataset', [ds.id.val], None, ctx)
-        assert len(dsImgs) == len(images),\
+        assert len(ds_imgs) == len(images),\
             "All Images should be in target Dataset"
 
         previous_gid = admin.getEventContext().groupId
@@ -1145,8 +1145,8 @@ class TestChgrpTarget(ITest):
         # One user in two groups
         client, user = self.new_client_and_user(perms=PRIVATE)
         target_grp = self.new_group([user], perms=PRIVATE)
-        eCtx = client.sf.getAdminService().getEventContext()  # Reset session
-        userId = eCtx.userId
+        e_ctx = client.sf.getAdminService().getEventContext()  # Reset session
+        user_id = e_ctx.userId
         target_gid = target_grp.id.val
 
         # User creates Dataset in current group...
@@ -1163,7 +1163,7 @@ class TestChgrpTarget(ITest):
             targetObjects={"Dataset": [ds.id.val]}, groupId=target_gid)
         requests.append(chgrp)
         link = ProjectDatasetLinkI()
-        link.details.owner = ExperimenterI(userId, False)
+        link.details.owner = ExperimenterI(user_id, False)
         link.child = DatasetI(ds.id.val, False)
         link.parent = ProjectI(pr.id.val, False)
         save = Save()
@@ -1177,9 +1177,9 @@ class TestChgrpTarget(ITest):
             c = self.root
         self.do_submit(requests, c, omero_group=target_gid)
 
-        queryService = client.sf.getQueryService()
+        query_service = client.sf.getQueryService()
         ctx = {'omero.group': '-1'}  # query across groups
-        dataset = queryService.get('Dataset', ds.id.val, ctx)
+        dataset = query_service.get('Dataset', ds.id.val, ctx)
         ds_gid = dataset.details.group.id.val
         assert target_gid == ds_gid,\
             "Dataset should be in group: %s, NOT %s" % (target_gid, ds_gid)

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -56,8 +56,8 @@ class TestChgrp(ITest):
         client.sf.getAdminService().getEventContext()  # Reset session
 
         # Import an image into the client context
-        images = self.import_mif(1,
-            name="testChgrpImportedImage", client=client)
+        images = self.import_mif(1, name="testChgrpImportedImage",
+                                 client=client)
         image = images[0]
 
         # Chgrp

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -56,8 +56,9 @@ class TestChgrp(ITest):
         client.sf.getAdminService().getEventContext()  # Reset session
 
         # Import an image into the client context
-        image = self.import_single_image(
+        images = self.import_mif(1,
             name="testChgrpImportedImage", client=client)
+        image = images[0]
 
         # Chgrp
         chgrp = Chgrp2(targetObjects={'Image': [image.id.val]}, groupId=gid)
@@ -176,8 +177,9 @@ class TestChgrp(ITest):
         member = self.new_client(group=source_grp)
 
         # Create an image as the owner
-        image = self.import_single_image(name="testChgrpRdef7825",
+        images = self.import_mif(1, name="testChgrpRdef7825",
                                          client=owner)
+        image = images[0]
 
         # Render as both users
         owner_g = omero.gateway.BlitzGateway(client_obj=owner)
@@ -984,7 +986,8 @@ class TestChgrp(ITest):
         # import two images into 'read-annotate'
         images = []
         for x in range(0, 2):
-            images.append(self.import_single_image(client=io_client))
+            values = self.import_mif(1, client=io_client)
+            images.append(values[0])
             image = io_client.sf.getQueryService().get("Image",
                                                        images[x].id.val)
             assert ra_group.id.val == image.details.group.id.val

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -56,7 +56,7 @@ class TestChgrp(ITest):
         client.sf.getAdminService().getEventContext()  # Reset session
 
         # Import an image into the client context
-        images = self.import_mif(1, name="testChgrpImportedImage",
+        images = self.import_fake_file(name="testChgrpImportedImage",
                                  client=client)
         image = images[0]
 
@@ -177,8 +177,8 @@ class TestChgrp(ITest):
         member = self.new_client(group=source_grp)
 
         # Create an image as the owner
-        images = self.import_mif(1, name="testChgrpRdef7825",
-                                         client=owner)
+        images = self.import_fake_file(name="testChgrpRdef7825",
+                                       client=owner)
         image = images[0]
 
         # Render as both users
@@ -213,7 +213,7 @@ class TestChgrp(ITest):
         target_gid = target_grp.id.val
 
         # 2 images sharing a fileset
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
 
         # Now chgrp
         chgrp = Chgrp2(
@@ -231,7 +231,7 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
 
         # chgrp should succeed
         ids = [images[0].id.val, images[1].id.val]
@@ -259,7 +259,7 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
 
         # chgrp should succeed
         chgrp1 = Chgrp2(
@@ -282,7 +282,7 @@ class TestChgrp(ITest):
 
         datasets = self.create_datasets(
             2, "testChgrpOneDatasetFilesetErr", client=client)
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
         for i in range(2):
             self.link(datasets[i], images[i], client=client)
 
@@ -325,7 +325,7 @@ class TestChgrp(ITest):
 
         datasets = self.create_datasets(
             2, "testChgrpAllDatasetsFilesetOK", client=client)
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
         for i in range(2):
             self.link(datasets[i], images[i], client=client)
 
@@ -358,7 +358,7 @@ class TestChgrp(ITest):
 
         ds = self.make_dataset(name="testChgrpOneDatasetFilesetOK",
                                client=client)
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
         for i in range(2):
             self.link(ds, images[i], client=client)
 
@@ -389,8 +389,8 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        imagesFsOne = self.import_mif(2, client=client)
-        imagesFsTwo = self.import_mif(2, client=client)
+        imagesFsOne = self.import_fake_file(2, client=client)
+        imagesFsTwo = self.import_fake_file(2, client=client)
 
         # chgrp should fail...
         ids = [imagesFsOne[0].id.val, imagesFsTwo[0].id.val]
@@ -407,12 +407,12 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        imagesFsOne = self.import_mif(2, client=client)
-        imagesFsTwo = self.import_mif(2, client=client)
+        imagesFsOne = self.import_fake_file(2, client=client)
+        imagesFsTwo = self.import_fake_file(2, client=client)
 
         ds = self.make_dataset(name="testChgrpDatasetTwoFilesetsErr",
                                client=client)
-        self.import_mif(2, client=client)
+        self.import_fake_file(2, client=client)
         for i in (imagesFsOne, imagesFsTwo):
             self.link(ds, i[0], client=client)
 
@@ -450,7 +450,7 @@ class TestChgrp(ITest):
 
         ds = self.make_dataset(name="testChgrpDatasetCheckFsGroup",
                                client=client)
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
         for i in range(2):
             self.link(ds, images[i], client=client)
 
@@ -481,7 +481,7 @@ class TestChgrp(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
         fsId = query.get("Image", images[0].id.val).fileset.id.val
 
         # Now chgrp, should succeed
@@ -509,7 +509,7 @@ class TestChgrp(ITest):
         # One user in two groups
         client, user = self.new_client_and_user(perms=PRIVATE)
         ds = self.make_dataset(name="testChgrp11000", client=client)
-        images = self.import_mif(2, client=client)
+        images = self.import_fake_file(2, client=client)
         for i in range(2):
             self.link(ds, images[i], client=client)
 
@@ -986,7 +986,7 @@ class TestChgrp(ITest):
         # import two images into 'read-annotate'
         images = []
         for x in range(0, 2):
-            values = self.import_mif(1, client=io_client)
+            values = self.import_fake_file(client=io_client)
             images.append(values[0])
             image = io_client.sf.getQueryService().get("Image",
                                                        images[x].id.val)
@@ -1052,7 +1052,7 @@ class TestChgrpTarget(ITest):
         target_grp = self.new_group([user], perms=PRIVATE)
         target_gid = target_grp.id.val
 
-        images = self.import_mif(imgCount, client=client)
+        images = self.import_fake_file(imgCount, client=client)
         ds = self.createDSInGroup(target_gid, client=client)
 
         # each chgrp includes a 'save' link to target dataset

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -416,7 +416,7 @@ class TestDelete(ITest):
         Delete one dataset, delete fails.
         """
         datasets = self.create_datasets(2, "testDeleteOneDatasetFilesetErr")
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         for i in range(2):
             self.link(datasets[i], images[i])
 
@@ -437,7 +437,7 @@ class TestDelete(ITest):
         two images in a MIF.
         Delete one image, the delete should fail.
         """
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
 
         # Now delete one image
         delete = Delete2(targetObjects={"Image": [images[0].id.val]})
@@ -456,7 +456,7 @@ class TestDelete(ITest):
         Delete the dataset, the delete should succeed.
         """
         ds = self.make_dataset("testDeleteDatasetFilesetOK")
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         for i in range(2):
@@ -479,7 +479,7 @@ class TestDelete(ITest):
         Delete all datasets, delete succeeds.
         """
         datasets = self.create_datasets(2, "testDeleteAllDatasetsFilesetOK")
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         for i in range(2):
@@ -503,7 +503,7 @@ class TestDelete(ITest):
         two images in a MIF.
         Delete all images, the delete should succeed.
         """
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         # Now delete all images, should succeed
@@ -522,7 +522,7 @@ class TestDelete(ITest):
         a single fileset containing 2 images.
         Delete the fileset, the delete should succeed.
         """
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         fsId = self.query.get("Image", images[0].id.val).fileset.id.val
 
         # Now delete the fileset, should succeed
@@ -540,8 +540,8 @@ class TestDelete(ITest):
         by the delete error
         """
         # 2 filesets, each with 2 images
-        imagesFsOne = self.import_mif(2)
-        imagesFsTwo = self.import_mif(2)
+        imagesFsOne = self.import_fake_file(2)
+        imagesFsTwo = self.import_fake_file(2)
 
         # delete should fail...
         iids = [imagesFsOne[0].id.val, imagesFsTwo[0].id.val]
@@ -554,11 +554,11 @@ class TestDelete(ITest):
         by the delete error
         """
         # 2 filesets, each with 2 images
-        imagesFsOne = self.import_mif(2)
-        imagesFsTwo = self.import_mif(2)
+        imagesFsOne = self.import_fake_file(2)
+        imagesFsTwo = self.import_fake_file(2)
 
         ds = self.make_dataset("testDeleteDatasetTwoFilesetsErr")
-        self.import_mif(2)
+        self.import_fake_file(2)
         for i in (imagesFsOne, imagesFsTwo):
             self.link(ds, i[0])
 

--- a/components/tools/OmeroPy/test/integration/test_exporter.py
+++ b/components/tools/OmeroPy/test/integration/test_exporter.py
@@ -46,12 +46,10 @@ class TestExporter(ITest):
         Runs a simple export through to completion
         as a smoke test.
         """
-        pix_ids = self.import_image()
-        image_id = self.client.sf.getQueryService().projection(
-            "select i.id from Image i join i.pixels p where p.id = :id",
-            omero.sys.ParametersI().addId(pix_ids[0]))[0][0].val
+        session = self.client.getSession()
+        image = self.create_test_image(100, 100, 1, 1, 1, session)
         exporter = self.client.sf.createExporter()
-        exporter.addImage(image_id)
+        exporter.addImage(image.id.val)
         length = exporter.generateTiff()
         offset = 0
         while True:

--- a/components/tools/OmeroPy/test/integration/test_exporter.py
+++ b/components/tools/OmeroPy/test/integration/test_exporter.py
@@ -32,7 +32,7 @@ import pytest
 class TestExporter(ITest):
 
     def bigimage(self):
-        pix = self.pix(x=4000, y=4000, z=1, t=1, c=1)
+        pix = self.create_pixels(x=4000, y=4000, z=1, t=1, c=1)
         rps = self.client.sf.createRawPixelsStore()
         try:
             rps.setPixelsId(pix.id.val, True)

--- a/components/tools/OmeroPy/test/integration/test_icontainer.py
+++ b/components/tools/OmeroPy/test/integration/test_icontainer.py
@@ -115,7 +115,7 @@ class TestSplitFilesets(ITest):
         """
         Fileset of 2 Images, we test split using 1 Image ID
         """
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
 
         # Lookup the fileset
         imgId = images[0].id.val
@@ -129,7 +129,7 @@ class TestSplitFilesets(ITest):
         """
         Fileset of 2 Images with No split (query with both Image IDs)
         """
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
 
         imgIds = [i.id.val for i in images]
 
@@ -142,7 +142,7 @@ class TestSplitFilesets(ITest):
         Fileset of 2 Images, one in a Dataset. Test split using Dataset ID
         """
         # Dataset contains 1 image of a 2-image fileset
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         ds = self.make_dataset("testFilesetSplitByDataset")
         self.link(ds, images[0])
 
@@ -174,7 +174,7 @@ class TestSplitFilesets(ITest):
         """
         # Datasets each contain 1 image of a 2-image fileset
         datasets = self.create_datasets(2, "testFilesetNotSplitByDatasets")
-        images = self.import_mif(2)
+        images = self.import_fake_file(2)
         for i in range(2):
             self.link(datasets[i], images[i])
 

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -23,6 +23,25 @@ from test.integration.helpers import createTestImage
 
 class TestIShare(ITest):
 
+    @classmethod
+    def create_share(cls, description="", timeout=None,
+                     objects=[], experimenters=[], guests=[],
+                     enabled=True, client=None):
+        """
+        Create share object
+
+        :param objects: a list of objects to include in the share
+        :param description: a string containing the description of the share
+        :param timeout: the timeout of the share
+        :param experimenters: a list of users associated with the share
+        :param client: The client to use to create the share
+        """
+        if client is None:
+            client = cls.client
+        share = client.sf.getShareService()
+        return share.createShare(description, timeout, objects,
+                                 experimenters, guests, enabled)
+
     def test_that_permissions_are_default_private(self):
         i = self.make_image()
         assert not i.details.permissions.isGroupRead()

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -19,6 +19,7 @@ from omero.rtypes import rtime, rlong, rlist, rint
 from omero.gateway import BlitzGateway
 
 from test.integration.helpers import createTestImage
+import warnings
 
 
 class TestIShare(ITest):
@@ -36,6 +37,8 @@ class TestIShare(ITest):
         :param experimenters: a list of users associated with the share
         :param client: The client to use to create the share
         """
+        warnings.warn(
+            "create_share is deprecated as of OMERO 5.3.0", DeprecationWarning)
         if client is None:
             client = cls.client
         share = client.sf.getShareService()

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -35,7 +35,8 @@ from omero.rtypes import unwrap
 class TestModel51(ITest):
 
     def testExposureTime(self):
-        img = self.import_fake_file(name="testExposureTime", exposureTime=1.2)[0]
+        imgs = self.import_fake_file(name="testExposureTime", exposureTime=1.2)
+        img = imgs[0]
         plane_info = self.query.findByQuery((
             "select pi from PlaneInfo pi "
             "join fetch pi.exposureTime "
@@ -54,22 +55,24 @@ class TestModel51(ITest):
         assert omero.model.enums.UnitsTime.MICROSECOND == unit
 
     def testPhysicalSize(self):
-        img = self.import_fake_file(name="testPhysicalSize", physicalSizeZ=2.0)[0]
+        imgs = self.import_fake_file(name="testPhysicalSize",
+                                     physicalSizeZ=2.0)
+        img = imgs[0]
         pixels = self.query.findByQuery((
             "select pix from Pixels pix "
             "join fetch pix.physicalSizeZ "
             "where pix.image.id = :id"),
             omero.sys.ParametersI().addId(img.id.val))
-        sizeZ = pixels.getPhysicalSizeZ()
-        unit = sizeZ.getUnit()
+        size_z = pixels.getPhysicalSizeZ()
+        unit = size_z.getUnit()
         assert omero.model.enums.UnitsLength.MICROMETER == unit
 
         mm = omero.model.enums.UnitsLength.MILLIMETER
 
-        sizeZ.setUnit(mm)
+        size_z.setUnit(mm)
         pixels = self.update.saveAndReturnObject(pixels)
-        sizeZ = pixels.getPhysicalSizeZ()
-        unit = sizeZ.getUnit()
+        size_z = pixels.getPhysicalSizeZ()
+        unit = size_z.getUnit()
         assert omero.model.enums.UnitsLength.MILLIMETER == unit
 
     UL = omero.model.enums.UnitsLength
@@ -191,7 +194,9 @@ class TestModel51(ITest):
             u2.saveAndReturnObject(m2)
 
     def testUnitProjections(self):
-        img = self.import_fake_file(name="testUnitProjections", exposureTime=1.2)[0]
+        imgs = self.import_fake_file(name="testUnitProjections",
+                                     exposureTime=1.2)
+        img = imgs[0]
 
         as_map = self.query.projection((
             "select pi.exposureTime from PlaneInfo pi "

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -35,7 +35,7 @@ from omero.rtypes import unwrap
 class TestModel51(ITest):
 
     def testExposureTime(self):
-        img = self.import_mif(name="testExposureTime", exposureTime=1.2)[0]
+        img = self.import_fake_file(name="testExposureTime", exposureTime=1.2)[0]
         plane_info = self.query.findByQuery((
             "select pi from PlaneInfo pi "
             "join fetch pi.exposureTime "
@@ -54,7 +54,7 @@ class TestModel51(ITest):
         assert omero.model.enums.UnitsTime.MICROSECOND == unit
 
     def testPhysicalSize(self):
-        img = self.import_mif(name="testPhysicalSize", physicalSizeZ=2.0)[0]
+        img = self.import_fake_file(name="testPhysicalSize", physicalSizeZ=2.0)[0]
         pixels = self.query.findByQuery((
             "select pix from Pixels pix "
             "join fetch pix.physicalSizeZ "
@@ -191,7 +191,7 @@ class TestModel51(ITest):
             u2.saveAndReturnObject(m2)
 
     def testUnitProjections(self):
-        img = self.import_mif(name="testUnitProjections", exposureTime=1.2)[0]
+        img = self.import_fake_file(name="testUnitProjections", exposureTime=1.2)[0]
 
         as_map = self.query.projection((
             "select pi.exposureTime from PlaneInfo pi "

--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -34,7 +34,7 @@ class TestRPS(ITest):
             rps.close()
 
     def testTicket4737WithClose(self):
-        pix = self.pix()
+        pix = self.create_pixels()
         rps = self.client.sf.createRawPixelsStore()
         try:
             rps.setPixelsId(pix.id.val, True)
@@ -44,7 +44,7 @@ class TestRPS(ITest):
         self.check_pix(pix)
 
     def testTicket4737WithSave(self):
-        pix = self.pix()
+        pix = self.create_pixels()
         rps = self.client.sf.createRawPixelsStore()
         try:
             rps.setPixelsId(pix.id.val, True)
@@ -56,7 +56,7 @@ class TestRPS(ITest):
         self.check_pix(pix)
 
     def testTicket4737WithForEachTile(self):
-        pix = self.pix()
+        pix = self.create_pixels()
 
         class Iteration(TileLoopIteration):
 
@@ -72,7 +72,7 @@ class TestRPS(ITest):
         self.check_pix(pix)
 
     def testBigPlane(self):
-        pix = self.pix(x=4000, y=4000, z=1, t=1, c=1)
+        pix = self.create_pixels(x=4000, y=4000, z=1, t=1, c=1)
         rps = self.client.sf.createRawPixelsStore()
         try:
             rps.setPixelsId(pix.id.val, True)

--- a/components/tools/OmeroPy/test/integration/test_reimport.py
+++ b/components/tools/OmeroPy/test/integration/test_reimport.py
@@ -120,8 +120,8 @@ class TestReimportArchivedFiles(ITest):
         from omero.sys import ParametersI
 
         # Produce an FS image as our template
-        orig_img = self.import_mif(name="reimport", sizeX=16, sizeY=16,
-                                   with_companion=True, skip=None)
+        orig_img = self.import_fake_file(name="reimport", sizeX=16, sizeY=16,
+                                         with_companion=True, skip=None)
         orig_img = orig_img[0]
         orig_pix = self.query.findByQuery(
             "select p from Pixels p where p.image.id = :id",

--- a/components/tools/OmeroPy/test/integration/test_reporawfilestore.py
+++ b/components/tools/OmeroPy/test/integration/test_reporawfilestore.py
@@ -28,7 +28,7 @@ class TestRepoRawFileStore(AbstractRepoTest):
     def setup_method(self, method):
         super(TestRepoRawFileStore, self).setup_method(method)
         tmp_dir = path(self.unique_dir)
-        self.repoPrx = self.getManagedRepo()
+        self.repoPrx = self.get_managed_repo()
         self.repo_filename = tmp_dir / self.uuid() + ".txt"
 
     def testCreate(self):

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -165,11 +165,11 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         # No intermediate directories
         ofile = self.create_file(f1.repo, filename)
 
-        self.assertRead(f1.repo, filename, ofile)
-        self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
-        self.assertWrite(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile, self.all(f1.client))
+        self.assert_write(f1.repo, filename, ofile)
 
-        self.assertNoRead(f2.repo, filename, ofile)
+        self.assert_no_read(f2.repo, filename, ofile)
 
         assert 0 == len(unwrap(f2.repo.treeList(".")))
 
@@ -181,12 +181,12 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         f1.repo.makeDir(dirname, True)
         ofile = self.create_file(f1.repo, filename)
 
-        self.assertRead(f1.repo, filename, ofile)
-        self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
-        self.assertListings(f1.repo, f1.testdir)
-        self.assertWrite(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile, self.all(f1.client))
+        self.assert_listings(f1.repo, f1.testdir)
+        self.assert_write(f1.repo, filename, ofile)
 
-        self.assertNoRead(f2.repo, filename, ofile)
+        self.assert_no_read(f2.repo, filename, ofile)
         assert 0 == len(f2.repo.listFiles(dirname))
 
     def testDirReadOnlyGroup(self):
@@ -197,16 +197,16 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         f1.repo.makeDir(dirname, True)
         ofile = self.create_file(f1.repo, filename)
 
-        self.assertRead(f1.repo, filename, ofile)
-        self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
-        self.assertListings(f1.repo, f1.testdir)
-        self.assertWrite(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile, self.all(f1.client))
+        self.assert_listings(f1.repo, f1.testdir)
+        self.assert_write(f1.repo, filename, ofile)
 
-        self.assertRead(f2.repo, filename, ofile)
-        self.assertRead(f2.repo, filename, ofile, self.all(f2.client))
-        self.assertListings(f2.repo, f1.testdir)
-        self.assertNoWrite(f2.repo, filename, ofile)
-        self.assertNoDirWrite(f2.repo, dirname)
+        self.assert_read(f2.repo, filename, ofile)
+        self.assert_read(f2.repo, filename, ofile, self.all(f2.client))
+        self.assert_listings(f2.repo, f1.testdir)
+        self.assert_no_write(f2.repo, filename, ofile)
+        self.assert_no_dir_write(f2.repo, dirname)
 
     def testDirReadWriteGroup(self):
         f1, f2 = self.setup2RepoUsers("rwrw--")
@@ -216,16 +216,16 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         f1.repo.makeDir(dirname, True)
         ofile = self.create_file(f1.repo, filename)
 
-        self.assertRead(f1.repo, filename, ofile)
-        self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
-        self.assertListings(f1.repo, f1.testdir)
-        self.assertWrite(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile, self.all(f1.client))
+        self.assert_listings(f1.repo, f1.testdir)
+        self.assert_write(f1.repo, filename, ofile)
 
-        self.assertRead(f2.repo, filename, ofile)
-        self.assertRead(f2.repo, filename, ofile, self.all(f2.client))
-        self.assertWrite(f2.repo, filename, ofile)
-        self.assertListings(f2.repo, f1.testdir)
-        self.assertDirWrite(f2.repo, dirname)
+        self.assert_read(f2.repo, filename, ofile)
+        self.assert_read(f2.repo, filename, ofile, self.all(f2.client))
+        self.assert_write(f2.repo, filename, ofile)
+        self.assert_listings(f2.repo, f1.testdir)
+        self.assert_dir_write(f2.repo, dirname)
 
     def testDirReadAnnotateGroup(self):
         f1, f2 = self.setup2RepoUsers("rwra--")
@@ -235,16 +235,16 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         f1.repo.makeDir(dirname, True)
         ofile = self.create_file(f1.repo, filename)
 
-        self.assertRead(f1.repo, filename, ofile)
-        self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
-        self.assertListings(f1.repo, f1.testdir)
-        self.assertWrite(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile)
+        self.assert_read(f1.repo, filename, ofile, self.all(f1.client))
+        self.assert_listings(f1.repo, f1.testdir)
+        self.assert_write(f1.repo, filename, ofile)
 
-        self.assertRead(f2.repo, filename, ofile)
-        self.assertRead(f2.repo, filename, ofile, self.all(f2.client))
-        self.assertListings(f2.repo, f1.testdir)
-        self.assertNoWrite(f2.repo, filename, ofile)
-        self.assertDirWrite(f2.repo, dirname)
+        self.assert_read(f2.repo, filename, ofile)
+        self.assert_read(f2.repo, filename, ofile, self.all(f2.client))
+        self.assert_listings(f2.repo, f1.testdir)
+        self.assert_no_write(f2.repo, filename, ofile)
+        self.assert_dir_write(f2.repo, dirname)
 
     def testMultiGroup(self):
         group1 = self.new_group(perms="rw----")
@@ -264,13 +264,13 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         mrepo1.makeDir(dirname, True)
         ofile = self.create_file(mrepo1, filename)
 
-        self.assertRead(mrepo1, filename, ofile)
-        self.assertRead(mrepo1, filename, ofile, self.all(client1))
+        self.assert_read(mrepo1, filename, ofile)
+        self.assert_read(mrepo1, filename, ofile, self.all(client1))
 
         with pytest.raises(omero.SecurityViolation):
-            self.assertRead(mrepo2, filename, ofile)
+            self.assert_read(mrepo2, filename, ofile)
 
-        self.assertRead(mrepo2, filename, ofile, self.all(client2))
+        self.assert_read(mrepo2, filename, ofile, self.all(client2))
 
 
 class TestPythonImporter(AbstractRepoTest):
@@ -287,7 +287,7 @@ class TestPythonImporter(AbstractRepoTest):
         paths = folder.files()
 
         proc = mrepo.importPaths(paths)
-        self.assertImport(client, proc, folder)
+        self.assert_import(client, proc, folder)
 
     def testReopenRawFileStoresPR2542(self):
         client = self.new_client()
@@ -300,7 +300,7 @@ class TestPythonImporter(AbstractRepoTest):
             proc.getUploader(idx).close()
         # Import should continue to work after
         # closing the resources
-        self.assertImport(client, proc, folder)
+        self.assert_import(client, proc, folder)
 
     # Assure that the template functionality supports the same user
     # importing from multiple groups on a given day
@@ -324,12 +324,12 @@ class TestRawAccess(AbstractRepoTest):
     def testAsNonAdmin(self):
         uuid = self.unique_dir + "./t.txt"
         cb = self.raw("touch", [uuid])
-        self.assertError(cb)
+        self.assert_error(cb)
 
     def testAsAdmin(self):
         uuid = self.unique_dir + "/t.txt"
         cb = self.raw("touch", [uuid])
-        self.assertError(cb)
+        self.assert_error(cb)
 
 
 class TestDbSync(AbstractRepoTest):
@@ -360,7 +360,7 @@ class TestDbSync(AbstractRepoTest):
 
         # foo.txt is created on the backend but doesn't show up.
         assert ['%s/file.txt' % self.unique_dir] == mrepo.list(self.unique_dir)
-        self.assertPasses(self.raw("touch", [fooname], client=self.root))
+        self.assert_passes(self.raw("touch", [fooname], client=self.root))
         assert ['%s/file.txt' % self.unique_dir] == mrepo.list(self.unique_dir)
 
         # If we try to create such a file, we should receive an exception
@@ -374,7 +374,7 @@ class TestDbSync(AbstractRepoTest):
             assert file.size == ufe.file.size
 
         # And if the file is a Dir, we should have a mimetype
-        self.assertPasses(self.raw("mkdir", ["-p", mydir], client=self.root))
+        self.assert_passes(self.raw("mkdir", ["-p", mydir], client=self.root))
         try:
             self.create_file(mrepo, mydir)
             assert False, "Should have thrown"
@@ -597,7 +597,7 @@ class TestDeletePerformance(AbstractRepoTest):
         req = handle.getRequest()
         fs = req.activity.getParent()
         cb = CmdCallbackI(client, handle)
-        self.assertError(cb, loops=200)
+        self.assert_error(cb, loops=200)
         delete = omero.cmd.Delete2()
         delete.targetObjects = {'Fileset': [fs.id.val]}
         s2 = time.time()

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -84,7 +84,7 @@ class TestRepository(AbstractRepoTest):
                         assert a.val == b.val
 
     def testManagedRepoAsPubliRepo(self):
-        mrepo = self.getManagedRepo(self.client)
+        mrepo = self.get_managed_repo(self.client)
 
         # Create a file in the repo
         base = self.unique_dir
@@ -116,14 +116,14 @@ class TestFileExists(AbstractRepoTest):
     # to launch our own FS instance locally.
 
     def testFileExistsForDirectory(self):
-        mrepo = self.getManagedRepo(self.client)
+        mrepo = self.get_managed_repo(self.client)
         base = self.unique_dir + "/t"
         assert not mrepo.fileExists(base)
         mrepo.makeDir(base, True)
         assert mrepo.fileExists(base)
 
     def testFileExistsForFile(self):
-        mrepo = self.getManagedRepo(self.client)
+        mrepo = self.get_managed_repo(self.client)
         base = self.unique_dir + "/t"
         file = base + "/myfile.txt"
         assert not mrepo.fileExists(file)
@@ -149,8 +149,8 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         client1, user1 = self.new_client_and_user(group=group)
         client2, user2 = self.new_client_and_user(group=group)
 
-        mrepo1 = self.getManagedRepo(client1)
-        mrepo2 = self.getManagedRepo(client2)
+        mrepo1 = self.get_managed_repo(client1)
+        mrepo2 = self.get_managed_repo(client2)
 
         testdir1 = self.test_dir(client1)
         testdir2 = self.test_dir(client2)
@@ -163,7 +163,7 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         filename = f1.testdir + "/file.txt"
 
         # No intermediate directories
-        ofile = self.createFile(f1.repo, filename)
+        ofile = self.create_file(f1.repo, filename)
 
         self.assertRead(f1.repo, filename, ofile)
         self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
@@ -179,7 +179,7 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         filename = dirname + "/file.txt"
 
         f1.repo.makeDir(dirname, True)
-        ofile = self.createFile(f1.repo, filename)
+        ofile = self.create_file(f1.repo, filename)
 
         self.assertRead(f1.repo, filename, ofile)
         self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
@@ -195,7 +195,7 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         filename = dirname + "/file.txt"
 
         f1.repo.makeDir(dirname, True)
-        ofile = self.createFile(f1.repo, filename)
+        ofile = self.create_file(f1.repo, filename)
 
         self.assertRead(f1.repo, filename, ofile)
         self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
@@ -214,7 +214,7 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         filename = dirname + "/file.txt"
 
         f1.repo.makeDir(dirname, True)
-        ofile = self.createFile(f1.repo, filename)
+        ofile = self.create_file(f1.repo, filename)
 
         self.assertRead(f1.repo, filename, ofile)
         self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
@@ -233,7 +233,7 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         filename = dirname + "/file.txt"
 
         f1.repo.makeDir(dirname, True)
-        ofile = self.createFile(f1.repo, filename)
+        ofile = self.create_file(f1.repo, filename)
 
         self.assertRead(f1.repo, filename, ofile)
         self.assertRead(f1.repo, filename, ofile, self.all(f1.client))
@@ -258,11 +258,11 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         client2 = self.new_client(group=group2, user=user)
         client2.sf.setSecurityContext(group2)
 
-        mrepo1 = self.getManagedRepo(client1)
-        mrepo2 = self.getManagedRepo(client2)
+        mrepo1 = self.get_managed_repo(client1)
+        mrepo2 = self.get_managed_repo(client2)
 
         mrepo1.makeDir(dirname, True)
-        ofile = self.createFile(mrepo1, filename)
+        ofile = self.create_file(mrepo1, filename)
 
         self.assertRead(mrepo1, filename, ofile)
         self.assertRead(mrepo1, filename, ofile, self.all(client1))
@@ -277,12 +277,12 @@ class TestPythonImporter(AbstractRepoTest):
 
     def testImportFileset(self):
         client = self.new_client()
-        self.fullImport(client)
+        self.full_import(client)
 
     # Tests the alternative importPaths method
     def testImportPaths(self):
         client = self.new_client()
-        mrepo = self.getManagedRepo(client)
+        mrepo = self.get_managed_repo(client)
         folder = self.create_test_dir()
         paths = folder.files()
 
@@ -291,7 +291,7 @@ class TestPythonImporter(AbstractRepoTest):
 
     def testReopenRawFileStoresPR2542(self):
         client = self.new_client()
-        mrepo = self.getManagedRepo(client)
+        mrepo = self.get_managed_repo(client)
         folder = self.create_test_dir()
         paths = folder.files()
 
@@ -312,11 +312,11 @@ class TestPythonImporter(AbstractRepoTest):
         admin = client.sf.getAdminService()
         # from group1
         assert group1.id.val == admin.getEventContext().groupId
-        self.fullImport(client)
+        self.full_import(client)
 
         # then group 2
         client.sf.setSecurityContext(group2)
-        self.fullImport(client)
+        self.full_import(client)
 
 
 class TestRawAccess(AbstractRepoTest):
@@ -336,17 +336,17 @@ class TestDbSync(AbstractRepoTest):
 
     def testMtime(self):
         filename = self.unique_dir + "/file.txt"
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
 
-        ofile = self.createFile(mrepo, filename)
+        ofile = self.create_file(mrepo, filename)
         assert ofile.mtime is not None
 
     def testFileExists(self):
         filename = self.unique_dir + "/file.txt"
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
 
         assert not mrepo.fileExists(filename)
-        self.createFile(mrepo, filename)
+        self.create_file(mrepo, filename)
         assert mrepo.fileExists(filename)
         assert "file.txt" in mrepo.list(self.unique_dir)[0]
 
@@ -354,9 +354,9 @@ class TestDbSync(AbstractRepoTest):
         filename = self.unique_dir + "/file.txt"
         fooname = self.unique_dir + "/foo.txt"
         mydir = self.unique_dir + "/mydir"
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
 
-        self.createFile(mrepo, filename)
+        self.create_file(mrepo, filename)
 
         # foo.txt is created on the backend but doesn't show up.
         assert ['%s/file.txt' % self.unique_dir] == mrepo.list(self.unique_dir)
@@ -365,7 +365,7 @@ class TestDbSync(AbstractRepoTest):
 
         # If we try to create such a file, we should receive an exception
         try:
-            self.createFile(mrepo, fooname)
+            self.create_file(mrepo, fooname)
             assert False, "Should have thrown"
         except omero.grid.UnregisteredFileException, ufe:
             file = mrepo.register(fooname, None)
@@ -376,7 +376,7 @@ class TestDbSync(AbstractRepoTest):
         # And if the file is a Dir, we should have a mimetype
         self.assertPasses(self.raw("mkdir", ["-p", mydir], client=self.root))
         try:
-            self.createFile(mrepo, mydir)
+            self.create_file(mrepo, mydir)
             assert False, "Should have thrown"
         except omero.grid.UnregisteredFileException, ufe:
             file = mrepo.register(mydir, None)
@@ -388,8 +388,8 @@ class TestRecursiveDelete(AbstractRepoTest):
     def setup_method(self, method):
         super(TestRecursiveDelete, self).setup_method(method)
         self.filename = self.unique_dir + "/file.txt"
-        self.mrepo = self.getManagedRepo()
-        self.ofile = self.createFile(self.mrepo, self.filename)
+        self.mrepo = self.get_managed_repo()
+        self.ofile = self.create_file(self.mrepo, self.filename)
 
         # There should me one key in each of the files
         # NB: globs not currently supported.
@@ -441,8 +441,8 @@ class TestDeleteLog(AbstractRepoTest):
 
     def testSimpleDelete(self):
         filename = self.unique_dir + "/file.txt"
-        mrepo = self.getManagedRepo()
-        ofile = self.createFile(mrepo, filename)
+        mrepo = self.get_managed_repo()
+        ofile = self.create_file(mrepo, filename)
         gateway = BlitzGateway(client_obj=self.client)
 
         # Assert contents of file
@@ -478,16 +478,16 @@ class TestUserTemplate(AbstractRepoTest):
 
     def testCreateUuidFails(self):
         uuid = self.uuid()  # ok
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
         pytest.raises(omero.ValidationException, mrepo.makeDir, uuid, True)
 
     def testCreateUserDirPasses(self):
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
         user_dir = self.user_dir()
         mrepo.makeDir(user_dir, True)
 
     def testCreateUuidUnderUserDirPasses(self):
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
         user_dir = self.user_dir()
         uuid = self.uuid()  # ok
         mydir = "%s/%s" % (user_dir, uuid)
@@ -497,14 +497,14 @@ class TestUserTemplate(AbstractRepoTest):
     # under her/his own directory regardless of
     # which group s/he is in.
     def testUserDirShouldBeGloballyWriteable(self):
-        mrepo = self.getManagedRepo()
+        mrepo = self.get_managed_repo()
         user_dir = self.user_dir()
         aDir = user_dir + "/" + self.uuid()  # ok
         aFile = aDir + "/a.txt"
 
         # Create a first file in one group
         mrepo.makeDir(aDir, True)
-        self.createFile(mrepo, aFile)
+        self.create_file(mrepo, aFile)
 
         uid = self.client.sf.getAdminService().getEventContext().userId
         users = [omero.model.ExperimenterI(uid, False)]
@@ -516,7 +516,7 @@ class TestUserTemplate(AbstractRepoTest):
         bDir = user_dir + "/" + self.uuid()  # ok
         bFile = bDir + "/b.txt"
         mrepo.makeDir(bDir, True)
-        self.createFile(mrepo, bFile)
+        self.create_file(mrepo, bFile)
 
 
 class TestFilesetQueries(AbstractRepoTest):
@@ -557,7 +557,7 @@ class TestOriginalMetadata(AbstractRepoTest):
         req = omero.cmd.OriginalMetadataRequest()
 
         client = self.new_client()
-        rsp = self.fullImport(client)  # Note: fake test produces no metadata!
+        rsp = self.full_import(client)  # Note: fake test produces no metadata!
         image = rsp.objects[0]
 
         req.imageId = image.id.val
@@ -585,7 +585,7 @@ class TestDeletePerformance(AbstractRepoTest):
         import time
         s1 = time.time()
         client = self.new_client()
-        mrepo = self.getManagedRepo(client)
+        mrepo = self.get_managed_repo(client)
         folder = create_path(folder=True)
         for x in range(200):
             name = "%s.unknown" % x

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -430,9 +430,10 @@ client.closeSession()
         scriptID = svc.getScriptID("/omero/figure_scripts/Thumbnail_Figure.py")
         if scriptID == -1:
             assert False, "Script not found"
-        pixID = self.import_image()[0]
+        session = self.client.getSession()
+        image = self.create_test_image(100, 100, 1, 1, 1, session)
         process = svc.runScript(
-            scriptID, wrap({"Data_Type": "Image", "IDs": [long(pixID)]}).val,
+            scriptID, wrap({"Data_Type": "Image", "IDs": [image.id.val]}).val,
             None)
         wait_time, ignore = self.timeit(
             omero.scripts.wait, self.client, process)

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -241,7 +241,7 @@ class TestSearch(ITest):
     def testFilename(self):
         client = self.new_client()
         uuid = self.simple_uuid()
-        images = self.import_mif(1, uuid, client)
+        images = self.import_fake_file(uuid, client)
         image = images[0]
         self.root.sf.getUpdateService().indexObject(image)
         search = client.sf.createSearchService()
@@ -273,7 +273,7 @@ class TestSearch(ITest):
 
     def attached_image(self, uuid, client, path, mimetype):
         _ = omero.rtypes.rstring
-        images = self.import_mif(1, uuid, client)
+        images = self.import_fake_file(uuid, client)
         image = images[0]
         ofile = omero.model.OriginalFileI()
         ofile.mimetype = _(mimetype)

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -241,7 +241,8 @@ class TestSearch(ITest):
     def testFilename(self):
         client = self.new_client()
         uuid = self.simple_uuid()
-        image = self.import_single_image(uuid, client)
+        images = self.import_mif(1, uuid, client)
+        image = images[0]
         self.root.sf.getUpdateService().indexObject(image)
         search = client.sf.createSearchService()
         search.onlyType("Image")
@@ -272,7 +273,8 @@ class TestSearch(ITest):
 
     def attached_image(self, uuid, client, path, mimetype):
         _ = omero.rtypes.rstring
-        image = self.import_single_image(uuid, client)
+        images = self.import_mif(1, uuid, client)
+        image = images[0]
         ofile = omero.model.OriginalFileI()
         ofile.mimetype = _(mimetype)
         ofile.path = _(os.path.dirname(path))

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -241,7 +241,7 @@ class TestSearch(ITest):
     def testFilename(self):
         client = self.new_client()
         uuid = self.simple_uuid()
-        images = self.import_fake_file(uuid, client)
+        images = self.import_fake_file(name=uuid, client=client)
         image = images[0]
         self.root.sf.getUpdateService().indexObject(image)
         search = client.sf.createSearchService()
@@ -273,7 +273,7 @@ class TestSearch(ITest):
 
     def attached_image(self, uuid, client, path, mimetype):
         _ = omero.rtypes.rstring
-        images = self.import_fake_file(uuid, client)
+        images = self.import_fake_file(name=uuid, client=client)
         image = images[0]
         ofile = omero.model.OriginalFileI()
         ofile.mimetype = _(mimetype)

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -20,6 +20,19 @@ from omero.rtypes import rint, unwrap
 
 class TestThumbs(ITest):
 
+    @classmethod
+    def open_jpeg_buffer(cls, buf):
+        try:
+            from PIL import Image
+        except ImportError:
+            try:
+                import Image
+            except ImportError:
+                assert False, "Pillow not installed"
+        from io import BytesIO
+        tfile = BytesIO(buf)
+        return Image.open(tfile)  # Raises if invalid
+
     def assertTb(self, buf, x=64, y=64):
         thumb = self.open_jpeg_buffer(buf)
         assert unwrap(x) == thumb.size[0]

--- a/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
+++ b/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+#
 # Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
@@ -42,8 +42,8 @@ class IWebTest(ITest):
         """Returns a logged in Django test client."""
         super(IWebTest, cls).setup_class()
         cls.django_clients = []
-        omeName = cls.ctx.userName
-        cls.django_client = cls.new_django_client(omeName, omeName)
+        ome_name = cls.ctx.userName
+        cls.django_client = cls.new_django_client(ome_name, ome_name)
         rootpass = cls.root.ic.getProperties().getProperty('omero.rootpass')
         cls.django_root_client = cls.new_django_client("root", rootpass)
 
@@ -89,6 +89,14 @@ class IWebTest(ITest):
         assert response.status_code == 200
         cls.django_clients.append(django_client)
         return django_client
+
+    def import_image_with_metadata(self, client=None):
+        """
+        Imports tinyTest. This should be replaced.
+        """
+        filename = self.omero_dist / ".." / \
+            "components" / "common" / "test" / "tinyTest.d3d.dv"
+        return self.import_image(filename=filename, client=client, skip=None)
 
 
 # Helpers

--- a/components/tools/OmeroWeb/test/integration/test_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_containers.py
@@ -45,7 +45,7 @@ class TestContainers(IWebTest):
         """
         print dir(self)
 
-        pixels = self.pix(client=self.client)
+        pixels = self.create_pixels(client=self.client)
         for the_c in range(pixels.getSizeC().val):
             channel = omero.model.ChannelI()
             channel.logicalChannel = omero.model.LogicalChannelI()

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -54,7 +54,7 @@ class TestCsrf(IWebTest):
         Returns a new foundational Image with Channel objects attached for
         view method testing.
         """
-        pixels = self.pix(client=self.client)
+        pixels = self.create_pixels(client=self.client)
         for the_c in range(pixels.getSizeC().val):
             channel = omero.model.ChannelI()
             channel.logicalChannel = omero.model.LogicalChannelI()

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -78,7 +78,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW orphaned Image.
         """
 
-        images = self.import_mif(1)
+        images = self.import_fake_file()
         image = images[0]
         # download archived files
         request_url = reverse('webgateway.views.archived_files',
@@ -90,7 +90,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW orphaned Image.
         """
 
-        images = self.import_mif(1)
+        images = self.import_fake_file()
         image = images[0]
 
         # download archived files
@@ -105,7 +105,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW Image in Dataset.
         """
 
-        images = self.import_mif(1)
+        images = self.import_fake_file()
         image = images[0]
         ds = self.make_dataset()
         self.link(ds, image)
@@ -122,7 +122,7 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW Image in Dataset in Project.
         """
 
-        images = self.import_mif(1)
+        images = self.import_fake_file()
         image = images[0]
         ds = self.make_dataset()
         pr = self.make_project()
@@ -155,7 +155,7 @@ class TestDownload(IWebTest):
         Download of attachement.
         """
 
-        images = self.import_mif(1)
+        images = self.import_fake_file()
         image = images[0]
         fa = self.make_file_annotation()
         self.link(image, fa)

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -78,8 +78,8 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW orphaned Image.
         """
 
-        image = self.import_single_image()
-
+        images = self.import_mif(1)
+        image = images[0]
         # download archived files
         request_url = reverse('webgateway.views.archived_files',
                               args=[image.id.val])
@@ -90,7 +90,8 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW orphaned Image.
         """
 
-        image = self.import_single_image()
+        images = self.import_mif(1)
+        image = images[0]
 
         # download archived files
         request_url = reverse('webgateway.views.archived_files')
@@ -104,7 +105,8 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW Image in Dataset.
         """
 
-        image = self.import_single_image()
+        images = self.import_mif(1)
+        image = images[0]
         ds = self.make_dataset()
         self.link(ds, image)
 
@@ -120,7 +122,8 @@ class TestDownload(IWebTest):
         Download of archived files for a non-SPW Image in Dataset in Project.
         """
 
-        image = self.import_single_image()
+        images = self.import_mif(1)
+        image = images[0]
         ds = self.make_dataset()
         pr = self.make_project()
 
@@ -152,7 +155,8 @@ class TestDownload(IWebTest):
         Download of attachement.
         """
 
-        image = self.import_single_image()
+        images = self.import_mif(1)
+        image = images[0]
         fa = self.make_file_annotation()
         self.link(image, fa)
 

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -29,6 +29,7 @@ from omeroweb.testlib import IWebTest, _get_response
 
 
 class TestImgDetail(IWebTest):
+
     """
     Tests json for webgateway/imgData/
     """
@@ -37,30 +38,27 @@ class TestImgDetail(IWebTest):
         """
         Download of archived files for a non-SPW Image.
         """
-        userName = "%s %s" % (self.user.firstName.val, self.user.lastName.val)
+        user_name = "%s %s" % (self.user.firstName.val, self.user.lastName.val)
 
         # Import "tinyTest.d3d.dv" and get ImageID
-        pids = self.import_image(client=self.client, skip=None)
+        pids = self.import_image_with_metadata(client=self.client)
         pixels = self.query.get("Pixels", long(pids[0]))
         iid = pixels.image.id.val
 
         json_url = reverse('webgateway.views.imageData_json', args=[iid])
         data = {}
-        imgData = _get_response_json(self.django_client, json_url,
-                                     data, status_code=200)
-
-        # Useful for debugging
-        print imgData
+        img_data = _get_response_json(self.django_client, json_url,
+                                      data, status_code=200)
 
         # Not a big image - tiles should be False with no other tiles metadata
-        assert imgData['tiles'] is False
-        assert 'levels' not in imgData
-        assert 'zoomLevelScaling' not in imgData
-        assert 'tile_size' not in imgData
+        assert img_data['tiles'] is False
+        assert 'levels' not in img_data
+        assert 'zoomLevelScaling' not in img_data
+        assert 'tile_size' not in img_data
 
         # Channels metadata
-        assert len(imgData['channels']) == 1
-        assert imgData['channels'][0] == {
+        assert len(img_data['channels']) == 1
+        assert img_data['channels'][0] == {
             'color': "808080",
             'active': True,
             'window': {
@@ -73,9 +71,9 @@ class TestImgDetail(IWebTest):
             'emissionWave': 500,
             'label': "500"
         }
-        assert imgData['pixel_range'] == [-32768, 32767]
-        assert imgData['nominalMagnification'] == 100
-        assert imgData['rdefs'] == {
+        assert img_data['pixel_range'] == [-32768, 32767]
+        assert img_data['nominalMagnification'] == 100
+        assert img_data['rdefs'] == {
             'defaultT': 0,
             'model': "greyscale",
             'invertAxis': False,
@@ -84,32 +82,32 @@ class TestImgDetail(IWebTest):
         }
 
         # Core image metadata
-        assert imgData['size'] == {
+        assert img_data['size'] == {
             'width': 20,
             'c': 1,
             'z': 5,
             't': 6,
             'height': 20
         }
-        assert imgData['meta']['pixelsType'] == "int16"
-        assert imgData['meta']['projectName'] == "Multiple"
-        assert imgData['meta']['imageId'] == iid
-        assert imgData['meta']['imageAuthor'] == userName
-        assert imgData['meta']['datasetId'] is None
-        assert imgData['meta']['projectDescription'] == ""
-        assert imgData['meta']['datasetName'] == "Multiple"
-        assert imgData['meta']['wellSampleId'] == ""
-        assert imgData['meta']['projectId'] is None
-        assert imgData['meta']['imageDescription'] == \
+        assert img_data['meta']['pixelsType'] == "int16"
+        assert img_data['meta']['projectName'] == "Multiple"
+        assert img_data['meta']['imageId'] == iid
+        assert img_data['meta']['imageAuthor'] == user_name
+        assert img_data['meta']['datasetId'] is None
+        assert img_data['meta']['projectDescription'] == ""
+        assert img_data['meta']['datasetName'] == "Multiple"
+        assert img_data['meta']['wellSampleId'] == ""
+        assert img_data['meta']['projectId'] is None
+        assert img_data['meta']['imageDescription'] == \
             "X:(88 107) Y:(169 188) Z:(9 13 1) T:(2 7 1)"
-        assert imgData['meta']['wellId'] == ""
-        assert imgData['meta']['imageName'] == "tinyTest.d3d.dv"
-        assert imgData['meta']['datasetDescription'] == ""
+        assert img_data['meta']['wellId'] == ""
+        assert img_data['meta']['imageName'] == "tinyTest.d3d.dv"
+        assert img_data['meta']['datasetDescription'] == ""
         # Don't know exact timestamp of import
-        assert 'imageTimestamp' in imgData['meta']
+        assert 'imageTimestamp' in img_data['meta']
 
         # Permissions - User is owner. All perms are True
-        assert imgData['perms'] == {
+        assert img_data['perms'] == {
             'canAnnotate': True,
             'canEdit': True,
             'canDelete': True,
@@ -117,7 +115,7 @@ class TestImgDetail(IWebTest):
         }
 
         # Sizes for split channel image
-        assert imgData['split_channel'] == {
+        assert img_data['split_channel'] == {
             'c': {
                 'width': 46,
                 'gridy': 1,

--- a/components/tools/OmeroWeb/test/integration/test_simple.py
+++ b/components/tools/OmeroWeb/test/integration/test_simple.py
@@ -21,6 +21,6 @@ class TestSimple(ITest):
         assert ec
 
     def testImport(self):
-        images = self.import_mif(1)
+        images = self.import_fake_file()
         image = images[0]
         assert image.id.val

--- a/components/tools/OmeroWeb/test/integration/test_simple.py
+++ b/components/tools/OmeroWeb/test/integration/test_simple.py
@@ -21,5 +21,6 @@ class TestSimple(ITest):
         assert ec
 
     def testImport(self):
-        image = self.import_single_image()
+        images = self.import_mif(1)
+        image = images[0]
         assert image.id.val


### PR DESCRIPTION
# What this PR does

Clean up ``testlib`` for first release.
Reduce the number of "import" methods so we do not overload the testing library
This will now be a "public" tool useful to test external app e.g. mapr

# Testing this PR

 * Check if further cleaning is required
 * Check that the tests are still green


# Related reading

See https://trello.com/c/ECAKLbUr/224-omero-testlib
