### PR TITLE
filesize null

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_fileanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_fileanns_pane.js
@@ -165,7 +165,7 @@ var FileAnnsPane = function FileAnnsPane($element, opts) {
                     // AddedBy IDs for filtering
                     ann.addedBy = [ann.link.owner.id];
                     ann.description = _.escape(ann.description);
-                    ann.file.size = ann.file.size.filesizeformat();
+                    ann.file.size = ann.file.size !== null ? ann.file.size.filesizeformat() : "";
                     return ann;
                 });
                 // Don't show companion files

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/fileanns_underscore.html
@@ -7,7 +7,9 @@
     <a class='tooltip'
         href="<% if (ann.permissions.canDownload) { print(webindex + 'annotation/' + ann.id)} else {print('#') } %>">
         <%= ann.file.name %>
-        <span>(<%= ann.file.size %>)</span>
+        <% if (ann.file.size) { %>
+            <span>(<%= ann.file.size %>)</span>
+        <% } %>
     </a>
 
     <span class="tooltip_html" style='display:none'>


### PR DESCRIPTION
# What this PR does

Fixes display of file annotations in right panel when file.size is None.
See https://trello.com/c/rqVzpUl6/279-bug-loading-attachments


# Testing this PR

1. Create a file-ann without setting size. Attach to object P/D/I etc.
2. Check that this displays correctly in right panel (no error as shown in trello card).

cc @bramalingam 