### PR TITLE
StartTime endTime for plate acquisition

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6060,6 +6060,16 @@ class _PlateAcquisitionWrapper (BlitzObjectWrapper):
             return [(rv, None)]
         return [rv]
 
+    def getStartTime(self):
+        """Get the StartTime as a datetime object or None if not set."""
+        if self.startTime:
+            return datetime.fromtimestamp(self.startTime/1000)
+
+    def getEndTime(self):
+        """Get the EndTime as a datetime object or None if not set."""
+        if self.endTime:
+            return datetime.fromtimestamp(self.endTime/1000)
+
 PlateAcquisitionWrapper = _PlateAcquisitionWrapper
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -561,6 +561,14 @@
                         <th>Creation Date:</th>
                         <td id='creation_date'>{{ manager.acquisition.getDate|date:"Y-m-d H:i:s" }}</td>
                     </tr>
+                    <tr>
+                        <th>Start Time:</th>
+                        <td>{{ manager.acquisition.getStartTime|date:"Y-m-d H:i:s" }}</td>
+                    </tr>
+                    <tr>
+                        <th>End Time:</th>
+                        <td>{{ manager.acquisition.getEndTime|date:"Y-m-d H:i:s" }}</td>
+                    </tr>
                 </table>
                 </div>
 


### PR DESCRIPTION
# What this PR does

Display startTime and endTime for a PlateAcquisition "Run" in right panel
https://trello.com/c/BmnuavC7/275-show-start-end-times-for-plate-acquisitions
Also see https://github.com/openmicroscopy/openmicroscopy/pull/3940

# Testing this PR

1. Import or find SPW data where PlateAcquisition has start/end times set.
E.g. cellworx/hms/plate1/plate1.HTD

2. Should be displayed under 'Run Details' in right panel

![screen shot 2017-02-24 at 14 36 39](https://cloud.githubusercontent.com/assets/900055/23307467/95bd8950-fa9f-11e6-8831-230e6e4b44eb.png)

cc @manics 