### PR TITLE
Disable cache (rebased onto metadata52)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tagging_form.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tagging_form.js
@@ -202,7 +202,6 @@ var tagging_form = function(
             }
             $.ajax({
                 url: url,
-                cache: false,
                 dataType: 'json',
                 success: callback
             });

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -512,7 +512,6 @@ $(function() {
                 $.ajax({
                     url: url,
                     data: payload,
-                    cache: false,
                     success: function (data, textStatus, jqXHR) {
                         callback.call(this, data);
                     },

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -228,7 +228,6 @@
                     var dialog_opts = ['Cancel', 'Create'];
                     $.ajax({
                         url: "{% url 'ome_tiff_info' manager.obj_id %}",
-                        cache: false,
                         dataType: 'json',
                         success: function(data) {
                             var msg = "This will create an OME-TIFF file from this Image.";

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.csrf.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.csrf.js
@@ -64,6 +64,7 @@ function sameOrigin(url) {
         !(/^(\/\/|http:|https:).*/.test(url));
 }
 $.ajaxSetup({
+    cache: false,
     beforeSend: function(xhr, settings) {
         if (!csrfSafeMethod(settings.type) && sameOrigin(settings.url)) {
             // Send the token to same-origin, relative URLs only.


### PR DESCRIPTION

This is the same as gh-5091 but rebased onto metadata52.

----

# What this PR does

disable jquery cache by default

https://trello.com/c/J266hcfA/261-ajaxsetup-cache-false


# Testing this PR

check if ajax request contains timestamp, see  trello card for more description


# Related reading

http://api.jquery.com/jquery.ajax/

cc: @will-moore 

                