### PR TITLE
fix minor typo issues in OMERO server component

### DIFF
--- a/components/server/src/ome/security/basic/EventHandler.java
+++ b/components/server/src/ome/security/basic/EventHandler.java
@@ -121,8 +121,8 @@ public class EventHandler implements MethodInterceptor, ApplicationListener<Cont
     }
 
     /**
-     * invocation interceptor for prepairing this {@link Thread} for execution
-     * and subsequently reseting it.
+     * Invocation interceptor for preparing this {@link Thread} for execution
+     * and subsequently resetting it.
      * 
      * @see org.aopalliance.intercept.MethodInterceptor#invoke(org.aopalliance.intercept.MethodInvocation)
      */

--- a/components/server/src/ome/services/fulltext/PersistentEventLogLoader.java
+++ b/components/server/src/ome/services/fulltext/PersistentEventLogLoader.java
@@ -20,7 +20,7 @@ import org.springframework.context.ApplicationEvent;
 /**
  * {@link EventLogLoader} implementation which keeps tracks of the last
  * {@link EventLog} instance, and always provides the next unindexed instance.
- * Reseting that saved value would restart indexing.
+ * Resetting that saved value would restart indexing.
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0-Beta3

--- a/components/server/src/ome/services/graphs/GraphPolicy.java
+++ b/components/server/src/ome/services/graphs/GraphPolicy.java
@@ -210,8 +210,8 @@ public abstract class GraphPolicy {
     public abstract boolean isCondition(String name);
 
     /**
-     * Any model object about which policy may be asked is first passed to {@link #noteDetails(Session, IObject, String, long)} before
-     * {@link GraphPolicy#review(Map, Details, Map, Set, boolean)}. Each object is passed only once.
+     * Any model object about which policy may be asked is first passed to {@link #noteDetails(Session, IObject, String, long)}
+     * before {@link GraphPolicy#review(Map, Details, Map, Set, boolean)}. Each object is passed only once.
      * Subclasses overriding this method probably ought also override {@link #getCleanInstance()}.
      * @param session the Hibernate session, for obtaining more information about the object
      * @param object an unloaded model object about which policy may be asked

--- a/components/server/src/ome/services/pixeldata/PersistentEventLogLoader.java
+++ b/components/server/src/ome/services/pixeldata/PersistentEventLogLoader.java
@@ -17,7 +17,7 @@ import ome.services.eventlogs.EventLogLoader;
 /**
  * {@link EventLogLoader} implementation which keeps tracks of the last
  * {@link EventLog} instance, and always provides the next unindexed instance.
- * Reseting that saved value would restart indexing.
+ * Resetting that saved value would restart indexing.
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since Beta4.3

--- a/components/server/src/ome/services/sessions/state/SessionCache.java
+++ b/components/server/src/ome/services/sessions/state/SessionCache.java
@@ -377,7 +377,7 @@ public class SessionCache implements ApplicationContextAware {
 
     /**
      * Returns all the data contained in the internal implementation of
-     * this manger.
+     * this manager.
      *
      * @param quietly If true, then the access time for the given UUID
      *                  will not be updated.

--- a/components/server/src/ome/tools/hibernate/SessionHandler.java
+++ b/components/server/src/ome/tools/hibernate/SessionHandler.java
@@ -368,7 +368,7 @@ public class SessionHandler implements MethodInterceptor,
 
     private void resetThreadSession() {
         if (isSessionBoundToThread()) {
-            debug("Session bound to thread. Reseting.");
+            debug("Session bound to thread. Resetting.");
             TransactionSynchronizationManager.unbindResource(factory);
             TransactionSynchronizationManager.bindResource(factory, DUMMY);
         } else {


### PR DESCRIPTION
# What this PR does

Fixes a few minor typos, mostly in comments, and slightly shortens a *really* long line.

# Testing this PR

CI suffices: this PR is trivial.