### PR TITLE
warn omero.jvmcfg.append users about "--"

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -298,9 +298,13 @@ omero.jvmcfg.percent=
 ## (For documentation only)
 # Contains other parameters which should be passed to the
 # JVM. The value of "append" is treated as if it were on
-# the command-line and so will be separated on whitespace.
+# the command line so will be separated on whitespace.
 # For example, '-XX:-PrintGC -XX:+UseCompressedOops' would
 # results in two new arguments.
+# Note that when using `config set` from the command line
+# one may need to give a prior `--` option to prevent a value
+# starting with `-` from already being parsed as an option.
+
 omero.jvmcfg.append=
 
 ## (For documentation only)

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -303,7 +303,9 @@ omero.jvmcfg.percent=
 # results in two new arguments.
 # Note that when using `config set` from the command line
 # one may need to give a prior `--` option to prevent a value
-# starting with `-` from already being parsed as an option.
+# starting with `-` from already being parsed as an option,
+# and values may need quoting to prevent whitespace or other
+# significant characters from being interpreted prematurely.
 
 omero.jvmcfg.append=
 


### PR DESCRIPTION
# What this PR does

When following advice like at https://www.openmicroscopy.org/site/support/omero5.2/sysadmins/config.html#jvm sysadmins may need to use `--` in lines like,

```shell
bin/omero config set -- omero.jvmcfg.append -XX:-PrintGC
```

# Testing this PR

Check that the added note is true.

# Related reading

https://trello.com/c/VxjfOeDR/553-setting-jvm-arguments