### PR TITLE
Spw wellimages launch viewer

### DIFF
--- a/components/tests/ui/testcases/web/show_test.txt
+++ b/components/tests/ui/testcases/web/show_test.txt
@@ -88,11 +88,11 @@ Test Show Well Images
     Click Well By Name                      A1
 
     # Images from a single Well shown in bottom panel
-    Wait Until Page Contains Element        xpath=//div[@id='wellImages']//li/img
-    Xpath Should Match X Times              //div[@id='wellImages']//li/img                 ${FIELD_COUNT}
+    Wait Until Page Contains Element        xpath=//div[@id='wellImages']//li/a
+    Xpath Should Match X Times              //div[@id='wellImages']//li/a                 ${FIELD_COUNT}
 
     # Select Range: Shift-click 5th image
-    Click Element                           xpath=//div[@id='wellImages']//li/img[1]
+    Click Element                           xpath=//div[@id='wellImages']//li/a/img[1]
     Shift Click Element                     "#wellImages img:eq(4)"
     Wait Until Page Contains Element        //h1[@id='batch_ann_title']/span[contains(text(), '5 objects')]
 
@@ -101,7 +101,7 @@ Test Show Well Images
     ${imagesUrl}=                           Get Element Attribute                   id=link_info_popup_string@value
     Go To                                   ${imagesUrl}
     Wait Until Page Contains Element        //h1[@id='batch_ann_title']/span[contains(text(), '5 objects')]
-    Xpath Should Match X Times              //div[@id='wellImages']//li/img                 ${FIELD_COUNT}
+    Xpath Should Match X Times              //div[@id='wellImages']//li/a                 ${FIELD_COUNT}
 
 
 Test Show PDI

--- a/components/tests/ui/testcases/web/spw_test.txt
+++ b/components/tests/ui/testcases/web/spw_test.txt
@@ -45,28 +45,35 @@ Test Spw Grid Layout
     Page Should Contain Element             xpath=//div[contains(@class,'data_heading')]/h1[contains(text(), 'A1')]
 
     # Images from a single Well shown in bottom panel
-    Wait Until Page Contains Element        xpath=//div[@id='wellImages']//li/img
-    Xpath Should Match X Times              //div[@id='wellImages']//li/img                 ${FIELD_COUNT}
+    Wait Until Page Contains Element        xpath=//div[@id='wellImages']//li/a
+    Xpath Should Match X Times              //div[@id='wellImages']//li/a                 ${FIELD_COUNT}
 
     # Shift-Click to select 3 Wells - All images shown in bottom panel
     Shift Click Element                     "img[name='A3']"
-    Wait Until Keyword Succeeds             ${TIMEOUT}    ${INTERVAL}     Xpath Should Match X Times    //div[@id='wellImages']//li/img     ${FIELD_COUNT3}
+    Wait Until Keyword Succeeds             ${TIMEOUT}    ${INTERVAL}     Xpath Should Match X Times    //div[@id='wellImages']//li/a     ${FIELD_COUNT3}
     # Right Panel - batch annotate 3 Wells
     Wait Until Page Contains Element        //h1[@id='batch_ann_title']/span[contains(text(), '3 objects')]
 
     # No Well-Images selected. Click to select
     Page Should Not Contain Element         xpath=//div[@id='wellImages']//li[contains(@class,'ui-selected')]
-    Click Element                           xpath=//div[@id='wellImages']//li/img[1]
+    Click Element                           xpath=//div[@id='wellImages']//li/a/img[1]
     Page Should Contain Element             xpath=//div[@id='wellImages']//li[1][contains(@class,'ui-selected')]
-    Wait For General Panel And Return Id    Image
+    ${imgName}=                             Wait For General Panel And Return Name          Image
+
+    # Double-click wellsample image to open viewer
+    Double Click Element                    xpath=//div[@id='wellImages']//li/a/img[1]
+    Wait Until Keyword Succeeds             ${TIMEOUT}      ${INTERVAL}     Select Window   title=${imgName}
+    Close Window
+    # Select parent window
+    Select Window
 
     # Wrap rows of images by fixed column count
     Input Text                              id=imagesPerRow             2
     Press Key                               id=imagesPerRow             \\13    # ASCII code for enter key
     # First, Third and Fifth images should be aligned
-    ${well1x}=                              Get Horizontal Position  xpath=//div[@id='wellImages']//li[1]/img
-    ${well3x}=                              Get Horizontal Position  xpath=//div[@id='wellImages']//li[3]/img
-    ${well5x}=                              Get Horizontal Position  xpath=//div[@id='wellImages']//li[5]/img
+    ${well1x}=                              Get Horizontal Position  xpath=//div[@id='wellImages']//li[1]/a
+    ${well3x}=                              Get Horizontal Position  xpath=//div[@id='wellImages']//li[3]/a
+    ${well5x}=                              Get Horizontal Position  xpath=//div[@id='wellImages']//li[5]/a
     Should Be Equal                         ${well1x}                   ${well3x}
     Should Be Equal                         ${well1x}                   ${well5x}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -107,10 +107,17 @@
                     .trigger("selection_change.ome");
             };
             // Handle click on Wellsample Images
-            $( '#wellImages' ).on( "click", "img", function(event) {
+            $( '#wellImages' ).on( "click", "a", function(event) {
+                event.preventDefault();
                 // Update 'ui-selected' on images, handling shift-click etc
-                OME.handleClickSelection(event, undefined, "#wellImages img");
+                var $a = $(event.target).parent();
+                OME.handleClickSelection(event, $a, "#wellImages a");
                 triggerWellImagesSelection();
+                return false;
+            });
+            // Listen for double-clicks to open image viewer
+            $( "#wellImages").on("dblclick", "a", function() {
+                window.open($(this).prop('href'), '_blank');
             });
             // Drag selection on WellSample images
             $('#wellImages').selectable({
@@ -267,13 +274,16 @@
                             if (selectImageIds && selectImageIds.indexOf(w.id) > -1) {
                                 cls = 'class="ui-selected"';
                             }
-                            html += '<li ' + cls + ' title="' + w.name + '" data-imageId="' + w.id + '"><img src="' + w.thumb_url + '" /></li>';
+                            html += '<li ' + cls + ' title="' + w.name + '" data-imageId="' + w.id + '">';
+                            html += '<a href="{% url 'webindex' %}img_detail/' + w.id + '/">';
+                            html += '<img src="' + w.thumb_url + '" />';
+                            html += '</a></li>';
                             if (!isNaN(imagesPerRow) && (idx+1)%imagesPerRow === 0) {
                                 html += '<br>';
                             }
                             return html;
                         }, "");
-                        $('#wellImages-' + wellId).append("<td><ul>" + html + "</ul></tr>");
+                        $('#wellImages-' + wellId).html("<td><ul>" + html + "</ul></tr>");
                         if (selectImageIds && selectImageIds.length > 0) {
                             triggerWellImagesSelection();
                         }

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -260,8 +260,9 @@
                 $selected.each(function(i, w){
                     var wellId = w.id.split('-')[1];
                     var label = $(w).children('.wellLabel').text();
+                    var labelHtml = "<td class='wellImagesLabel'><h1>" + label + "</h1></td>";
                     // create placeholders for each Well
-                    $table.append("<tr id='wellImages-" + wellId + "'><td class='wellImagesLabel'><h1>" + label + "</h1></td></tr>");
+                    $table.append("<tr id='wellImages-" + wellId + "'>" + labelHtml + "</tr>");
                     var url = "{% url 'webgateway' %}well/" + wellId + "/children/";
                     {% if acquisition %}
                         url += '?run={{ acquisition }}'
@@ -283,7 +284,8 @@
                             }
                             return html;
                         }, "");
-                        $('#wellImages-' + wellId).html("<td><ul>" + html + "</ul></tr>");
+                        // We use .html() instead of .append() so double-clicks don't give duplicate html
+                        $('#wellImages-' + wellId).html(labelHtml + "<td><ul>" + html + "</ul></td>");
                         if (selectImageIds && selectImageIds.length > 0) {
                             triggerWellImagesSelection();
                         }


### PR DESCRIPTION
# What this PR does

Opens the image viewer when user double-clicks on a WellSample image in bottom panel of SPW layout.
Also fixes a minor bug loading bottom panel when double-clicking on Well.

# Testing this PR

 - Double-click on Well to launch viewer for current field and check that WellSample images have loaded in bottom panel and are not duplicated.
 - Double-click on WellSample image to open image viewer.
 - Check that other clicks on these images are still working, including shift-click / ctrl-click to select multiple images.
 - Robot test 'spw_test' should pass.

# Related reading

See https://trello.com/c/FW5KKs5Q/289-bug-no-full-viewer-when-click-on-image-in-spw-web

cc @pwalczysko 