### PR TITLE
Fix script deletion

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2008 University of Dundee. All rights reserved.
+ *   Copyright 2008-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -15,6 +15,7 @@ import ome.api.IUpdate;
 import ome.api.RawFileStore;
 import ome.model.core.OriginalFile;
 import ome.model.enums.ChecksumAlgorithm;
+import ome.parameters.Parameters;
 import ome.services.blitz.util.BlitzExecutor;
 import ome.services.blitz.util.BlitzOnly;
 import ome.services.blitz.util.ParamsCache;
@@ -564,6 +565,11 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
 
                             @Transactional(readOnly = false)
                             public Object doWork(Session session, ServiceFactory sf) {
+                                for (final ome.model.IObject foundLink : sf.getQueryService().findAllByQuery(
+                                        "FROM JobOriginalFileLink WHERE child.id = :id", new Parameters().addId(id))) {
+                                    // TODO: instead use Delete2 which automatically handles any necessary unlinking
+                                    session.delete(foundLink);
+                                }
                                 session.delete(file);
                                 return null;
                             }

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -198,8 +198,8 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
     /**
      * Upload script to the server.
      *
-     * @param path Path to the script.
-     * @param scriptText
+     * @param path the path to the script
+     * @param scriptText the content for the new script
      * @param __current
      *            ice context.
      */

--- a/components/blitz/src/ome/services/blitz/impl/ScriptI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ScriptI.java
@@ -711,7 +711,6 @@ public class ScriptI extends AbstractAmdServant implements _IScriptOperations,
      * @return original file or null if script does not exist or more than one
      *         script with name exists.
      */
-    @SuppressWarnings("unchecked")
     private OriginalFile getOriginalFileOrNull(long id, final Ice.Current current) {
 
         try {


### PR DESCRIPTION
# What this PR does

Before attempting to delete a script, unlink it from jobs.

# Testing this PR

Observe that https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_script/TestScript/testDemo/ no longer causes `ConstraintViolationException` server errors in the "Standard Error" section at the bottom of that webpage.

# Related reading

https://trello.com/c/h8OylVrf/209-bugs-lut-follow-up