### PR TITLE
Fix If-statement containing empty block

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/CreateTopContainerAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/CreateTopContainerAction.java
@@ -331,8 +331,8 @@ public class CreateTopContainerAction
                         String ns = tag.getNameSpace();
                         if (ns != null &&
                                 TagAnnotationData.INSIGHT_TAGSET_NS.equals(
-                                        ns));
-                        withParent = model.canLink(tag);
+                                        ns))
+                            withParent = model.canLink(tag);
                     }
                 }
             }


### PR DESCRIPTION
Fixes gh-5102 by removing the `;` character which makes the if statement
pointless. Unclear what the impact of this is on users was previously.