### PR TITLE
highlight selected menu

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -170,10 +170,12 @@ class render_response(omeroweb.decorators.render_response):
             try:
                 # test if complex dictionary view with args and query_string
                 l["link"] = reverse_with_params(**link_id)
+                l["url"] = link_id
             except TypeError:
                 # assume is only view name
                 try:
                     l["link"] = reverse(link_id)
+                    l["url"] = {"viewname": link_id}
                 except NoReverseMatch:
                     # assume we've been passed a url
                     l["link"] = link_id

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/menu.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/menu.html
@@ -22,12 +22,14 @@
 <ul>
     <!-- Handle links from settings -->
     {% for link in ome.top_links %}
-        <li class="menu_link">
+        {% url link.url.viewname menu=menu as selected_url %}
+        <li class="menu_link {% if selected_url %}selected{% endif %}">
           <a href="{{ link.link }}"
             {% if link.attrs %}
               {% for k, v in link.attrs.items %} {{ k }}="{{v}}"{% endfor %}
             {% endif %}
-          >{{ link.label }}</a>
+          >{{ link.label }}
+        </a>
         </li>
     {% endfor %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/menu.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/menu.html
@@ -28,8 +28,7 @@
             {% if link.attrs %}
               {% for k, v in link.attrs.items %} {{ k }}="{{v}}"{% endfor %}
             {% endif %}
-          >{{ link.label }}
-        </a>
+          >{{ link.label }}</a>
         </li>
     {% endfor %}
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -79,7 +79,7 @@
 		font-size:1.2em;
 	}
 	
-	#middle_header_left ul a:hover, #user_dropdown:hover {
+	#middle_header_left ul li.selected a, #middle_header_left ul a:hover, #user_dropdown:hover {
 		text-decoration:none;
 		color:white;
 		background-color:rgba(255,255,255,.1);

--- a/components/tools/OmeroWeb/test/unit/test_render_response.py
+++ b/components/tools/OmeroWeb/test/unit/test_render_response.py
@@ -51,10 +51,12 @@ class TestRenderResponse(object):
         context = call_load_settings(self.r, None)
         defaults = [
             {
+                'url': {'viewname': u'webindex'},
                 'link': u'/webclient/',
                 'attrs': {u'title': u'Browse Data via Projects, Tags etc'},
                 'label': u'Data'
             }, {
+                'url': {'viewname': u'history'},
                 'link': u'/webclient/history/',
                 'attrs': {u'title': u'History'},
                 'label': u'History'


### PR DESCRIPTION
# What this PR does

Temporary fix for top links menu to make sure selected section is highlighted.

<img width="414" alt="firefoxscreensnapz047" src="https://cloud.githubusercontent.com/assets/1065155/23587625/7aee7354-01a8-11e7-8d61-49103ecf4fcb.png">


# Testing this PR

1. configure top_links and check if the right one is selected while swithcing between them 
2. Limitations, it doesn't work with existing webadmin link so not suitable to be rebased

# Related reading

https://trello.com/c/s0HD7Vi6/173-mapr-i-e-tagexport-py#comment-5764396d81e872aee908a977

> There's no indicator (other than the URL) for which of the sections you're currently looking at.


--no-rebase