### PR TITLE
fiji bug

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1586,9 +1586,11 @@ public class ImportDialog extends ClosableTabbedPaneComponent
                 if (path != null && values != null) {
                     for (int i = 0; i < values.length; i++) {
                         p = WindowManager.getImage(values[i]);
-                        ff = new FileObject(p);
-                        if (path.equals(ff.getAbsolutePath())) {
-                            f.addAssociatedFile(ff);
+                        if (p != null) {
+                            ff = new FileObject(p);
+                            if (path.equals(ff.getAbsolutePath())) {
+                                f.addAssociatedFile(ff);
+                            }
                         }
                     }
                 }
@@ -1600,16 +1602,18 @@ public class ImportDialog extends ClosableTabbedPaneComponent
                     for (int i = 0; i < values.length; i++) {
                         //need to check if it is the same image
                         ImagePlus p = WindowManager.getImage(values[i]);
-                        f = new FileObject(p);
-                        String path = f.getAbsolutePath();
-                        if (!paths.contains(path)) {
-                            paths.add(path);
-                            list.add(f);
-                            for (int j = 0; j < values.length; j++) {
-                                p = WindowManager.getImage(values[j]);
-                                ff = new FileObject(p);
-                                if (path.equals(ff.getAbsolutePath())) {
-                                    f.addAssociatedFile(ff);
+                        if (p != null) {
+                            f = new FileObject(p);
+                            String path = f.getAbsolutePath();
+                            if (!paths.contains(path)) {
+                                paths.add(path);
+                                list.add(f);
+                                for (int j = 0; j < values.length; j++) {
+                                    p = WindowManager.getImage(values[j]);
+                                    ff = new FileObject(p);
+                                    if (path.equals(ff.getAbsolutePath())) {
+                                        f.addAssociatedFile(ff);
+                                    }
                                 }
                             }
                         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -21,8 +21,8 @@
 package org.openmicroscopy.shoola.agents.fsimporter.chooser;
 
 
+import ij.IJ;
 import ij.ImagePlus;
-
 import ij.WindowManager;
 import info.clearthought.layout.TableLayout;
 
@@ -1575,12 +1575,15 @@ public class ImportDialog extends ClosableTabbedPaneComponent
             FileObject f, ff;
             if (active) {
                 ImagePlus p = WindowManager.getCurrentImage();
+                if (p == null) {
+                    IJ.log("Please open an image first.");
+                    return;
+                }
                 f = new FileObject(p);
-                int id = p.getID();
                 //check if there are associated files
                 int[] values = WindowManager.getIDList();
                 String path = f.getAbsolutePath();
-                if (path != null) {
+                if (path != null && values != null) {
                     for (int i = 0; i < values.length; i++) {
                         p = WindowManager.getImage(values[i]);
                         ff = new FileObject(p);


### PR DESCRIPTION
# What this PR does

Handle case when no image is opened

# Testing this PR

 * Add the insight.ij plugin to fix
 * Select OMERO > Connect to OMERO
 * Click on the importer button
 * Use the default selection i.e. Import Active image
 * Click on "Add to queue"
 * Make sure that the following error 
``
java.lang.IllegalArgumentException: No object to import at org.openmicroscopy.shoola.env.data.model.FileObject.<init>(FileObject.java:167) at org.openmicroscopy.shoola.agents.fsimporter.chooser.ImportDialog.addImageJFiles(ImportDialog.java:1578) at org.openmicroscopy.shoola.agents.fsimporter.chooser.ImportDialog.propertyChange(ImportDialog.java:1688) at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
``
does not show up in the fiji error dialog

# Related reading

https://trello.com/c/ySbQlSSk/8-imagej

cc @bramalingam 
