### PR TITLE
paths_to_object pagesize

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -573,13 +573,13 @@ def paths_to_object(conn, experimenter_id=None, project_id=None,
                 ds = {
                     'type': 'dataset',
                     'id': datasetId,
+                    'childCount': imgCount,
                 }
                 if imgCount > page_size:
                     # Need to know which page image is on
                     iids = get_image_ids(conn, datasetId)
                     index = iids.index(imageId)
                     page = (index / page_size) + 1  # 1-based index
-                    ds['childCount'] = imgCount
                     ds['childIndex'] = index
                     ds['childPage'] = page
                 path.append(ds)

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1041,6 +1041,7 @@ def api_paths_to_object(request, conn=None, **kwargs):
         tag_id = get_long_or_default(request, 'tag', None)
         tagset_id = get_long_or_default(request, 'tagset', None)
         group_id = get_long_or_default(request, 'group', None)
+        page_size = get_long_or_default(request, 'page_size', settings.PAGE)
     except ValueError:
         return HttpResponseBadRequest('Invalid parameter value')
 
@@ -1050,7 +1051,8 @@ def api_paths_to_object(request, conn=None, **kwargs):
     else:
         paths = paths_to_object(conn, experimenter_id, project_id,
                                 dataset_id, image_id, screen_id, plate_id,
-                                acquisition_id, well_id, group_id)
+                                acquisition_id, well_id, group_id,
+                                page_size=page_size)
     return JsonResponse({'paths': paths})
 
 

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1265,7 +1265,7 @@ class TestShow(IWebTest):
         expected = [
             [{'type': 'experimenter', 'id': project.details.owner.id.val},
              {'type': 'project', 'id': project.id.val},
-             {'type': 'dataset', 'id': dataset.id.val},
+             {'type': 'dataset', 'id': dataset.id.val, 'childCount': 1},
              {'type': 'image', 'id': image.id.val}]]
 
         assert paths == expected


### PR DESCRIPTION
# What this PR does

Adds ```?page_size=10``` support to ```/paths_to_object/```.
See https://github.com/ome/omero-iviewer/pull/43/

NB: This ```page_size``` parameter is already testing in ```OmeroWeb/test/integration/test_show.py``` in ```test_project_dataset_images_pagination()```. This PR simply allows the parameter to be set via the request query string.

# Testing this PR

 - Pick an Image in a Dataset with more than 10 images
 - Use the image ID in a URL: ```/webclient/api/paths_to_object/?image=56797&page_size=10```
 - Should see that the path to the Image includes Dataset with pagination info
```
{
  "childIndex": 53,
  "type": "dataset",
  "id": 17752,
  "childPage": 6,
  "childCount": 61
},
```

 # Further reading

The iViewer needs to show 10 thumbnails from the Dataset that includes the current Image, so it needs to know which "page" of the Dataset the current image comes from.
See https://github.com/ome/omero-iviewer/pull/43/
This functionality already exists in paths_to_objects, so that the webclient can open on the correct page of a Dataset to show the specified Image. But previously the page_size defaulted to the currently configured default.

cc @waxenegger 
