### PR TITLE
New role cleaned

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerImportTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerImportTest.java
@@ -40,6 +40,7 @@ import omero.cmd.HandlePrx;
 import omero.grid.ImportLocation;
 import omero.grid.ImportProcessPrx;
 import omero.grid.ImportRequest;
+import omero.model.IObject;
 
 import org.testng.Assert;
 
@@ -56,7 +57,7 @@ public class AbstractServerImportTest extends AbstractServerTest {
      *             unexpected
      */
     protected ImportLocation importFileset(List<String> srcPaths) throws Exception {
-        return importFileset(srcPaths, srcPaths.size());
+        return importFileset(srcPaths, srcPaths.size(), null);
     }
 
     /**
@@ -70,7 +71,7 @@ public class AbstractServerImportTest extends AbstractServerTest {
      * @throws Exception
      *             unexpected
      */
-    protected ImportLocation importFileset(List<String> srcPaths, int numberToUpload) throws Exception {
+    protected ImportLocation importFileset(List<String> srcPaths, int numberToUpload, IObject targetObject) throws Exception {
 
         // Setup that should be easier, most likely a single ctor on IL
         OMEROMetadataStoreClient client = new OMEROMetadataStoreClient();
@@ -80,7 +81,7 @@ public class AbstractServerImportTest extends AbstractServerTest {
 
         // This should also be simplified.
         ImportContainer container = new ImportContainer(new File(
-                srcPaths.get(0)), null /* target */, null /* user pixels */,
+                srcPaths.get(0)), targetObject /* target */, null /* user pixels */,
                 FakeReader.class.getName(), srcPaths.toArray(new String[srcPaths.size()]),
                 false /* isspw */);
 

--- a/components/tools/OmeroJava/test/integration/AbstractServerImportTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerImportTest.java
@@ -67,6 +67,8 @@ public class AbstractServerImportTest extends AbstractServerTest {
      *            the source paths
      * @param numberToUpload
      *            how many of the source paths to actually upload
+     * @param targetObject
+     *            object (Dataset or Screen) to import the Fileset into
      * @return the resulting import location
      * @throws Exception
      *             unexpected

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -153,7 +153,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         rootSession.getAdminService().setAdminPrivileges(user, privileges);
         /* avoid old session as privileges are briefly cached */
         loginUser(ctx);
-        System.out.println(ctx.userId);
         return ctx;
     }
 
@@ -187,8 +186,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     @Test(dataProvider = "isAdmin cases")
     public void testImporterAsSudoPrivileges(boolean isAdmin) throws Exception {
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        System.out.println("normalUser");
-        System.out.println(normalUser.userId);
         loginNewAdmin(isAdmin, AdminPrivilegeSudo.value);
         
         try {
@@ -224,8 +221,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             final Project retrievedProject = (Project) iQuery.get("Project", projId);
             Assert.assertEquals(retrievedProject.getDetails().getOwner().getId().getValue(), normalUser.userId);
             long datId = sentDat.getId().getValue();
-            System.out.println("dataset Id");
-            System.out.println(datId);
             final Dataset retrievedDataset = (Dataset) iQuery.get("Dataset", datId);
             Assert.assertEquals(retrievedDataset.getDetails().getOwner().getId().getValue(), normalUser.userId);
         } else {
@@ -284,12 +279,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 new ParametersI().addId(link.getId()));
         Assert.assertEquals(image.getDetails().getOwner().getId().getValue(), normalUser.userId);
         Assert.assertEquals(imageDatasetLink.getDetails().getOwner().getId().getValue(), normalUser.userId);
-        System.out.println(imageDatasetLink.getId().getValue());
         Assert.assertEquals(retrievedProjectDatasetLink.getDetails().getOwner().getId().getValue(), normalUser.userId);
-        System.out.println(retrievedProjectDatasetLink.getId().getValue());
-
-        /* Check that the ImporterAs can chown only if the Chown
-         * permission is True */
 
         /* Now check that the ImporterAs can delete the objects
          * created on behalf of the user */
@@ -318,8 +308,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     @Test(dataProvider = "isAdmin cases")
     public void testImporterAsSudoEdit(boolean isAdmin) throws Exception {
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        System.out.println("normalUser");
-        System.out.println(normalUser.userId);
         loginNewAdmin(isAdmin, AdminPrivilegeSudo.value);
         try {
             sudo(new ExperimenterI(normalUser.userId, false));
@@ -351,7 +339,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * chgrp on behalf of another user solely with <tt>Sudo</tt> privilege
      * only when this user is a member of both original and target groups
      * Also test that ImporterAs can, having the <tt>Chgrp</tt>
-     * privilege chgrp another users data into another group whether the
+     * privilege move another user's data into another group whether the
      * owner of the data is member of target group or not.
      * @throws Exception unexpected
      */
@@ -367,15 +355,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final EventContext normalUser = newUserAndGroup("rwr-r-");
         final long anotherGroupId = newUserAndGroup("rwr-r-").groupId;
         final long normalUsersOtherGroupId = newGroupAddUser("rwr-r-", normalUser.userId, false).getId().getValue();
-        System.out.println("normalUser");
-        System.out.println(normalUser.userId);
         /* set up the light admin's permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
-        System.out.println(permissions);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
 
@@ -413,7 +398,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 "FROM Image WHERE fileset IN "
                 + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
                 new ParametersI().addId(remoteFile.getId()));
-        System.out.println(image.getId().getValue());
         /* take care of post-import workflows which do not use sudo */
         if (!isSudoing) {
             loginUser(lightAdmin); // TODO
@@ -470,10 +454,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * Test that an ImporterAs can
+     * Test that an ImporterAs cannot
      * chown on behalf of another user in any combination of <tt>Sudo</tt> privilege
-     * with having or not having also the <tt>Chown</tt> . The <tt>WriteOwned</tt> and
-     * <tt>WriteFile</tt> privileges except for having all of them (in which case
+     * with having or not having also the <tt>Chown</tt>. <tt>WriteOwned</tt> and
+     * <tt>WriteFile</tt> privileges except for having all three of them (in which case
      * the chown action wiill succeed)
      * @throws Exception unexpected
      */
@@ -482,15 +466,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             boolean permWriteOwned, boolean permWriteFile) throws Exception {
         final EventContext normalUser = newUserAndGroup("rwr-r-");
         final long anotherUserId = newUserAndGroup("rwr-r-").userId;
-        System.out.println("normalUser");
-        System.out.println(normalUser.userId);
         /* set up the basic permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
-        System.out.println(permissions);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         try {
@@ -521,11 +502,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                 new ParametersI().addId(previousId).add("name", imageName));
         if (isAdmin) {
-            System.out.println("remote file is empty?");
-            boolean remoteFileEmpty = (remoteFile == null);
-            System.out.println("remote file owner is empty?");
-            System.out.println(remoteFileEmpty);
-            
             Assert.assertEquals(remoteFile.getDetails().getOwner().getId().getValue(), normalUser.userId);
             Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), normalUser.groupId);
         }
@@ -533,10 +509,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 "FROM Image WHERE fileset IN "
                 + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
                 new ParametersI().addId(remoteFile.getId()));
+        /* stop sudoing for some test cases by logging in as light admin */
         if (!isSudoing) {
-            loginUser(lightAdmin); // TODO
+            loginUser(lightAdmin);
         }
-
         /* try to chown the image of the normalUser just being sudoed,
          * which should fail in both cases you have no chown permissions or
          * not */
@@ -548,7 +524,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(image.getDetails().getGroup().getId().getValue(), normalUser.groupId);
         } else {
             /* when trying to chown the image NOT being sudoed,
-             * this should fail in case you have no chown & WriteOwned permissions */
+             * this should fail in case you have not all of Chown & WriteOwned & WriteFile
+             * permissions */
             if (permChown && permWriteOwned && permWriteFile) {
                 doChange(client, factory, Requests.chown().target(image).toUser(anotherUserId).build(), true);
                 image = (Image) iQuery.get("Image", image.getId().getValue());
@@ -561,8 +538,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 Assert.assertEquals(image.getDetails().getGroup().getId().getValue(), normalUser.groupId);
             }
         }
-
-
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import ome.formats.OMEROMetadataStoreClient;
+import ome.formats.importer.ImportConfig;
+import ome.formats.importer.ImportContainer;
+import ome.formats.importer.ImportLibrary;
+import ome.formats.importer.OMEROWrapper;
+import ome.formats.importer.ImportLibrary.ImportCallback;
+import ome.formats.importer.util.ProportionalTimeEstimatorImpl;
+import ome.formats.importer.util.TimeEstimator;
+import ome.services.blitz.repo.path.FsFile;
+import ome.util.checksum.ChecksumProviderFactory;
+import ome.util.checksum.ChecksumProviderFactoryImpl;
+import omero.RLong;
+import omero.RString;
+import omero.RType;
+import omero.SecurityViolation;
+import omero.ServerError;
+import omero.api.IScriptPrx;
+import omero.api.RawFileStorePrx;
+import omero.api.ServiceFactoryPrx;
+import omero.cmd.CmdCallbackI;
+import omero.cmd.HandlePrx;
+import omero.gateway.util.Requests;
+import omero.gateway.util.Requests.Delete2Builder;
+import omero.grid.ImportLocation;
+import omero.grid.ImportProcessPrx;
+import omero.grid.ImportRequest;
+import omero.grid.ManagedRepositoryPrx;
+import omero.grid.ManagedRepositoryPrxHelper;
+import omero.grid.RepositoryMap;
+import omero.grid.RepositoryPrx;
+import omero.model.AdminPrivilege;
+import omero.model.AdminPrivilegeI;
+import omero.model.ChecksumAlgorithm;
+import omero.model.ChecksumAlgorithmI;
+import omero.model.Dataset;
+import omero.model.DatasetI;
+import omero.model.Experimenter;
+import omero.model.ExperimenterGroup;
+import omero.model.ExperimenterGroupI;
+import omero.model.ExperimenterI;
+import omero.model.Folder;
+import omero.model.GroupExperimenterMapI;
+import omero.model.IObject;
+import omero.model.NamedValue;
+import omero.model.OriginalFile;
+import omero.model.OriginalFileI;
+import omero.model.Project;
+import omero.model.ProjectI;
+import omero.model.Session;
+import omero.model.enums.AdminPrivilegeChgrp;
+import omero.model.enums.AdminPrivilegeChown;
+import omero.model.enums.AdminPrivilegeModifyUser;
+import omero.model.enums.AdminPrivilegeReadSession;
+import omero.model.enums.AdminPrivilegeSudo;
+import omero.model.enums.AdminPrivilegeWriteFile;
+import omero.model.enums.AdminPrivilegeWriteOwned;
+import omero.model.enums.ChecksumAlgorithmMurmur3128;
+import omero.model.enums.ChecksumAlgorithmSHA1160;
+import omero.sys.EventContext;
+import omero.sys.ParametersI;
+import omero.sys.Principal;
+import omero.util.TempFileManager;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import loci.formats.in.FakeReader;
+
+/**
+ * Tests the effectiveness of light administrator privileges.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.3.0
+ */
+public class LightAdminRolesTest extends AbstractServerImportTest {
+
+    private static final TempFileManager TEMPORARY_FILE_MANAGER = new TempFileManager(
+            "test-" + LightAdminRolesTest.class.getSimpleName());
+
+    private ImmutableSet<AdminPrivilege> allPrivileges = null;
+
+    private File fakeImageFile = null;
+
+    /**
+     * Populate the set of available light administrator privileges.
+     * @throws ServerError unexpected
+     */
+    @BeforeClass
+    public void populateAllPrivileges() throws ServerError {
+        final ImmutableSet.Builder<AdminPrivilege> privileges = ImmutableSet.builder();
+        for (final IObject privilege : factory.getTypesService().allEnumerations("AdminPrivilege")) {
+            privileges.add((AdminPrivilege) privilege);
+        }
+        allPrivileges = privileges.build();
+    }
+
+    /**
+     * Create a fake image file for use in import tests.
+     * @throws IOException unexpected
+     */
+    @BeforeClass
+    public void createFakeImageFile() throws IOException {
+        final File temporaryDirectory = TEMPORARY_FILE_MANAGER.createPath("images", null, true);
+        fakeImageFile = new File(temporaryDirectory, "image.fake");
+        fakeImageFile.createNewFile();
+    }
+
+    /**
+     * Create a light administrator, with a specific privilege, and log in as them.
+     * All the other privileges will be set to False.
+     * @param isAdmin if the user should be a member of the <tt>system</tt> group
+     * @param restriction the privilege that the user should not have, or {@code null} if they should have all privileges
+     * @return the new user's context
+     * @throws Exception if the light administrator could not be created
+     */
+    private EventContext loginNewAdmin(boolean isAdmin, String permission) throws Exception {
+        final EventContext ctx = isAdmin ? newUserInGroup(iAdmin.lookupGroup(SYSTEM_GROUP), false) : newUserAndGroup("rwr-r-");
+        final ServiceFactoryPrx rootSession = root.getSession();
+        Experimenter user = new ExperimenterI(ctx.userId, false);
+        user = (Experimenter) rootSession.getQueryService().get("Experimenter", ctx.userId);
+        final AdminPrivilege privilege = new AdminPrivilegeI();
+        privilege.setValue(omero.rtypes.rstring(permission));
+        final List<AdminPrivilege> privileges = new ArrayList<>();
+        rootSession.getAdminService().setAdminPrivileges(user, privileges);
+        privileges.add(privilege);
+        rootSession.getAdminService().setAdminPrivileges(user, privileges);
+        /* avoid old session as privileges are briefly cached */
+        loginUser(ctx);
+        System.out.println(ctx.userId);
+        return ctx;
+    }
+
+    /**
+     * Sudo to the given user.
+     * @param target a user
+     * @return context for a session owned by the given user
+     * @throws Exception if the sudo could not be performed
+     */
+    private EventContext sudo(Experimenter target) throws Exception {
+        if (!target.isLoaded()) {
+            target = iAdmin.getExperimenter(target.getId().getValue());
+        }
+        final Principal principal = new Principal();
+        principal.name = target.getOmeName().getValue();
+        final Session session = factory.getSessionService().createSessionWithTimeout(principal, 100 * 1000);
+        final omero.client client = newOmeroClient();
+        final String sessionUUID = session.getUuid().getValue();
+        client.createSession(sessionUUID, sessionUUID);
+        return init(client);
+    }
+
+    /**
+     * Create a light administrator, possibly without a specific privilege, and log in as them, possibly sudo'ing afterward.
+     * @param isAdmin if the user should be a member of the <tt>system</tt> group
+     * @param isSudo if the user should then sudo to be a member of the <tt>system</tt> group with all privileges
+     * @param restriction the privilege that the user should not have, or {@code null} if they should have all privileges
+     * @return the new user's context (may be a sudo session)
+     * @throws Exception if the light administrator actor could not be set up as specified
+     */
+    private EventContext loginNewActor(boolean isAdmin, boolean isSudo, String restriction) throws Exception {
+        final EventContext adminContext = loginNewAdmin(isAdmin, restriction);
+        if (isSudo) {
+            final EventContext fullAdminContext = loginNewAdmin(true, null);
+            loginUser(adminContext);
+            try {
+                final EventContext sudoContext = sudo(new ExperimenterI(fullAdminContext.userId, false));
+                Assert.assertTrue(isAdmin, "normal users cannot sudo");
+                return sudoContext;
+            } catch (SecurityViolation sv) {
+                Assert.assertFalse(isAdmin, "admins can sudo");
+                throw sv;
+            }
+        } else {
+            return adminContext;
+        }
+    }
+
+    /**
+     * Identifies expected repositories and provides their name for looking them up from the database.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.3.0
+     */
+    private static enum Repository {
+        MANAGED("ManagedRepository"), SCRIPT("scripts");
+
+        /* corresponds to OriginalFile.name */
+        final String name;
+
+        private Repository(String name) {
+            this.name = name;
+        }
+    }
+
+    /**
+     * Get a proxy for the given repository. It is assumed that such a repository exists.
+     * @param repository a repository
+     * @return a proxy for the repository
+     * @throws ServerError unexpected
+     */
+    private RepositoryPrx getRepository(Repository repository) throws ServerError {
+        final RepositoryMap repositories = factory.sharedResources().repositories();
+        int index;
+        for (index = 0; !repository.name.equals(repositories.descriptions.get(index).getName().getValue()); index++);
+        return repositories.proxies.get(index);
+    }
+
+    /**
+     * Test that an ImporterAs can create new Project and Dataset
+     * and import data on behalf of another user solely with <tt>Sudo</tt> privilege
+     * into this Dataset. Further link the Dataset to the Project, check
+     * that the link belongs to the user (not to the ImporterAs) and finally
+     * delete the Project, Dataset and Image.
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "roles test cases")
+    public void testImporterAsSudoPrivileges(boolean isAdmin) throws Exception {
+        final EventContext normalUser = newUserAndGroup("rwr-r-");
+        System.out.println("normalUser");
+        System.out.println(normalUser.userId);
+        final EventContext ctx = loginNewAdmin(isAdmin, AdminPrivilegeSudo.value);
+        
+        try {
+            sudo(new ExperimenterI(normalUser.userId, false));
+            if (!isAdmin) {
+                Assert.fail("Sudo-permitted non-administrators cannot sudo.");
+            } else {
+                
+            }
+        } catch (SecurityViolation sv) {
+            /* sudo expected to fail if the user is not in system group */
+        }
+        /* First, check that the light admin/importer As 
+         * can create Project and Dataset on behalf of the normalUser
+         * in the group of the normalUser in anticipation of importing
+         * data for the normalUser in the next step into these containers */
+        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
+        Project proj = mmFactory.simpleProject();
+        Dataset dat = mmFactory.simpleDataset();
+        Project sentProj = new ProjectI();
+        sentProj = null;
+        Dataset sentDat = new DatasetI();
+        sentDat = null;
+        try {
+            sentProj = (Project) iUpdate.saveAndReturnObject(proj);
+            sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+            Assert.assertTrue(isAdmin);
+        } catch (ServerError se) {
+            Assert.assertFalse(isAdmin);
+        }
+        /* Check the owner of the project and dataset is the normalUser in case
+         * these were created */
+        if (isAdmin) {
+            long projId = sentProj.getId().getValue();
+            final Project retrievedProject = (Project) iQuery.get("Project", projId);
+            Assert.assertEquals(retrievedProject.getDetails().getOwner().getId().getValue(), normalUser.userId);
+            long datId = sentDat.getId().getValue();
+            System.out.println("dataset Id");
+            System.out.println(datId);
+            final Dataset retrievedDataset = (Dataset) iQuery.get("Dataset", datId);
+            Assert.assertEquals(retrievedDataset.getDetails().getOwner().getId().getValue(), normalUser.userId);
+        } else {
+            Assert.assertNull(sentProj);
+            Assert.assertNull(sentDat);
+        }
+
+        /* check that after sudo, the light admin is able to ImportAs and target
+         * the import into the just created Dataset.
+         * Check thus that the light admin can import and write the original file
+         * on behalf of the normalUser and into the group of normalUser */
+        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
+        final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
+        final List<List<RType>> result = iQuery.projection(
+                "SELECT id FROM OriginalFile WHERE name = :name ORDER BY id DESC LIMIT 1",
+                new ParametersI().add("name", imageName));
+        final long previousId = result.isEmpty() ? -1 : ((RLong) result.get(0).get(0)).getValue();
+        try {
+            List<String> path = Collections.singletonList(fakeImageFile.getPath());
+            importFileset(path, path.size(), sentDat);
+            Assert.assertTrue(isAdmin);
+        } catch (ServerError se) {
+            Assert.assertFalse(isAdmin);
+        }
+        final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
+                "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
+                new ParametersI().addId(previousId).add("name", imageName));
+        if (isAdmin) {
+            Assert.assertEquals(remoteFile.getDetails().getOwner().getId().getValue(), normalUser.userId);
+            Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), normalUser.groupId);
+        } else {
+            Assert.assertNull(remoteFile);
+        }
+        if (isAdmin) {
+            final IObject image = iQuery.findByQuery(
+                    "FROM Image WHERE fileset IN "
+                    + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
+                    new ParametersI().addId(remoteFile.getId()));
+            System.out.println(image.getId().getValue());
+        }
+    }
+
+    /**
+     * @return a variety of test cases for light administrator privileges
+     */
+    @DataProvider(name = "roles test cases")
+    public Object[][] provideAdminPrivilegeCases() {
+        int index = 0;
+        final int IS_ADMIN = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isAdmin : booleanCases) {
+                    final Object[] testCase = new Object[index];
+                    testCase[IS_ADMIN] = isAdmin;
+                    // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                    testCases.add(testCase);
+                }
+
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+}

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -139,7 +139,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception if the light administrator could not be created
      */
     private EventContext loginNewAdmin(boolean isAdmin, List <String> permissions) throws Exception {
-        final EventContext ctx = isAdmin ? newUserInGroup(iAdmin.lookupGroup(SYSTEM_GROUP), false) : newUserAndGroup("rwr-r-");
+        final EventContext ctx = isAdmin ? newUserInGroup(iAdmin.lookupGroup(roles.systemGroupName), false) : newUserAndGroup("rwr-r-");
         final ServiceFactoryPrx rootSession = root.getSession();
         Experimenter user = new ExperimenterI(ctx.userId, false);
         user = (Experimenter) rootSession.getQueryService().get("Experimenter", ctx.userId);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1285,7 +1285,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
         /* create an image with pixels as normalUser in a group of the normalUser */
         loginUser(normalUser);
-        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Image image = mmFactory.createImage();
         Image sentImage = (Image) iUpdate.saveAndReturnObject(image);
         Pixels pixelsOfImage = sentImage.getPrimaryPixels();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1356,7 +1356,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             roi = (Roi) iUpdate.saveAndReturnObject(roi);
             Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
         } catch (SecurityViolation sv) {
-            /* will not work in private group or when the permissions are unsufficient */
+            /* will not work in private group or when the permissions are insufficient */
             Assert.assertFalse(isExpectSuccessCreateROIRndSettings);
         }
 
@@ -1367,7 +1367,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                     Arrays.asList(pixelsOfImage.getId().getValue()));
             Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
         } catch (SecurityViolation sv) {
-            /* will not work in private group or when the permissions are unsufficient */
+            /* will not work in private group or when the permissions are insufficient */
             Assert.assertFalse(isExpectSuccessCreateROIRndSettings);
         }
         /* retrieve the image corresponding to the roi and Rnd settings

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -405,11 +405,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                "SELECT id FROM OriginalFile WHERE name = :name ORDER BY id DESC LIMIT 1",
                new ParametersI().add("name", imageName));
        final long previousId = result.isEmpty() ? -1 : ((RLong) result.get(0).get(0)).getValue();
-       try {
-           List<String> path = Collections.singletonList(fakeImageFile.getPath());
-           importFileset(path, path.size(), sentDat);
-       } catch (ServerError se) {
-       }
+       List<String> path = Collections.singletonList(fakeImageFile.getPath());
+       importFileset(path, path.size(), sentDat);
        final List<RType> resultAfterImport = iQuery.projection(
                "SELECT id, details.group.id FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                new ParametersI().addId(previousId).add("name", imageName)).get(0);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1622,6 +1622,35 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
     }
 
+
+    /**
+     * Test that light admin can modify group membership when he/she has
+     * only the <tt>ModifyGroupMembership</tt> privilege.
+     * The removal of a user is being attempted here.
+     */
+    @Test(dataProvider = "script privileges cases")
+    public void testModifyGroupMembershipRemoveUser(boolean isAdmin, boolean permModifyGroupMembership,
+            String groupPermissions) throws Exception {
+        if (!isAdmin) return;
+        /* the permModifyGroupMembership should be a sufficient permission to perform
+         * the user removal from a group */
+        boolean isExpectSuccessRemoveUserFromGroup = isAdmin && permModifyGroupMembership;
+        final EventContext normalUser = newUserAndGroup(groupPermissions);
+        /* one extra group is needed which the normalUser is also a member of */
+        final ExperimenterGroup otherGroup = newGroupAddUser("rwr-r-", normalUser.userId);
+        List<String> permissions = new ArrayList<String>();
+        if (permModifyGroupMembership) permissions.add(AdminPrivilegeModifyGroupMembership.value);
+        final EventContext lightAdmin;
+        lightAdmin = loginNewAdmin(isAdmin, permissions);
+        final Experimenter user = new ExperimenterI(normalUser.userId, false);
+        try {
+            iAdmin.removeGroups(user, Collections.singletonList(otherGroup));
+            Assert.assertTrue(isExpectSuccessRemoveUserFromGroup);
+        } catch (ServerError se) {
+            Assert.assertFalse(isExpectSuccessRemoveUserFromGroup);
+        }
+    }
+
     /**
      * @return test cases for adding the privileges combined with isAdmin cases
      */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -55,6 +55,7 @@ import omero.model.ProjectI;
 import omero.model.Session;
 import omero.model.enums.AdminPrivilegeChgrp;
 import omero.model.enums.AdminPrivilegeChown;
+import omero.model.enums.AdminPrivilegeDeleteOwned;
 import omero.model.enums.AdminPrivilegeSudo;
 import omero.model.enums.AdminPrivilegeWriteFile;
 import omero.model.enums.AdminPrivilegeWriteOwned;
@@ -1132,13 +1133,13 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      */
     @Test(dataProvider = "combined privileges cases")
     public void testDataOrganizerChownAll(boolean isAdmin, boolean permChgrp, boolean permChown,
-            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
-        final boolean isExpectSuccess = isAdmin && permChown && permWriteOwned && permWriteFile;
+            boolean permWriteOwned, boolean permWriteFile, boolean permDeleteOwned, String groupPermissions) throws Exception {
+        final boolean isExpectSuccess = isAdmin && permChown && permWriteOwned && permWriteFile && permDeleteOwned;
         /* chown is passing in this test with isAdmin, permChown and permWriteOwned only,
          * the permWriteFile is not necessary, but note that this is just because we have
          * images with no original files linked to them. If there would be original files, then
          * chown would work only with permWriteFile, just as in testImporterAsSudoChown.*/
-        final boolean chownPassing = isAdmin && permChown && permWriteOwned;
+        final boolean chownPassing = isAdmin && permChown && permWriteOwned && permDeleteOwned;
         if (!isExpectSuccess) return;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         ExperimenterGroup otherGroup = newGroupAddUser(groupPermissions, normalUser.userId, false);
@@ -1149,6 +1150,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
+        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* create two sets of P/D/I hierarchy as normalUser in the default
@@ -1296,6 +1298,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final int PERM_ADDITIONAL = index++;
         final int PERM_ADDITIONAL2 = index++;
         final int PERM_ADDITIONAL3 = index++;
+        final int PERM_ADDITIONAL4 = index++;
         final int GROUP_PERMS = index++;
 
         final boolean[] booleanCases = new boolean[]{false, true};
@@ -1307,22 +1310,24 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 for (final boolean permAdditional : booleanCases) {
                     for (final boolean permAdditional2 : booleanCases) {
                         for (final boolean permAdditional3 : booleanCases) {
-                            for (final String groupPerms : permsCases) {
-                            final Object[] testCase = new Object[index];
-                            testCase[IS_ADMIN] = isAdmin;
-                            testCase[IS_SUDOING] = isSudoing;
-                            testCase[PERM_ADDITIONAL] = permAdditional;
-                            testCase[PERM_ADDITIONAL2] = permAdditional2;
-                            testCase[PERM_ADDITIONAL3] = permAdditional3;
-                            testCase[GROUP_PERMS] = groupPerms;
-                            // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
-                            testCases.add(testCase);
+                            for (final boolean permAdditional4 : booleanCases) {
+                                for (final String groupPerms : permsCases) {
+                                    final Object[] testCase = new Object[index];
+                                    testCase[IS_ADMIN] = isAdmin;
+                                    testCase[IS_SUDOING] = isSudoing;
+                                    testCase[PERM_ADDITIONAL] = permAdditional;
+                                    testCase[PERM_ADDITIONAL2] = permAdditional2;
+                                    testCase[PERM_ADDITIONAL3] = permAdditional3;
+                                    testCase[PERM_ADDITIONAL4] = permAdditional4;
+                                    testCase[GROUP_PERMS] = groupPerms;
+                                    // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                                    testCases.add(testCase);
+                                }
                             }
                         }
                     }
                 }
             }
-
         }
         return testCases.toArray(new Object[testCases.size()][]);
     }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -328,7 +328,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
            String groupPermissions) throws Exception {
        /* only DeleteOwned permission is truly needed for deletion of links, dataset
         * and image (with original file) when not sudoing */
-       boolean deletePassing = (!isSudoing && permDeleteOwned) || isSudoing;
+       boolean deletePassing = permDeleteOwned || isSudoing;
        final EventContext normalUser = newUserAndGroup(groupPermissions);
        /* set up the light admin's permissions for this test */
        ArrayList <String> permissions = new ArrayList <String>();
@@ -400,15 +400,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        /* Now check that the ImporterAs can delete the objects
         * created on behalf of the user */
        if (deletePassing) {
-           try {
-               doChange(Requests.delete().target(datasetImageLink).build());
-               doChange(Requests.delete().target(projectDatasetLink).build());
-               doChange(Requests.delete().target(image).build());
-               doChange(Requests.delete().target(sentDat).build());
-               doChange(Requests.delete().target(sentProj).build());
-           } catch (ServerError se) {
-           /* not expected */
-           }
+           doChange(Requests.delete().target(datasetImageLink).build());
+           doChange(Requests.delete().target(projectDatasetLink).build());
+           doChange(Requests.delete().target(image).build());
+           doChange(Requests.delete().target(sentDat).build());
+           doChange(Requests.delete().target(sentProj).build());
        }
        /* Check one of the objects for non-existence after deletion. First, logging
         * in as root, retrieve all the objects to check them later*/

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -990,11 +990,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         assertOwnedBy(sentDat, normalUser);
         assertOwnedBy(sentProj, normalUser);
         if (isExpectSuccessLinkAndChown) {
-            assertOwnedBy((new DatasetImageLinkI (linkDatasetImageId, false)), normalUser);
-            assertOwnedBy((new ProjectDatasetLinkI (linkProjectDatasetId, false)), normalUser);
+            assertOwnedBy((new DatasetImageLinkI(linkDatasetImageId, false)), normalUser);
+            assertOwnedBy((new ProjectDatasetLinkI(linkProjectDatasetId, false)), normalUser);
         } else {
-            assertOwnedBy((new DatasetImageLinkI (linkDatasetImageId, false)), lightAdmin);
-            assertOwnedBy((new ProjectDatasetLinkI (linkProjectDatasetId, false)), lightAdmin);
+            assertOwnedBy((new DatasetImageLinkI(linkDatasetImageId, false)), lightAdmin);
+            assertOwnedBy((new ProjectDatasetLinkI(linkProjectDatasetId, false)), lightAdmin);
         }
     }
 
@@ -1138,7 +1138,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(imageGroupId, normalUser.groupId);
             assertOwnedBy(sentDat, normalUser);
             Assert.assertEquals(datasetGroupId, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
             Assert.assertEquals(datasetImageLinkGroupId, normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
@@ -1165,7 +1165,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(imageGroupId, lightAdmin.groupId);
             assertOwnedBy(sentDat, normalUser);
             Assert.assertEquals(datasetGroupId, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
             Assert.assertEquals(datasetImageLinkGroupId, lightAdmin.groupId);
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
@@ -1193,7 +1193,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(imageGroupId, normalUser.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             Assert.assertEquals(datasetGroupId, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
             Assert.assertEquals(datasetImageLinkGroupId, normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
@@ -1220,7 +1220,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(imageGroupId, lightAdmin.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             Assert.assertEquals(datasetGroupId, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
             Assert.assertEquals(datasetImageLinkGroupId, lightAdmin.groupId);
         }
     }
@@ -1401,7 +1401,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                     new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();
             assertOwnedBy(roi, lightAdmin);
             assertOwnedBy(rDef, lightAdmin);
-            assertOwnedBy((new ImageI (imageId, false)), normalUser);
+            assertOwnedBy((new ImageI(imageId, false)), normalUser);
         } else {/* as the permissions were not sufficient
                  * no rendering settings were created and no roi saved */
             roi = (Roi) iQuery.findByQuery("FROM Roi WHERE image.id = :id",
@@ -1423,17 +1423,17 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                     new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();
             if (isExpectSuccessCreateAndChownROI) {/* whole workflow succeeded for ROI, all belongs to normalUser */
                 assertOwnedBy(roi, normalUser);
-                assertOwnedBy((new ImageI (imageId, false)), normalUser);
+                assertOwnedBy((new ImageI(imageId, false)), normalUser);
             } else {/* the creation of ROI succeeded, but the chown failed */
                 assertOwnedBy(roi, lightAdmin);
-                assertOwnedBy((new ImageI (imageId, false)), normalUser);
+                assertOwnedBy((new ImageI(imageId, false)), normalUser);
             }
             if (isExpectSuccessCreateAndChownRndSettings) {/* whole workflow succeeded for Rnd settings, all belongs to normalUser */
                 assertOwnedBy(rDef, normalUser);
-                assertOwnedBy((new ImageI (imageId, false)), normalUser);
+                assertOwnedBy((new ImageI(imageId, false)), normalUser);
             } else {/* the creation of the Rnd settings succeeded, but the chown failed */
                 assertOwnedBy(rDef, lightAdmin);
-                assertOwnedBy((new ImageI (imageId, false)), normalUser);
+                assertOwnedBy((new ImageI(imageId, false)), normalUser);
             }
         } else {/* neither ROI nor rendering settings were not created, and chown was not attempted */
             Assert.assertNull(roi);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1535,7 +1535,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testOfficialSciptUploadNoSudo(boolean isAdmin, boolean permWriteScriptRepo,
             String groupPermissions) throws Exception {
         /* upload/creation of File Attachment should be always permitted as long as light admin is in System Group
@@ -1589,7 +1589,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testOfficialScriptDeleteNoSudo(boolean isAdmin, boolean permDeleteScriptRepo,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1666,7 +1666,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipAddUser(boolean isAdmin, boolean permModifyGroupMembership,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1699,7 +1699,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipRemoveUser(boolean isAdmin, boolean permModifyGroupMembership,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1730,7 +1730,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipMakeOwner(boolean isAdmin, boolean permModifyGroupMembership,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1760,7 +1760,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipUnsetOwner(boolean isAdmin, boolean permModifyGroupMembership,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1798,7 +1798,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyUserCreate(boolean isAdmin, boolean permModifyUser,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1833,7 +1833,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyUserEdit(boolean isAdmin, boolean permModifyUser,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1863,7 +1863,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupCreate(boolean isAdmin, boolean permModifyGroup,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -1895,7 +1895,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "script privileges cases")
+    @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupEdit(boolean isAdmin, boolean permModifyGroup,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
@@ -2308,7 +2308,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * tested privilege in particular tests and combines them with group permissions
      */
     @DataProvider(name = "isPrivileged cases")
-    public Object[][] provideScriptPrivilegesCases() {
+    public Object[][] provideIsPrivilegesCases() {
         int index = 0;
         final int IS_ADMIN = index++;
         final int IS_PRIVILEGED = index++;

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -872,19 +872,20 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         ProjectDatasetLink linkOfProjectDataset = linkProjectDataset(sentProj, sentDat);
         /* after successful linkage, transfer the ownership
          * of both links to the normalUser. For that the light admin
-         * needs additonally the Chown permission. Note that as you transfer
-         * the whole project to normalUser, all the objects contained
-         * under this project will be transferred too. This enables a one-step
-         * transfer of both the links to be transferred in one step. */
-        Project retrievedProject = (Project) iQuery.get("Project", sentProj.getId().getValue());
-        Chown2 chown = Requests.chown().target(retrievedProject).toUser(normalUser.userId).build();
+         * needs additonally the Chown permission. Note that the links
+         * have to be transferred step by step, as the Chown feature
+         * of whole hierarchy does not transfer links owned by non-owners
+         * of the P/D?I objects. */
+        Chown2 chown = Requests.chown().target(linkOfDatasetImage).toUser(normalUser.userId).build();
+        doChange(client, factory, chown, permChown);
+        chown = Requests.chown().target(linkOfProjectDataset).toUser(normalUser.userId).build();
         doChange(client, factory, chown, permChown);
 
         /* now retrieve and check that the links, image, dataset and project
          * are owned by normalUser */
         Image retrievedImage = (Image) iQuery.get("Image", sentImage.getId().getValue());
         Dataset retrievedDataset = (Dataset) iQuery.get("Dataset", sentDat.getId().getValue());
-        retrievedProject = (Project) iQuery.get("Project", sentProj.getId().getValue());
+        Project retrievedProject = (Project) iQuery.get("Project", sentProj.getId().getValue());
         DatasetImageLink retrievedDatasetImageLink = (DatasetImageLink) iQuery.findByQuery(
                 "FROM DatasetImageLink WHERE parent.id  = :id",
                 new ParametersI().addId(sentDat.getId()));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -201,7 +201,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isAdmin cases")
-    public void testImporterAsSudoCreateImportDelete(boolean isAdmin) throws Exception {
+    public void testImporterAsSudoCreateImport(boolean isAdmin) throws Exception {
         final EventContext normalUser = newUserAndGroup("rwr-r-");
         loginNewAdmin(isAdmin, AdminPrivilegeSudo.value);
         

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -248,7 +248,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * the import into the just created Dataset.
          * Check thus that the light admin can import and write the original file
          * on behalf of the normalUser and into the group of normalUser */
-        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
         if (!isAdmin) return;/* exit the test in case light admin is not an admin,
         too complicated and uninteresting case */
@@ -475,7 +474,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* set up the project as the normalUser */
         loginUser(normalUser);
-        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Project proj = mmFactory.simpleProject();
         final String originalName = "OriginalNameOfNormalUser";
         proj.setName(omero.rtypes.rstring(originalName));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -260,7 +260,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * and when he/she is not sudoing, except for Link and Import (both tested
      * only when sudoing, as the non-sudoing workflows are too complicated
      * for those two actions and thus covered by separate tests).
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
@@ -490,7 +489,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * edit the name of a project
      * on behalf of another user solely with <tt>Sudo</tt> privilege
      * or without it, using permWriteOwned privilege
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
@@ -561,7 +559,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * having the image which is getting moved into a different group in a dataset
      * in the original group (the chgrp has to sever the DatasetImageLink to perform
      * the move (chgrp)).
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
@@ -684,7 +681,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * the <tt>Chown</tt> privilege.
      * Test is in case of private group severing the link between the Dataset and Image.
      * For this, only the Chown permissions are sufficient, no other permissions are necessary.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
@@ -775,7 +771,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      *  <tt>WriteFile</tt> and <tt>WriteManagedRepo</tt> privileges will be explored
      * for the light admin. For this workflow the creation and targeting of a Dataset
      * is tested too.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param permWriteManagedRepo if to test a user who has the <tt>WriteManagedRepo</tt> privilege
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
@@ -923,7 +918,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * here the image and/or dataset will be created and saved instead and just
      * the linking to a container will be tested. Only when the light admin has
      * WriteOwned privilege is the linking possible.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
@@ -1006,7 +1000,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * privileges is explored for the light admin.
          * For this workflow the creation and targeting of a Dataset
          * is tested too.
-         * @param isAdmin if to test a member of the <tt>system</tt> group
          * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
          * @param permChown if to test a user who has the <tt>Chown</tt> privilege
          * @param groupPermissions if to test the effect of group permission level
@@ -1231,7 +1224,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * option of the Chown2 command which transfers all the data owned by one
      * user to another user. The data are in 2 groups, of which the original data owner
      * is a member of, the recipient of the data is just a member of one of the groups.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1329,7 +1321,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * The workflow deals with the eventuality of putting ROI and Rendering Settings on an
      * image of the user and then transferring the ownership of the ROI and settings
      * to the user.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
@@ -1446,7 +1437,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * and linking it to an image of the user and then transferring
      * the ownership of the attachment and link
      * to the user.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
@@ -1536,7 +1526,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /** Test of light admin without using Sudo.
      * The workflow tries to upload an official script.
      * The only permission light admin needs for this is WriteScriptRepo
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>WriteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1588,7 +1577,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that users may delete official scripts only if they are a member of the <tt>system</tt> group and
      * have the <tt>DeleteScriptRepo</tt> privilege.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>DeleteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1663,7 +1651,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can modify group membership when he/she has
      * only the <tt>ModifyGroupMembership</tt> privilege.
      * The addition of a user is being attempted here.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1694,7 +1681,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can modify group membership when he/she has
      * only the <tt>ModifyGroupMembership</tt> privilege.
      * The removal of a user is being attempted here.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1724,7 +1710,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can make a user an owner of a group
      * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1752,7 +1737,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can unset a user to be an owner of a group
      * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1789,7 +1773,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can create a new user
      * when the light admin has only the <tt>ModifyUser</tt> privilege.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1823,7 +1806,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can edit an existing user
      * when the light admin has only the <tt>ModifyUser</tt> privilege.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1852,7 +1834,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can create a new group
      * when the light admin has only the <tt>ModifyGroup</tt> privilege.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1883,7 +1864,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can edit an existing group
      * when the light admin has only the <tt>ModifyGroup</tt> privilege.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -259,7 +259,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * All workflows are tested here both when light admin is sudoing
      * and when he/she is not sudoing, except for Link and Import (both tested
      * only when sudoing, as the non-sudoing workflows are too complicated
-     * for those two actions and thus covered by separate tests.
+     * for those two actions and thus covered by separate tests).
      * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
@@ -292,10 +292,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Project proj = mmFactory.simpleProject();
         Dataset dat = mmFactory.simpleDataset();
-        Project sentProj = new ProjectI();
-        Dataset sentDat = new DatasetI();
-        sentDat = null;
-        sentProj = null;
+        Project sentProj = null;
+        Dataset sentDat = null;
         /* set the normalUser as the owner of the newly created P/D but do this only
          * when the light admin is not sudoing (if sudoing, this step is not necessary
          * because the created P/D already belongs to the normalUser) */
@@ -367,7 +365,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * user. Behaviors of the system are explored when light admin
      * is and is not using <tt>Sudo</tt> privilege
      * for this action.
-     * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
@@ -394,10 +391,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
        Project proj = mmFactory.simpleProject();
        Dataset dat = mmFactory.simpleDataset();
-       Project sentProj = new ProjectI();
-       sentProj = null;
-       Dataset sentDat = new DatasetI();
-       sentDat = null;
+       Project sentProj = null;
+       Dataset sentDat = null;
        try {
            sentProj = (Project) iUpdate.saveAndReturnObject(proj);
            sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1142,16 +1142,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * is a member of, the recipient of the data is just a member of one of the groups.
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "combined privileges cases")
+    @Test(dataProvider = "narrowed combined privileges cases")
     public void testDataOrganizerChownAll(boolean isAdmin, boolean permChgrp, boolean permChown,
-            boolean permWriteOwned, boolean permWriteFile, boolean permDeleteOwned, String groupPermissions) throws Exception {
-        final boolean isExpectSuccess = isAdmin && permChown && permWriteOwned && permWriteFile && permDeleteOwned;
-        /* chown is passing in this test with isAdmin, permChown and permWriteOwned only,
-         * the permWriteFile is not necessary, but note that this is just because we have
-         * images with no original files linked to them. If there would be original files, then
-         * chown would work only with permWriteFile, just as in testImporterAsSudoChown.*/
-        final boolean chownPassing = isAdmin && permChown && permWriteOwned && permDeleteOwned;
-        if (!isExpectSuccess) return;
+            String groupPermissions) throws Exception {
+        /* chown is passing in this test with isAdmin and permChown only.*/
+        final boolean chownPassing = isAdmin && permChown;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         ExperimenterGroup otherGroup = newGroupAddUser(groupPermissions, normalUser.userId, false);
         final EventContext recipient = newUserInGroup(otherGroup, false);
@@ -1159,9 +1154,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         ArrayList <String> permissions = new ArrayList <String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
-        if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
-        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* create two sets of P/D/I hierarchy as normalUser in the default
@@ -1208,7 +1200,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         client.getImplicitContext().put("omero.group", Long.toString(-1));
         /* transfer can proceed only if chownPassing boolean is true */
         doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), chownPassing);
-        if (!isExpectSuccess) {
+        if (!chownPassing) {
             return;
         }
         /* check the transfer of all the data in the first group was successful */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -472,7 +472,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
     /**
      * Test that a light admin can
-     * edit the name of a dataset
+     * edit the name of a project
      * on behalf of another user solely with <tt>Sudo</tt> privilege
      * or without it, using permWriteOwned privilege
      * @throws Exception unexpected
@@ -768,16 +768,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * the light admin is not a member of is expected to succeed
          */
         boolean importNotYourGroupExpectSuccess = (isAdmin && permWriteOwned && permWriteFile && permWriteManagedRepo);
-        /* the first workflow with importing into the group of the normalUser directly
+        /* importing into the group of the normalUser directly
          * will succeed if the import will succeed and the subsequent Chown is possible
          */
         boolean importNotYourGroupAndChownExpectSuccess =
                 (isAdmin && permWriteOwned && permWriteFile && permChown && permWriteManagedRepo);
-        /* the second workflow with importing into the group of the light admin and
-         * subsequent moving the data into the group of normalUser and chowning
-         * them to the normal user will succeed if Chgrp and Chown is possible,
-         * which needs permChgrp, permChown, permWriteFile and permWriteOwned
-         */
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -42,8 +42,6 @@ import omero.gateway.util.Requests;
 import omero.gateway.util.Requests.Delete2Builder;
 import omero.model.AdminPrivilege;
 import omero.model.AdminPrivilegeI;
-import omero.model.Annotation;
-import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
 import omero.model.DatasetI;
 import omero.model.DatasetImageLink;
@@ -54,7 +52,6 @@ import omero.model.ExperimenterGroupI;
 import omero.model.ExperimenterI;
 import omero.model.FileAnnotation;
 import omero.model.FileAnnotationI;
-import omero.model.Folder;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
@@ -63,7 +60,6 @@ import omero.model.ImageI;
 import omero.model.NamedValue;
 import omero.model.OriginalFile;
 import omero.model.OriginalFileI;
-import omero.model.Permissions;
 import omero.model.PermissionsI;
 import omero.model.Pixels;
 import omero.model.Project;
@@ -72,15 +68,11 @@ import omero.model.ProjectDatasetLinkI;
 import omero.model.ProjectI;
 import omero.model.RectangleI;
 import omero.model.RenderingDef;
-import omero.model.RenderingDefI;
 import omero.model.Roi;
 import omero.model.RoiI;
 import omero.model.Session;
-import omero.model.TagAnnotationI;
 import omero.model.enums.AdminPrivilegeChgrp;
 import omero.model.enums.AdminPrivilegeChown;
-import omero.model.enums.AdminPrivilegeDeleteFile;
-import omero.model.enums.AdminPrivilegeDeleteManagedRepo;
 import omero.model.enums.AdminPrivilegeDeleteOwned;
 import omero.model.enums.AdminPrivilegeDeleteScriptRepo;
 import omero.model.enums.AdminPrivilegeModifyGroup;
@@ -236,6 +228,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * and when he/she is not sudoing, except for Link and Import (both tested
      * only when sudoing, as the non-sudoing workflows are too complicated
      * for those two actions and thus covered by separate tests.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param isSudoing if to test a success of workflows where Sudoed in
+     * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
@@ -322,7 +318,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         Assert.assertEquals(remoteFile.getDetails().getOwner().getId().getValue(), normalUser.userId);
         Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), normalUser.groupId);
 
-
         /* check that the light admin when sudoed, can link the created Dataset
          * to the created Project, check the ownership of the links
          * is of the simple user */
@@ -352,6 +347,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * user. Behaviors of the system are explored when ImporterAs
      * is and is not using <tt>Sudo</tt> privilege
      * for this action.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param isSudoing if to test a success of workflows where Sudoed in
+     * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
    @Test(dataProvider = "narrowed combined privileges cases")
@@ -485,6 +484,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * edit the name of a project
      * on behalf of another user solely with <tt>Sudo</tt> privilege
      * or without it, using permWriteOwned privilege
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param isSudoing if to test a success of workflows where Sudoed in
+     * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
@@ -555,6 +558,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * having the image which is getting moved into a different group in a dataset
      * in the original group (the chgrp has to sever the DatasetImageLink to perform
      * the move (chgrp).
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param isSudoing if to test a success of workflows where Sudoed in
+     * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
@@ -665,6 +672,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * the <tt>Chown</tt> privilege.
      * Test is in case of private group severing the link between the Dataset and Image.
      * For this, only the Chown permissions are sufficient, no other permissions are necessary.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param isSudoing if to test a success of workflows where Sudoed in
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
@@ -758,6 +769,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      *  <tt>WriteFile</tt> and <tt>WriteManagedRepo</tt> privileges will be explored
      * for the light admin. For this workflow the creation and targeting of a Dataset
      * is tested too.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param permWriteManagedRepo if to test a user who has the <tt>WriteManagedRepo</tt> privilege
+     * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
 
@@ -883,6 +900,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * here the image and/or dataset will be created and saved instead and just
      * the linking to a container will be tested. Only when the light admin has
      * WriteOwned privilege is the linking possible.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
@@ -961,6 +982,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * privileges is explored for the light admin.
          * For this workflow the creation and targeting of a Dataset
          * is tested too.
+         * @param isAdmin if to test a member of the <tt>system</tt> group
+         * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
+         * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+         * @param groupPermissions if to test the effect of group permission level
          * @throws Exception unexpected
          */
         @Test(dataProvider = "narrowed combined privileges cases")
@@ -1156,6 +1181,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * option of the Chown2 command which transfers all the data owned by one
      * user to another user. The data are in 2 groups, of which the original data owner
      * is a member of, the recipient of the data is just a member of one of the groups.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
@@ -1193,7 +1222,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         DatasetImageLink linkOfDatasetImage2 = linkDatasetImage(sentDat2, sentImage2);
         ProjectDatasetLink linkOfProjectDataset1 = linkProjectDataset(sentProj1, sentDat1);
         ProjectDatasetLink linkOfProjectDataset2 = linkProjectDataset(sentProj2, sentDat2);
+
         /* now also create this hierarchy in the other group as the normalUser */
+
         client.getImplicitContext().put("omero.group", Long.toString(otherGroup.getId().getValue()));
         Image image1OtherGroup = mmFactory.createImage();
         Image image2OtherGroup = mmFactory.createImage();
@@ -1284,6 +1315,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * The workflow deals with the eventuality of putting ROI and Rendering Settings on an
      * image of the user and then transferring the ownership of the ROI and settings
      * to the user.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
@@ -1393,6 +1428,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * and linking it to an image of the user and then transferring
      * the ownership of the attachment and link
      * to the user.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "fileAttachment privileges cases")
@@ -1477,9 +1517,13 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(link.getDetails().getOwner().getId().getValue(), lightAdmin.userId);
         }
     }
+
     /** Test of light admin without using Sudo.
      * The workflow tries to upload an official script.
-     * The only permission light admin needs for this is zWriteScriptRepo
+     * The only permission light admin needs for this is WriteScriptRepo
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permWriteScriptRepo if to test a user who has the <tt>WriteScriptRepo</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
@@ -1527,9 +1571,14 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         rfs.close();
         Assert.assertEquals(currentScript, actualScript);
     }
+
     /**
      * Test that users may delete official scripts only if they are a member of the <tt>system</tt> group and
      * have the <tt>DeleteScriptRepo</tt> privilege.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permDeleteScriptRepo if to test a user who has the <tt>DeleteScriptRepo</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testOfficialScriptDeleteNoSudo(boolean isAdmin, boolean permDeleteScriptRepo,
@@ -1603,6 +1652,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can modify group membership when he/she has
      * only the <tt>ModifyGroupMembership</tt> privilege.
      * The addition of a user is being attempted here.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyGroupMembershipAddUser(boolean isAdmin, boolean permModifyGroupMembership,
@@ -1632,6 +1685,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can modify group membership when he/she has
      * only the <tt>ModifyGroupMembership</tt> privilege.
      * The removal of a user is being attempted here.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyGroupMembershipRemoveUser(boolean isAdmin, boolean permModifyGroupMembership,
@@ -1659,6 +1716,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can make a user an owner of a group
      * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyGroupMembershipMakeOwner(boolean isAdmin, boolean permModifyGroupMembership,
@@ -1685,6 +1746,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can unset a user to be an owner of a group
      * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyGroupMembershipUnsetOwner(boolean isAdmin, boolean permModifyGroupMembership,
@@ -1719,6 +1784,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can create a new user
      * when the light admin has only the <tt>ModifyUser</tt> privilege.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyUser if to test a user who has the <tt>ModifyUser</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyUserCreate(boolean isAdmin, boolean permModifyUser,
@@ -1750,6 +1819,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can edit an existing user
      * when the light admin has only the <tt>ModifyUser</tt> privilege.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyUser if to test a user who has the <tt>ModifyUser</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyUserEdit(boolean isAdmin, boolean permModifyUser,
@@ -1776,6 +1849,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can create a new group
      * when the light admin has only the <tt>ModifyGroup</tt> privilege.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyGroup if to test a user who has the <tt>ModifyGroup</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyGroupCreate(boolean isAdmin, boolean permModifyGroup,
@@ -1804,6 +1881,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     /**
      * Test that light admin can edit an existing group
      * when the light admin has only the <tt>ModifyGroup</tt> privilege.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param permModifyGroup if to test a user who has the <tt>ModifyGroup</tt> privilege
+     * @param groupPermissions if to test the effect of group permission level
+     * @throws Exception unexpected
      */
     @Test(dataProvider = "script privileges cases")
     public void testModifyGroupEdit(boolean isAdmin, boolean permModifyGroup,
@@ -1873,6 +1954,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         return testCases.toArray(new Object[testCases.size()][]);
     }
+
     /**
      * @return test cases for adding the privileges combined with isAdmin cases
      */
@@ -1909,6 +1991,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         return testCases.toArray(new Object[testCases.size()][]);
     }
+
     /**
      * @return narrowed test cases for adding the privileges combined with isAdmin cases
      */
@@ -1941,6 +2024,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         return testCases.toArray(new Object[testCases.size()][]);
     }
+
     /**
      * @return upload script test cases for adding the privileges combined with isAdmin cases
      */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -433,7 +433,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        /* Now check that the ImporterAs can delete the objects
         * created on behalf of the user. Note that deletion of the Project
         * would delete the whole hierarchy, which was successfully tested
-        * during writing of this test.*/
+        * during writing of this test. The order of the below delete() commands
+        * is intentional, as the ability to delete the links and P/D/I separately is
+        * tested in this way.*/
        if (deletePassing) {
            doChange(Requests.delete().target(datasetImageLink).build());
            doChange(Requests.delete().target(projectDatasetLink).build());
@@ -558,7 +560,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * to sever necessary links for performing the chgrp. This is achieved by
      * having the image which is getting moved into a different group in a dataset
      * in the original group (the chgrp has to sever the DatasetImageLink to perform
-     * the move (chgrp).
+     * the move (chgrp)).
      * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
@@ -660,7 +662,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         remoteFileGroupId = ((RLong) iQuery.projection(
                 "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
                 new ParametersI().addId(remoteFileId)).get(0).get(0)).getValue();
-        if(chgrpNoSudoExpectSuccessAnyGroup) {
+        if (chgrpNoSudoExpectSuccessAnyGroup) {
             /* check that the image moved to another group */
             Assert.assertEquals(afterSecondChgrpImageGroupId, anotherGroupId);
             Assert.assertEquals(afterSecondChgrpImageGroupId, anotherGroupId);
@@ -769,7 +771,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * is a member of, then just chowned to the user.
      * This workflow is possible only if PR#4957 dealing with
      * admins importing data into groups they are not member of will get
-     * merged. For this test, combinations of  <tt>Chown</tt>, <tt>WriteOwned</tt>,
+     * merged. For this test, combinations of <tt>Chown</tt>, <tt>WriteOwned</tt>,
      *  <tt>WriteFile</tt> and <tt>WriteManagedRepo</tt> privileges will be explored
      * for the light admin. For this workflow the creation and targeting of a Dataset
      * is tested too.
@@ -998,7 +1000,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * The data will be imported to the group
          * of the light admin (where the user is not a member)
          * and chgrp-ed and chowned into the correct group/user afterwards.
-         * For this test, combinations of  <tt>Chown</tt>, <tt>Chgrp</tt>,
+         * For this test, combinations of <tt>Chown</tt>, <tt>Chgrp</tt>,
          * privileges is explored for the light admin.
          * For this workflow the creation and targeting of a Dataset
          * is tested too.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -998,7 +998,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * @param groupPermissions if to test the effect of group permission level
          * @throws Exception unexpected
          */
-        @Test(dataProvider = "narrowed combined privileges cases")
+        @Test(dataProvider = "Chgrp and Chown privileges cases")
         public void testImporterAsNoSudoChgrpChownWorkflow(boolean isAdmin, boolean permChgrp, boolean permChown,
                 String groupPermissions) throws Exception {
         /* importing into the group of the light admin and
@@ -2257,6 +2257,43 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                             continue;
                         testCase[IS_ADMIN] = isAdmin;
                         testCase[PERM_WRITEOWNED] = permWriteOwned;
+                        testCase[PERM_CHOWN] = permChown;
+                        testCase[GROUP_PERMS] = groupPerms;
+                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        testCases.add(testCase);
+                    }
+                }
+            }
+        }
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return Chgrp and Chown test cases combined with groupPermissions
+     */
+    @DataProvider(name = "Chgrp and Chown privileges cases")
+    public Object[][] provideChgrpAndChown() {
+        int index = 0;
+        final int IS_ADMIN = index++;
+        final int PERM_CHGRP = index++;
+        final int PERM_CHOWN = index++;
+        final int GROUP_PERMS = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isAdmin : booleanCases) {
+            for (final boolean permChgrp : booleanCases) {
+                for (final boolean permChown : booleanCases) {
+                    for (final String groupPerms : permsCases) {
+                        final Object[] testCase = new Object[index];
+                        /* No test cases are excluded here, because Chgrp
+                         * and Chown are two separate steps which can work
+                         * independently on each other and both are tested
+                         * in the test.*/
+                        testCase[IS_ADMIN] = isAdmin;
+                        testCase[PERM_CHGRP] = permChgrp;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
                         // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -839,10 +839,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (importNotYourGroupExpectSuccess) {
             assertOwnedBy(remoteFile, lightAdmin);
             Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), normalUser.groupId);
-        } else Assert.assertNull(remoteFile, "if import failed, the remoteFile should be null");
+        } else {
+            Assert.assertNull(remoteFile, "if import failed, the remoteFile should be null");
+        }
         /* check that also the image corresponding to the original file is in the right group */
         Image image = null;
-        if (!(remoteFile == null)) {
+        if (remoteFile != null) {
             image = (Image) iQuery.findByQuery("FROM Image WHERE fileset IN "
                     + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
                     new ParametersI().addId(remoteFile.getId()));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -300,12 +300,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
    @Test(dataProvider = "combined privileges cases")
    public void testImporterDelete(boolean isAdmin, boolean isSudoing, boolean permChgrp,
            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
-       //if (!(!isSudoing && permWriteOwned && !permWriteFile)) return;
-       /* define case where the Sudo is not being used post-import
-        * to perform the chgrp action. Such cases are all expected to fail
-        * except the light admin has Chgrp permission. WriteOwned and WriteFile
-        * are not important for the Chgrp success in such situation.
-        */
        final EventContext normalUser = newUserAndGroup(groupPermissions);
        /* set up the light admin's permissions for this test */
        ArrayList <String> permissions = new ArrayList <String>();
@@ -431,9 +425,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
            Assert.assertNull(retrievedDatasetImageLink, "Dat-Image link should be deleted");
            Assert.assertNull(retrievedProjectDatasetLink, "Proj-Dat link should be deleted");
        } else if (!isSudoing && permWriteOwned && !permWriteFile){
-           /* only deletions of OMERO objects should have been successful, but
-            * not the original file and the image
-            */
+           /* When WriteFile permission is missing, general expectation is that only OMERO objects
+            * would be successfully deleted, except image, because image has under itself original file,
+            * for deletion of which WriteFile is necessary. Unfortunately, in actual fact, slightly non-standard
+            * functionality in the back end (considering the original file orphaned after image
+            * was deleted first) allows the deletion of the image and original file also in this case.*/
            Assert.assertNull(retrievedRemoteFile, "original file deleted - this is surprising, because WriteFile is false");
            Assert.assertNull(retrievedImage, "image deleted - this is surprising, because WriteFile is false");
            Assert.assertNull(retrievedDat, "dataset should be deleted");

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -845,7 +845,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
     }
 
-    /** Additonal test of ImporterAs without using Sudo.
+    /** Additonal test of light amdin without using Sudo.
      * The workflow deals with the eventuality of pre-existing container
      * in the target group and linking of the image or dataset to this container
      * (dataset or project). The image import has been tested in other tests,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -809,8 +809,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * a member of this goup) */
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Dataset dat = mmFactory.simpleDataset();
-        Dataset sentDat = new DatasetI();
-        sentDat = null;
+        Dataset sentDat = null;
         if (createDatasetExpectSuccess) {/* you are allowed to create the dataset only
         with sufficient permissions, which are captured in createDatasetExpectSuccess.*/
             sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
@@ -1025,9 +1024,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* First create a Dataset in your (light admin's) group */
         client.getImplicitContext().put("omero.group", Long.toString(lightAdmin.groupId));
         Dataset dat = mmFactory.simpleDataset();
-        Dataset sentDat = new DatasetI();
-        sentDat = null;
-        sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+        Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
         /* import an image into the created Dataset */
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
         List<List<RType>> result = iQuery.projection(

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1729,7 +1729,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         boolean isExpectSuccessCreateUser= isAdmin && permModifyUser;
         final long newGroupId = newUserAndGroup(groupPermissions).groupId;
         List<String> permissions = new ArrayList<String>();
-        if (isExpectSuccessCreateUser) permissions.add(AdminPrivilegeModifyUser.value);
+        if (permModifyUser) permissions.add(AdminPrivilegeModifyUser.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter newUser = new ExperimenterI();
@@ -1760,7 +1760,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         boolean isExpectSuccessEditUser= isAdmin && permModifyUser;
         final long newUserId = newUserAndGroup(groupPermissions).userId;
         List<String> permissions = new ArrayList<String>();
-        if (isExpectSuccessEditUser) permissions.add(AdminPrivilegeModifyUser.value);
+        if (permModifyUser) permissions.add(AdminPrivilegeModifyUser.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter newUser = (Experimenter) iQuery.get("Experimenter", newUserId);
@@ -1790,7 +1790,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         newGroup.getDetails().setPermissions(new PermissionsI(groupPermissions));
         /* set up the permissions for the light admin */
         List<String> permissions = new ArrayList<String>();
-        if (isExpectSuccessCreateGroup) permissions.add(AdminPrivilegeModifyGroup.value);
+        if (permModifyGroup) permissions.add(AdminPrivilegeModifyGroup.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         try {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1381,7 +1381,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "fileAttachment privileges cases")
-    public void testFileAttachmentAndTagNoSudo(boolean isAdmin, boolean permChown,
+    public void testFileAttachmentNoSudo(boolean isAdmin, boolean permChown,
             boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
         /* upload/creation of File Attachment should be always permitted as long as light admin is in System Group
          * and has WriteOwned and WriteFile permissions. */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1488,8 +1488,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* The attachment was certainly created. In cases in which it was not created,
          * the test was terminated (see above). */
         doChange(client, factory, Requests.chown().target(fileAnnotation).toUser(normalUser.userId).build(), isExpectSuccessCreateFileAttAndChown);
-        fileAnnotation = (FileAnnotation) iQuery.findByQuery("FROM FileAnnotation WHERE id = :id",
-                new ParametersI().addId(fileAnnotation.getId()));
         if (isExpectSuccessCreateFileAttAndChown) {/* file ann creation and chowning succeeded */
             assertOwnedBy(fileAnnotation, normalUser);
         } else {/* the creation of file annotation succeeded, but the chown failed */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -525,9 +525,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * owner of the data is member of target group or not.
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "combined privileges cases")
+    @Test(dataProvider = "narrowed combined privileges cases")
     public void testImporterAsSudoChgrp(boolean isAdmin, boolean isSudoing, boolean permChgrp,
-            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
+            String groupPermissions) throws Exception {
         /* define case where the Sudo is not being used post-import
          * to perform the chgrp action. Such cases are all expected to fail
          * except the light admin has Chgrp permission. WriteOwned and WriteFile
@@ -545,8 +545,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         ArrayList <String> permissions = new ArrayList <String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
-        if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         try {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1192,13 +1192,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * user to another user. The data are in 2 groups, of which the original data owner
      * is a member of, the recipient of the data is just a member of one of the groups.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "narrowed combined privileges cases")
-    public void testChownAllBelongingToUser(boolean isAdmin, boolean permChgrp, boolean permChown,
+    @Test(dataProvider = "isPrivileged cases")
+    public void testChownAllBelongingToUser(boolean isAdmin, boolean permChown,
             String groupPermissions) throws Exception {
         /* chown is passing in this test with isAdmin and permChown only.*/
         final boolean chownPassing = isAdmin && permChown;
@@ -1208,7 +1207,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* set up the light admin's permissions for this test */
         List<String> permissions = new ArrayList<String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);
-        if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* create two sets of P/D/I hierarchy as normalUser in the default
@@ -2306,13 +2304,14 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return upload script test cases for adding the privileges combined with isAdmin cases
+     * @return isPrivileged test cases. The isPrivileged parameter translates into one
+     * tested privilege in particular tests and combines them with group permissions
      */
-    @DataProvider(name = "script privileges cases")
+    @DataProvider(name = "isPrivileged cases")
     public Object[][] provideScriptPrivilegesCases() {
         int index = 0;
         final int IS_ADMIN = index++;
-        final int PERM_ADDITIONAL = index++;
+        final int IS_PRIVILEGED = index++;
         final int GROUP_PERMS = index++;
 
         final boolean[] booleanCases = new boolean[]{false, true};
@@ -2320,11 +2319,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
         for (final boolean isAdmin : booleanCases) {
-            for (final boolean permAdditional : booleanCases) {
+            for (final boolean isPrivileged : booleanCases) {
                 for (final String groupPerms : permsCases) {
                     final Object[] testCase = new Object[index];
                     testCase[IS_ADMIN] = isAdmin;
-                    testCase[PERM_ADDITIONAL] = permAdditional;
+                    testCase[IS_PRIVILEGED] = isPrivileged;
                     testCase[GROUP_PERMS] = groupPerms;
                     // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
                     testCases.add(testCase);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1165,27 +1165,74 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         DatasetImageLink linkOfDatasetImage2OtherGroup = linkDatasetImage(sentDat2OtherGroup, sentImage2OtherGroup);
         ProjectDatasetLink linkOfProjectDataset1OtherGroup = linkProjectDataset(sentProj1OtherGroup, sentDat1OtherGroup);
         ProjectDatasetLink linkOfProjectDataset2OtherGroup = linkProjectDataset(sentProj2OtherGroup, sentDat2OtherGroup);
-        /* now transfer all the data of normalUser to recipient
-         * but note that because of the lack of the targetUser feature at
-         * this branch I am transferring by now only the first dataset */
+        /* now transfer all the data of normalUser to recipient */
         loginUser(lightAdmin);
         client.getImplicitContext().put("omero.group", Long.toString(-1));
         if (chownPassing) {
-            doChange(client, factory, Requests.chown().target(sentDat1).toUser(recipient.userId).build(), true);
+            doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), true);
         }
         if (!isExpectSuccess) {
             return;
         }
+        /* check the transfer of all the data in the first group was successful */
         client.getImplicitContext().put("omero.group", Long.toString(-1));
-        Dataset retrievedDataset = (Dataset) iQuery.get("Dataset", sentDat1.getId().getValue());
-        Image retrievedImage = (Image) iQuery.get("Image", sentImage1.getId().getValue());
-        DatasetImageLink retrievedDatasetImageLink = (DatasetImageLink) iQuery.findByQuery(
+        Project retrievedProject1 = (Project) iQuery.get("Project", sentProj1.getId().getValue());
+        Dataset retrievedDataset1 = (Dataset) iQuery.get("Dataset", sentDat1.getId().getValue());
+        Image retrievedImage1 = (Image) iQuery.get("Image", sentImage1.getId().getValue());
+        DatasetImageLink retrievedDatasetImageLink1 = (DatasetImageLink) iQuery.findByQuery(
                 "FROM DatasetImageLink WHERE parent.id  = :id",
                 new ParametersI().addId(sentDat1.getId()));
-        Assert.assertEquals(retrievedDataset.getDetails().getOwner().getId().getValue(), recipient.userId);
-        Assert.assertEquals(retrievedImage.getDetails().getOwner().getId().getValue(), recipient.userId);
-        Assert.assertEquals(retrievedDatasetImageLink.getDetails().getOwner().getId().getValue(), recipient.userId);
-
+        ProjectDatasetLink retrievedProjectDatasetLink1 = (ProjectDatasetLink) iQuery.findByQuery(
+                "FROM ProjectDatasetLink WHERE child.id  = :id",
+                new ParametersI().addId(sentDat1.getId()));
+        Assert.assertEquals(retrievedProject1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDataset1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedImage1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDatasetImageLink1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedProjectDatasetLink1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Project retrievedProject2 = (Project) iQuery.get("Project", sentProj2.getId().getValue());
+        Dataset retrievedDataset2 = (Dataset) iQuery.get("Dataset", sentDat2.getId().getValue());
+        Image retrievedImage2 = (Image) iQuery.get("Image", sentImage2.getId().getValue());
+        DatasetImageLink retrievedDatasetImageLink2 = (DatasetImageLink) iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE parent.id  = :id",
+                new ParametersI().addId(sentDat2.getId()));
+        ProjectDatasetLink retrievedProjectDatasetLink2 = (ProjectDatasetLink) iQuery.findByQuery(
+                "FROM ProjectDatasetLink WHERE child.id  = :id",
+                new ParametersI().addId(sentDat2.getId()));
+        Assert.assertEquals(retrievedProject2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDataset2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedImage2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDatasetImageLink2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedProjectDatasetLink2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        /* check ownership of the objects in otherGroup */
+        Project retrievedProjectOtherGroup1 = (Project) iQuery.get("Project", sentProj1OtherGroup.getId().getValue());
+        Dataset retrievedDatasetOtherGroup1 = (Dataset) iQuery.get("Dataset", sentDat1OtherGroup.getId().getValue());
+        Image retrievedImageOtherGroup1 = (Image) iQuery.get("Image", sentImage1OtherGroup.getId().getValue());
+        DatasetImageLink retrievedDatasetImageLinkOtherGroup1 = (DatasetImageLink) iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE parent.id  = :id",
+                new ParametersI().addId(sentDat1OtherGroup.getId()));
+        ProjectDatasetLink retrievedProjectDatasetLinkOtherGroup1 = (ProjectDatasetLink) iQuery.findByQuery(
+                "FROM ProjectDatasetLink WHERE child.id  = :id",
+                new ParametersI().addId(sentDat1OtherGroup.getId()));
+        Assert.assertEquals(retrievedProjectOtherGroup1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDatasetOtherGroup1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedImageOtherGroup1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDatasetImageLinkOtherGroup1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedProjectDatasetLinkOtherGroup1.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Project retrievedProjectOtherGroup2 = (Project) iQuery.get("Project", sentProj2OtherGroup.getId().getValue());
+        Dataset retrievedDatasetOtherGroup2 = (Dataset) iQuery.get("Dataset", sentDat2OtherGroup.getId().getValue());
+        Image retrievedImageOtherGroup2 = (Image) iQuery.get("Image", sentImage2OtherGroup.getId().getValue());
+        DatasetImageLink retrievedDatasetImageLinkOtherGroup2 = (DatasetImageLink) iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE parent.id  = :id",
+                new ParametersI().addId(sentDat2OtherGroup.getId()));
+        ProjectDatasetLink retrievedProjectDatasetLinkOtherGroup2 = (ProjectDatasetLink) iQuery.findByQuery(
+                "FROM ProjectDatasetLink WHERE child.id  = :id",
+                new ParametersI().addId(sentDat2OtherGroup.getId()));
+        Assert.assertEquals(retrievedProjectOtherGroup2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDatasetOtherGroup2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedImageOtherGroup2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedDatasetImageLinkOtherGroup2.getDetails().getOwner().getId().getValue(), recipient.userId);
+        Assert.assertEquals(retrievedProjectDatasetLinkOtherGroup2.getDetails().getOwner().getId().getValue(), recipient.userId);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -60,6 +60,7 @@ import omero.model.Image;
 import omero.model.ImageAnnotationLink;
 import omero.model.ImageAnnotationLinkI;
 import omero.model.ImageI;
+import omero.model.NamedValue;
 import omero.model.OriginalFile;
 import omero.model.OriginalFileI;
 import omero.model.Pixels;
@@ -1740,6 +1741,32 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertTrue(isExpectSuccessCreateUser);
         } catch (ServerError se) {
             Assert.assertFalse(isExpectSuccessCreateUser);
+        }
+    }
+
+    /**
+     * Test that light admin can edit an existing user
+     * when the light admin has only the <tt>ModifyUser</tt> privilege.
+     */
+    @Test(dataProvider = "script privileges cases")
+    public void testModifyUserEdit(boolean isAdmin, boolean permModifyUser,
+            String groupPermissions) throws Exception {
+        if (!isAdmin) return;
+        /* the permModifyUser should be a sufficient permission to perform
+         * the editing of a user */
+        boolean isExpectSuccessEditUser= isAdmin && permModifyUser;
+        final long newUserId = newUserAndGroup(groupPermissions).userId;
+        List<String> permissions = new ArrayList<String>();
+        if (isExpectSuccessEditUser) permissions.add(AdminPrivilegeModifyUser.value);
+        final EventContext lightAdmin;
+        lightAdmin = loginNewAdmin(isAdmin, permissions);
+        final Experimenter newUser = (Experimenter) iQuery.get("Experimenter", newUserId);
+        newUser.setConfig(ImmutableList.of(new NamedValue("color", "green")));
+        try {
+            iAdmin.updateExperimenter(newUser);
+            Assert.assertTrue(isExpectSuccessEditUser);
+        } catch (ServerError se) {
+            Assert.assertFalse(isExpectSuccessEditUser);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -201,10 +201,14 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * and import data on behalf of another user solely with <tt>Sudo</tt> privilege
      * into this Dataset. Further link the Dataset to the Project, check
      * that the link belongs to the user (not to the ImporterAs).
+     * All workflows are tested here both when light admin is sudoing
+     * and when he/she is not sudoing, except for Link and Import (both tested
+     * only when sudoing, as the non-sudoing workflows are too complicated
+     * for those two actions and thus covered by separate tests.
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
-    public void testImporterAsSudoCreateImport(boolean isAdmin, boolean isSudoing, boolean permWriteOwned,
+    public void testCreateLinkImportSudo(boolean isAdmin, boolean isSudoing, boolean permWriteOwned,
             String groupPermissions) throws Exception {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         final boolean isExpectSuccessCreate = (isAdmin && permWriteOwned) || (isAdmin && isSudoing);
@@ -320,7 +324,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
    @Test(dataProvider = "narrowed combined privileges cases")
-   public void testImporterDelete(boolean isAdmin, boolean isSudoing, boolean permDeleteOwned,
+   public void testDelete(boolean isAdmin, boolean isSudoing, boolean permDeleteOwned,
            String groupPermissions) throws Exception {
        /* only DeleteOwned permission is truly needed for deletion of links, dataset
         * and image (with original file) when not sudoing */
@@ -457,7 +461,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
-    public void testLightAdminEdit(boolean isAdmin, boolean isSudoing,
+    public void testEdit(boolean isAdmin, boolean isSudoing,
             boolean permWriteOwned, String groupPermissions) throws Exception {
         final boolean isExpectSuccess = (isAdmin && isSudoing) || (isAdmin && permWriteOwned);
         final EventContext normalUser = newUserAndGroup(groupPermissions);
@@ -522,7 +526,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
-    public void testImporterAsSudoChgrp(boolean isAdmin, boolean isSudoing, boolean permChgrp,
+    public void testChgrp(boolean isAdmin, boolean isSudoing, boolean permChgrp,
             String groupPermissions) throws Exception {
         /* define case where the Sudo is not being used post-import
          * to perform the chgrp action. Such cases are all expected to fail
@@ -635,7 +639,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
-    public void testImporterAsSudoChown(boolean isAdmin, boolean isSudoing, boolean permChown,
+    public void testChown(boolean isAdmin, boolean isSudoing, boolean permChown,
             String groupPermissions) throws Exception {
         /* define the conditions for the chown passing (when not sudoing) */
         final boolean chownPassing = isAdmin && permChown;
@@ -860,7 +864,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
-    public void testImporterAsNoSudoLinkInTargetGroup(boolean isAdmin, boolean permChown,
+    public void testLinkNoSudo(boolean isAdmin, boolean permChown,
             boolean permWriteOwned, String groupPermissions) throws Exception {
         /* linking should be always permitted as long as light admin is in System Group
          * and has WriteOwned permissions. Exception is Private group, where linking will
@@ -1133,7 +1137,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
-    public void testDataOrganizerChownAll(boolean isAdmin, boolean permChgrp, boolean permChown,
+    public void testChownAllBelongingToUser(boolean isAdmin, boolean permChgrp, boolean permChown,
             String groupPermissions) throws Exception {
         /* chown is passing in this test with isAdmin and permChown only.*/
         final boolean chownPassing = isAdmin && permChown;

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -859,20 +859,19 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * WriteOwned privilege is the linking possible.
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "combined privileges cases")
-    public void testImporterAsNoSudoLinkInTargetGroup(boolean isAdmin, boolean permChgrp, boolean permChown,
-            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
+    @Test(dataProvider = "narrowed combined privileges cases")
+    public void testImporterAsNoSudoLinkInTargetGroup(boolean isAdmin, boolean permChown,
+            boolean permWriteOwned, String groupPermissions) throws Exception {
         /* linking should be always permitted as long as light admin is in System Group
          * and has WriteOwned permissions. Exception is Private group, where linking will
          * always fail.*/
-        boolean isExpectSuccess = isAdmin && permWriteOwned;
+        boolean isExpectLinkingSuccess = isAdmin && permWriteOwned;
+        boolean isExpectSuccessLinkAndChown = isAdmin && permWriteOwned && permChown;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
-        if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* create an image, dataset and project as normalUser in a group of the normalUser */
@@ -890,7 +889,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          */
         loginUser(lightAdmin);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
-        if (!isExpectSuccess) return; /* further testing not necessary in case links could not be created */
+        if (!isExpectLinkingSuccess) return; /* further testing not necessary in case links could not be created */
         if (groupPermissions == "rw----") return; /* in private group linking not possible */
         DatasetImageLink linkOfDatasetImage = linkDatasetImage(sentDat, sentImage);
         ProjectDatasetLink linkOfProjectDataset = linkProjectDataset(sentProj, sentDat);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1282,8 +1282,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         List<String> permissions = new ArrayList<String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(isAdmin, permissions);
+
         /* create an image with pixels as normalUser in a group of the normalUser */
         loginUser(normalUser);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
@@ -1292,7 +1291,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         Pixels pixelsOfImage = sentImage.getPrimaryPixels();
 
         /* login as light admin */
-        loginUser(lightAdmin);
+        final EventContext lightAdmin;
+        lightAdmin = loginNewAdmin(isAdmin, permissions);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
 
         /* set the ROI as light admin on the image of the user */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1254,7 +1254,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         Assert.assertEquals(retrievedProjectDatasetLinkOtherGroup2.getDetails().getOwner().getId().getValue(), recipient.userId);
     }
 
-    /** Test of light amdin without using Sudo.
+    /** Test of light admin without using Sudo.
      * The workflow deals with the eventuality of putting Rendering Settings on an
      * image of the user and then transferring the ownership of these settings
      * to the user.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -624,7 +624,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         /*in order to find the image in whatever group, get context with group
          * set to -1 (=all groups) */
-        client.getImplicitContext().put("omero.group", Long.toString(-1));
+        client.getImplicitContext().put("omero.group", "-1");
         /* try to move the image into another group of the normalUser
          * which should succeed if sudoing and also in case
          * the light admin has Chgrp permissions
@@ -1053,7 +1053,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /*in order to find the image in whatever group, get context with group
          * set to -1 (=all groups)
          */
-        client.getImplicitContext().put("omero.group", Long.toString(-1));
+        client.getImplicitContext().put("omero.group", "-1");
         /* try to move the dataset (and with it the linked image)
          * from light admin's default group
          * into the default group of the normalUser
@@ -1274,7 +1274,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         ProjectDatasetLink linkOfProjectDataset2OtherGroup = linkProjectDataset(sentProj2OtherGroup, sentDat2OtherGroup);
         /* now transfer all the data of normalUser to recipient */
         loginUser(lightAdmin);
-        client.getImplicitContext().put("omero.group", Long.toString(-1));
+        client.getImplicitContext().put("omero.group", "-1");
         /* transfer can proceed only if chownPassing boolean is true */
         doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), chownPassing);
         if (!chownPassing) {
@@ -1282,7 +1282,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         /* check the transfer of all the data in the first group was successful */
         /* check ownership of the first hierarchy set*/
-        client.getImplicitContext().put("omero.group", Long.toString(-1));
+        client.getImplicitContext().put("omero.group", "-1");
         assertOwnedBy(sentProj1, recipient);
         assertOwnedBy(sentDat1, recipient);
         assertOwnedBy(sentImage1, recipient);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1622,7 +1622,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
     }
 
-
     /**
      * Test that light admin can modify group membership when he/she has
      * only the <tt>ModifyGroupMembership</tt> privilege.
@@ -1648,6 +1647,32 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertTrue(isExpectSuccessRemoveUserFromGroup);
         } catch (ServerError se) {
             Assert.assertFalse(isExpectSuccessRemoveUserFromGroup);
+        }
+    }
+
+    /**
+     * Test that light admin can make a user an owner of a group
+     * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
+     */
+    @Test(dataProvider = "script privileges cases")
+    public void testModifyGroupMembershipMakeOwner(boolean isAdmin, boolean permModifyGroupMembership,
+            String groupPermissions) throws Exception {
+        if (!isAdmin) return;
+        /* the permModifyGroupMembership should be a sufficient permission to perform
+         * the setting of a new group owner */
+        boolean isExpectSuccessMakeOwnerOfGroup= isAdmin && permModifyGroupMembership;
+        final EventContext normalUser = newUserAndGroup(groupPermissions);
+        List<String> permissions = new ArrayList<String>();
+        if (permModifyGroupMembership) permissions.add(AdminPrivilegeModifyGroupMembership.value);
+        final EventContext lightAdmin;
+        lightAdmin = loginNewAdmin(isAdmin, permissions);
+        final Experimenter user = new ExperimenterI(normalUser.userId, false);
+        final ExperimenterGroup group = new ExperimenterGroupI(normalUser.groupId, false);
+        try {
+            iAdmin.setGroupOwner(group, user);
+            Assert.assertTrue(isExpectSuccessMakeOwnerOfGroup);
+        } catch (ServerError se) {
+            Assert.assertFalse(isExpectSuccessMakeOwnerOfGroup);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1166,9 +1166,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* now transfer all the data of normalUser to recipient */
         loginUser(lightAdmin);
         client.getImplicitContext().put("omero.group", Long.toString(-1));
-        if (chownPassing) {
-            doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), true);
-        }
+        /* transfer can proceed only if chownPassing boolean is true */
+        doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), chownPassing);
         if (!isExpectSuccess) {
             return;
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -267,7 +267,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
-    public void testCreateLinkImportSudo(boolean isSudoing, boolean permWriteOwned,
+    public void testImporterAsSudoCreateImport(boolean isSudoing, boolean permWriteOwned,
             String groupPermissions) throws Exception {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         final boolean isExpectSuccessCreate = permWriteOwned || isSudoing;
@@ -362,9 +362,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * Test whether an ImporterAs can delete image, Project and Dataset
+     * Test whether a light admin can delete image, Project and Dataset
      * and their respective links belonging to another
-     * user. Behaviors of the system are explored when ImporterAs
+     * user. Behaviors of the system are explored when light admin
      * is and is not using <tt>Sudo</tt> privilege
      * for this action.
      * @param isAdmin if to test a member of the <tt>system</tt> group

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -662,9 +662,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      */
     @Test(dataProvider = "combined privileges cases")
     public void testImporterAsSudoChown(boolean isAdmin, boolean isSudoing, boolean permChown,
-            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
+            boolean permWriteOwned, boolean permWriteFile, boolean permDeleteOwned, String groupPermissions) throws Exception {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
-        final boolean chownPassing = isAdmin && permChown && permWriteOwned && permWriteFile;
+        final boolean chownPassing = isAdmin && permChown && permWriteOwned && permWriteFile && permDeleteOwned;
         final long anotherUserId = newUserAndGroup(groupPermissions).userId;
         /* set up the basic permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();
@@ -672,6 +672,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
+        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         try {
@@ -766,8 +767,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* define case where the import without any sudo importing into a group
          * the light admin is not a member of is expected to succeed
          */
-        boolean permDeleteOwned = true;
-        if (!isAdmin) return;
         boolean importNotYourGroupExpectSuccess = (isAdmin && permWriteOwned && permWriteFile && permWriteManagedRepo);
         /* the first workflow with importing into the group of the normalUser directly
          * will succeed if the import will succeed and the subsequent Chown is possible
@@ -786,7 +785,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
-        if (permDeleteOwned) permissions.add(AdminPrivilegeWriteFile.value);
         if (permWriteManagedRepo) permissions.add(AdminPrivilegeWriteManagedRepo.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -823,7 +823,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         Dataset sentDat = new DatasetI();
         sentDat = null;
         if (createDatasetExpectSuccess) {/* you are allowed to create the dataset only
-        with sufficient permissions, which are the same as permissions for importing */
+        with sufficient permissions, which are captured in createDatasetExpectSuccess.*/
             sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
         }
         /* import an image into the created Dataset */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -666,20 +666,17 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * the chown action wiill succeed)
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "widened combined privileges cases")
+    @Test(dataProvider = "narrowed combined privileges cases")
     public void testImporterAsSudoChown(boolean isAdmin, boolean isSudoing, boolean permChown,
-            boolean permWriteOwned, boolean permWriteFile, boolean permDeleteOwned, boolean permDeleteManagedRepo, String groupPermissions) throws Exception {
-        final boolean chownPassing = isAdmin && permChown && permWriteOwned && permWriteFile && permDeleteOwned && permDeleteManagedRepo;
+            String groupPermissions) throws Exception {
+        final boolean chownPassing = isAdmin && permChown;
+        if (!isAdmin) return;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         final long anotherUserId = newUserAndGroup(groupPermissions).userId;
         /* set up the basic permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
-        if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
-        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
-        if (permDeleteManagedRepo) permissions.add(AdminPrivilegeDeleteManagedRepo.value);
 
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
@@ -1334,6 +1331,38 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                                 }
                             }
                         }
+                    }
+                }
+            }
+        }
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+    /**
+     * @return narrowed test cases for adding the privileges combined with isAdmin cases
+     */
+    @DataProvider(name = "narrowed combined privileges cases")
+    public Object[][] provideNarrowedCombinedPrivilegesCases() {
+        int index = 0;
+        final int IS_ADMIN = index++;
+        final int IS_SUDOING = index++;
+        final int PERM_ADDITIONAL = index++;
+        final int GROUP_PERMS = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isAdmin : booleanCases) {
+            for (final boolean isSudoing : booleanCases) {
+                for (final boolean permAdditional : booleanCases) {
+                    for (final String groupPerms : permsCases) {
+                        final Object[] testCase = new Object[index];
+                        testCase[IS_ADMIN] = isAdmin;
+                        testCase[IS_SUDOING] = isSudoing;
+                        testCase[PERM_ADDITIONAL] = permAdditional;
+                        testCase[GROUP_PERMS] = groupPerms;
+                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        testCases.add(testCase);
                     }
                 }
             }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1970,7 +1970,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_WRITEOWNED] = permWriteOwned;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
                     }
                 }
@@ -2002,7 +2002,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_DELETEOWNED] = permDeleteOwned;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
                     }
                 }
@@ -2034,7 +2034,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_CHGRP] = permChgrp;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
                     }
                 }
@@ -2066,7 +2066,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
                     }
                 }
@@ -2111,7 +2111,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                                 testCase[PERM_WRITEMANAGEDREPO] = permWriteManagedRepo;
                                 testCase[PERM_CHOWN] = permChown;
                                 testCase[GROUP_PERMS] = groupPerms;
-                                // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                                // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                                 testCases.add(testCase);
                             }
                         }
@@ -2146,7 +2146,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[PERM_WRITEOWNED] = permWriteOwned;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
                     }
                 }
@@ -2179,7 +2179,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[PERM_CHGRP] = permChgrp;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
                     }
                 }
@@ -2207,7 +2207,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                     final Object[] testCase = new Object[index];
                     testCase[IS_PRIVILEGED] = isPrivileged;
                     testCase[GROUP_PERMS] = groupPerms;
-                    // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                    // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
                     testCases.add(testCase);
                 }
             }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1192,21 +1192,21 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * user to another user. The data are in 2 groups, of which the original data owner
      * is a member of, the recipient of the data is just a member of one of the groups.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testChownAllBelongingToUser(boolean isAdmin, boolean permChown,
+    public void testChownAllBelongingToUser(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         /* chown is passing in this test with isAdmin and permChown only.*/
-        final boolean chownPassing = isAdmin && permChown;
+        final boolean chownPassing = isAdmin && isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         ExperimenterGroup otherGroup = newGroupAddUser(groupPermissions, normalUser.userId, false);
         final EventContext recipient = newUserInGroup(otherGroup, false);
         /* set up the light admin's permissions for this test */
         List<String> permissions = new ArrayList<String>();
-        if (permChown) permissions.add(AdminPrivilegeChown.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeChown.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* create two sets of P/D/I hierarchy as normalUser in the default
@@ -1531,21 +1531,21 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * The workflow tries to upload an official script.
      * The only permission light admin needs for this is WriteScriptRepo
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permWriteScriptRepo if to test a user who has the <tt>WriteScriptRepo</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>WriteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testOfficialSciptUploadNoSudo(boolean isAdmin, boolean permWriteScriptRepo,
+    public void testOfficialSciptUploadNoSudo(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         /* upload/creation of File Attachment should be always permitted as long as light admin is in System Group
          * and has WriteOwned and WriteFile permissions. */
         if (!isAdmin) return;
-        boolean isExpectSuccessUploadOfficialScript = isAdmin && permWriteScriptRepo;
+        boolean isExpectSuccessUploadOfficialScript = isAdmin && isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
         List<String> permissions = new ArrayList<String>();
-        if (permWriteScriptRepo) permissions.add(AdminPrivilegeWriteScriptRepo.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeWriteScriptRepo.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
@@ -1585,21 +1585,21 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that users may delete official scripts only if they are a member of the <tt>system</tt> group and
      * have the <tt>DeleteScriptRepo</tt> privilege.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permDeleteScriptRepo if to test a user who has the <tt>DeleteScriptRepo</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>DeleteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testOfficialScriptDeleteNoSudo(boolean isAdmin, boolean permDeleteScriptRepo,
+    public void testOfficialScriptDeleteNoSudo(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         if (groupPermissions.equals("rwrw--")) {
             throw new SkipException("does not work in read-write group");
         }
-        boolean isExpectSuccessDeleteOfficialScript = isAdmin && permDeleteScriptRepo;
+        boolean isExpectSuccessDeleteOfficialScript = isAdmin && isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();
-        if (permDeleteScriptRepo) permissions.add(AdminPrivilegeDeleteScriptRepo.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeDeleteScriptRepo.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
@@ -1662,22 +1662,22 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * only the <tt>ModifyGroupMembership</tt> privilege.
      * The addition of a user is being attempted here.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyGroupMembershipAddUser(boolean isAdmin, boolean permModifyGroupMembership,
+    public void testModifyGroupMembershipAddUser(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyGroupMembership should be a sufficient permission to perform
          * the user addition into a group */
-        boolean isExpectSuccessAddUserToGroup = isAdmin && permModifyGroupMembership;
+        boolean isExpectSuccessAddUserToGroup = isAdmin && isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* one extra group is needed to add the existing normalUser to */
         final EventContext otherUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();
-        if (permModifyGroupMembership) permissions.add(AdminPrivilegeModifyGroupMembership.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
@@ -1695,22 +1695,22 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * only the <tt>ModifyGroupMembership</tt> privilege.
      * The removal of a user is being attempted here.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyGroupMembershipRemoveUser(boolean isAdmin, boolean permModifyGroupMembership,
+    public void testModifyGroupMembershipRemoveUser(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyGroupMembership should be a sufficient permission to perform
          * the user removal from a group */
-        boolean isExpectSuccessRemoveUserFromGroup = isAdmin && permModifyGroupMembership;
+        boolean isExpectSuccessRemoveUserFromGroup = isAdmin && isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* one extra group is needed which the normalUser is also a member of */
         final ExperimenterGroup otherGroup = newGroupAddUser("rwr-r-", normalUser.userId);
         List<String> permissions = new ArrayList<String>();
-        if (permModifyGroupMembership) permissions.add(AdminPrivilegeModifyGroupMembership.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
@@ -1726,20 +1726,20 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can make a user an owner of a group
      * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyGroupMembershipMakeOwner(boolean isAdmin, boolean permModifyGroupMembership,
+    public void testModifyGroupMembershipMakeOwner(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyGroupMembership should be a sufficient permission to perform
          * the setting of a new group owner */
-        boolean isExpectSuccessMakeOwnerOfGroup= isAdmin && permModifyGroupMembership;
+        boolean isExpectSuccessMakeOwnerOfGroup= isAdmin && isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();
-        if (permModifyGroupMembership) permissions.add(AdminPrivilegeModifyGroupMembership.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
@@ -1756,22 +1756,22 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can unset a user to be an owner of a group
      * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyGroupMembership if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyGroupMembershipUnsetOwner(boolean isAdmin, boolean permModifyGroupMembership,
+    public void testModifyGroupMembershipUnsetOwner(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyGroupMembership should be a sufficient permission to perform
          * the unsetting of a new group owner */
-        boolean isExpectSuccessUnsetOwnerOfGroup= isAdmin && permModifyGroupMembership;
+        boolean isExpectSuccessUnsetOwnerOfGroup= isAdmin && isPrivileged;
         /* set up the normalUser and make him an Owner by passing "true" in the
          * newUserAndGroup method argument */
         final EventContext normalUser = newUserAndGroup(groupPermissions, true);
         List<String> permissions = new ArrayList<String>();
-        if (permModifyGroupMembership) permissions.add(AdminPrivilegeModifyGroupMembership.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
@@ -1794,20 +1794,20 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can create a new user
      * when the light admin has only the <tt>ModifyUser</tt> privilege.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyUser if to test a user who has the <tt>ModifyUser</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyUserCreate(boolean isAdmin, boolean permModifyUser,
+    public void testModifyUserCreate(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyUser should be a sufficient permission to perform
          * the creation of a new user */
-        boolean isExpectSuccessCreateUser= isAdmin && permModifyUser;
+        boolean isExpectSuccessCreateUser= isAdmin && isPrivileged;
         final long newGroupId = newUserAndGroup(groupPermissions).groupId;
         List<String> permissions = new ArrayList<String>();
-        if (permModifyUser) permissions.add(AdminPrivilegeModifyUser.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyUser.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter newUser = new ExperimenterI();
@@ -1829,20 +1829,20 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can edit an existing user
      * when the light admin has only the <tt>ModifyUser</tt> privilege.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyUser if to test a user who has the <tt>ModifyUser</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyUserEdit(boolean isAdmin, boolean permModifyUser,
+    public void testModifyUserEdit(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyUser should be a sufficient permission to perform
          * the editing of a user */
-        boolean isExpectSuccessEditUser= isAdmin && permModifyUser;
+        boolean isExpectSuccessEditUser= isAdmin && isPrivileged;
         final long newUserId = newUserAndGroup(groupPermissions).userId;
         List<String> permissions = new ArrayList<String>();
-        if (permModifyUser) permissions.add(AdminPrivilegeModifyUser.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyUser.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         final Experimenter newUser = (Experimenter) iQuery.get("Experimenter", newUserId);
@@ -1859,24 +1859,24 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can create a new group
      * when the light admin has only the <tt>ModifyGroup</tt> privilege.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyGroup if to test a user who has the <tt>ModifyGroup</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyGroupCreate(boolean isAdmin, boolean permModifyGroup,
+    public void testModifyGroupCreate(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyGroup should be a sufficient permission to perform
          * a group creation */
-        boolean isExpectSuccessCreateGroup = isAdmin && permModifyGroup;
+        boolean isExpectSuccessCreateGroup = isAdmin && isPrivileged;
         final ExperimenterGroup newGroup = new ExperimenterGroupI();
         newGroup.setLdap(omero.rtypes.rbool(false));
         newGroup.setName(omero.rtypes.rstring(UUID.randomUUID().toString()));
         newGroup.getDetails().setPermissions(new PermissionsI(groupPermissions));
         /* set up the permissions for the light admin */
         List<String> permissions = new ArrayList<String>();
-        if (permModifyGroup) permissions.add(AdminPrivilegeModifyGroup.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyGroup.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         try {
@@ -1891,23 +1891,23 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that light admin can edit an existing group
      * when the light admin has only the <tt>ModifyGroup</tt> privilege.
      * @param isAdmin if to test a member of the <tt>system</tt> group
-     * @param permModifyGroup if to test a user who has the <tt>ModifyGroup</tt> privilege
+     * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testModifyGroupEdit(boolean isAdmin, boolean permModifyGroup,
+    public void testModifyGroupEdit(boolean isAdmin, boolean isPrivileged,
             String groupPermissions) throws Exception {
         if (!isAdmin) return;
         /* the permModifyGroup should be a sufficient permission to perform
          * group editing */
-        boolean isExpectSuccessEditGroup = isAdmin && permModifyGroup;
+        boolean isExpectSuccessEditGroup = isAdmin && isPrivileged;
         /* set up the new group as Read-Write as the downgrade (edit) to all group
          * types by the light admin will be tested later in the test */
         final long newGroupId = newUserAndGroup("rwrw--").groupId;
         /* set up the permissions for the light admin */
         List<String> permissions = new ArrayList<String>();
-        if (permModifyGroup) permissions.add(AdminPrivilegeModifyGroup.value);
+        if (isPrivileged) permissions.add(AdminPrivilegeModifyGroup.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* light admin will downgrade the group to all possible permission levels and

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -674,7 +674,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* set up the basic permissions for this test */
         List<String> permissions = new ArrayList<String>();
         permissions.add(AdminPrivilegeSudo.value);
-        if (permChown) permissions.add(AdminPrivilegeChown.value);;
+        if (permChown) permissions.add(AdminPrivilegeChown.value);
 
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
@@ -873,7 +873,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
         List<String> permissions = new ArrayList<String>();
-        if (permChown) permissions.add(AdminPrivilegeChown.value);;
+        if (permChown) permissions.add(AdminPrivilegeChown.value);
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
@@ -1145,8 +1145,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final EventContext recipient = newUserInGroup(otherGroup, false);
         /* set up the light admin's permissions for this test */
         List<String> permissions = new ArrayList<String>();
-        if (permChown) permissions.add(AdminPrivilegeChown.value);;
-        if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
+        if (permChown) permissions.add(AdminPrivilegeChown.value);
+        if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* create two sets of P/D/I hierarchy as normalUser in the default
@@ -1280,7 +1280,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
         List<String> permissions = new ArrayList<String>();
-        if (permChown) permissions.add(AdminPrivilegeChown.value);;
+        if (permChown) permissions.add(AdminPrivilegeChown.value);
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1256,76 +1256,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return test cases for isAdmin (member of system group) all group permissions cases
-     */
-    @DataProvider(name = "isAdmin and groupPerms cases")
-    public Object[][] provideAdminPrivilegeCases() {
-        int index = 0;
-        final int IS_ADMIN = index++;
-        final int GROUP_PERMS = index++;
-
-        final boolean[] booleanCases = new boolean[]{false, true};
-        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        for (final boolean isAdmin : booleanCases) {
-            for (final String groupPerms : permsCases) {
-                final Object[] testCase = new Object[index];
-                testCase[IS_ADMIN] = isAdmin;
-                testCase[GROUP_PERMS] = groupPerms;
-                // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
-                testCases.add(testCase);
-            }
-        }
-
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
-     * @return test cases for adding the privileges combined with isAdmin cases
-     */
-    @DataProvider(name = "combined privileges cases")
-    public Object[][] provideCombinedPrivilegesCases() {
-        int index = 0;
-        final int IS_ADMIN = index++;
-        final int IS_SUDOING = index++;
-        final int PERM_ADDITIONAL = index++;
-        final int PERM_ADDITIONAL2 = index++;
-        final int PERM_ADDITIONAL3 = index++;
-        final int PERM_ADDITIONAL4 = index++;
-        final int GROUP_PERMS = index++;
-
-        final boolean[] booleanCases = new boolean[]{false, true};
-        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        for (final boolean isAdmin : booleanCases) {
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permAdditional : booleanCases) {
-                    for (final boolean permAdditional2 : booleanCases) {
-                        for (final boolean permAdditional3 : booleanCases) {
-                            for (final boolean permAdditional4 : booleanCases) {
-                                for (final String groupPerms : permsCases) {
-                                    final Object[] testCase = new Object[index];
-                                    testCase[IS_ADMIN] = isAdmin;
-                                    testCase[IS_SUDOING] = isSudoing;
-                                    testCase[PERM_ADDITIONAL] = permAdditional;
-                                    testCase[PERM_ADDITIONAL2] = permAdditional2;
-                                    testCase[PERM_ADDITIONAL3] = permAdditional3;
-                                    testCase[PERM_ADDITIONAL4] = permAdditional4;
-                                    testCase[GROUP_PERMS] = groupPerms;
-                                    // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
-                                    testCases.add(testCase);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-    /**
      * @return test cases for adding the privileges combined with isAdmin cases
      */
     @DataProvider(name = "6 privileges cases")
@@ -1391,54 +1321,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[GROUP_PERMS] = groupPerms;
                         // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
-                    }
-                }
-            }
-        }
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-    /**
-     * @return widened test cases for adding the privileges combined with isAdmin cases
-     */
-    @DataProvider(name = "widened combined privileges cases")
-    public Object[][] provideWidenedCombinedPrivilegesCases() {
-        int index = 0;
-        final int IS_ADMIN = index++;
-        final int IS_SUDOING = index++;
-        final int PERM_ADDITIONAL = index++;
-        final int PERM_ADDITIONAL2 = index++;
-        final int PERM_ADDITIONAL3 = index++;
-        final int PERM_ADDITIONAL4 = index++;
-        final int PERM_ADDITIONAL5 = index++;
-        final int GROUP_PERMS = index++;
-
-        final boolean[] booleanCases = new boolean[]{false, true};
-        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        for (final boolean isAdmin : booleanCases) {
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permAdditional : booleanCases) {
-                    for (final boolean permAdditional2 : booleanCases) {
-                        for (final boolean permAdditional3 : booleanCases) {
-                            for (final boolean permAdditional4 : booleanCases) {
-                                for (final boolean permAdditional5 : booleanCases) {
-                                    for (final String groupPerms : permsCases) {
-                                        final Object[] testCase = new Object[index];
-                                        testCase[IS_ADMIN] = isAdmin;
-                                        testCase[IS_SUDOING] = isSudoing;
-                                        testCase[PERM_ADDITIONAL] = permAdditional;
-                                        testCase[PERM_ADDITIONAL2] = permAdditional2;
-                                        testCase[PERM_ADDITIONAL3] = permAdditional3;
-                                        testCase[PERM_ADDITIONAL4] = permAdditional4;
-                                        testCase[PERM_ADDITIONAL5] = permAdditional5;
-                                        testCase[GROUP_PERMS] = groupPerms;
-                                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
-                                        testCases.add(testCase);
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
             }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -102,7 +102,7 @@ import com.google.common.collect.ImmutableSet;
 /**
  * Tests the concrete workflows of the light admins
  * @author p.walczysko@dundee.ac.uk
- * @since 5.3.0
+ * @since 5.4.0
  */
 public class LightAdminRolesTest extends AbstractServerImportTest {
 
@@ -280,9 +280,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (isSudoing) {
             try {
                 sudo(new ExperimenterI(normalUser.userId, false));
-                }catch (SecurityViolation sv) {
-                    /* sudo expected to fail if the user is not in system group */
-                }
+            } catch (SecurityViolation sv) {
+                /* sudo expected to fail if the user is not in system group */
+            }
         }
 
         /* First, check that the light admin (=importer As)

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1924,56 +1924,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return test cases for adding the privileges combined with isAdmin cases
-     */
-    @DataProvider(name = "6 privileges cases")
-    public Object[][] provide6CombinedPrivilegesCases() {
-        int index = 0;
-        final int IS_ADMIN = index++;
-        final int IS_SUDOING = index++;
-        final int PERM_ADDITIONAL = index++;
-        final int PERM_ADDITIONAL2 = index++;
-        final int PERM_ADDITIONAL3 = index++;
-        final int GROUP_PERMS = index++;
-
-        final boolean[] booleanCases = new boolean[]{false, true};
-        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        for (final boolean isAdmin : booleanCases) {
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permAdditional : booleanCases) {
-                    for (final boolean permAdditional2 : booleanCases) {
-                        for (final boolean permAdditional3 : booleanCases) {
-                            for (final String groupPerms : permsCases) {
-                                final Object[] testCase = new Object[index];
-                                testCase[IS_ADMIN] = isAdmin;
-                                testCase[IS_SUDOING] = isSudoing;
-                                testCase[PERM_ADDITIONAL] = permAdditional;
-                                testCase[PERM_ADDITIONAL2] = permAdditional2;
-                                testCase[PERM_ADDITIONAL3] = permAdditional3;
-                                testCase[GROUP_PERMS] = groupPerms;
-                                // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
-                                testCases.add(testCase);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
-     * @return test cases for adding the privileges combined with isAdmin cases
+     * @return test cases for File Attachment workflow testFileAttachmentNoSudo
      */
     @DataProvider(name = "fileAttachment privileges cases")
     public Object[][] provideFileAttachmentPrivilegesCases() {
         int index = 0;
         final int IS_ADMIN = index++;
-        final int PERM_ADDITIONAL = index++;
-        final int PERM_ADDITIONAL2 = index++;
-        final int PERM_ADDITIONAL3 = index++;
+        final int PERM_CHOWN = index++;
+        final int PERM_WRITEOWNED = index++;
+        final int PERM_WRITEFILE = index++;
         final int GROUP_PERMS = index++;
 
         final boolean[] booleanCases = new boolean[]{false, true};
@@ -1981,15 +1940,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
         for (final boolean isAdmin : booleanCases) {
-            for (final boolean permAdditional : booleanCases) {
-                for (final boolean permAdditional2 : booleanCases) {
-                    for (final boolean permAdditional3 : booleanCases) {
+            for (final boolean permChown : booleanCases) {
+                for (final boolean permWriteOwned : booleanCases) {
+                    for (final boolean permWriteFile : booleanCases) {
                         for (final String groupPerms : permsCases) {
                             final Object[] testCase = new Object[index];
                             testCase[IS_ADMIN] = isAdmin;
-                            testCase[PERM_ADDITIONAL] = permAdditional;
-                            testCase[PERM_ADDITIONAL2] = permAdditional2;
-                            testCase[PERM_ADDITIONAL3] = permAdditional3;
+                            testCase[PERM_CHOWN] = permChown;
+                            testCase[PERM_WRITEOWNED] = permWriteOwned;
+                            testCase[PERM_WRITEFILE] = permWriteFile;
                             testCase[GROUP_PERMS] = groupPerms;
                             //DEBUG if (isAdmin == true && permAdditional == true && permAdditional2 == true && permAdditional3 == true)
                             testCases.add(testCase);
@@ -2002,40 +1961,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return narrowed test cases for adding the privileges combined with isAdmin cases
-     */
-    @DataProvider(name = "narrowed combined privileges cases")
-    public Object[][] provideNarrowedCombinedPrivilegesCases() {
-        int index = 0;
-        final int IS_ADMIN = index++;
-        final int IS_SUDOING = index++;
-        final int PERM_ADDITIONAL = index++;
-        final int GROUP_PERMS = index++;
-
-        final boolean[] booleanCases = new boolean[]{false, true};
-        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
-        final List<Object[]> testCases = new ArrayList<Object[]>();
-
-        for (final boolean isAdmin : booleanCases) {
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permAdditional : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        testCase[IS_ADMIN] = isAdmin;
-                        testCase[IS_SUDOING] = isSudoing;
-                        testCase[PERM_ADDITIONAL] = permAdditional;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
-                        testCases.add(testCase);
-                    }
-                }
-            }
-        }
-        return testCases.toArray(new Object[testCases.size()][]);
-    }
-
-    /**
-     * @return narrowed test cases for adding the privileges combined with isAdmin cases
+     * @return test cases for testCreateLinkImportSudo and testEdit
      */
     @DataProvider(name = "isSudoing and WriteOwned privileges cases")
     public Object[][] provideIsSudoingAndWriteOwned() {
@@ -2071,7 +1997,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return narrowed test cases for adding the privileges combined with isAdmin cases
+     * @return test cases for testDelete
      */
     @DataProvider(name = "isSudoing and Delete privileges cases")
     public Object[][] provideIsSudoingAndDeleteOwned() {
@@ -2107,8 +2033,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return isSudoing and Chgrp test cases for adding the privileges combined with
-     * groupPermission cases
+     * @return isSudoing and Chgrp test cases for testChgrp
      */
     @DataProvider(name = "isSudoing and Chgrp privileges cases")
     public Object[][] provideIsSudoingAndChgrpOwned() {
@@ -2144,7 +2069,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return narrowed test cases for adding the privileges combined with isAdmin cases
+     * @return isSudoing and Chgrp test cases for testChown
      */
     @DataProvider(name = "isSudoing and Chown privileges cases")
     public Object[][] provideIsSudoingAndChown() {
@@ -2181,7 +2106,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
     /**
      * @return provide WriteOwned, WriteFile, WriteManagedRepo and Chown cases
-     * combined with group Permissions
+     * for testImporterAsNoSudoChownOnly
      */
     @DataProvider(name = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
     public Object[][] provideWriteOwnedWriteFileWriteManagedRepoAndChown() {
@@ -2231,7 +2156,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return WriteOwned and Chown test cases combined with groupPermissions
+     * @return WriteOwned and Chown test cases for
+     * testLinkNoSudo and testROIAndRenderingSettingsNoSudo
      */
     @DataProvider(name = "WriteOwned and Chown privileges cases")
     public Object[][] provideWriteOwnedAndChown() {
@@ -2267,7 +2193,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return Chgrp and Chown test cases combined with groupPermissions
+     * @return Chgrp and Chown test cases for testImporterAsNoSudoChgrpChown
      */
     @DataProvider(name = "Chgrp and Chown privileges cases")
     public Object[][] provideChgrpAndChown() {
@@ -2305,7 +2231,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
     /**
      * @return isPrivileged test cases. The isPrivileged parameter translates into one
-     * tested privilege in particular tests and combines them with group permissions
+     * tested privilege in particular tests (for example in testScriptUpload isPrivileged
+     * concerns WriteScriptRepo privilege specifically)
      */
     @DataProvider(name = "isPrivileged cases")
     public Object[][] provideIsPrivilegesCases() {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -660,15 +660,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
     /**
      * Test that an ImporterAs cannot
-     * chown on behalf of another user in any combination of <tt>Sudo</tt> privilege
-     * with having or not having also the <tt>Chown</tt>. <tt>WriteOwned</tt> and
-     * <tt>WriteFile</tt> privileges except for having all three of them (in which case
-     * the chown action wiill succeed)
+     * chown on behalf of another user if sudoed in as that user.
+     * Chown will be successful only when not sudoed and having
+     * the <tt>Chown</tt> privilege.
      * @throws Exception unexpected
      */
     @Test(dataProvider = "narrowed combined privileges cases")
     public void testImporterAsSudoChown(boolean isAdmin, boolean isSudoing, boolean permChown,
             String groupPermissions) throws Exception {
+        /* define the conditions for the chown passing (when not sudoing) */
         final boolean chownPassing = isAdmin && permChown;
         if (!isAdmin) return;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
@@ -734,8 +734,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(remoteFile.getDetails().getOwner().getId().getValue(), normalUser.userId);
         } else {
             /* when trying to chown the image NOT being sudoed,
-             * this should fail in case you have not all of Chown & WriteOwned & WriteFile
-             * permissions, collated in "chownPassing" boolean */
+             * this should fail in case you have not Chown
+             * privilege, collated in "chownPassing" boolean together with isAdmin */
             doChange(client, factory, Requests.chown().target(image).toUser(anotherUserId).build(), chownPassing);
             image = (Image) iQuery.get("Image", image.getId().getValue());
             remoteFile = (OriginalFile) iQuery.findByQuery(

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1059,12 +1059,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * into the default group of the normalUser
          * which should succeed in case the light admin has Chgrp permissions
          */
-        if (permChgrp) {
-            doChange(client, factory, Requests.chgrp().target(sentDat).toGroup(normalUser.groupId).build(), true);
-
-        } else {
-            doChange(client, factory, Requests.chgrp().target(sentDat).toGroup(normalUser.groupId).build(), false);
-        }
+        doChange(client, factory, Requests.chgrp().target(sentDat).toGroup(normalUser.groupId).build(), permChgrp);
         /* retrieve again the image, dataset and link */
         long datasetGroupId =((RLong) iQuery.projection(
                 "SELECT details.group.id FROM Dataset d WHERE d.id = :id",

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1234,7 +1234,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
     }
 
     /**
-     * @return two test cases for isAdmin (member of system group) case
+     * @return test cases for isAdmin (member of system group) all group permissions cases
      */
     @DataProvider(name = "isAdmin and groupPerms cases")
     public Object[][] provideAdminPrivilegeCases() {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -784,13 +784,13 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @throws Exception unexpected
      */
 
-    @Test(dataProvider = "6 privileges cases")
-    public void testImporterAsNoSudoChownOnlyWorkflow(boolean isAdmin, boolean permWriteOwned, boolean permWriteManagedRepo, boolean permWriteFile, boolean permChown,
+    @Test(dataProvider = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
+    public void testImporterAsNoSudoChownOnlyWorkflow(boolean isAdmin, boolean permWriteOwned, boolean permWriteFile, boolean permWriteManagedRepo, boolean permChown,
             String groupPermissions) throws Exception {
         /* define case where the import without any sudo importing into a group
          * the light admin is not a member of is expected to succeed
          */
-        boolean importNotYourGroupExpectSuccess = isAdmin && permWriteManagedRepo && permWriteOwned && permWriteFile;
+        boolean importNotYourGroupExpectSuccess = isAdmin && permWriteOwned && permWriteFile && permWriteManagedRepo;
         /* define case where the creation of a dataset belonging to light admin
          * in the group where light admin is not a member
          * without any sudo is expected to succeed */
@@ -808,7 +808,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
         if (permWriteManagedRepo) permissions.add(AdminPrivilegeWriteManagedRepo.value);
-        //permissions.add(AdminPrivilegeWriteFile.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         if (!isAdmin) return;
@@ -2144,7 +2143,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @return narrowed test cases for adding the privileges combined with isAdmin cases
      */
     @DataProvider(name = "isSudoing and Chown privileges cases")
-    public Object[][] provideIsSudoingAndChownOwned() {
+    public Object[][] provideIsSudoingAndChown() {
         int index = 0;
         final int IS_ADMIN = index++;
         final int IS_SUDOING = index++;
@@ -2169,6 +2168,58 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[GROUP_PERMS] = groupPerms;
                         // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);
+                    }
+                }
+            }
+        }
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+
+    /**
+     * @return provide WriteOwned, WriteFile, WriteManagedRepo and Chown cases
+     * combined with group Permissions
+     */
+    @DataProvider(name = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
+    public Object[][] provideWriteOwnedWriteFileWriteManagedRepoAndChown() {
+        int index = 0;
+        final int IS_ADMIN = index++;
+        final int PERM_WRITEOWNED = index++;
+        final int PERM_WRITEFILE = index++;
+        final int PERM_WRITEMANAGEDREPO = index++;
+        final int PERM_CHOWN = index++;
+        final int GROUP_PERMS = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isAdmin : booleanCases) {
+            for (final boolean permWriteOwned : booleanCases) {
+                for (final boolean permWriteFile : booleanCases) {
+                    for (final boolean permWriteManagedRepo : booleanCases) {
+                        for (final boolean permChown : booleanCases) {
+                            for (final String groupPerms : permsCases) {
+                                final Object[] testCase = new Object[index];
+                                if (!permWriteOwned && !permWriteFile)
+                                    /* not an interesting case */
+                                    continue;
+                                if (!permWriteOwned && !permWriteManagedRepo)
+                                    /* not an interesting case */
+                                    continue;
+                                if (!permWriteOwned && !permWriteFile && !permWriteManagedRepo)
+                                    /* not an interesting case */
+                                    continue;
+                                testCase[IS_ADMIN] = isAdmin;
+                                testCase[PERM_WRITEOWNED] = permWriteOwned;
+                                testCase[PERM_WRITEFILE] = permWriteFile;
+                                testCase[PERM_WRITEMANAGEDREPO] = permWriteManagedRepo;
+                                testCase[PERM_CHOWN] = permChown;
+                                testCase[GROUP_PERMS] = groupPerms;
+                                // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                                testCases.add(testCase);
+                            }
+                        }
                     }
                 }
             }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -203,17 +203,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * that the link belongs to the user (not to the ImporterAs).
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "combined privileges cases")
-    public void testImporterAsSudoCreateImport(boolean isAdmin, boolean isSudoing, boolean permChgrp,
-            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
+    @Test(dataProvider = "narrowed combined privileges cases")
+    public void testImporterAsSudoCreateImport(boolean isAdmin, boolean isSudoing, boolean permWriteOwned,
+            String groupPermissions) throws Exception {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         final boolean isExpectSuccessCreate = (isAdmin && permWriteOwned) || (isAdmin && isSudoing);
         /* set up the light admin's permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();
         permissions.add(AdminPrivilegeSudo.value);
-        if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         if (isSudoing) {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -221,7 +221,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         final boolean isExpectSuccessCreate = (isAdmin && permWriteOwned) || (isAdmin && isSudoing);
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         final EventContext lightAdmin;
@@ -339,7 +339,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        boolean deletePassing = permDeleteOwned || isSudoing;
        final EventContext normalUser = newUserAndGroup(groupPermissions);
        /* set up the light admin's permissions for this test */
-       ArrayList <String> permissions = new ArrayList <String>();
+       List<String> permissions = new ArrayList<String>();
        permissions.add(AdminPrivilegeSudo.value);
        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
        final EventContext lightAdmin;
@@ -470,7 +470,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final boolean isExpectSuccess = (isAdmin && isSudoing) || (isAdmin && permWriteOwned);
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         final EventContext lightAdmin;
@@ -571,7 +571,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
                 new ParametersI().addId(remoteFile.getId()));
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
         final EventContext lightAdmin;
@@ -672,7 +672,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
                 new ParametersI().addId(remoteFile.getId()));
         /* set up the basic permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
 
@@ -757,7 +757,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 isAdmin && permChown && permWriteManagedRepo && permWriteOwned && permWriteFile;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
@@ -872,7 +872,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         boolean isExpectSuccessLinkAndChown = isAdmin && permWriteOwned && permChown;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         final EventContext lightAdmin;
@@ -952,7 +952,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 (isAdmin && permChgrp && permChown);
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
         final EventContext lightAdmin;
@@ -1144,7 +1144,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         ExperimenterGroup otherGroup = newGroupAddUser(groupPermissions, normalUser.userId, false);
         final EventContext recipient = newUserInGroup(otherGroup, false);
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         final EventContext lightAdmin;
@@ -1279,7 +1279,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         boolean isExpectSuccessCreateAndChownRndSettings = isExpectSuccessCreateROIRndSettings && permChown;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
-        ArrayList <String> permissions = new ArrayList <String>();
+        List<String> permissions = new ArrayList<String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         final EventContext lightAdmin;

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1331,9 +1331,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "narrowed combined privileges cases")
-    public void testROIAndRenderingSettingsNoSudo(boolean isAdmin, boolean permChown,
-            boolean permWriteOwned, String groupPermissions) throws Exception {
+    @Test(dataProvider = "WriteOwned and Chown privileges cases")
+    public void testROIAndRenderingSettingsNoSudo(boolean isAdmin, boolean permWriteOwned, boolean permChown,
+            String groupPermissions) throws Exception {
         /* creation of rendering settings should be always permitted as long as light admin is in System Group
          * and has WriteOwned permissions. Exception is Private group, where it will
          * always fail.*/
@@ -1404,7 +1404,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         /* after this, as light admin try to chown the ROI and the rendering settings to normalUser */
         if (isExpectSuccessCreateROIRndSettings) {/* only attempt the chown if the ROI and rendering settings exist
-             and also in case of ROIs cannot chown in read-only group (see definition of boolean isExpectSuccessCreateAndChownROI */
+             and also in case of ROIs cannot chown in read-only group. See definition of boolean
+             isExpectSuccessCreateAndChownROI */
             doChange(client, factory, Requests.chown().target(roi).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChownROI);
             doChange(client, factory, Requests.chown().target(rDef).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChownRndSettings);
             roi = (Roi) iQuery.findByQuery("FROM Roi WHERE image.id = :id",

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -952,7 +952,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         ArrayList <String> permissions = new ArrayList <String>();
         if (permChown) permissions.add(AdminPrivilegeChown.value);
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
-        permissions.add(AdminPrivilegeWriteFile.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* Workflow2: import an image as lightAdmin into a group you are a member of */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -196,8 +196,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * Test that an ImporterAs can create new Project and Dataset
      * and import data on behalf of another user solely with <tt>Sudo</tt> privilege
      * into this Dataset. Further link the Dataset to the Project, check
-     * that the link belongs to the user (not to the ImporterAs) and finally
-     * delete the links and the Project, Dataset and Image.
+     * that the link belongs to the user (not to the ImporterAs).
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isAdmin cases")

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1909,7 +1909,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                             testCase[PERM_WRITEOWNED] = permWriteOwned;
                             testCase[PERM_WRITEFILE] = permWriteFile;
                             testCase[GROUP_PERMS] = groupPerms;
-                            //DEBUG if (isAdmin == true && permAdditional == true && permAdditional2 == true && permAdditional3 == true)
+                            //DEBUG if (permChown == true && permWriteOwned == true && permWriteFile == true)
                             testCases.add(testCase);
                         }
                     }
@@ -1942,7 +1942,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_WRITEOWNED] = permWriteOwned;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isSudoing == true && permWriteOwned == true)
                         testCases.add(testCase);
                     }
                 }
@@ -1974,7 +1974,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_DELETEOWNED] = permDeleteOwned;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isSudoing == true && permDeleteOwned == true)
                         testCases.add(testCase);
                     }
                 }
@@ -2006,7 +2006,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_CHGRP] = permChgrp;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isSudiong == true && permChgrp == true)
                         testCases.add(testCase);
                     }
                 }
@@ -2038,7 +2038,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (isSudoing == true && permChown == true)
                         testCases.add(testCase);
                     }
                 }
@@ -2083,7 +2083,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                                 testCase[PERM_WRITEMANAGEDREPO] = permWriteManagedRepo;
                                 testCase[PERM_CHOWN] = permChown;
                                 testCase[GROUP_PERMS] = groupPerms;
-                                // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                                // DEBUG if (permWriteOwned == true && permWriteFile == true && permWriteManagedRepo == true && permChown == true)
                                 testCases.add(testCase);
                             }
                         }
@@ -2118,7 +2118,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[PERM_WRITEOWNED] = permWriteOwned;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (permWriteOwned == true && permChown == true)
                         testCases.add(testCase);
                     }
                 }
@@ -2151,7 +2151,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[PERM_CHGRP] = permChgrp;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                        // DEBUG if (permChgrp == true && permChown == true)
                         testCases.add(testCase);
                     }
                 }
@@ -2179,7 +2179,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                     final Object[] testCase = new Object[index];
                     testCase[IS_PRIVILEGED] = isPrivileged;
                     testCase[GROUP_PERMS] = groupPerms;
-                    // DEBUG if (isAdmin == false && isRestricted == true && isSudo == false)
+                    // DEBUG if (isPrivileged == true)
                     testCases.add(testCase);
                 }
             }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -234,7 +234,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "narrowed combined privileges cases")
+    @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testCreateLinkImportSudo(boolean isAdmin, boolean isSudoing, boolean permWriteOwned,
             String groupPermissions) throws Exception {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
@@ -294,7 +294,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertNull(sentProj);
             Assert.assertNull(sentDat);
         }
-        /* finish the test if light admin is not sudoing, the firther part
+        /* finish the test if light admin is not sudoing, the further part
         of the test deals with the imports. Imports when not sudoing workflows are covered in
         other tests in this class */
         if (!isSudoing) return;
@@ -490,7 +490,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "narrowed combined privileges cases")
+    @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testEdit(boolean isAdmin, boolean isSudoing,
             boolean permWriteOwned, String groupPermissions) throws Exception {
         final boolean isExpectSuccess = (isAdmin && isSudoing) || (isAdmin && permWriteOwned);
@@ -2015,6 +2015,42 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                         testCase[IS_ADMIN] = isAdmin;
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_ADDITIONAL] = permAdditional;
+                        testCase[GROUP_PERMS] = groupPerms;
+                        // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
+                        testCases.add(testCase);
+                    }
+                }
+            }
+        }
+        return testCases.toArray(new Object[testCases.size()][]);
+    }
+
+    /**
+     * @return narrowed test cases for adding the privileges combined with isAdmin cases
+     */
+    @DataProvider(name = "isSudoing and WriteOwned privileges cases")
+    public Object[][] provideIsSudoingAndWriteOwned() {
+        int index = 0;
+        final int IS_ADMIN = index++;
+        final int IS_SUDOING = index++;
+        final int PERM_WRITEOWNED = index++;
+        final int GROUP_PERMS = index++;
+
+        final boolean[] booleanCases = new boolean[]{false, true};
+        final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
+        final List<Object[]> testCases = new ArrayList<Object[]>();
+
+        for (final boolean isAdmin : booleanCases) {
+            for (final boolean isSudoing : booleanCases) {
+                for (final boolean permWriteOwned : booleanCases) {
+                    for (final String groupPerms : permsCases) {
+                        final Object[] testCase = new Object[index];
+                        if (isSudoing && permWriteOwned)
+                            /* not an interesting case */
+                            continue;
+                        testCase[IS_ADMIN] = isAdmin;
+                        testCase[IS_SUDOING] = isSudoing;
+                        testCase[PERM_WRITEOWNED] = permWriteOwned;
                         testCase[GROUP_PERMS] = groupPerms;
                         // DEBUG  if (isAdmin == false && isRestricted == true && isSudo == false)
                         testCases.add(testCase);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -458,17 +458,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      * or without it, using permWriteOwned privilege
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "combined privileges cases")
-    public void testLightAdminEdit(boolean isAdmin, boolean isSudoing, boolean permChgrp,
-            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
+    @Test(dataProvider = "narrowed combined privileges cases")
+    public void testLightAdminEdit(boolean isAdmin, boolean isSudoing,
+            boolean permWriteOwned, String groupPermissions) throws Exception {
         final boolean isExpectSuccess = (isAdmin && isSudoing) || (isAdmin && permWriteOwned);
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         /* set up the light admin's permissions for this test */
         ArrayList <String> permissions = new ArrayList <String>();
         permissions.add(AdminPrivilegeSudo.value);
-        if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         /* set up the project as the normalUser */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1225,8 +1225,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* chown is passing in this test with isAdmin and permChown only.*/
         final boolean chownPassing = isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
-        ExperimenterGroup otherGroup = newGroupAddUser(groupPermissions, normalUser.userId, false);
-        final EventContext recipient = newUserInGroup(otherGroup, false);
+        ExperimenterGroup anotherGroup = newGroupAddUser(groupPermissions, normalUser.userId, false);
+        final EventContext recipient = newUserInGroup(anotherGroup, false);
         /* set up the light admin's permissions for this test */
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeChown.value);
@@ -1255,23 +1255,23 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
         /* now also create this hierarchy in the other group as the normalUser */
 
-        client.getImplicitContext().put("omero.group", Long.toString(otherGroup.getId().getValue()));
-        Image image1OtherGroup = mmFactory.createImage();
-        Image image2OtherGroup = mmFactory.createImage();
-        Image sentImage1OtherGroup = (Image) iUpdate.saveAndReturnObject(image1OtherGroup);
-        Image sentImage2OtherGroup = (Image) iUpdate.saveAndReturnObject(image2OtherGroup);
-        Dataset dat1OtherGroup = mmFactory.simpleDataset();
-        Dataset dat2OtherGroup = mmFactory.simpleDataset();
-        Dataset sentDat1OtherGroup = (Dataset) iUpdate.saveAndReturnObject(dat1OtherGroup);
-        Dataset sentDat2OtherGroup = (Dataset) iUpdate.saveAndReturnObject(dat2OtherGroup);
-        Project proj1OtherGroup = mmFactory.simpleProject();
-        Project proj2OtherGroup = mmFactory.simpleProject();
-        Project sentProj1OtherGroup = (Project) iUpdate.saveAndReturnObject(proj1OtherGroup);
-        Project sentProj2OtherGroup = (Project) iUpdate.saveAndReturnObject(proj2OtherGroup);
-        DatasetImageLink linkOfDatasetImage1OtherGroup = linkDatasetImage(sentDat1OtherGroup, sentImage1OtherGroup);
-        DatasetImageLink linkOfDatasetImage2OtherGroup = linkDatasetImage(sentDat2OtherGroup, sentImage2OtherGroup);
-        ProjectDatasetLink linkOfProjectDataset1OtherGroup = linkProjectDataset(sentProj1OtherGroup, sentDat1OtherGroup);
-        ProjectDatasetLink linkOfProjectDataset2OtherGroup = linkProjectDataset(sentProj2OtherGroup, sentDat2OtherGroup);
+        client.getImplicitContext().put("omero.group", Long.toString(anotherGroup.getId().getValue()));
+        Image image1AnotherGroup = mmFactory.createImage();
+        Image image2AnotherGroup = mmFactory.createImage();
+        Image sentImage1AnootherGroup = (Image) iUpdate.saveAndReturnObject(image1AnotherGroup);
+        Image sentImage2AnotherGroup = (Image) iUpdate.saveAndReturnObject(image2AnotherGroup);
+        Dataset dat1AnotherGroup = mmFactory.simpleDataset();
+        Dataset dat2AnotherGroup = mmFactory.simpleDataset();
+        Dataset sentDat1AnotherGroup = (Dataset) iUpdate.saveAndReturnObject(dat1AnotherGroup);
+        Dataset sentDat2AnotherGroup = (Dataset) iUpdate.saveAndReturnObject(dat2AnotherGroup);
+        Project proj1AnotherGroup = mmFactory.simpleProject();
+        Project proj2AnotherGroup = mmFactory.simpleProject();
+        Project sentProj1AnootherGroup = (Project) iUpdate.saveAndReturnObject(proj1AnotherGroup);
+        Project sentProj2AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj2AnotherGroup);
+        DatasetImageLink linkOfDatasetImage1AnotherGroup = linkDatasetImage(sentDat1AnotherGroup, sentImage1AnootherGroup);
+        DatasetImageLink linkOfDatasetImage2AnotherGroup = linkDatasetImage(sentDat2AnotherGroup, sentImage2AnotherGroup);
+        ProjectDatasetLink linkOfProjectDataset1AnotherGroup = linkProjectDataset(sentProj1AnootherGroup, sentDat1AnotherGroup);
+        ProjectDatasetLink linkOfProjectDataset2AnotherGroup = linkProjectDataset(sentProj2AnotherGroup, sentDat2AnotherGroup);
         /* now transfer all the data of normalUser to recipient */
         loginUser(lightAdmin);
         client.getImplicitContext().put("omero.group", "-1");
@@ -1296,17 +1296,17 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         assertOwnedBy(linkOfProjectDataset2, recipient);
         /* check ownership of the objects in otherGroup */
         /* check ownership of the first hierarchy in the other group */
-        assertOwnedBy(sentProj1OtherGroup, recipient);
-        assertOwnedBy(sentDat1OtherGroup, recipient);
-        assertOwnedBy(sentImage1OtherGroup, recipient);
-        assertOwnedBy(linkOfDatasetImage1OtherGroup, recipient);
-        assertOwnedBy(linkOfProjectDataset1OtherGroup, recipient);
+        assertOwnedBy(sentProj1AnootherGroup, recipient);
+        assertOwnedBy(sentDat1AnotherGroup, recipient);
+        assertOwnedBy(sentImage1AnootherGroup, recipient);
+        assertOwnedBy(linkOfDatasetImage1AnotherGroup, recipient);
+        assertOwnedBy(linkOfProjectDataset1AnotherGroup, recipient);
         /* check ownership of the second hierarchy in the other group */
-        assertOwnedBy(sentProj2OtherGroup, recipient);
-        assertOwnedBy(sentDat2OtherGroup, recipient);
-        assertOwnedBy(sentImage1OtherGroup, recipient);
-        assertOwnedBy(linkOfDatasetImage2OtherGroup, recipient);
-        assertOwnedBy(linkOfProjectDataset2OtherGroup, recipient);
+        assertOwnedBy(sentProj2AnotherGroup, recipient);
+        assertOwnedBy(sentDat2AnotherGroup, recipient);
+        assertOwnedBy(sentImage1AnootherGroup, recipient);
+        assertOwnedBy(linkOfDatasetImage2AnotherGroup, recipient);
+        assertOwnedBy(linkOfProjectDataset2AnotherGroup, recipient);
     }
 
     /** Test of light admin without using Sudo.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -58,6 +58,7 @@ import omero.model.enums.AdminPrivilegeChown;
 import omero.model.enums.AdminPrivilegeDeleteOwned;
 import omero.model.enums.AdminPrivilegeSudo;
 import omero.model.enums.AdminPrivilegeWriteFile;
+import omero.model.enums.AdminPrivilegeWriteManagedRepo;
 import omero.model.enums.AdminPrivilegeWriteOwned;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
@@ -761,16 +762,18 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
     @Test(dataProvider = "combined privileges cases")
     public void testImporterAsNoSudoChownOnlyWorkflow(boolean isAdmin, boolean permChgrp, boolean permChown,
-            boolean permWriteOwned, boolean permWriteFile, String groupPermissions) throws Exception {
+            boolean permWriteOwned, boolean permWriteFile, boolean permWriteManagedRepo, String groupPermissions) throws Exception {
         /* define case where the import without any sudo importing into a group
          * the light admin is not a member of is expected to succeed
          */
-        boolean importNotYourGroupExpectSuccess = (isAdmin && permWriteOwned && permWriteFile);
+        boolean permDeleteOwned = true;
+        if (!isAdmin) return;
+        boolean importNotYourGroupExpectSuccess = (isAdmin && permWriteOwned && permWriteFile && permWriteManagedRepo);
         /* the first workflow with importing into the group of the normalUser directly
          * will succeed if the import will succeed and the subsequent Chown is possible
          */
         boolean importNotYourGroupAndChownExpectSuccess =
-                (isAdmin && permWriteOwned && permWriteFile && permChown);
+                (isAdmin && permWriteOwned && permWriteFile && permChown && permWriteManagedRepo);
         /* the second workflow with importing into the group of the light admin and
          * subsequent moving the data into the group of normalUser and chowning
          * them to the normal user will succeed if Chgrp and Chown is possible,
@@ -783,6 +786,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);;
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         if (permWriteFile) permissions.add(AdminPrivilegeWriteFile.value);
+        if (permDeleteOwned) permissions.add(AdminPrivilegeWriteFile.value);
+        if (permWriteManagedRepo) permissions.add(AdminPrivilegeWriteManagedRepo.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(isAdmin, permissions);
         if (!isAdmin) return;

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -461,7 +461,7 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
         srcPaths.add(file2.getAbsolutePath());
         // TODO: due to verifyUpload one cannot obtain the import location
         // without uploading both files
-        ImportLocation data = importFileset(srcPaths, 2);
+        ImportLocation data = importFileset(srcPaths, 2, null);
 
         assertFileExists("Upload failed. File does not exist: ",
                 pathToUsedFile(data, 0));


### PR DESCRIPTION
# What this PR does
This PR supersedes https://github.com/openmicroscopy/openmicroscopy/pull/5048.

# What this PR does

Adds a basic set of workflow-based java tests (server-side) to the new roles features.

The accompanying tests deal with two problematics:

# Testing this PR

Mainly check that the accompanying tests as well as all the other integration tests are passing and make sense.
The tests here are setting up the lightAdmin always in following manner:
   - take all the privileges away from the newly set up lightAdmin (see the [list of privileges](https://github.com/openmicroscopy/openmicroscopy/blob/roles/components/model/resources/mappings/meta.ome.xml#L180)
   - give to the lightAdmin "back" only the privileges which are being investigated in the particular test
   - using the test, see if the lightAdmin, equipped with this minimal set of privileges, is able to perform a meaningful workflow (such as ImportAs, Delete others' data, Edit others' Project etc.)

For understanding of particual tests, see the [explanatory ppt](https://docs.google.com/presentation/d/18kc75LHiItkHr_dvG1R6jW1qmTNayan8x4ZQC6s7XmI/edit#slide=id.g1b11290c7c_2_96). 
   - the link should bring you to the slide 3 of the ppt
   - on this slide, there is the list of tests
   - follow the links to the single test explanatory ppts
   - only the complex tests have links to graphical explanatory ppts, the simple tests (12. - 21.) shoiuld be readable from the code itself


# Related reading

[design issue](https://github.com/openmicroscopy/design/issues/62)
[trello card](https://trello.com/c/t0nT7KYa/133-new-role)
Can* methods are tested in #5248 
Annotations test are added in https://github.com/openmicroscopy/openmicroscopy/pull/5275

cc @jburel @joshmoore @mtbc @bramalingam 
