### PR TITLE
SPW black thumbnails for not-owner

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -134,8 +134,12 @@ public class ThumbnailLoader
                 store.setPixelsId(pxd.getId());
             }
             if (userID >= 0) {
-                store.setRenderingDefId(service.getRenderingDef(ctx,
-                        pxd.getId(), userID));
+                long rndDefId = service.getRenderingDef(ctx,
+                        pxd.getId(), userID);
+                // the user might not have own rendering settings
+                // for this image
+                if (rndDefId >= 0)
+                    store.setRenderingDefId(rndDefId);
             }
             thumbPix = WriterImage.bytesToImage(
                     store.getThumbnail(omero.rtypes.rint(sizeX),


### PR DESCRIPTION
# What this PR does

Bugfix: When a user views another user's plate, the field thumbnails were black, if the user doesn't have own rendering settings for them.

# Testing this PR

View another user's plate (check that the logged in user doesn't already have own rendering settings for the images), click on a well, check that the field thumbnails are shown (with the owner's rendering settings).

# Related reading

https://trello.com/c/6BpPK9Ch/307-bug-insight-thumbnails-black-in-spw-when-not-your-images

/cc @jburel @pwalczysko 