### PR TITLE
Config property

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -337,8 +337,16 @@ INTERNAL_SETTINGS_MAPPING = {
 
 CUSTOM_SETTINGS_MAPPINGS = {
     "Ice.Default.Host":
-        ["ADMINS", '[empty]', str, ("Used to pick up a single interface "
-         "e.g. 10.41.26.240. If unset, all interfaces are set.")],
+        ["ADMINS", '[empty]', str,
+         ("Used to pick up a single interface. If unset, "
+          "all interfaces are set. This is useful when running "
+          "multiple servers on the same host.")],
+    "omero.master.host":
+        ["ADMINS", '[empty]', str,
+         ("This property allows the master's IP "
+          "to be set in all templates as described in "
+          ":doc: `nodes-on-multiple-hosts <sysadmins/grid>`"
+          " without actually setting Ice.Default.Host.")],
     # Deployment configuration
     "omero.web.debug":
         ["DEBUG",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -340,14 +340,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["ADMINS", '[empty]', str,
          ("Used to pick up a single interface. If unset, "
           "all interfaces are set. This is useful when running "
-          "multiple servers on the same host."
+          "multiple servers on the same host. "
           "See omero.master.host property.")],
     "omero.master.host":
         ["ADMINS", '[empty]', str,
          ("This property allows the master's IP "
           "to be set in all templates as described in "
-          ":doc: `nodes-on-multiple-hosts <sysadmins/grid>`"
-          " without actually setting Ice.Default.Host. "
+          ":doc: `nodes-on-multiple-hosts <sysadmins/grid>` "
+          "without actually setting Ice.Default.Host. "
           "See Ice.Default.Host property.")],
     # Deployment configuration
     "omero.web.debug":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -332,6 +332,9 @@ INTERNAL_SETTINGS_MAPPING = {
 }
 
 CUSTOM_SETTINGS_MAPPINGS = {
+    "Ice.Default.Host":
+        ["ADMINS", '[empty]', str, ("Used to pick up a single interface "
+            "e.g. 10.41.26.240. If unset, all interfaces are set.")],
     # Deployment configuration
     "omero.web.debug":
         ["DEBUG",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -42,6 +42,10 @@ import string
 
 from omero_ext import portalocker
 from omero.install.python_warning import py27_only, PYTHON_WARNING
+from omero.util.concurrency import get_event
+# Load server list and freeze
+from connector import Server
+
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +167,7 @@ LOGGING = {
 
 # Load custom settings from etc/grid/config.xml
 # Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
-from omero.util.concurrency import get_event
+
 CONFIG_XML = os.path.join(OMERO_HOME, 'etc', 'grid', 'config.xml')
 count = 10
 event = get_event("websettings")
@@ -334,7 +338,7 @@ INTERNAL_SETTINGS_MAPPING = {
 CUSTOM_SETTINGS_MAPPINGS = {
     "Ice.Default.Host":
         ["ADMINS", '[empty]', str, ("Used to pick up a single interface "
-            "e.g. 10.41.26.240. If unset, all interfaces are set.")],
+         "e.g. 10.41.26.240. If unset, all interfaces are set.")],
     # Deployment configuration
     "omero.web.debug":
         ["DEBUG",
@@ -1193,9 +1197,6 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # JSON serializer, which is now the default, cannot handle
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
-
-# Load server list and freeze
-from connector import Server
 
 
 def load_server_list():

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -340,13 +340,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["ADMINS", '[empty]', str,
          ("Used to pick up a single interface. If unset, "
           "all interfaces are set. This is useful when running "
-          "multiple servers on the same host.")],
+          "multiple servers on the same host."
+          "See omero.master.host property.")],
     "omero.master.host":
         ["ADMINS", '[empty]', str,
          ("This property allows the master's IP "
           "to be set in all templates as described in "
           ":doc: `nodes-on-multiple-hosts <sysadmins/grid>`"
-          " without actually setting Ice.Default.Host.")],
+          " without actually setting Ice.Default.Host. "
+          "See Ice.Default.Host property.")],
     # Deployment configuration
     "omero.web.debug":
         ["DEBUG",


### PR DESCRIPTION
# What this PR does

Add entry for Ice.Default.Host and omero.master.host


# Testing this PR

Run for example ``bin/omero config parse --rst > test_config.txt`` and check that the content has an entry for the property ``Ice.Default.Host`` and one for ``omero.master.host``

# Related reading
https://trello.com/c/2RQhTNt1/107-ice-default-host


cc @hflynn 