### PR TITLE
Don't trigger unnecessary field metadata reload (spw)

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/WellSampleNode.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/browser/WellSampleNode.java
@@ -20,6 +20,11 @@
  */
 package org.openmicroscopy.shoola.agents.dataBrowser.browser;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
 import org.openmicroscopy.shoola.agents.dataBrowser.ThumbnailProvider;
 
 import omero.gateway.model.WellSampleData;
@@ -128,6 +133,39 @@ public class WellSampleNode
             WellSampleData dother = (WellSampleData) other.getHierarchyObject();
             return d.getImage().getId() == dother.getImage().getId();
         }
+    }
+    
+    /**
+     * Compares two WellSampleNode collections
+     * 
+     * @param sel1
+     *            The collection
+     * @param sel2
+     *            The other collection
+     * @return <code>true<code> if they contain equivalent elements
+     */
+    public static boolean isSame(Collection<WellSampleNode> sel1,
+            Collection<WellSampleNode> sel2) {
+        if (sel1 == null ^ sel2 == null)
+            return false;
+        if (sel1 == null && sel2 == null)
+            return true;
+        if (sel1.size() != sel2.size())
+            return false;
+
+        List<WellSampleNode> tmp = new ArrayList<WellSampleNode>(sel1);
+        Iterator<WellSampleNode> it = tmp.iterator();
+        while (it.hasNext()) {
+            WellSampleNode next = it.next();
+            for (WellSampleNode n2 : sel2) {
+                if (next.isSame(n2)) {
+                    it.remove();
+                    break;
+                }
+            }
+        }
+
+        return tmp.isEmpty();
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/RowFieldCanvas.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/RowFieldCanvas.java
@@ -32,6 +32,8 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.swing.BorderFactory;
@@ -96,6 +98,9 @@ class RowFieldCanvas extends WellFieldsCanvas {
                         newSelection.add(n);
                 }
 
+                if (WellSampleNode.isSame(oldSelection, newSelection))
+                    return;
+
                 if (e.isShiftDown()) {
                     // Determine the start and end nodes of the selection
                     // and add every node in between to the new selection
@@ -147,7 +152,7 @@ class RowFieldCanvas extends WellFieldsCanvas {
 
         });
     }
-
+    
     /**
      * Calculates an index for the given {@link WellSampleNode} based on the row
      * and column where it is displayed.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -134,8 +134,12 @@ public class ThumbnailLoader
                 store.setPixelsId(pxd.getId());
             }
             if (userID >= 0) {
-                store.setRenderingDefId(service.getRenderingDef(ctx,
-                        pxd.getId(), userID));
+                long rndDefId = service.getRenderingDef(ctx,
+                        pxd.getId(), userID);
+                // the user might not have own rendering settings
+                // for this image
+                if (rndDefId >= 0)
+                    store.setRenderingDefId(rndDefId);
             }
             thumbPix = WriterImage.bytesToImage(
                     store.getThumbnail(omero.rtypes.rint(sizeX),


### PR DESCRIPTION
# What this PR does

Bugfix: When you click on a Field (SPW) which already has been selected, the right hand side metadata panel, reloads but gets stuck in the "Loading..." state. With this PR the selection is checked beforehand before triggering a reload.

# Testing this PR

Perform above mentioned workflow.


# Related reading

https://trello.com/c/JA02JNJf/309-bug-insight-second-click-on-thumb-in-fields-causes-endless-spinner-in-preview
