### PR TITLE
Remove showWellImages button

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -231,13 +231,6 @@
                 $("li:nth-child(" + imagesPerRow + "n)", $lists).after('<br>');
             });
 
-            // Toggle lower panel visibility
-            var imagesInWellVisible = true;
-            $("#showWellImages").click(function(){
-                imagesInWellVisible = !imagesInWellVisible;
-                showImagesInWell();
-            });
-
             // Callback for the spatial birds eye component
             var selectImages = function(imageIds) {
                 $("#wellImages li").removeClass('ui-selected');
@@ -250,10 +243,6 @@
             var wellBirdsEye = OME.WellBirdsEye({callback: selectImages});
             var showImagesInWell = function(selectImageIds) {
                 var $table = $("#wellImages table");
-                if (!imagesInWellVisible) {
-                    $table.empty();
-                    return;
-                }
                 var $selected = $('td.ui-selected', wpv.self);
                 $table.empty();
                 wellBirdsEye.clear();
@@ -312,7 +301,6 @@
         </table>
         </form>
         <div id="toolbar" class="toolbar_noborder">
-            <button style="margin: -4px 8px;" id="showWellImages">Hide Images in Well</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
# What this PR does

Removes the "Show Well Images" button as suggested in [internal testing doc](https://docs.google.com/spreadsheets/d/1lrRaJ60utV_lHqXa_zxQhkz3RKNnbW6sw8B68xTYltA/edit#gid=1694399126) and agreed in discussion just now.

# Testing this PR

1. The "Hide images in Well" button above the plate should be gone.
2. Otherwise everything should still be working as before.

cc @pwalczysko 