### PR TITLE
in 5.2-to-5.3 upgrade, schedule wells for reindexing

### DIFF
--- a/sql/psql/OMERO5.3__0/OMERO5.2__0.sql
+++ b/sql/psql/OMERO5.3__0/OMERO5.2__0.sql
@@ -2031,6 +2031,13 @@ CREATE SEQUENCE seq_adminprivilege;
 
 INSERT INTO _lock_ids (name, id) SELECT 'seq_adminprivilege', nextval('_lock_seq');
 
+-- ... and reindex wells:
+
+INSERT INTO eventlog (id, action, permissions, entitytype, entityid, event)
+    WITH new_event AS (SELECT _current_or_new_event() AS id)
+    SELECT ome_nextval('seq_eventlog'), 'REINDEX', -52, 'ome.model.screen.Well', well.id,  new_event.id
+    FROM well, new_event;
+
 
 --
 -- FINISHED

--- a/sql/psql/OMERO5.3__0/OMERO5.3DEV__14.sql
+++ b/sql/psql/OMERO5.3__0/OMERO5.3DEV__14.sql
@@ -54,7 +54,12 @@ DROP FUNCTION omero_assert_db_version(varchar, int);
 INSERT INTO dbpatch (currentVersion, currentPatch, previousVersion, previousPatch)
              VALUES ('OMERO5.3',     0,            'OMERO5.3DEV',   14);
 
--- nothing more is required
+-- Reindex wells
+
+INSERT INTO eventlog (id, action, permissions, entitytype, entityid, event)
+    WITH new_event AS (SELECT _current_or_new_event() AS id)
+    SELECT ome_nextval('seq_eventlog'), 'REINDEX', -52, 'ome.model.screen.Well', well.id,  new_event.id
+    FROM well, new_event;
 
 
 --


### PR DESCRIPTION
# What this PR does

Adjusts the to-`OMERO5.3__0` upgrade scripts to have the server reindex the existing wells after startup.

# Testing this PR

From both OMERO 5.2 and some development patch release of OMERO 5.3,

1. Import a plate and annotate some wells.

1. In `psql` substitute the plate's ID into the below query and note the action counts,

```sql
 SELECT action, COUNT(entityid) FROM eventlog
    WHERE entitytype = 'ome.model.screen.Well'
    AND entityid IN (SELECT id FROM well WHERE plate = 12345)
    GROUP BY action;
```

1. Upgrade to DEV-merge OMERO 5.3 and restart the server.

1. Run the `psql` query again and observe that the `REINDEX` count is increased by the number of wells in the plate.

1. Observe that the previously annotated wells now appear as search results.

# Related reading

https://trello.com/c/tuktfBvg/310-fulltext-index-all-wells