### PR TITLE
do not attempt to create rendering settings in all-groups context

### DIFF
--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -643,7 +643,7 @@ public class ThumbnailCtx
      * dimension pools. We're extended graph critical if:
      * <ul>
      *   <li>
-     *      <code>isGraphGritical() == true</code> and the Pixels set does not
+     *      <code>isGraphCritical() == true</code> and the Pixels set does not
      *      belong to us.
      *   </li>
      *   <li>

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2010-2014 University of Dundee. All rights reserved.
+ *   Copyright 2010-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -661,7 +661,7 @@ public class ThumbnailCtx
         Permissions currentGroupPermissions = ec.getCurrentGroupPermissions();
         Permissions readOnly = Permissions.parseString("rwr---");
 
-        if (ec.getCurrentShareId() != null)
+        if (ec.getCurrentShareId() != null || ec.getCurrentGroupId() < 0)
         {
             return true;
         }

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -245,6 +245,7 @@ public class ThumbnailStoreTest extends AbstractServerTest {
         ThumbnailStorePrx svc = factory.createThumbnailStore();
         svc.setPixelsId(pixelsIdα);
         final byte[] thumbnailα = svc.getThumbnailByLongestSide(null);
+        Assert.assertTrue(thumbnailα.length > 0);
         svc.close();
 
         /* import the image as another user in another group and get its thumbnail */
@@ -253,6 +254,7 @@ public class ThumbnailStoreTest extends AbstractServerTest {
         svc = factory.createThumbnailStore();
         svc.setPixelsId(pixelsIdβ);
         final byte[] thumbnailβ = svc.getThumbnailByLongestSide(null);
+        Assert.assertTrue(thumbnailβ.length > 0);
 
         /* have that other user use all-groups context to fetch both thumbnails at once */
         final List<Long> pixelsIdsαβ = ImmutableList.of(pixelsIdα, pixelsIdβ);

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -1,7 +1,7 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
  *
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,8 +32,11 @@ import omero.api.ThumbnailStorePrx;
 import omero.model.Pixels;
 
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Collections of tests for the <code>ThumbnailStore</code> service.
@@ -52,14 +55,12 @@ public class ThumbnailStoreTest extends AbstractServerTest {
     private OMEROMetadataStoreClient importer;
 
     /**
-     * Overridden to initialize the list.
-     *
-     * @see AbstractServerTest#setUp()
+     * Set up a new user in a new group and set the local {@code importer} field.
+     * @throws Exception unexpected
      */
-    @Override
-    @BeforeClass
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeMethod
+    protected void setUpNewUserWithImporter() throws Exception {
+        newUserAndGroup("rwr-r-");
         importer = new OMEROMetadataStoreClient();
         importer.initialize(factory);
     }
@@ -228,5 +229,42 @@ public class ThumbnailStoreTest extends AbstractServerTest {
             Assert.assertTrue(values.length > 0);
         }
         svc.close();
+    }
+
+    /**
+     * Test that thumbnails can be retrieved from multiple groups at once.
+     * @throws Throwable unexpected
+     */
+    @Test
+    public void testGetThumbnailsMultipleGroups() throws Throwable {
+        /* create a fake image file */
+        final File file = File.createTempFile(getClass().getSimpleName(), ".fake");
+
+        /* import the image as one user in one group and get its thumbnail */
+        final long pixelsIdα = importFile(importer, file, "fake", false).get(0).getId().getValue();
+        ThumbnailStorePrx svc = factory.createThumbnailStore();
+        svc.setPixelsId(pixelsIdα);
+        final byte[] thumbnailα = svc.getThumbnailByLongestSide(null);
+        svc.close();
+
+        /* import the image as another user in another group and get its thumbnail */
+        setUpNewUserWithImporter();
+        final long pixelsIdβ = importFile(importer, file, "fake", false).get(0).getId().getValue();
+        svc = factory.createThumbnailStore();
+        svc.setPixelsId(pixelsIdβ);
+        final byte[] thumbnailβ = svc.getThumbnailByLongestSide(null);
+
+        /* have that other user use all-groups context to fetch both thumbnails at once */
+        final List<Long> pixelsIdsαβ = ImmutableList.of(pixelsIdα, pixelsIdβ);
+        final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
+        final Map<Long, byte[]> thumbs = svc.getThumbnailByLongestSideSet(null, pixelsIdsαβ, allGroupsContext);
+
+        /* check that the thumbnails are as before */
+        Assert.assertEquals(thumbnailα, thumbs.get(pixelsIdα));
+        Assert.assertEquals(thumbnailβ, thumbs.get(pixelsIdβ));
+
+        /* clean up */
+        svc.close();
+        file.delete();
     }
 }


### PR DESCRIPTION
# What this PR does

Allows the retrieval of thumbnails from multiple groups at once.

--rebased-to #5173 partially

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/ThumbnailStoreTest/testGetThumbnailsMultipleGroups/ should pass.

# Related reading

https://trello.com/c/bJqd3SkJ/316-getthumbnailbylongestsideset-doesn-t-accept-ctx