### PR TITLE
do not attempt to create rendering settings in all-groups context (rebased from develop)

### DIFF
--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -643,7 +643,7 @@ public class ThumbnailCtx
      * dimension pools. We're extended graph critical if:
      * <ul>
      *   <li>
-     *      <code>isGraphGritical() == true</code> and the Pixels set does not
+     *      <code>isGraphCritical() == true</code> and the Pixels set does not
      *      belong to us.
      *   </li>
      *   <li>

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2010-2014 University of Dundee. All rights reserved.
+ *   Copyright 2010-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -661,7 +661,7 @@ public class ThumbnailCtx
         Permissions currentGroupPermissions = ec.getCurrentGroupPermissions();
         Permissions readOnly = Permissions.parseString("rwr---");
 
-        if (ec.getCurrentShareId() != null)
+        if (ec.getCurrentShareId() != null || ec.getCurrentGroupId() < 0)
         {
             return true;
         }


### PR DESCRIPTION
# What this PR does

Allows the retrieval of thumbnails from multiple groups at once.

--rebased-from #5172 partially

# Testing this PR

See if @aleksandra-tarkowska is happy.

# Related reading

https://trello.com/c/bJqd3SkJ/316-getthumbnailbylongestsideset-doesn-t-accept-ctx