### PR TITLE
Test move annotations script

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -369,9 +369,9 @@ class ITest(object):
         query = client.sf.getQueryService()
         plates = query.findAllByQuery((
             "select p from Plate p "
-            "join p.wells as w "
-            "join w.wellSamples as ws "
-            "join ws.image as i "
+            "join fetch p.wells as w "
+            "join fetch w.wellSamples as ws "
+            "join fetch ws.image as i "
             "where i.id in (:ids)"),
             omero.sys.ParametersI().addIds(images))
         return plates

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
@@ -167,16 +167,16 @@ class TestUtilScripts(ScriptTest):
         assert count == n
 
     @pytest.mark.parametrize("remove", [True, False])
-    @pytest.mark.parametrize("script_runner", ['user', 'root'])
+    @pytest.mark.parametrize("script_runner", ['user', 'admin'])
     def test_move_annotations(self, remove, script_runner):
 
         script_id = super(TestUtilScripts, self).get_script(move_annotations)
         assert script_id > 0
 
-        root_group = self.root.sf.getAdminService().getEventContext().groupId
-        # create new user in same group as root
-        # (script run in same context by user OR root)
-        client, user = self.new_client_and_user(group=root_group)
+        # create new Admin and user in same group
+        admin_client, admin = self.new_client_and_user(system=True)
+        group = admin_client.sf.getAdminService().getEventContext().groupId
+        client, user = self.new_client_and_user(group=group)
         user_id = user.id.val
         field_count = 2
 
@@ -205,7 +205,7 @@ class TestUtilScripts(ScriptTest):
         if script_runner == 'user':
             script_runner_client = client
         else:
-            script_runner_client = self.root
+            script_runner_client = admin_client
 
         # Run script on each type, with/without removing Annotations
         for anntype in ('Tag', 'Comment', 'Rating'):

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
@@ -177,12 +177,6 @@ class TestUtilScripts(ScriptTest):
 
         plate = self.import_plates(client=client, fields=field_count)[0]
 
-        def link_ann(client, ann, image_id):
-            link = omero.model.ImageAnnotationLinkI()
-            link.parent = omero.model.ImageI(image_id, False)
-            link.child = ann
-            client.getSession().getUpdateService().saveObject(link)
-
         well_ids = []
         for well in plate.copyWells():
             well_ids.append(well.id)
@@ -191,15 +185,15 @@ class TestUtilScripts(ScriptTest):
                 # Add annotations
                 tag = omero.model.TagAnnotationI()
                 tag.textValue = omero.rtypes.rstring("testTag")
-                link_ann(client, tag, image.id.val)
+                self.link(image, tag, client=client)
                 comment = omero.model.CommentAnnotationI()
                 comment.textValue = omero.rtypes.rstring("test Comment")
-                link_ann(client, comment, image.id.val)
+                self.link(image, comment, client=client)
                 rating = omero.model.LongAnnotationI()
                 rating.longValue = omero.rtypes.rlong(5)
                 rating.ns = omero.rtypes.rstring(
                     omero.constants.metadata.NSINSIGHTRATING)
-                link_ann(client, rating, image.id.val)
+                self.link(image, rating, client=client)
 
         # Run script on each type, with/without removing Annotations
         for anntype in ('Tag', 'Comment', 'Rating'):

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_util_scripts.py
@@ -32,6 +32,7 @@ channel_offsets = "/omero/util_scripts/Channel_Offsets.py"
 combine_images = "/omero/util_scripts/Combine_Images.py"
 images_from_rois = "/omero/util_scripts/Images_From_ROIs.py"
 dataset_to_plate = "/omero/util_scripts/Dataset_To_Plate.py"
+move_annotations = "/omero/util_scripts/Move_Annotations.py"
 
 
 class TestUtilScripts(ScriptTest):
@@ -162,3 +163,17 @@ class TestUtilScripts(ScriptTest):
                 count += 1
 
         assert count == n
+
+    def test_move_annotations(self):
+
+        script_id = super(TestUtilScripts, self).get_script(move_annotations)
+        assert script_id > 0
+
+        session = self.root.sf
+        client = self.root
+
+        plate = self.import_plates(fields=2)[0]
+        for well_sample in plate.copyWellSamples():
+            for image in well_sample.getImage():
+                print image.id.val
+

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -3175,7 +3175,7 @@ def getObjectUrl(conn, obj):
                 break
 
     if obj.__class__.__name__ in (
-            "ImageI", "DatasetI", "ProjectI", "ScreenI", "PlateI"):
+            "ImageI", "DatasetI", "ProjectI", "ScreenI", "PlateI", "WellI"):
         otype = obj.__class__.__name__[:-1].lower()
         base_url += "?show=%s-%s" % (otype, obj.id.val)
         return base_url


### PR DESCRIPTION
# What this PR does

Tests the ```Move_Annotation.py``` script added in https://github.com/ome/scripts/pull/134
Also adds support for "Activities panel" handling a "Well" returned from a script.
Includes a small fix to ```testlib.import_plates()``` since the plates were being returned with unloaded Wells. cc @aleksandra-tarkowska

# Testing this PR

1. Test is Green
1. Also check that running the ```Move Annotations``` script with a single Well as the input, results in a "Browse to Well" button being shown in the Activities panel on completion.

cc @jburel