### PR TITLE
color scripts

### DIFF
--- a/sql/psql/OMERO5.3__0/reverse_shape_color_argb_to_rgba.sql
+++ b/sql/psql/OMERO5.3__0/reverse_shape_color_argb_to_rgba.sql
@@ -23,3 +23,5 @@ UPDATE shape
   WHERE (strokecolor IS NOT NULL OR
          fillcolor   IS NOT NULL) AND
         TRUE;
+
+DROP FUNCTION unfix_color(INTEGER);

--- a/sql/psql/OMERO5.3__0/reverse_shape_color_argb_to_rgba.sql
+++ b/sql/psql/OMERO5.3__0/reverse_shape_color_argb_to_rgba.sql
@@ -13,6 +13,10 @@ BEGIN
 
 END;$$ LANGUAGE plpgsql;
 
+--
+-- Edit TRUE to apply change to a subset of ROIs
+--
+
 UPDATE shape
   SET strokecolor = CASE WHEN strokecolor IS NOT NULL THEN unfix_color(strokecolor) END,
       fillcolor   = CASE WHEN fillcolor   IS NOT NULL THEN unfix_color(fillcolor)   END

--- a/sql/psql/OMERO5.3__0/reverse_shape_color_argb_to_rgba.sql
+++ b/sql/psql/OMERO5.3__0/reverse_shape_color_argb_to_rgba.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION unfix_color(color INTEGER) RETURNS INTEGER AS $$
+
+DECLARE
+    least_3_bytes CONSTANT INTEGER := (1 << 24) - 1;
+    least_1_byte CONSTANT INTEGER := (1 << 8) - 1;
+    rgb INTEGER;
+    alpha INTEGER;
+
+BEGIN
+    rgb := color >> 8 & least_3_bytes;
+    alpha := color & least_1_byte;
+    RETURN alpha << 24 | rgb;
+
+END;$$ LANGUAGE plpgsql;
+
+UPDATE shape
+  SET strokecolor = CASE WHEN strokecolor IS NOT NULL THEN unfix_color(strokecolor) END,
+      fillcolor   = CASE WHEN fillcolor   IS NOT NULL THEN unfix_color(fillcolor)   END
+  WHERE (strokecolor IS NOT NULL OR
+         fillcolor   IS NOT NULL) AND
+        TRUE;

--- a/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
+++ b/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION fix_color(color INTEGER) RETURNS INTEGER AS $$
+
+DECLARE
+    least_3_bytes CONSTANT INTEGER := (1 << 24) - 1;
+    least_1_byte CONSTANT INTEGER := (1 << 8) - 1;
+    rgb INTEGER;
+    alpha INTEGER;
+
+BEGIN
+    rgb := color & least_3_bytes;
+    alpha := color >> 24 & least_1_byte;
+    IF alpha = 0 THEN
+        alpha := least_1_byte;
+    END IF;
+	  RETURN rgb << 8 | alpha;
+
+END;$$ LANGUAGE plpgsql;
+
+
+UPDATE shape
+  SET strokecolor = CASE WHEN strokecolor IS NOT NULL THEN fix_color(strokecolor) END,
+      fillcolor   = CASE WHEN fillcolor   IS NOT NULL THEN fix_color(fillcolor)   END
+  WHERE (strokecolor IS NOT NULL OR
+         fillcolor   IS NOT NULL) AND
+        TRUE;

--- a/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
+++ b/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
@@ -16,6 +16,9 @@ BEGIN
 
 END;$$ LANGUAGE plpgsql;
 
+--
+-- Edit TRUE to apply change to a subset of ROIs
+--
 
 UPDATE shape
   SET strokecolor = CASE WHEN strokecolor IS NOT NULL THEN fix_color(strokecolor) END,

--- a/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
+++ b/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
@@ -12,7 +12,7 @@ BEGIN
     IF alpha = 0 THEN
         alpha := least_1_byte;
     END IF;
-	  RETURN rgb << 8 | alpha;
+    RETURN rgb << 8 | alpha;
 
 END;$$ LANGUAGE plpgsql;
 

--- a/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
+++ b/sql/psql/OMERO5.3__0/shape_color_argb_to_rgba.sql
@@ -26,3 +26,5 @@ UPDATE shape
   WHERE (strokecolor IS NOT NULL OR
          fillcolor   IS NOT NULL) AND
         TRUE;
+
+DROP FUNCTION fix_color(INTEGER);


### PR DESCRIPTION
# What this PR does

Add scripts used to reset the color of shape to match data model

# Testing this PR

Scripts have already been tested but a final check will be good

To test:
 * Using 5.2 server, create shape and set fill color and stroke color
 * Upgrade to 5.3. Check the color, they should not match the ones previously set
 * Run shape_color script to reset the color. They should now match the color created in 5.2

# Related reading

https://trello.com/c/sGlYbbvB/213-color-in-shape-settings

cc @bramalingam @mtbc 