### PR TITLE
ROIFolders Java example

### DIFF
--- a/examples/Training/java/src/training/ROIFolders.java
+++ b/examples/Training/java/src/training/ROIFolders.java
@@ -125,10 +125,10 @@ public class ROIFolders {
         }
 
         // Get the ROI folders associated with the image
-        Collection<FolderData> folders = roifac.getROIFolders(ctx, imageId);
+        Collection<FolderData> folders = roifac.getROIFolders(ctx, image.getId());
         for (FolderData folder : folders) {
             Collection<ROIResult> result = roifac.loadROIsForFolder(ctx,
-                    imageId, folder.getId());
+                    image.getId(), folder.getId());
             Collection<ROIData> folderRois = result.iterator().next().getROIs();
             // Do something with the ROIs
         }


### PR DESCRIPTION
# What this PR does

Tiny fix for the Java ROI folders example (use `image.getId()` instead of `imageId`, to match the other Java examples).

Updated doc PR https://github.com/openmicroscopy/ome-documentation/pull/1644 accordingly.

/cc @jburel  @hflynn 
