### PR TITLE
training_examples_update_5.3.0

### DIFF
--- a/examples/Training/python/Read_Data.py
+++ b/examples/Training/python/Read_Data.py
@@ -11,7 +11,6 @@
 FOR TRAINING PURPOSES ONLY!
 """
 
-import omero
 from omero.gateway import BlitzGateway
 from Parse_OMERO_Properties import USERNAME, PASSWORD, HOST, PORT
 from Parse_OMERO_Properties import datasetId, imageId, plateId

--- a/examples/Training/python/Read_Data.py
+++ b/examples/Training/python/Read_Data.py
@@ -39,49 +39,54 @@ def print_obj(obj, indent=0):
         obj.getOwnerOmeName())
 
 
-# List all Projects available to the user currently logged in
-# ===========================================================
-# The only_owned=True parameter limits the Projects which are returned.
-# If the parameter is omitted or the value is False, then all Projects
-# visible in the current group are returned.
+# List all Projects owned by the user currently logged in
+# =======================================================
+# By default this returns Projects from all owners across
+# all groups. We can filter by group and owner using the
+# optional opts dict (new in 5.3.0)
+# We also order by name and use 'limit' and 'offset',
+# to load the first 5 Projects
 print "\nList Projects:"
 print "=" * 50
 my_exp_id = conn.getUser().getId()
-for project in conn.listProjects(my_exp_id):
+default_group_id = conn.getEventContext().groupId
+for project in conn.getObjects("Project", opts={'owner': my_exp_id,
+                                                'group': default_group_id,
+                                                'order_by': 'lower(obj.name)',
+                                                'limit': 5, 'offset': 0}):
     print_obj(project)
+    assert project.getDetails().getOwner().id == my_exp_id
+    # We can get Datasets with listChildren, since we have the Project already.
+    # Or conn.getObjects("Dataset", opts={'project', id}) if we have Project ID
     for dataset in project.listChildren():
         print_obj(dataset, 2)
         for image in dataset.listChildren():
             print_obj(image, 4)
 
 
-# Retrieve the datasets owned by the user currently logged in
-# ===========================================================
-# Here we create an omero.sys.ParametersI instance which we
-# can use to filter the results that are returned. If we did
-# not pass the params argument to getObjects, then all Datasets
-# in the current group would be returned.
-print "\nList Datasets:"
-print "=" * 50
-params = omero.sys.ParametersI()
-params.exp(conn.getUser().getId())  # only show current user's Datasets
-datasets = conn.getObjects("Dataset", params=params)
+# Retrieve 'orphaned' objects
+# ===========================
+# We can use the 'orphaned' filter to find Datasets, Images
+# or Plates that are not in any parent container
+print "\nList orphaned Datasets: \n", "=" * 50
+datasets = conn.getObjects("Dataset", opts={'orphaned': True})
 for dataset in datasets:
     print_obj(dataset)
 
 
-# Retrieve the images contained in a dataset
+# Retrieve objects in a container
 # ==========================================
-print "\nDataset:%s" % datasetId
-print "=" * 50
-dataset = conn.getObject("Dataset", datasetId)
-print "\nImages in Dataset:", dataset.getName()
-for image in dataset.listChildren():
+# We can filter Images by their parent Dataset
+# We can also filter Datasets by 'project', Plates by 'screen',
+# Wells by 'plate'
+print "\nImages in Dataset:", datasetId, "\n", "=" * 50
+for image in conn.getObjects('Image', opts={'dataset': datasetId}):
     print_obj(image)
 
 
 # Retrieve an image by ID
 # =======================
+# Pixels and Channels will be loaded automatically as needed
 image = conn.getObject("Image", imageId)
 print "\nImage:%s" % imageId
 print "=" * 50
@@ -92,6 +97,13 @@ print " Y:", image.getSizeY()
 print " Z:", image.getSizeZ()
 print " C:", image.getSizeC()
 print " T:", image.getSizeT()
+# List Channels (loads the Rendering settings to get channel colors)
+for channel in image.getChannels():
+    print 'Channel:', channel.getLabel(),
+    print 'Color:', channel.getColor().getRGB()
+    print 'Lookup table:', channel.getLut()
+    print 'Is reverse intensity?', channel.isReverseIntensity()
+
 # render the first timepoint, mid Z section
 z = image.getSizeZ() / 2
 t = 0

--- a/examples/Training/python/Write_Data.py
+++ b/examples/Training/python/Write_Data.py
@@ -73,6 +73,20 @@ project = conn.getObject("Project", projectId)
 project.linkAnnotation(map_ann)
 
 
+# Count the number of annotations on one or many objects
+# ===========================================================
+print conn.countAnnotations('Project', [projectId])
+
+
+# List all annotations on an object. Get text from tags
+# ===========================================================
+for ann in project.listAnnotations():
+    print ann.getId(), ann.OMERO_TYPE,
+    print " added by ", ann.link.getDetails().getOwner().getOmeName()
+    if ann.OMERO_TYPE == omero.model.TagAnnotationI:
+        print "Tag value:", ann.getTextValue()
+
+
 # How to create a file annotation and link to a Dataset
 # =====================================================
 dataset = conn.getObject("Dataset", dataset_id)


### PR DESCRIPTION
# What this PR does

Updates the python Training examples to demonstrate some of the new
functionality of the Blitz Gateway.

Adds examples for:
 - ```conn.countAnnotations()```
 - Several options for the new ```opts``` argument for conn.getObjects()
 - channel.getLut()
 - channel.isReverseIntensity()

Other changes not yet covered (which of these do we want to cover in this PR)?
 - conn.buildCountQuery() 
 - removed internal __bstrap__() for Wrappers
 - plateAcquisition.getStartTime()  & getEndTime()
 - well.getWellPos()
 - colorHolder.getInt() fixes (covered elsewhere?)
 - setActiveChannels(.. colors=['cool.lut', 'FF00FF'] reverseMaps=[True, False, False])
 - image.getHistogram(self, channels, binCount, globalRange=True, theZ=0, theT=0)
 - image.setReverseIntensity(0, True)

# Testing this PR

 - Training job should be green
 - Check console output from job for newly added print statements to see if new code is working

# Related reading

1. https://trello.com/c/PEvlrmHX/36-document-breaking-api-changes-for-devs-add-new-examples 
