### PR TITLE
listWellImages_json handles no acquisition

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1525,7 +1525,8 @@ def listWellImages_json(request, did, conn=None, **kwargs):
     wellImgs = []
     for ws in well.listChildren():
         # optionally filter by acquisition 'run'
-        if acq is not None and ws.plateAcquisition.id.val != acq:
+        if (acq is not None and ws.plateAcquisition is not None and
+                ws.plateAcquisition.id.val != acq):
             continue
         img = ws.getImage()
         if img is not None:


### PR DESCRIPTION
# What this PR does

Fixes bug reported at:
https://trello.com/c/imVvuA2K/318-bug-plate-acquisition

This is not normally found, but it is possible (found in some OME fake/test files)

# Testing this PR
Check that you can view well-sample images panel for plate data.
