### PR TITLE
adjust "fs sets" test to expect subsets of IDs

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -84,14 +84,18 @@ class TestFS(CLITest):
         self.args += ["sets", "--style=plain"]
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
-        assert set(self.parse_ids(o)) == set([x.id.val for x in f.values()])
+        printed_ids = set(self.parse_ids(o))
+        expected_ids = set([x.id.val for x in f.values()])
+        assert expected_ids.issubset(printed_ids)
 
         for transfer in transfers:
             self.cli.invoke(self.args + ['--with-transfer', '%s' % transfer],
                             strict=True)
             o, e = capsys.readouterr()
-            assert set(self.parse_ids(o)) == \
-                set([x.id.val for (k, x) in f.iteritems() if k == transfer])
+            printed_ids = set(self.parse_ids(o))
+            expected_ids = set([x.id.val for (k, x) in f.iteritems()
+                                if k == transfer])
+            assert expected_ids.issubset(printed_ids)
 
     def testSetsAdminOnly(self, capsys):
         """Test fs sets --check is admin-only"""


### PR DESCRIPTION
# What this PR does

Loosens test criteria because extra results may legitimately be returned.

# Testing this PR

Check if https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_fs/TestFS/ is fixed.