### PR TITLE
Remove the hidden file restrictions

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/FileElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/FileElement.java
@@ -178,7 +178,7 @@ class FileElement
 		List<File> files = new ArrayList<File>();
 		if (list == null || list.length == 0) return files;
 		for (int i = 0; i < list.length; i++) {
-			if (!list[i].isHidden() && !list[i].isDirectory()) 
+			if (!list[i].isDirectory()) 
 				files.add(list[i]);
 		}
 		return files;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1091,17 +1091,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	 * @return See above.
 	 */
 	private int handleFilesSelection(File[] files) {
-		int count = 0;
-		if (files == null)
-			return count;
-		File f;
-		for (int i = 0; i < files.length; i++) {
-			f = files[i];
-			if (!f.isHidden()) {
-				count++;
-			}
-		}
-		return count;
+	    return files == null ? 0 : files.length;
 	}
 
 	/** Imports the selected files. */
@@ -1196,7 +1186,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	 */
 	private boolean checkFile(File f, List<FileObject> l)
 	{
-		if (f == null || f.isHidden())
+		if (f == null)
 			return false;
 		if (f.isFile()) {
 			if (isFileImportable(f))
@@ -1220,7 +1210,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	 * @return See above.
 	 */
 	private boolean isFileImportable(File f) {
-		return !(f == null || f.isHidden());
+		return f != null;
 	}
 
 	/**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/BrowseContainerAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/BrowseContainerAction.java
@@ -172,7 +172,7 @@ public class BrowseContainerAction
         	setEnabled(false);
         } else if (ho instanceof File) {
         	File f = (File) ho;
-        	if (f.isDirectory() && !f.isHidden()) {
+        	if (f.isDirectory()) {
         		putValue(Action.SHORT_DESCRIPTION, 
                         UIUtilities.formatToolTipText(DESCRIPTION_FOLDER));
             	setEnabled(true);
@@ -250,7 +250,7 @@ public class BrowseContainerAction
             		if (!withThumbnails) setEnabled(false);
                 } else if (ho instanceof FileData) {
             		FileData f = (FileData) ho;
-            		if (f.isDirectory() && !f.isHidden()) {
+            		if (f.isDirectory()) {
             			setEnabled(true);
             			description = DESCRIPTION_FOLDER;
             		} else setEnabled(false);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserComponent.java
@@ -1131,7 +1131,6 @@ class BrowserComponent
 				if (!(ho instanceof ExperimenterData)) return;
         		if (uo instanceof FileData) {
         			FileData dir = (FileData) uo;
-        			if (dir.isHidden()) return;
         			if (dir.isDirectory()) {
         				//Check if data loaded
         				List<DataObject> list = new ArrayList<DataObject>();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserModel.java
@@ -330,12 +330,7 @@ class BrowserModel
         		currentLoader = new AdminLoader(component, ctx,
         				(TreeImageSet) expNode);
         		currentLoader.load();
-            } else if (ho instanceof FileData) {
-            	FileData fa = (FileData) ho;
-            	if (fa.isDirectory() && !fa.isHidden()) {
-            		
-            	}
-            }
+            } 
     	}
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/browser/BrowserUI.java
@@ -616,13 +616,10 @@ class BrowserUI
     			if (object instanceof FileData) {
 					file = (FileData) object;
     				if (file.isDirectory()) {
-            			if (!file.isHidden()) {
-            				display = new TreeImageSet(file);
-            				buildEmptyNode(display);
-            			}
+            			display = new TreeImageSet(file);
+            			buildEmptyNode(display);
             		} else {
-            			if (!file.isHidden()) 
-            				display = new TreeImageNode(file);
+            			display = new TreeImageNode(file);
             		}
     			} else if (object instanceof ImageData) {
     				display = TreeViewerTranslator.transformImage(
@@ -652,7 +649,7 @@ class BrowserUI
     	FileData[] files = fs.getRoots();
 		for (int j = 0; j < files.length; j++) {
 			file = files[j];
-			if (file.isDirectory() && !file.isHidden()) {
+			if (file.isDirectory()) {
 				display = new TreeImageSet(file);
 				//display.setChildrenLoaded(true);
 				expNode.addChildDisplay(display);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -2780,12 +2780,10 @@ class TreeViewerComponent
 			
 		} else if (parentObject instanceof FileData) {
 			FileData f = (FileData) parentObject;
-			if (!f.isHidden()) {
-				if (f.isDirectory()) 
-					db = DataBrowserFactory.getFSFolderBrowser(
-							model.getSecurityContext(parent),
-							(FileData) parentObject, leaves);
-			}
+			if (f.isDirectory()) 
+				db = DataBrowserFactory.getFSFolderBrowser(
+						model.getSecurityContext(parent),
+						(FileData) parentObject, leaves);
 		} else {
 			db = DataBrowserFactory.getDataBrowser(
 					model.getSecurityContext(parent), grandParentObject, 
@@ -3471,7 +3469,7 @@ class TreeViewerComponent
 			model.browsePlates(plates, withThumbnails);
 		} else if (uo instanceof File) {
 			File f = (File) uo;
-			if (f.isDirectory() && !f.isHidden()) {
+			if (f.isDirectory()) {
 				List l = node.getChildrenDisplay();
 				if (l != null && l.size() > 0) {
 					Set leaves = new HashSet();
@@ -3490,14 +3488,12 @@ class TreeViewerComponent
 			}
 		} else if (uo instanceof FileData) {
 			FileData fa = (FileData) uo;
-			if (!fa.isHidden()) {
-				if (fa.isDirectory()) {
-					model.getSelectedBrowser().loadExperimenterData(
-							BrowserFactory.getDataOwner(node), 
-		        			node);
-				} else {
-					//Import, register and view.
-				}
+			if (fa.isDirectory()) {
+				model.getSelectedBrowser().loadExperimenterData(
+						BrowserFactory.getDataOwner(node), 
+		       			node);
+			} else {
+				//Import, register and view.
 			}
 		}
 		fireStateChange();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/FSFileSystemView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/FSFileSystemView.java
@@ -311,13 +311,4 @@ public class FSFileSystemView
     	*/
     	return null;
     }
-    
-    /**
-     * Returns <code>true</code> if the file is hidden, <code>false</code>
-     * otherwise.
-     * 
-     * @return See above.
-     */
-    public boolean isHiddenFile(FileData f) { return f.isHidden(); }
-
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/file/IOUtil.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/file/IOUtil.java
@@ -271,8 +271,6 @@ public class IOUtil
 	    for (int i = 0; i < entries.length; i++) {
 	        try {
 	            f = entries[i];
-	            if (f.isHidden())
-	                continue;
 	            if (f.isDirectory()) {
 	                zipDir(f, out, f.getName());
 	                continue;


### PR DESCRIPTION
# What this PR does

For some reason Insight/Importer didn't allow to import hidden files (which includes files in hidden directories). This PR removes this restriction.

# Testing this PR

Has to be tested on Windows. Linux and OSX don't show the hidden folders/files in the import dialog in first place, but Windows does if you set the Windows Explorer to do so.

- Create a hidden folder and put some image files into it.
- Import them via Insight and/or Importer.

# Related reading
http://lists.openmicroscopy.org.uk/pipermail/ome-users/2017-March/006399.html

