### PR TITLE
AutoCloseable Facilities

### DIFF
--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -111,6 +111,9 @@ public class Gateway {
 
     /** Property to indicate that a {@link Facility} has been created */
     public static final String PROP_FACILITY_CREATED = "PROP_FACILITY_CREATED";
+    
+    /** Property to indicate that a {@link Facility} has been closed */
+    public static final String PROP_FACILITY_CLOSED = "PROP_FACILITY_CLOSED";
 
     /** Property to indicate that an import store has been created */
     public static final String PROP_IMPORTSTORE_CREATED = "PROP_IMPORTSTORE_CREATED";

--- a/components/blitz/src/omero/gateway/facility/Facility.java
+++ b/components/blitz/src/omero/gateway/facility/Facility.java
@@ -20,6 +20,7 @@
  */
 package omero.gateway.facility;
 
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.net.UnknownHostException;
@@ -161,6 +162,32 @@ public abstract class Facility {
                 this.pcs.removePropertyChangeListener(l);
         }
         this.pcs.removePropertyChangeListener(listener);
+    }
+    
+    /**
+     * Fires a {@link PropertyChangeEvent}
+     * 
+     * @param event
+     *            The PropertyChangeEvent
+     */
+    public void firePropertyChanged(PropertyChangeEvent event) {
+        this.pcs.firePropertyChange(event);
+    }
+
+    /**
+     * Fires a {@link PropertyChangeEvent}
+     * 
+     * @param propertyName
+     *            The property name
+     * @param oldValue
+     *            The old value
+     * @param newValue
+     *            The new value
+     * 
+     */
+    public void firePropertyChanged(String propertyName, Object oldValue,
+            Object newValue) {
+        this.pcs.firePropertyChange(propertyName, oldValue, newValue);
     }
     
     /**

--- a/components/blitz/src/omero/gateway/facility/Facility.java
+++ b/components/blitz/src/omero/gateway/facility/Facility.java
@@ -152,8 +152,11 @@ public abstract class Facility {
     }
 
     /**
-     * Removes a {@link PropertyChangeListener}
-     * @param listener The listener
+     * Removes a {@link PropertyChangeListener} 
+     * (Pass <code>null</code> to remove all {@link PropertyChangeListener}s)
+     * 
+     * @param listener
+     *            The listener
      */
     public void removePropertyChangeListener(PropertyChangeListener listener) {
         if (listener == null) {

--- a/components/blitz/src/omero/gateway/facility/Facility.java
+++ b/components/blitz/src/omero/gateway/facility/Facility.java
@@ -22,7 +22,6 @@ package omero.gateway.facility;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
-import java.io.Closeable;
 import java.net.UnknownHostException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -96,7 +95,7 @@ public abstract class Facility {
     public static <T extends Facility> T getFacility(final Class<T> type,
             final Gateway gateway) throws ExecutionException {
 
-        if (Closeable.class.isAssignableFrom(type)) {
+        if (AutoCloseable.class.isAssignableFrom(type)) {
             // Don't cache closeable (~ stateful) Facilities,
             // just create a new instance and return it.
             try {
@@ -156,6 +155,11 @@ public abstract class Facility {
      * @param listener The listener
      */
     public void removePropertyChangeListener(PropertyChangeListener listener) {
+        if (listener == null) {
+            for (PropertyChangeListener l : this.pcs
+                    .getPropertyChangeListeners())
+                this.pcs.removePropertyChangeListener(l);
+        }
         this.pcs.removePropertyChangeListener(listener);
     }
     

--- a/components/blitz/src/omero/gateway/facility/RawDataFacility.java
+++ b/components/blitz/src/omero/gateway/facility/RawDataFacility.java
@@ -20,8 +20,6 @@
  */
 package omero.gateway.facility;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Map;
 
 import omero.gateway.Gateway;
@@ -45,7 +43,7 @@ import org.apache.commons.collections.map.MultiKeyMap;
  * @since 5.1
  */
 
-public class RawDataFacility extends Facility implements Closeable {
+public class RawDataFacility extends Facility implements AutoCloseable {
 
     /** Cache the {@link DataSink}s for re-use (keys: ctx.groupid and pixelsId) */
     private MultiKeyMap cache = new MultiKeyMap();
@@ -255,11 +253,12 @@ public class RawDataFacility extends Facility implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         MapIterator it = cache.mapIterator();
         while (it.hasNext()) {
             it.next();
             ((DataSink) it.getValue()).close();
         }
+        removePropertyChangeListener(null);
     }
 }

--- a/components/blitz/src/omero/gateway/facility/RawDataFacility.java
+++ b/components/blitz/src/omero/gateway/facility/RawDataFacility.java
@@ -259,6 +259,8 @@ public class RawDataFacility extends Facility implements AutoCloseable {
             it.next();
             ((DataSink) it.getValue()).close();
         }
+        firePropertyChanged(Gateway.PROP_FACILITY_CLOSED,
+                null, getClass().getName());
         removePropertyChangeListener(null);
     }
 }

--- a/components/blitz/src/omero/gateway/facility/RawDataFacility.java
+++ b/components/blitz/src/omero/gateway/facility/RawDataFacility.java
@@ -187,19 +187,22 @@ public class RawDataFacility extends Facility implements AutoCloseable {
      * @throws DataSourceException
      *             If an error occurs while retrieving the plane data from the
      *             pixels source.
-     * @Deprecated Use getPlane(SecurityContext, PixelsData, z, t, c) instead
+     * @deprecated Use getPlane(SecurityContext, PixelsData, z, t, c) instead
      */
     @Deprecated
     public Plane2D getPlane(SecurityContext ctx, PixelsData pixels, int z,
             int t, int c, boolean close) throws DataSourceException {
         Plane2D data = null;
+        DataSink ds = null;
         try {
-            DataSink ds = getDataSink(ctx, pixels, gateway);
+            ds = getDataSink(ctx, pixels, gateway);
             data = ds.getPlane(z, t, c);
-            if (close)
-                ds.close();
         } catch (DSOutOfServiceException e) {
             throw new DataSourceException("Can't initiate DataSink", e);
+        }
+        finally {
+            if (close)
+                ds.close();
         }
         return data;
     }

--- a/components/blitz/src/omero/gateway/rnd/DataSink.java
+++ b/components/blitz/src/omero/gateway/rnd/DataSink.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,11 +20,17 @@
  */
 package omero.gateway.rnd;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+import omero.ServerError;
 import omero.api.RawPixelsStorePrx;
 import omero.gateway.Gateway;
 import omero.gateway.SecurityContext;
-import omero.gateway.cache.CacheService;
+import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.exception.DataSourceException;
+import omero.romio.PlaneDef;
 import omero.util.ReadOnlyByteArray;
 import omero.gateway.model.PixelsData;
 
@@ -41,7 +47,7 @@ import omero.gateway.model.PixelsData;
 * @version 3.0
 * @since OME3.0
 */
-public class DataSink
+public class DataSink implements Closeable
 {
 
     /** Identifies the type used to store pixel values. */
@@ -68,44 +74,6 @@ public class DataSink
     /** Identifies the type used to store pixel values. */
     public static final String DOUBLE = PixelsData.DOUBLE_TYPE;
 
-    /**
-     * Factory method to create a new <code>DataSink</code> to handle
-     * access to the metadata associated with the specified pixels set.
-     * 
-     * @param source The pixels set. Mustn't be <code>null</code>.
-     * @param gw Reference to the {@link Gateway} Mustn't be <code>null</code>.
-     * @return See above.
-     */
-    public static DataSink makeNew(PixelsData source, Gateway gw)
-    {
-        if (source == null)
-            throw new NullPointerException("No pixels.");
-        if (gw == null) 
-            throw new NullPointerException("No Gateway.");
-        return new DataSink(source, gw);
-    }
-
-    /**
-     * Factory method to create a new <code>DataSink</code> to handle access to
-     * the metadata associated with the specified pixels set.
-     * 
-     * @param source
-     *            The pixels set. Mustn't be <code>null</code>.
-     * @param gw
-     *            Reference to the {@link Gateway} Mustn't be <code>null</code>.
-     * @param cacheSize
-     *            The size of the cache to use. (Make sure the {@link Gateway} provides
-     *            a {@link CacheService})
-     * @return See above.
-     */
-    public static DataSink makeNew(PixelsData source, Gateway gw, int cacheSize) {
-        if (source == null)
-            throw new NullPointerException("No pixels.");
-        if (gw == null)
-            throw new NullPointerException("No Gateway.");
-        return new DataSink(source, gw, cacheSize);
-    }
-
     /** The data source. */
     private PixelsData source;
 
@@ -115,50 +83,40 @@ public class DataSink
     /** Strategy used to transform the raw data. */
     private BytesConverter strategy;
 
-    /** The id of the cache. */
-    private int cacheID = -1;
-
     /** The pixels store for that pixels set.*/
     private RawPixelsStorePrx store;
 
     /**Reference to the gateway.*/
     private Gateway gw;
 
-    /**
-     * Creates a new instance without using a cache.
-     *
-     * @param source The pixels set.
-     * @param context The container's registry.
-     */
-    private DataSink(PixelsData source, Gateway gw)
-    {
-        this(source, gw, 0);
-    }
-
+    /**Reference to the SecurityContext.*/
+    private SecurityContext ctx;
+    
     /**
      * Creates a new instance.
      *
-     * @param source The pixels set.
-     * @param context The container's registry.
-     * @param cacheSize The size of the cache.
+     * @param source
+     *            The pixels set.
+     * @param gw
+     *            Reference to the gateway.
+     * @param ctx
+     *            The SecurityContext
+     * @throws DSOutOfServiceException
+     *             If the PixelsStore can't be accessed
      */
-    private DataSink(PixelsData source, Gateway gw, int cacheSize)
-    {
+    public DataSink(SecurityContext ctx, PixelsData source, Gateway gw)
+            throws DSOutOfServiceException {
+        this.ctx = ctx;
         this.gw = gw;
         this.source = source;
-        String type = source.getPixelType();
-        bytesPerPixels = getBytesPerPixels(type); 
-
-        if (cacheSize > 0) {
-            if (gw.getCacheService() == null)
-                throw new IllegalArgumentException("No cache provided!");
-
-            int maxEntries =
-                    cacheSize/(source.getSizeX()*source.getSizeY()*bytesPerPixels);
-            cacheID = gw.getCacheService().createCache(
-                    CacheService.IN_MEMORY, maxEntries);
+        store = gw.createPixelsStore(ctx);
+        try {
+            store.setPixelsId(source.getId(), false);
+        } catch (ServerError e) {
+            throw new DSOutOfServiceException("Can't set pixels id", e);
         }
-
+        String type = source.getPixelType();
+        bytesPerPixels = getBytesPerPixels(type);
         strategy = BytesConverter.getConverter(type);
     }
 
@@ -179,87 +137,37 @@ public class DataSink
     }
 
     /**
-     * Transforms 3D coords into linear coords.
-     * The returned value <code>L</code> is calculated as follows: 
-     * <nobr><code>L = sizeZ*sizeC*t + sizeZ*w + z</code></nobr>.
-     *
-     * @param z The z coord. Must be in the range <code>[0, sizeZ)</code>.
-     * @param c The c coord. Must be in the range <code>[0, sizeC)</code>.
-     * @param t The t coord. Must be in the range <code>[0, sizeT)</code>.
-     * @return The linearized value corresponding to <code>(z, c, t)</code>.
-     */
-    private Integer linearize(int z, int c, int t)
-    {
-        int sizeZ = source.getSizeZ();
-        int sizeC = source.getSizeC();
-        if (z < 0 || sizeZ <= z)
-            throw new IllegalArgumentException(
-                    "z out of range [0, "+sizeZ+"): "+z+".");
-        if (c < 0 || sizeC <= c)
-            throw new IllegalArgumentException(
-                    "c out of range [0, "+sizeC+"): "+c+".");
-        if (t < 0 || source.getSizeT() <= t)
-            throw new IllegalArgumentException(
-                    "t out of range [0, "+source.getSizeT()+"): "+t+".");
-        return Integer.valueOf(sizeZ*sizeC*t + sizeZ*c + z);
-    }
-
-    /**
      * Factory method to fetch plane data and create an object to access it.
-     *
-     * @param ctx The security context.
      * @param z The z-section at which data is to be fetched.
      * @param t The timepoint at which data is to be fetched.
      * @param c The channel at which data is to be fetched.
      * @param strategy To transform bytes into pixels values.
-     * @param close Indicates to close the service if <code>true</code>.
      * @return A plane 2D object that encapsulates the actual plane pixels.
      * @throws DataSourceException If an error occurs while retrieving the
      *                              plane data from the pixels source.
      */
-    private Plane2D createPlane(SecurityContext ctx, int z, int t, int c,
-            BytesConverter strategy, boolean close)
+    private Plane2D createPlane(int z, int t, int c,
+            BytesConverter strategy)
                     throws DataSourceException
     {
         //Retrieve data
-        Integer planeIndex = linearize(z, c, t);
         Plane2D plane = null;
-        if (cacheID >= 0) {
-            CacheService cache = gw.getCacheService();
-            plane = (Plane2D) cache.getElement(cacheID, planeIndex);
-            if (plane != null)
-                return plane;
-        }
         byte[] data = null; 
         try {
-            //initializes if null.
-            if (store == null) {
-                store = gw.createPixelsStore(ctx);
-                store.setPixelsId(source.getId(), false);
-            }
             data = store.getPlane(z, c, t);
         } catch (Exception e) {
             String p = "("+z+", "+c+", "+t+")";
             throw new DataSourceException("Cannot retrieve the plane "+p, e);
-        } finally {
-            if (close) {
-                gw.closeService(ctx, store);
-                store = null;
-            }
         }
         ReadOnlyByteArray array = new ReadOnlyByteArray(data, 0, data.length);
         plane = new Plane2D(array, source.getSizeX(), source.getSizeY(), 
                 bytesPerPixels, strategy);
-        if (cacheID >= 0)
-            gw.getCacheService().addElement(cacheID, planeIndex, plane);
         return plane;
     }
 
     /**
      * Extracts a 2D tile from the pixels set this object is working for.
      *
-     * @param ctx
-     *            The security context.
      * @param z
      *            The z-section at which data is to be fetched.
      * @param t
@@ -274,32 +182,20 @@ public class DataSink
      *            The width of the tile
      * @param h
      *            The height of the tile
-     * @param close
-     *            Indicates to close the service if <code>true</code>.
      * @return A plane 2D object that encapsulates the actual plane pixels.
      * @throws DataSourceException
      *             If an error occurs while retrieving the plane data from the
      *             pixels source.
      */
-    public Plane2D getTile(SecurityContext ctx, int z, int t, int c, int x,
-            int y, int w, int h, boolean close) throws DataSourceException {
+    public Plane2D getTile(int z, int t, int c, int x,
+            int y, int w, int h) throws DataSourceException {
         byte[] data = null;
         try {
-            // initializes if null.
-            if (store == null) {
-                store = gw.createPixelsStore(ctx);
-                store.setPixelsId(source.getId(), false);
-            }
             data = store.getTile(z, c, t, x, y, w, h);
         } catch (Exception e) {
             String p = "(" + z + ", " + c + ", " + t + ", " + x + ", " + y
                     + ", " + w + ", " + h + ")";
             throw new DataSourceException("Cannot retrieve the plane " + p, e);
-        } finally {
-            if (close) {
-                gw.closeService(ctx, store);
-                store = null;
-            }
         }
         ReadOnlyByteArray array = new ReadOnlyByteArray(data, 0, data.length);
         return new Plane2D(array, w, h, bytesPerPixels, strategy);
@@ -308,7 +204,6 @@ public class DataSink
     /**
      * Extracts a 2D plane from the pixels set this object is working for.
      *
-     * @param ctx The security context.
      * @param z The z-section at which data is to be fetched.
      * @param t The timepoint at which data is to be fetched.
      * @param c The channel at which data is to be fetched.
@@ -316,31 +211,43 @@ public class DataSink
      * @throws DataSourceException If an error occurs while retrieving the
      *                              plane data from the pixels source.
      */
-    public Plane2D getPlane(SecurityContext ctx, int z, int t, int c)
+    public Plane2D getPlane(int z, int t, int c)
             throws DataSourceException
     {
-        return createPlane(ctx, z, t, c, strategy, true);
+        return createPlane( z, t, c, strategy);
     }
 
     /**
-     * Extracts a 2D plane from the pixels set this object is working for.
+     * Get the histogram data for the given image. Currently only non-tiled
+     * images are supported.
      *
-     * @param ctx The security context.
-     * @param z The z-section at which data is to be fetched.
-     * @param t The timepoint at which data is to be fetched.
-     * @param c The channel at which data is to be fetched.
-     * @param close Indicate to close or not the service.
-     * @return A plane 2D object that encapsulates the actual plane pixels.
-     * @throws DataSourceException If an error occurs while retrieving the
-     *                              plane data from the pixels source.
+     * @param channels
+     *            The channel indices
+     * @param binCount
+     *            The number of bins (optional, default: 256)
+     * @param globalRange
+     *            Use the global minimum/maximum to determine the histogram
+     *            range, otherwise use plane minimum/maximum value
+     * @param plane
+     *            The plane to specify z/t and/or a certain region (optional,
+     *            default: whole region of the first z/t plane)
+     * @return A {@link Map} of histogram data, where the key is the channel
+     *         index
+     * @throws DataSourceException  If an error occurred 
      */
-    public Plane2D getPlane(SecurityContext ctx, int z, int t, int c, boolean
-            close)
-                    throws DataSourceException
-    {
-        return createPlane(ctx, z, t, c, strategy, close);
+    public Map<Integer, int[]> getHistogram(int[] channels, int binCount,
+            boolean globalRange, PlaneDef plane)
+            throws DataSourceException {
+        try {
+            if (plane == null)
+                plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0,
+                        0, 0, null, -1);
+            return store.getHistogram(channels, binCount, globalRange, plane);
+        } catch (Exception e) {
+            throw new DataSourceException("Couldn't get histogram data", e);
+        }
     }
-
+    
     /**
      * Returns <code>true</code> if a data source has already been created
      * for the specified pixels set, <code>false</code> otherwise.
@@ -353,30 +260,8 @@ public class DataSink
         return pixelsID == source.getId();
     }
 
-    /** Erases the cache. */
-    public void clearCache()
-    {
-        if (cacheID == -1)
-            return;
-
-        gw.getCacheService().clearCache(cacheID);
+    @Override
+    public void close() throws IOException {
+        gw.closeService(ctx, store);
     }
-
-    /**
-     * Sets the size either to 1 or 0 depending on the passed value.
-     *
-     * @param cacheInMemory Passed <code>true</code> to set the size to 1,
-     *                      <code>false</code> to set to 0.
-     */
-    public void setCacheInMemory(boolean cacheInMemory)
-    {
-        if (cacheID == -1)
-            return;
-
-        clearCache();
-        if (cacheInMemory)
-            gw.getCacheService().setCacheEntries(cacheID, 1);
-        else gw.getCacheService().setCacheEntries(cacheID, 0);
-    }
-
 }

--- a/components/blitz/src/omero/gateway/rnd/DataSink.java
+++ b/components/blitz/src/omero/gateway/rnd/DataSink.java
@@ -93,12 +93,12 @@ public class DataSink implements AutoCloseable
     /**
      * Creates a new instance.
      *
+     * @param ctx
+     *            The SecurityContext
      * @param source
      *            The pixels set.
      * @param gw
      *            Reference to the gateway.
-     * @param ctx
-     *            The SecurityContext
      * @throws DSOutOfServiceException
      *             If the PixelsStore can't be accessed
      */
@@ -212,7 +212,7 @@ public class DataSink implements AutoCloseable
     public Plane2D getPlane(int z, int t, int c)
             throws DataSourceException
     {
-        return createPlane( z, t, c, strategy);
+        return createPlane(z, t, c, strategy);
     }
 
     /**

--- a/components/blitz/src/omero/gateway/rnd/DataSink.java
+++ b/components/blitz/src/omero/gateway/rnd/DataSink.java
@@ -20,8 +20,6 @@
  */
 package omero.gateway.rnd;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Map;
 
 import omero.ServerError;
@@ -47,7 +45,7 @@ import omero.gateway.model.PixelsData;
 * @version 3.0
 * @since OME3.0
 */
-public class DataSink implements Closeable
+public class DataSink implements AutoCloseable
 {
 
     /** Identifies the type used to store pixel values. */
@@ -261,7 +259,7 @@ public class DataSink implements Closeable
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         gw.closeService(ctx, store);
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/HistogramLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/HistogramLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2016-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -61,11 +61,11 @@ public class HistogramLoader extends BatchCallTree {
             final int z, final int t) {
         loadCall = new BatchCall("Loading Histogram data") {
             public void doCall() throws Exception {
-                result = context
-                        .getGateway()
-                        .getFacility(RawDataFacility.class)
-                        .getHistogram(ctx, img.getDefaultPixels(), channels, z,
-                                t);
+                try (RawDataFacility f = context.getGateway().getFacility(
+                        RawDataFacility.class)) {
+                    result = f.getHistogram(ctx, img.getDefaultPixels(),
+                            channels, z, t);
+                }
             }
         };
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/PixelsServicesFactory.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -46,14 +46,12 @@ import org.openmicroscopy.shoola.env.Container;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.config.Registry;
 
-import omero.gateway.Gateway;
 import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.exception.RenderingServiceException;
 import omero.gateway.rnd.DataSink;
 import omero.log.Logger;
 import omero.gateway.model.ChannelData;
-import omero.gateway.model.PixelsData;
 
 
 /** 
@@ -435,50 +433,9 @@ public class PixelsServicesFactory
 	}
 	
 	/**
-	 * Creates a new data sink for the specified set of pixels.
-	 * 
-	 * @param pixels The pixels set the data sink is for.
-	 * @return See above.
-	 */
-	public static DataSink createDataSink(PixelsData pixels, Gateway gw)
-	{
-		if (pixels == null)
-			throw new IllegalArgumentException("Pixels cannot be null.");
-		if (singleton.pixelsSource != null && 
-				singleton.pixelsSource.isSame(pixels.getId()))
-			return singleton.pixelsSource;
-		registry.getCacheService().clearAllCaches(); 
-		int size = getCacheSize();
-		if (size <= 0) size = 0;
-		singleton.pixelsSource = DataSink.makeNew(pixels, registry.getGateway(), size);
-		return singleton.pixelsSource;
-	}
-
-	/**
-	 * Shuts downs the data sink attached to the specified pixels set.
-	 * 
-	 * @param context   Reference to the registry. To ensure that agents cannot
-	 *                  call the method. It must be a reference to the
-	 *                  container's registry.
-	 * @param pixelsID  The ID of the pixels set.
-	 */
-	public static void shutDownDataSink(Registry context, long pixelsID)
-	{
-		if (!(context.equals(registry)))
-			throw new IllegalArgumentException("Not allow to access method.");
-		if (singleton.pixelsSource != null && 
-				singleton.pixelsSource.isSame(pixelsID)) {
-			int size = getCacheSize();
-			boolean cacheInMemory = true;
-			if (size <= 0) cacheInMemory = false;
-			singleton.pixelsSource.clearCache();
-			singleton.pixelsSource.setCacheInMemory(cacheInMemory);
-		}
-	}
-	
-	/**
 	 * Renders the specified {@link PlaneDef 2D-plane}.
 	 * 
+	 * @param ctx       The SecurityContext
 	 * @param context   Reference to the registry. To ensure that agents cannot
 	 *                  call the method. It must be a reference to the
 	 *                  container's registry.
@@ -487,7 +444,6 @@ public class PixelsServicesFactory
 	 * @param largeImage Indicates to set the resolution to <code>0</code>.
 	 * @param compression The compression level.
 	 * @return          The image representing the plane.
-	 * @return See above.
 	 * 
      * @throws RenderingServiceException 	If an error occurred while setting 
      * 										the value.
@@ -628,6 +584,7 @@ public class PixelsServicesFactory
 	/**
 	 * Makes a new {@link RenderingControl}.
 	 * 
+	 * @param ctx The SecurityContext
 	 * @param reList The rendering engines.
 	 * @param pixels The pixels set.
 	 * @param metadata The related metadata.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/PointIterator.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/PointIterator.java
@@ -290,7 +290,7 @@ class PointIterator
                 notifyPlaneEnd(z, w, t, length);
             }
         } catch (ExecutionException e) {
-            new DataSourceException(e);
+            throw new DataSourceException(e);
         } finally {  
             //Give the observers a chance to clean up even when 
             //something goes wrong. 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/PointIterator.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/rnd/roi/PointIterator.java
@@ -289,8 +289,6 @@ class PointIterator
                 }
                 notifyPlaneEnd(z, w, t, length);
             }
-        } catch (IOException e) {
-            new DataSourceException(e);
         } catch (ExecutionException e) {
             new DataSourceException(e);
         } finally {  

--- a/examples/Training/java/src/training/RawDataAccess.java
+++ b/examples/Training/java/src/training/RawDataAccess.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2006-2017 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -91,21 +91,18 @@ public class RawDataAccess
     private void retrievePlane()
             throws Exception
     {
-        RawDataFacility rdf = gateway.getFacility(RawDataFacility.class);
-        //To retrieve the image, see above.
-        PixelsData pixels = image.getDefaultPixels();
-        int sizeZ = pixels.getSizeZ();
-        int sizeT = pixels.getSizeT();
-        int sizeC = pixels.getSizeC();
-        try {
+        try (RawDataFacility rdf = gateway.getFacility(RawDataFacility.class)) {
+            // To retrieve the image, see above.
+            PixelsData pixels = image.getDefaultPixels();
+            int sizeZ = pixels.getSizeZ();
+            int sizeT = pixels.getSizeT();
+            int sizeC = pixels.getSizeC();
             Plane2D p;
-            for (int z = 0; z < sizeZ; z++) 
-                for (int t = 0; t < sizeT; t++) 
-                    for (int c = 0; c < sizeC; c++) 
+            for (int z = 0; z < sizeZ; z++)
+                for (int t = 0; t < sizeT; t++)
+                    for (int c = 0; c < sizeC; c++)
                         p = rdf.getPlane(ctx, pixels, z, t, c);
-        } catch (Exception e) {
-            throw new Exception("Cannot read the plane", e);
-        } 
+        }
     }
 
 // Retrieve tile
@@ -118,13 +115,12 @@ public class RawDataAccess
     private void retrieveTile()
             throws Exception
     {
-        RawDataFacility rdf = gateway.getFacility(RawDataFacility.class);
-        //To retrieve the image, see above.
-        PixelsData pixels = image.getDefaultPixels();
-        int sizeZ = pixels.getSizeZ();
-        int sizeT = pixels.getSizeT();
-        int sizeC = pixels.getSizeC();
-        try {
+        try (RawDataFacility rdf = gateway.getFacility(RawDataFacility.class)) {
+            //To retrieve the image, see above.
+            PixelsData pixels = image.getDefaultPixels();
+            int sizeZ = pixels.getSizeZ();
+            int sizeT = pixels.getSizeT();
+            int sizeC = pixels.getSizeC();
             //tile = (50, 50, 10, 10)  x, y, width, height of tile
             int x = 0;
             int y = 0;
@@ -139,8 +135,6 @@ public class RawDataAccess
                     }
                 }
             }
-        } catch (Exception e) {
-            throw new Exception("Cannot read the tiles", e);
         }
     }
 


### PR DESCRIPTION
# What this PR does

Makes the `RawDataFacility` `AutoCloseable`, so that it can be used in try-with-resources blocks.
The other Facility classes should be ok, as they only use stateless services.

# Testing this PR

Just check that integration tests and Insight (particularly code which uses the RawDataFacility, e.g. show histogram) still works.

# Related reading

https://trello.com/c/Uavp5lOO/30-gateway-facility
