### PR TITLE
handle requestline limit

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -76,6 +76,14 @@ $(function () {
                         }
                     }
                     $metadata_general.html(data);
+                },
+                error: function(data) {
+                    // If request string too long. e.g. image=1&image=2&image=3.... etc
+                    // Just show the error message in right panel.
+                    // This error will be ignored by OME.setupAjaxError();
+                    if (data.responseText.indexOf('Request Line is too large') > -1) {
+                        $metadata_general.html(data.responseText);
+                    }
                 }
             });
             

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -81,7 +81,7 @@ $(function () {
                     // If request string too long. e.g. image=1&image=2&image=3.... etc
                     // Just show the error message in right panel.
                     // This error will be ignored by OME.setupAjaxError();
-                    if (data.responseText.indexOf('Request Line is too large') > -1) {
+                    if (data.status == 414 || data.responseText.indexOf('Request Line is too large') > -1) {
                         $metadata_general.html(data.responseText);
                     }
                 }

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
@@ -516,11 +516,15 @@ OME.setupAjaxError = function(feedbackUrl){
             error = req.responseText;
             OME.feedback_dialog(error, feedbackUrl);
         } else if (req.status == 400) {
-            // 400 Bad Request. Usually indicates some invalid parameter, e.g. an invalid group id
-            // Usually indicates a problem with the webclient rather than the server as the webclient
-            // requested something invalid
-            error = req.responseText;
-            OME.feedback_dialog(error, feedbackUrl);
+            if (req.responseText.indexOf('Request Line is too large') > -1) {
+                // This should be handled by the caller - e.g. loading of right panel
+            } else {
+                // 400 Bad Request. Usually indicates some invalid parameter, e.g. an invalid group id
+                // Usually indicates a problem with the webclient rather than the server as the webclient
+                // requested something invalid
+                error = req.responseText;
+                OME.feedback_dialog(error, feedbackUrl);
+            }
         }
     });
 };


### PR DESCRIPTION
# What this PR does

Improves handling of error when request string is too long.
See https://trello.com/c/iDzN7Dw9/21-request-string-too-long

When many (e.g. >400) images are selected, the right hand panel loads a url that is too long
with all the images as ```/?image=1&image=2&image=3...```.
Now, instead of an error with feedback form, we simply show this error in the right panel.

![screen shot 2017-03-28 at 12 27 57](https://cloud.githubusercontent.com/assets/900055/24413022/179f5e76-13d2-11e7-82a6-7cdb15e977c3.png)

This relies on the response having text "Request Line is too large" in it.

# Testing this PR

1. In order to select a large number of objects you will need lots of images in a Dataset and to configure the ```omero.web.page_size = 500``` OR lots of Datasets in Project (not paginated) OR search for something that gives > 400 results.

2. Select many objects. Check that you see the expected message in right panel (see screenshot).
