### PR TITLE
expose enum constants in generated ome.model classes

### DIFF
--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -1369,7 +1369,6 @@ implements java.io.Serializable, IObject
     }
 #end
 
-    @SuppressWarnings("unchecked")
     @Override
     public boolean acceptFilter(ome.util.Filter __filter){
         try {
@@ -1490,7 +1489,6 @@ implements java.io.Serializable, IObject
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void putAt(String field, Object value)
     {

--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -1483,7 +1483,7 @@ implements java.io.Serializable, IObject
         } else if (field.equals(${prop.name.toUpperCase()}COUNTPEROWNER)) {
             return get${prop.nameCapped}CountPerOwner();
 #end
-        } else if (field.equals(${prop.nameUpper})) { // TODO use == here first??
+        } else if (field.equals(${prop.nameUpper})) {
             return get${prop.nameCapped}();
 #end
         } else {

--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -319,6 +319,15 @@ implements java.io.Serializable, IObject
     */
     private static final long serialVersionUID = 0000000030000020302L;
 
+#if($type.isEnum && !$type.shortname.startsWith("Units") && ${type.shortname} != "Binning" && ${type.shortname} != "PixelsType")
+#foreach($prop in $type.properties)
+#if($prop.class.name == "ome.dsl.EntryField")
+#set($enumSymbol = ${prop.name.replaceAll("-","_").replaceAll("[^a-zA-Z0-9_]","")})
+    public final static String VALUE_${enumSymbol} = "${prop.name}";
+#end
+#end
+
+#end
 #if(!$type.global)
    /*
     * Constants naming filters used by the OMERO
@@ -328,8 +337,8 @@ implements java.io.Serializable, IObject
     public final static String GROUP_FILTER = "${gfilter}";
     public final static String EVENT_FILTER = "${efilter}";
     public final static String PERMS_FILTER = "${pfilter}";
-#end
 
+#end
     public ${type.shortname} () {
         this(null, true);
     }

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -479,7 +479,7 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
             file.setName(filename);
             file.setPath(filename); // FIXME this should be something like /users/<name>/photo
             file.setSize((long) data.length);
-            file.setHasher(new ChecksumAlgorithm("SHA1-160"));
+            file.setHasher(new ChecksumAlgorithm(ChecksumAlgorithm.VALUE_SHA1_160));
             file.setHash(cpf.getProvider(ChecksumType.SHA1).putBytes(data)
                     .checksumAsString());
             file.setMimetype(mimetype);

--- a/components/server/src/ome/services/RawFileBean.java
+++ b/components/server/src/ome/services/RawFileBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2006-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -40,6 +40,7 @@ import ome.conditions.SecurityViolation;
 import ome.io.nio.FileBuffer;
 import ome.io.nio.OriginalFilesService;
 import ome.model.core.OriginalFile;
+import ome.model.enums.ChecksumAlgorithm;
 import ome.security.policy.BinaryAccessPolicy;
 import ome.util.ShallowCopy;
 import ome.util.checksum.ChecksumProviderFactory;
@@ -59,8 +60,6 @@ import com.google.common.collect.ImmutableMap;
  *
  * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
- * @version 3.0 <small> (<b>Internal version:</b> $Revision$ $Date:
- *          2005/06/08 15:21:59 $) </small>
  * @since OMERO3.0
  */
 @Transactional(readOnly = true)
@@ -79,13 +78,13 @@ public class RawFileBean extends AbstractStatefulBean implements RawFileStore {
     /* Map of checksum algorithm names to the corresponding checksum type. */
     private static final ImmutableMap<String, ChecksumType> checksumAlgorithms =
             ImmutableMap.<String, ChecksumType> builder().
-            put("Adler-32", ChecksumType.ADLER32).
-            put("CRC-32", ChecksumType.CRC32).
-            put("MD5-128", ChecksumType.MD5).
-            put("Murmur3-32", ChecksumType.MURMUR32).
-            put("Murmur3-128", ChecksumType.MURMUR128).
-            put("SHA1-160", ChecksumType.SHA1).
-            put("File-Size-64", ChecksumType.FILE_SIZE).
+            put(ChecksumAlgorithm.VALUE_Adler_32, ChecksumType.ADLER32).
+            put(ChecksumAlgorithm.VALUE_CRC_32, ChecksumType.CRC32).
+            put(ChecksumAlgorithm.VALUE_MD5_128, ChecksumType.MD5).
+            put(ChecksumAlgorithm.VALUE_Murmur3_32, ChecksumType.MURMUR32).
+            put(ChecksumAlgorithm.VALUE_Murmur3_128, ChecksumType.MURMUR128).
+            put(ChecksumAlgorithm.VALUE_SHA1_160, ChecksumType.SHA1).
+            put(ChecksumAlgorithm.VALUE_File_Size_64, ChecksumType.FILE_SIZE).
             build();
 
     /** The id of the original files instance. */

--- a/components/server/src/ome/services/scripts/RepoFile.java
+++ b/components/server/src/ome/services/scripts/RepoFile.java
@@ -119,7 +119,7 @@ public class RepoFile {
 
         final public String path;
         final public String name;
-        final private ChecksumAlgorithm hasher = new ChecksumAlgorithm("SHA1-160");
+        final private ChecksumAlgorithm hasher = new ChecksumAlgorithm(ChecksumAlgorithm.VALUE_SHA1_160);
 
         FsFile(String path) {
             this.path = FilenameUtils.normalize(path);


### PR DESCRIPTION
# What this PR does

This PR exposes many enumeration values (at least the easier ones!) as string constants in OMERO.server. The idea is to eliminate bugs arising from server code having to copy literal values that then are not updated if the enumeration value is changed.

# Testing this PR

Take a look at how this PR changes the generated Java classes in `components/model/target/generated/src/ome/model/enums/`. This PR includes some changes to server code to illustrate with the `ChecksumAlgorithm` enumeration the use of these new constants. This PR should leave the server's actual behavior unchanged.

# Related reading

http://trac.openmicroscopy.org/ome/ticket/10691