### PR TITLE
Well preview panel

### DIFF
--- a/components/tests/ui/testcases/web/spw_test.txt
+++ b/components/tests/ui/testcases/web/spw_test.txt
@@ -44,6 +44,11 @@ Test Spw Grid Layout
     # Right panel should show Well
     Page Should Contain Element             xpath=//div[contains(@class,'data_heading')]/h1[contains(text(), 'A1')]
 
+    # Preview panel enabled for Well
+    Click Link                              Preview
+    Wait Until Page Contains Element        id=viewport-img
+    Click Link                              General
+
     # Images from a single Well shown in bottom panel
     Wait Until Page Contains Element        xpath=//div[@id='wellImages']//li/a
     Xpath Should Match X Times              //div[@id='wellImages']//li/a                 ${FIELD_COUNT}

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -41,6 +41,9 @@ $(function() {
         multiselection = data.selected.length > 1;
 
         OME.tree_selection_changed(data, e);
+        if (OME.hideWellBirdsEye) {
+            OME.hideWellBirdsEye();
+        }
     })
     .on('selection_change.ome', function(e, nElements) {
         multiselection = nElements > 1;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
@@ -103,8 +103,6 @@
                 $("#annotationFilter").change(function(){
                     OME.filterAnnotationsAddedBy();
                 });
-
-                OME.initToolbarDropdowns();
             });
             
     </script>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -283,3 +283,18 @@
 
 </div>
 <div style="clear:both"></div>
+
+<!-- panel for extra info shown by toolbar buttons if needed - Duplicated under well below -->
+<div id="toolbar_info_panel" style="display:none; background: #fff; border: solid 1px #ddd; margin:5px 0">
+    <img title="Close" src="{% static 'webgateway/img/close.gif' %}" style="float:right; margin:3px"/>
+    <div class="panel_title" style="margin: 4px">
+        <!-- text loaded here -->
+    </div>
+    <div class="panel_div"></div>
+    <div style="clear:both"></div>
+</div>
+
+<div id="link_info_popup" class="info_popup" style="right:0px; top:30px; padding:4px; display:none">
+    <input type="text" size="30">
+    <img title="Close" src="{% static 'webgateway/img/close.gif' %}" />
+</div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -423,22 +423,6 @@
                 {% include "webclient/annotations/includes/toolbar.html" %}
             {% endwith %}
 
-
-            <!-- panel for extra info shown by toolbar buttons if needed - Duplicated under well below -->
-            <div id="toolbar_info_panel" style="display:none; background: #fff; border: solid 1px #ddd; margin:5px 0">
-                <img title="Close" src="{% static 'webgateway/img/close.gif' %}" style="float:right; margin:3px"/>
-                <div class="panel_title" style="margin: 4px">
-                    <!-- text loaded here -->
-                </div>
-                <div class="panel_div"></div>
-                <div style="clear:both"></div>
-            </div>
-
-            <div id="link_info_popup" class="info_popup" style="right:0px; top:30px; padding:4px; display:none">
-                <input type="text" size="30">
-                <img title="Close" src="{% static 'webgateway/img/close.gif' %}" />
-            </div>
-
             <!-- Image Name, ID, owner -->
             {% with obj=manager.image nameText=manager.image.name %}
                 {% include "webclient/annotations/includes/name.html" %}
@@ -529,7 +513,9 @@
         {% endif %}
             
         {% if manager.well %}
-            {% include "webclient/annotations/includes/toolbar.html" %}
+            {% with image=manager.getWellSampleImage %}
+                {% include "webclient/annotations/includes/toolbar.html" %}
+            {% endwith %}
 
             <!-- Well Label (not editable), ID, Owner -->
             {% with obj=manager.well nameText=manager.well.getWellPos %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -165,7 +165,7 @@ $(document).ready(function() {
             parentNode = inst.get_node(inst.get_parent(selected[0]));
         } else if (dtype === "plate" || dtype === "acquisition") {
             parentId = undefined;
-            clearThumbnailsPanel();
+            console.log(dtype, event, data);
             load_spw(event, data);
             return;
         // All other types have blank centre panel
@@ -788,7 +788,7 @@ $(document).ready(function() {
             });
         }
 
-        if (event.type === 'changed' || event.type === 'center_plugin_changed.ome') {
+        // if (event.type === 'changed' || event.type === 'center_plugin_changed.ome') {
             // If the containerNode is the current container then this is
             // a selection change within the container or a pagination/field
             // change
@@ -829,34 +829,34 @@ $(document).ready(function() {
             loadThumbnailsPanel(containerNode, nodePage, nodeField);
             return;
 
-        } else if (event.type === 'move_node') {
-            // The only relevant update is if a node has been added or removed
-            // from the currently displayed container, however, if this was a
-            // move of a selected image, the containerNode will be wrong as it
-            // points to the old location of the node
+        // } else if (event.type === 'move_node') {
+        //     // The only relevant update is if a node has been added or removed
+        //     // from the currently displayed container, however, if this was a
+        //     // move of a selected image, the containerNode will be wrong as it
+        //     // points to the old location of the node
 
-            var node = inst.get_node(data.node);
-            var parent = inst.get_node(data.parent);
-            var old_parent = inst.get_node(data.old_parent);
+        //     var node = inst.get_node(data.node);
+        //     var parent = inst.get_node(data.parent);
+        //     var old_parent = inst.get_node(data.old_parent);
 
-            // It is also possible that the moved node was the displayed container itself,
-            // but not an image
-            if (inst.is_selected(node)) {
-                // Update the contentDetails with this node
-                setThumbnailsPanel(node.type, node.data.obj.id, inst.get_omepath(node));
-                // And make the containerNode this node straight away
-                containerNode = node;
-            }
+        //     // It is also possible that the moved node was the displayed container itself,
+        //     // but not an image
+        //     if (inst.is_selected(node)) {
+        //         // Update the contentDetails with this node
+        //         setThumbnailsPanel(node.type, node.data.obj.id, inst.get_omepath(node));
+        //         // And make the containerNode this node straight away
+        //         containerNode = node;
+        //     }
 
-            // Is the moved node in the displayed container?
-            if (containerNode === parent && containerNode === old_parent) {
-                // Do nothing as it was reordered only
-            } else if (containerNode === parent) {
-                // Reload thumbnails
-                loadThumbnailsPanel(containerNode, getPageOr1(inst, containerNode), getfieldOr0(inst, containerNode));
-            }
+        //     // Is the moved node in the displayed container?
+        //     if (containerNode === parent && containerNode === old_parent) {
+        //         // Do nothing as it was reordered only
+        //     } else if (containerNode === parent) {
+        //         // Reload thumbnails
+        //         loadThumbnailsPanel(containerNode, getPageOr1(inst, containerNode), getfieldOr0(inst, containerNode));
+        //     }
 
-        }
+        // }
     };
 
         // Load the thumbnails (Will wait until there are no new requests

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -165,7 +165,6 @@ $(document).ready(function() {
             parentNode = inst.get_node(inst.get_parent(selected[0]));
         } else if (dtype === "plate" || dtype === "acquisition") {
             parentId = undefined;
-            console.log(dtype, event, data);
             load_spw(event, data);
             return;
         // All other types have blank centre panel
@@ -788,75 +787,45 @@ $(document).ready(function() {
             });
         }
 
-        // if (event.type === 'changed' || event.type === 'center_plugin_changed.ome') {
-            // If the containerNode is the current container then this is
-            // a selection change within the container or a pagination/field
-            // change
-            if (containerNode) {
-                // This is a page change
-                if (getPageOr1(inst, containerNode) !== currentPage) {
-                    loadThumbnailsPanel(containerNode, getPageOr1(inst, containerNode), undefined);
+        // If the containerNode is the current container then this is
+        // a selection change within the container or a pagination/field
+        // change
+        if (containerNode) {
+            // This is a page change
+            if (getPageOr1(inst, containerNode) !== currentPage) {
+                loadThumbnailsPanel(containerNode, getPageOr1(inst, containerNode), undefined);
 
-                // Fields are only applicable for acquisitions
-                } else if ((containerNode.type === 'acquisition' || containerNode.type === 'plate') && 
-                           getfieldOr0(inst, containerNode) !== currentField) {
-                    loadThumbnailsPanel(containerNode, undefined, getfieldOr0(inst, containerNode));
-                }
-
-                // Return as this was either a page/field change or image
-                // selection only
-                return;
+            // Fields are only applicable for acquisitions
+            } else if ((containerNode.type === 'acquisition' || containerNode.type === 'plate') &&
+                       getfieldOr0(inst, containerNode) !== currentField) {
+                loadThumbnailsPanel(containerNode, undefined, getfieldOr0(inst, containerNode));
             }
 
-            // There was no current node or it was not selected
-            // Load the first of the selected nodes
-            containerNode = selected[0];
-
-            // While the new selection may not be the same path as the old one
-            // if it is an equivalent node, we can save a reload and simply update
-            // the recorded path, but only if it is the same page/field
-            if (currentNode &&
-                inst.omecompare(containerNode, currentNode) &&
-                (currentPage === inst.get_page(containerNode || (containerNode.type === 'acquisition' && currentField === inst.get_field(containerNode))))) {
-                $contentDetails.data('path', JSON.stringify(inst.get_omepath(containerNode)));
-                return;
-            }
-
-            // Load the thumbnails for this container with the appropriate page/field
-            // E.g. public.html tree doesn't support pages/fields
-            var nodePage = inst.get_page ? inst.get_page(containerNode) : 1;
-            var nodeField = inst.get_field ? inst.get_field(containerNode) : 0;
-            loadThumbnailsPanel(containerNode, nodePage, nodeField);
+            // Return as this was either a page/field change or image
+            // selection only
             return;
+        }
 
-        // } else if (event.type === 'move_node') {
-        //     // The only relevant update is if a node has been added or removed
-        //     // from the currently displayed container, however, if this was a
-        //     // move of a selected image, the containerNode will be wrong as it
-        //     // points to the old location of the node
+        // There was no current node or it was not selected
+        // Load the first of the selected nodes
+        containerNode = selected[0];
 
-        //     var node = inst.get_node(data.node);
-        //     var parent = inst.get_node(data.parent);
-        //     var old_parent = inst.get_node(data.old_parent);
+        // While the new selection may not be the same path as the old one
+        // if it is an equivalent node, we can save a reload and simply update
+        // the recorded path, but only if it is the same page/field
+        if (currentNode &&
+            inst.omecompare(containerNode, currentNode) &&
+            (currentPage === inst.get_page(containerNode || (containerNode.type === 'acquisition' && currentField === inst.get_field(containerNode))))) {
+            $contentDetails.data('path', JSON.stringify(inst.get_omepath(containerNode)));
+            return;
+        }
 
-        //     // It is also possible that the moved node was the displayed container itself,
-        //     // but not an image
-        //     if (inst.is_selected(node)) {
-        //         // Update the contentDetails with this node
-        //         setThumbnailsPanel(node.type, node.data.obj.id, inst.get_omepath(node));
-        //         // And make the containerNode this node straight away
-        //         containerNode = node;
-        //     }
-
-        //     // Is the moved node in the displayed container?
-        //     if (containerNode === parent && containerNode === old_parent) {
-        //         // Do nothing as it was reordered only
-        //     } else if (containerNode === parent) {
-        //         // Reload thumbnails
-        //         loadThumbnailsPanel(containerNode, getPageOr1(inst, containerNode), getfieldOr0(inst, containerNode));
-        //     }
-
-        // }
+        // Load the thumbnails for this container with the appropriate page/field
+        // E.g. public.html tree doesn't support pages/fields
+        var nodePage = inst.get_page ? inst.get_page(containerNode) : 1;
+        var nodeField = inst.get_field ? inst.get_field(containerNode) : 0;
+        loadThumbnailsPanel(containerNode, nodePage, nodeField);
+        return;
     };
 
         // Load the thumbnails (Will wait until there are no new requests

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.preview.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.preview.js.html
@@ -54,7 +54,7 @@ $(document).ready(function() {
             //$this.html("<h1 style='padding: 20px 15px'>Loading...</h1>");
             $(this).load(url);
         },
-        supported_obj_types: ['image']
+        supported_obj_types: ['image', 'well']
     });
 
 });

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -3755,8 +3755,17 @@ def figure_script(request, scriptName, conn=None, **kwargs):
 
     imageIds = request.GET.get('Image', None)    # comma - delimited list
     datasetIds = request.GET.get('Dataset', None)
+    wellIds = request.GET.get('Well', None)
+
+    if wellIds is not None:
+        wellIds = [long(i) for i in wellIds.split(",")]
+        wells = conn.getObjects("Well", wellIds)
+        wellIdx = getIntOrDefault(request, 'Index', 0)
+        imageIds = [str(w.getImage(wellIdx).getId()) for w in wells]
+        imageIds = ",".join(imageIds)
     if imageIds is None and datasetIds is None:
-        return HttpResponse("Need to specify /?Image=1,2 or /?Dataset=1,2")
+        return HttpResponse(
+            "Need to specify /?Image=1,2 or /?Dataset=1,2 or /?Well=1,2")
 
     def validateIds(dtype, ids):
         ints = [int(oid) for oid in ids.split(",")]
@@ -3843,7 +3852,7 @@ def figure_script(request, scriptName, conn=None, **kwargs):
             thumbSets.append({'name': 'images', 'imageTags': imageTags})
             tags.extend(ts)
             parent = conn.getObject("Image", imageIds[0]).getParent()
-            figureName = parent.getName()
+            figureName = parent.getName() or "Thumbnail Figure"
             context['parent_id'] = parent.getId()
         uniqueTagIds = set()      # remove duplicates
         uniqueTags = []

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1544,9 +1544,14 @@ def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None,
     """
     context = {}
 
+    # the index of a field within a well
+    index = getIntOrDefault(request, 'index', 0)
+
     manager = BaseContainer(conn, **{str(c_type): long(c_id)})
     if share_id:
         context['share'] = BaseShare(conn, share_id)
+    if c_type == "well":
+        manager.image = manager.well.getImage(index)
 
     allRdefs = manager.image.getAllRenderingDefs()
     rdefs = {}

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1458,6 +1458,9 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
     data is handled by the template.
     """
 
+    # the index of a field within a well
+    index = getIntOrDefault(request, 'index', 0)
+
     context = dict()
 
     # we only expect a single object, but forms can take multiple objects
@@ -1510,7 +1513,7 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
     else:
         try:
             manager = BaseContainer(
-                conn, **{str(c_type): long(c_id)})
+                conn, **{str(c_type): long(c_id), 'index': index})
         except AttributeError, x:
             return handlerInternalError(request, x)
         if share_id is not None:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.spwgridview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.spwgridview.js
@@ -83,7 +83,6 @@ $(function(){
                 });
             },
             addWell: function(data) {
-                showPanel();
 
                 var minX,
                     maxX,
@@ -92,6 +91,11 @@ $(function(){
 
                 // first filter for well-samples that have positions
                 data = data.filter(function(ws){ return ws.position !== undefined });
+
+                // Only show panel if we have some data
+                if (data.length > 0) {
+                    showPanel();
+                }
 
                 var xVals = data.map(getPos('x')).filter(notUndef);
                 var yVals = data.map(getPos('y')).filter(notUndef);


### PR DESCRIPTION
# What this PR does

Adds back support for Preview panel when a Well is selected.
Browsing Wells is much nicer when you can directly preview the image (as you could in 5.2.x), instead of having to select Image first.

Also, we only show the spatial Well layout panel (below tree) when we have Well Sample position info and this panel is hidden when selecting data in tree since we know that non-Well data is being selected.

# Testing this PR

1. Browse Plate, click on Well and see that Preview tab is enabled and should work as normal.
2. Selecting a different field (chooser above plate) and re-selecting a Well should show the current field in Well preview tab.
3. Browsing Wells that have no spatial info for WellSamples will not show the spatial layout panel below tree.
4. When spatial panel is shown (when WellSamples have position data) and then you select data in tree, panel will be hidden again.

# Related reading

https://trello.com/c/kdYC8t7w/54-spw-layout-follow-up
