### PR TITLE
Bump omero-marshal to 0.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ before_install:
     - git config --global user.email snoopycrimecop@gmail.com
     - git config --global user.name 'Snoopy Crime Cop'
     - pip install --user scc pytest
+    - scc travis-merge
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all.txt; fi
     - export PATH=$PATH:$HOME/.local/bin
-    - scc travis-merge
     - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest==2.7.3; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
 

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -9,4 +9,6 @@ Django>=1.8,<1.9
 django-pipeline==1.3.20
 gunicorn>=19.3
 
-omero-marshal==0.5.0
+# Consumes bug fixing branch for the OMERO version post 5.3.0
+# See https://github.com/openmicroscopy/omero-marshal/pull/38
+git+git://github.com/sbesson/omero-marshal.git@omero_version_fix#egg=omero-marshal

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -9,6 +9,4 @@ Django>=1.8,<1.9
 django-pipeline==1.3.20
 gunicorn>=19.3
 
-# Consumes bug fixing branch for the OMERO version post 5.3.0
-# See https://github.com/openmicroscopy/omero-marshal/pull/38
-git+git://github.com/sbesson/omero-marshal.git@omero_version_fix#egg=omero-marshal
+omero-marshal==0.5.1


### PR DESCRIPTION
Following the OMERO 5.3.0 release, the OMERO.web unit tests started failing because of the stringent version check in `omero-marshal`. This PR bumps the requirements to use the latest `omero-marshal` release including https://github.com/openmicroscopy/omero-marshal/pull/38 and should fix the Travis build.

The `.travis.yml` is also updated to merge all PRs marked as dependent before installing the requirements so strategies similar to https://github.com/openmicroscopy/openmicroscopy/pull/5208#issuecomment-290216822 work in the future.

/cc @jburel @mtbc