### PR TITLE
Insight530 bugs

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/RowFieldCanvas.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/RowFieldCanvas.java
@@ -79,6 +79,15 @@ class RowFieldCanvas extends WellFieldsCanvas {
         addMouseListener(new MouseAdapter() {
 
             @Override
+            public void mouseClicked(MouseEvent e) {
+                WellSampleNode node = getNode(e.getPoint());
+                if (e.getClickCount() == 2 && node != null) {
+                    RowFieldCanvas.this.firePropertyChange(VIEW_PROPERTY, null,
+                            node);
+                }
+            }
+
+            @Override
             public void mouseReleased(MouseEvent e) {
                 WellSampleNode node = getNode(e.getPoint());
                 if (node == null)
@@ -140,13 +149,8 @@ class RowFieldCanvas extends WellFieldsCanvas {
                     }
                 }
 
-                if (e.getClickCount() == 2)
-                    RowFieldCanvas.this.firePropertyChange(VIEW_PROPERTY, null,
-                            newSelection);
-
-                else
-                    RowFieldCanvas.this.firePropertyChange(SELECTION_PROPERTY,
-                            oldSelection, newSelection);
+                RowFieldCanvas.this.firePropertyChange(SELECTION_PROPERTY,
+                        oldSelection, newSelection);
 
             }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellFieldsView.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/WellFieldsView.java
@@ -149,11 +149,10 @@ class WellFieldsView
                 }
                 else if (WellFieldsCanvas.VIEW_PROPERTY.equals(evt
                         .getPropertyName())) {
-                    List<WellSampleNode> selection = (List<WellSampleNode>) evt
+                    WellSampleNode selection = (WellSampleNode) evt
                             .getNewValue();
-                    if (!selection.isEmpty()) {
-                        WellSampleNode n = selection.get(0);
-                        controller.viewDisplay(n);
+                    if (selection != null) {
+                        controller.viewDisplay(selection);
                     }
                 }
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/SaveAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/SaveAction.java
@@ -60,7 +60,7 @@ public class SaveAction
     private static final String NAME = "Save As...";
     
     /** The description of the action. */
-    public static final String DESCRIPTION = "Save the image as TIFF, " +
+    public static final String DESCRIPTION = "Save the (zoomed) image as TIFF, " +
                                                 "JPEG, PNG, etc.";
 
     /** 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -388,7 +388,8 @@ class BrowserModel
      */
     private double getBarSizeInPx(double ratio)
     {
-        if(unitBarLength == null)
+        if (unitBarLength == null
+                || !Double.isFinite(getPixelsSizeX().getValue()))
             return 1;
         
         try {
@@ -753,6 +754,10 @@ class BrowserModel
      */
     String getUnitBarValue()
     {
+        if (unitBarLength == null
+                || !Double.isFinite(getPixelsSizeX().getValue()))
+            return "1";
+        
     	return UIUtilities.twoDecimalPlaces(unitBarLength.getValue());
     }
     
@@ -761,6 +766,10 @@ class BrowserModel
      * @return See above.
      */
     String getUnitBarUnit() {
+        if (unitBarLength == null
+                || !Double.isFinite(getPixelsSizeX().getValue()))
+            return LengthI.lookupSymbol(UnitsLength.PIXEL);
+        
         return LengthI.lookupSymbol(unitBarLength.getUnit());
     }
     

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/browser/BrowserModel.java
@@ -389,7 +389,8 @@ class BrowserModel
     private double getBarSizeInPx(double ratio)
     {
         if (unitBarLength == null
-                || !Double.isFinite(getPixelsSizeX().getValue()))
+                || Double.isInfinite(getPixelsSizeX().getValue())
+                || Double.isNaN(getPixelsSizeX().getValue()))
             return 1;
         
         try {
@@ -755,7 +756,8 @@ class BrowserModel
     String getUnitBarValue()
     {
         if (unitBarLength == null
-                || !Double.isFinite(getPixelsSizeX().getValue()))
+                || Double.isInfinite(getPixelsSizeX().getValue())
+                || Double.isNaN(getPixelsSizeX().getValue()))
             return "1";
         
     	return UIUtilities.twoDecimalPlaces(unitBarLength.getValue());
@@ -767,7 +769,8 @@ class BrowserModel
      */
     String getUnitBarUnit() {
         if (unitBarLength == null
-                || !Double.isFinite(getPixelsSizeX().getValue()))
+                || Double.isInfinite(getPixelsSizeX().getValue())
+                || Double.isNaN(getPixelsSizeX().getValue()))
             return LengthI.lookupSymbol(UnitsLength.PIXEL);
         
         return LengthI.lookupSymbol(unitBarLength.getUnit());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -123,7 +123,7 @@ class ImViewerModel
 {
 
     /** Default maximum export size, 12kx12kx image */
-    static int DEFAULT_MAX_EXPORT_SIZE = 144000000;
+    static long DEFAULT_MAX_EXPORT_SIZE = 144000000;
     
 	/** The maximum size for the bird eye view for standard screen size.*/
 	private static final int BIRD_EYE_SIZE_LOWER = 128;
@@ -1367,13 +1367,13 @@ class ImViewerModel
         if (getPixelsData() == null)
             return false;
 
-        int imgSize = getPixelsData().getSizeX() * getPixelsData().getSizeY();
-        int maxSize = DEFAULT_MAX_EXPORT_SIZE;
+        long imgSize = (long)getPixelsData().getSizeX() * (long)getPixelsData().getSizeY();
+        long maxSize = DEFAULT_MAX_EXPORT_SIZE;
         String tmp = (String) ImViewerAgent.getRegistry().lookup(
                 LookupNames.MAX_EXPORT_SIZE);
         if (tmp != null) {
             try {
-                maxSize = Integer.parseInt(tmp);
+                maxSize = Long.parseLong(tmp);
             } catch (NumberFormatException e) {
                 ImViewerAgent
                         .getRegistry()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -1367,7 +1367,8 @@ class ImViewerModel
         if (getPixelsData() == null)
             return false;
 
-        long imgSize = (long)getPixelsData().getSizeX() * (long)getPixelsData().getSizeY();
+        long imgSize = (long) (getPixelsData().getSizeX() * getZoomFactor())
+                * (long) (getPixelsData().getSizeY() * getZoomFactor());
         long maxSize = DEFAULT_MAX_EXPORT_SIZE;
         String tmp = (String) ImViewerAgent.getRegistry().lookup(
                 LookupNames.MAX_EXPORT_SIZE);

--- a/components/insight/config/about.xml
+++ b/components/insight/config/about.xml
@@ -11,7 +11,7 @@ Build: @DATE@<br></br>
 </p>
 <p>
 <br></br>
-(c) Copyright 2006-2014 University of Dundee &amp; Open Microscopy Environment.
+(c) Copyright 2006-2017 University of Dundee &amp; Open Microscopy Environment.
  All Rights Reserved.
 </p>
 <p>


### PR DESCRIPTION
# What this PR does

Some bugfixes for Insight.

1) Update copyright date in 'About' dialog
2) Avoid Insight crash, when viewing an image with invalid pixel sizes. ()
3) Double click to open full viewer didn't work on field thumbnails.
4) Large image JPEG export from full viewer could crash Insight
5) ~~Preview was disabled for Wells~~

# Testing this PR

1) Open the 'About' dialog (Help), check copyright date.
2) Once nightshade is upgraded to 5.3, open image `3859301`, Insight shouldn't crash.
3) Double click on an field thumbnail, full viewer should open with the field image.
4) Open a large (> 12k x 12k px) image in full viewer. Zoom out, so that the zoomed image is smaller than 12k x 12k px. You should be able to save it as JPEG/PNG/... . Zoom in. Once the zoomed image would be bigger than 12k x 12k px, the "Save as" button should be disabled.
5) ~~Select a well, check that preview shows the selected field for the well.~~

# Related reading
Re 2) https://www.openmicroscopy.org/qa2/qa/feedback/17673/ 
Re 4) http://lists.openmicroscopy.org.uk/pipermail/ome-users/2017-March/006409.html
