### PR TITLE
Search temp fix (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -308,9 +308,9 @@
 
                         <!-- when 'All Groups' - can choose 'Me' or 'All users' -->
                         <select name="ownedBy" id="searchByGroupMember--1">
-                            <option value="-1">All Users</option>
+                            <option value="-1" selected="selected">All Users</option>
                             {% for user in myColleagues %}}
-                                <option value="{{ user.id }}" {% ifequal user.id ome.user.id %}selected="selected"{% endifequal %}>
+                                <option value="{{ user.id }}">
                                     {{ user.getFullName|truncateafter:"50" }}
                                 </option>
                             {% endfor %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -30,7 +30,6 @@ from Ice import Exception as IceException
 import logging
 import traceback
 import json
-import re
 import sys
 
 from time import time

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1411,30 +1411,6 @@ def load_searching(request, form=None, conn=None, **kwargs):
         manager.search(query_search, onlyTypes, fields, searchGroup, ownedBy,
                        useAcquisitionDate, date)
 
-        # if the query is only numbers (separated by commas or spaces)
-        # we search for objects by ID
-        isIds = re.compile('^[\d ,]+$')
-        if isIds.search(query_search) is not None:
-            conn.SERVICE_OPTS.setOmeroGroup(-1)
-            idSet = set()
-            for queryId in re.split(' |,', query_search):
-                if len(queryId) == 0:
-                    continue
-                try:
-                    searchById = long(queryId)
-                    if searchById in idSet:
-                        continue
-                    idSet.add(searchById)
-                    for t in onlyTypes:
-                        t = t[0:-1]  # remove 's'
-                        if t in ('project', 'dataset', 'image', 'screen',
-                                 'plate', 'well'):
-                            obj = conn.getObject(t, searchById)
-                            if obj is not None:
-                                foundById.append({'otype': t, 'obj': obj})
-                except ValueError:
-                    pass
-
     else:
         # simply display the search home page.
         template = "webclient/search/search.html"


### PR DESCRIPTION

This is the same as gh-4436 but rebased onto metadata53.

----

Disable id helper in search and allow search in all groups by default, as tweaked in #4246


                