### PR TITLE
Add support for twitter cards (full image viewer only) (rebased onto metadata52) (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -508,6 +508,18 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.public.cache.timeout":
         ["PUBLIC_CACHE_TIMEOUT", 60 * 60 * 24, int, None],
 
+    # Social media integration
+    "omero.web.twitter.enabled":
+        ["TWITTER_ENABLED",
+         "false",
+         parse_boolean,
+         "Enable Twitter cards."],
+    "omero.web.twitter.siteuser":
+        ["TWITTER_SITE_USER",
+         None,
+         leave_none_unset,
+         "Twitter site username."],
+
     # Application configuration
     "omero.web.server_list":
         ["SERVER_LIST",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -516,6 +516,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Dictionary of `server-name: @twitter-site-username`, where "
           "server-name matches a name from `omero.web.server_list`. "
           "For example: ``'{\"omero\": \"@openmicroscopy\"}'``")],
+    "omero.web.sharing.opengraph":
+        ["SHARING_OPENGRAPH",
+         {},
+         json.loads,
+         ("Dictionary of `server-name: site-name`, where "
+          "server-name matches a name from `omero.web.server_list`. "
+          "For example: ``'{\"omero\": \"Open Microscopy\"}'``")],
 
     # Application configuration
     "omero.web.server_list":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -509,16 +509,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["PUBLIC_CACHE_TIMEOUT", 60 * 60 * 24, int, None],
 
     # Social media integration
-    "omero.web.twitter.enabled":
-        ["TWITTER_ENABLED",
-         "false",
-         parse_boolean,
-         "Enable Twitter cards."],
-    "omero.web.twitter.siteuser":
-        ["TWITTER_SITE_USER",
-         None,
-         leave_none_unset,
-         "Twitter site username."],
+    "omero.web.sharing.twitter":
+        ["SHARING_TWITTER",
+         {},
+         json.loads,
+         ("Dictionary of `server-name: @twitter-site-username`, where "
+          "server-name matches a name from `omero.web.server_list`. "
+          "For example: ``'{\"omero\": \"@openmicroscopy\"}'``")],
 
     # Application configuration
     "omero.web.server_list":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -511,14 +511,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
     # Social media integration
     "omero.web.sharing.twitter":
         ["SHARING_TWITTER",
-         {},
+         '{}',
          json.loads,
          ("Dictionary of `server-name: @twitter-site-username`, where "
           "server-name matches a name from `omero.web.server_list`. "
           "For example: ``'{\"omero\": \"@openmicroscopy\"}'``")],
     "omero.web.sharing.opengraph":
         ["SHARING_OPENGRAPH",
-         {},
+         '{}',
          json.loads,
          ("Dictionary of `server-name: site-name`, where "
           "server-name matches a name from `omero.web.server_list`. "

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -42,14 +42,24 @@
     <link rel="stylesheet" type="text/css" href="{% static "webgateway/css/ome.iehacks.css"|add:url_suffix %}" media="all" />
 <![endif]-->
 
+{% if opengraph %}
+    <meta name="og:title" content="{{ image.getName|escape }}">
+    <meta name="og:type" content="website">
+    <meta name="og:site_name" content="{{ opengraph }}">
+    <meta name="og:description" content="{{ image.getDescription|default:image.getOwner.getName|escape }}">
+    <meta name="og:url" content="{{ page_url }}">
+    <meta name="og:image" content="{{ image_preview }}512">
+{% endif %}
+
 {% if twitter %}
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="{{ twitter|escape }}">
     <meta name="twitter:title" content="{{ image.getName|truncateafter:'67'|escape }}">
     <meta name="twitter:description" content="{{ image.getDescription|default:image.getOwner.getName|truncateafter:'197'|escape }}">
     <meta name="twitter:creator" content="{{ twitter|escape }}">
-    <meta name="twitter:image" content="{{ twitter_img }}280">
+    <meta name="twitter:image" content="{{ image_preview }}280">
 {% endif %}
+
 {% endblock %}
 
 {% block script %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -1,5 +1,6 @@
 {% extends "webgateway/core_html.html" %}
 {% load i18n %}
+{% load common_filters %}
 
 {% comment %}
 <!--
@@ -41,6 +42,14 @@
     <link rel="stylesheet" type="text/css" href="{% static "webgateway/css/ome.iehacks.css"|add:url_suffix %}" media="all" />
 <![endif]-->
 
+{% if twitter %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="{{ twitter|escape }}">
+    <meta name="twitter:title" content="{{ image.getName|truncateafter:'67'|escape }}">
+    <meta name="twitter:description" content="{{ image.getDescription|default:image.getOwner.getName|truncateafter:'197'|escape }}">
+    <meta name="twitter:creator" content="{{ twitter|escape }}">
+    <meta name="twitter:image" content="{{ twitter_img }}280">
+{% endif %}
 {% endblock %}
 
 {% block script %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/viewport/omero_image.html
@@ -48,7 +48,7 @@
     <meta name="og:site_name" content="{{ opengraph }}">
     <meta name="og:description" content="{{ image.getDescription|default:image.getOwner.getName|escape }}">
     <meta name="og:url" content="{{ page_url }}">
-    <meta name="og:image" content="{{ image_preview }}512">
+    <meta name="og:image" content="{{ image_preview }}512/">
 {% endif %}
 
 {% if twitter %}
@@ -57,7 +57,7 @@
     <meta name="twitter:title" content="{{ image.getName|truncateafter:'67'|escape }}">
     <meta name="twitter:description" content="{{ image.getDescription|default:image.getOwner.getName|truncateafter:'197'|escape }}">
     <meta name="twitter:creator" content="{{ twitter|escape }}">
-    <meta name="twitter:image" content="{{ image_preview }}280">
+    <meta name="twitter:image" content="{{ image_preview }}280/">
 {% endif %}
 
 {% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2120,21 +2120,30 @@ def full_viewer(request, iid, conn=None, **kwargs):
         if image is None:
             logger.debug("(a)Image %s not found..." % (str(iid)))
             raise Http404
+
+        opengraph = None
         twitter = None
-        twitter_img = None
+        image_preview = None
+        page_url = None
+
+        if hasattr(settings, 'SHARING_OPENGRAPH'):
+            opengraph = settings.SHARING_OPENGRAPH.get(server_name)
+            logger.debug('Open Graph enabled: %s', twitter)
 
         if hasattr(settings, 'SHARING_TWITTER'):
             twitter = settings.SHARING_TWITTER.get(server_name)
-        if twitter:
+            logger.debug('Twitter enabled: %s', twitter)
+
+        if opengraph or twitter:
             prefix = kwargs.get(
                 'thumbprefix', 'webgateway.views.render_thumbnail')
 
             def urlprefix(iid):
                 return reverse(prefix, args=(iid,))
 
-            twitter_img = request.build_absolute_uri(urlprefix(iid))
-
-            logger.debug('Twitter enabled: %s %s', twitter, twitter_img)
+            image_preview = request.build_absolute_uri(urlprefix(iid))
+            page_url = request.build_absolute_uri(reverse(
+                'webgateway.views.full_viewer', args=(iid,)))
 
         d = {'blitzcon': conn,
              'image': image,
@@ -2147,8 +2156,10 @@ def full_viewer(request, iid, conn=None, **kwargs):
                  # remove any trailing slash
                  'viewport_server', reverse('webgateway')).rstrip('/'),
 
+             'opengraph': opengraph,
              'twitter': twitter,
-             'twitter_img': twitter_img,
+             'image_preview': image_preview,
+             'page_url': page_url,
 
              'object': 'image:%i' % int(iid)}
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2116,6 +2116,20 @@ def full_viewer(request, iid, conn=None, **kwargs):
         if image is None:
             logger.debug("(a)Image %s not found..." % (str(iid)))
             raise Http404
+        twitter = None
+        twitter_img = None
+
+        if settings.TWITTER_ENABLED and hasattr(settings, 'TWITTER_SITE_USER'):
+            twitter = settings.TWITTER_SITE_USER
+        if twitter:
+            prefix = kwargs.get(
+                'thumbprefix', 'webgateway.views.render_thumbnail')
+
+            def urlprefix(iid):
+                return reverse(prefix, args=(iid,))
+
+            twitter_img = request.build_absolute_uri(urlprefix(iid))
+
         d = {'blitzcon': conn,
              'image': image,
              'opts': rid,
@@ -2126,6 +2140,9 @@ def full_viewer(request, iid, conn=None, **kwargs):
              'viewport_server': kwargs.get(
                  # remove any trailing slash
                  'viewport_server', reverse('webgateway')).rstrip('/'),
+
+             'twitter': twitter,
+             'twitter_img': twitter_img,
 
              'object': 'image:%i' % int(iid)}
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -51,7 +51,7 @@ from omero import ApiUsageException
 from omero.util.decorators import timeit, TimeIt
 from omeroweb.http import HttpJavascriptResponse, \
     HttpJavascriptResponseServerError
-from connector import Server
+from omeroweb.connector import Server
 
 import glob
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -51,6 +51,7 @@ from omero import ApiUsageException
 from omero.util.decorators import timeit, TimeIt
 from omeroweb.http import HttpJavascriptResponse, \
     HttpJavascriptResponseServerError
+from connector import Server
 
 import glob
 
@@ -2105,6 +2106,9 @@ def full_viewer(request, iid, conn=None, **kwargs):
     @return:            html page of image and metadata
     """
 
+    server_id = request.session['connector'].server_id
+    server_name = Server.get(server_id).server
+
     rid = getImgDetailsFromReq(request)
     server_settings = request.session.get('server_settings', {}) \
                                      .get('viewer', {})
@@ -2119,8 +2123,8 @@ def full_viewer(request, iid, conn=None, **kwargs):
         twitter = None
         twitter_img = None
 
-        if settings.TWITTER_ENABLED and hasattr(settings, 'TWITTER_SITE_USER'):
-            twitter = settings.TWITTER_SITE_USER
+        if hasattr(settings, 'SHARING_TWITTER'):
+            twitter = settings.SHARING_TWITTER.get(server_name)
         if twitter:
             prefix = kwargs.get(
                 'thumbprefix', 'webgateway.views.render_thumbnail')
@@ -2129,6 +2133,8 @@ def full_viewer(request, iid, conn=None, **kwargs):
                 return reverse(prefix, args=(iid,))
 
             twitter_img = request.build_absolute_uri(urlprefix(iid))
+
+            logger.debug('Twitter enabled: %s %s', twitter, twitter_img)
 
         d = {'blitzcon': conn,
              'image': image,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2128,7 +2128,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
 
         if hasattr(settings, 'SHARING_OPENGRAPH'):
             opengraph = settings.SHARING_OPENGRAPH.get(server_name)
-            logger.debug('Open Graph enabled: %s', twitter)
+            logger.debug('Open Graph enabled: %s', opengraph)
 
         if hasattr(settings, 'SHARING_TWITTER'):
             twitter = settings.SHARING_TWITTER.get(server_name)


### PR DESCRIPTION

This is the same as gh-4613 but rebased onto metadata53.

----

This is the same as gh-4260 but rebased onto metadata52.

---

I've had this lurking around since January 2014. Given that we now have a public resource and Twitter no longer require manual approvals I thought it's time to resurrect it. See https://dev.twitter.com/cards/types/summary-large-image

The `title` and `description` fields are mandatory, I'm assuming there will always be a non-empty image name, description is set to the owner's name if empty.

At risk of stating the obvious this can only be tested with a public image on an external server. Open an image in the full image viewer, copy the url into a tweet.


                