### PR TITLE
Metadata column column types and datasets (rebased onto metadata53)

### DIFF
--- a/components/blitz/resources/omero/Tables.ice
+++ b/components/blitz/resources/omero/Tables.ice
@@ -61,6 +61,10 @@ module omero {
             omero::api::LongArray values;
         };
 
+        class DatasetColumn extends Column {
+            omero::api::LongArray values;
+        };
+
         class RoiColumn extends Column {
             omero::api::LongArray values;
         };

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -135,10 +135,11 @@ class HeaderResolver(object):
         'plate': PlateColumn,
     }, **plate_keys)
 
-    def __init__(self, target_object, headers):
+    def __init__(self, target_object, headers, column_types=None):
         self.target_object = target_object
         self.headers = headers
         self.headers_as_lower = [v.lower() for v in self.headers]
+        self.types = column_types
 
     def create_columns(self):
         target_class = self.target_object.__class__
@@ -179,12 +180,15 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            try:
-                column = self.screen_keys[header_as_lower](name, description,
-                                                           list())
-            except KeyError:
-                column = StringColumn(name, description,
-                                      self.DEFAULT_COLUMN_SIZE, list())
+            if self.types is not None:
+                column = COLUMN_TYPES[self.types[i]](name, description, list())
+            else:
+                try:
+                    column = self.screen_keys[header_as_lower](
+                        name, description, list())
+                except KeyError:
+                    column = StringColumn(
+                        name, description, self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:
@@ -214,12 +218,15 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            try:
-                column = self.plate_keys[header_as_lower](name, description,
-                                                          list())
-            except KeyError:
-                column = StringColumn(name, description,
-                                      self.DEFAULT_COLUMN_SIZE, list())
+            if self.types is not None:
+                column = COLUMN_TYPES[self.types[i]](name, description, list())
+            else:
+                try:
+                    column = self.plate_keys[header_as_lower](
+                        name, description, list())
+                except KeyError:
+                    column = StringColumn(
+                        name, description, self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
         for column in columns:
             if column.__class__ is PlateColumn:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -168,6 +168,9 @@ class HeaderResolver(object):
         log.debug('Sanity check passed')
 
     def create_columns_screen(self):
+        if len(self.types) != len(self.headers):
+            message = "Number of columns and column types not equal."
+            raise MetadataError(message)
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
@@ -210,6 +213,9 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_plate(self):
+        if len(self.types) != len(self.headers):
+            message = "Number of columns and column types not equal."
+            raise MetadataError(message)
         columns = list()
         for i, header_as_lower in enumerate(self.headers_as_lower):
             name = self.headers[i]
@@ -252,6 +258,9 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_dataset(self):
+        if len(self.types) != len(self.headers):
+            message = "Number of columns and column types not equal."
+            raise MetadataError(message)
         raise Exception('To be implemented!')
 
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -102,6 +102,8 @@ COLUMN_TYPES = {
     'b': BoolColumn
 }
 
+REGEX_HEADER_SPECIFIER = r'# header '
+
 
 class Skip(object):
     """Instance to denote a row skip request."""
@@ -142,6 +144,23 @@ class HeaderResolver(object):
         self.headers = headers
         self.headers_as_lower = [v.lower() for v in self.headers]
         self.types = column_types
+
+    @staticmethod
+    def is_row_column_types(row):
+        if "# header" in row[0]:
+            return True
+        return False
+
+    @staticmethod
+    def get_column_types(row):
+        if "# header" not in row[0]:
+            return None
+        get_first_type = re.compile(REGEX_HEADER_SPECIFIER)
+        column_types = [get_first_type.sub('', row[0])]
+        for column in row[1:]:
+            column_types.append(column)
+        column_types = parse_column_types(column_types)
+        return column_types
 
     def create_columns(self):
         target_class = self.target_object.__class__

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -187,7 +187,7 @@ class HeaderResolver(object):
         log.debug('Sanity check passed')
 
     def create_columns_screen(self):
-        if len(self.types) != len(self.headers):
+        if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
         columns = list()
@@ -232,7 +232,7 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_plate(self):
-        if len(self.types) != len(self.headers):
+        if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
         columns = list()
@@ -277,7 +277,7 @@ class HeaderResolver(object):
         return columns
 
     def create_columns_dataset(self):
-        if len(self.types) != len(self.headers):
+        if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
         raise Exception('To be implemented!')

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -43,6 +43,7 @@ from omero.model import ScreenAnnotationLinkI
 from omero.model import MapAnnotationI, NamedValue
 from omero.grid import ImageColumn, LongColumn, PlateColumn, RoiColumn
 from omero.grid import StringColumn, WellColumn, DoubleColumn, BoolColumn
+from omero.grid import DatasetColumn
 from omero.util.metadata_utils import KeyValueListPassThrough
 from omero.util.metadata_utils import KeyValueListTransformer
 from omero.util.metadata_utils import NSBULKANNOTATIONSCONFIG
@@ -133,6 +134,13 @@ class HeaderResolver(object):
         'image_name': StringColumn,
     }
 
+    project_keys = {
+        'dataset': DatasetColumn,
+        'dataset_name': StringColumn,
+        'image': ImageColumn,
+        'image_name': StringColumn,
+    }
+
     plate_keys = dict({
         'well': WellColumn,
         'field': ImageColumn,
@@ -174,12 +182,15 @@ class HeaderResolver(object):
         if ScreenI is target_class:
             log.debug('Creating columns for Screen:%d' % target_id)
             return self.create_columns_screen()
-        if PlateI is target_class:
+        elif PlateI is target_class:
             log.debug('Creating columns for Plate:%d' % target_id)
             return self.create_columns_plate()
-        if DatasetI is target_class:
+        elif DatasetI is target_class:
             log.debug('Creating columns for Dataset:%d' % target_id)
             return self.create_columns_dataset()
+        elif ProjectI is target_class:
+            log.debug('Creating columns for Project:%d' % target_id)
+            return self.create_columns_project()
         raise MetadataError(
             'Unsupported target object class: %s' % target_class)
 
@@ -200,6 +211,9 @@ class HeaderResolver(object):
 
     def create_columns_dataset(self):
         return self._create_columns("dataset")
+
+    def create_columns_project(self):
+        return self._create_columns("project")
 
     def _create_columns(self, klass):
         if self.types is not None and len(self.types) != len(self.headers):
@@ -275,6 +289,8 @@ class ValueResolver(object):
             return self.load_dataset()
         elif ScreenI is self.target_class:
             return self.load_screen()
+        elif ProjectI is self.target_class:
+            return self.load_project()
         raise MetadataError(
             'Unsupported target object class: %s' % self.target_class)
 
@@ -416,6 +432,60 @@ class ValueResolver(object):
             else:
                 images_by_name[iname] = iid
         log.debug('Completed parsing dataset: %s' % dname)
+
+    def load_project(self):
+        query_service = self.client.getSession().getQueryService()
+        parameters = omero.sys.ParametersI()
+        parameters.addId(self.target_object.id.val)
+        log.debug('Loading Project:%d' % self.target_object.id.val)
+
+        parameters.page(0, 1)
+        self.target_object = unwrap(query_service.findByQuery(
+            'select p from Project p where p.id = :id',
+            parameters, {'omero.group': '-1'}))
+        self.target_name = self.target_object.name.val
+
+        data = list()
+        while True:
+            parameters.page(len(data), 1000)
+            rv = unwrap(query_service.projection((
+                'select distinct i.id, i.name '
+                'from Project p '
+                'join p.datasetLinks as pdl '
+                'join pdl.child as d '
+                'join d.imageLinks as l '
+                'join l.child as i '
+                'where p.id = :id order by i.id desc'),
+                parameters, {'omero.group': '-1'}))
+            if len(rv) == 0:
+                break
+            else:
+                data.extend(rv)
+        if not data:
+            raise MetadataError('Could not find target object!')
+
+        self.images_by_id = dict()
+        self.images_by_name = dict()
+        images_by_id = dict()
+        images_by_name = dict()
+
+        self.images_by_id[self.target_object.id.val] = images_by_id
+        self.images_by_name[self.target_object.id.val] = images_by_name
+        self.parse_project(
+            self.target_name, images_by_id, images_by_name, data
+        )
+
+    def parse_project(self, pname, images_by_id, images_by_name, data):
+        # TODO: idential to parse_dataset
+        for iid, iname in data:
+            images_by_id[iid] = iname
+            if iname in images_by_name:
+                log.warn("Image named %s(id=%d) present. Skipping %s" % (
+                    iname, images_by_name[iname], iid
+                ))
+            else:
+                images_by_name[iname] = iid
+        log.debug('Completed parsing dataset: %s' % pname)
 
     def resolve(self, column, value, row):
         column_class = column.__class__
@@ -1003,6 +1073,7 @@ class DeleteMapAnnotationContext(_QueryContext):
             "WellSample": None,
             "Image": None,
             "Dataset": None,
+            "Project": None,
         }
 
         target = self.target_object
@@ -1047,6 +1118,14 @@ class DeleteMapAnnotationContext(_QueryContext):
         if parentids["WellSample"]:
             q = "SELECT image.id FROM WellSample WHERE id IN (:ids)"
             parentids["Image"] = self.projection(q, parentids["WellSample"])
+
+        if isinstance(target, ProjectI):
+            parentids["Project"] = ids
+        if parentids["Project"]:
+            q = ("SELECT ds.id FROM ProjectDatasetLink link "
+                 "join link.parent prj "
+                 "join link.child as ds WHERE prj.id IN (:ids)")
+            parentids["Dataset"] = self.projection(q, parentids["Project"])
 
         if isinstance(target, DatasetI):
             parentids["Dataset"] = ids

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1024,8 +1024,8 @@ def parse_column_types(column_type_list):
             column_types.append(column_type.lower())
         else:
             column_types = []
-            message = "\nColumn type '%s' unknown.\nChoose from following: %s" \
-                % (column_type, ",".join(COLUMN_TYPES.keys()))
+            message = "\nColumn type '%s' unknown.\nChoose from following: " \
+                "%s" % (column_type, ",".join(COLUMN_TYPES.keys()))
             raise MetadataError(message)
     return column_types
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -543,19 +543,30 @@ class ParsingContext(object):
 
     def parse_from_handle(self, data):
         rows = list(csv.reader(data, delimiter=','))
-        log.debug('Header: %r' % rows[0])
+        first_row_is_types = HeaderResolver.is_row_column_types(rows[0])
+        header_index = 0
+        rows_index = 1
+        if first_row_is_types:
+            header_index = 1
+            rows_index = 2
+        log.debug('Header: %r' % rows[header_index])
         for h in rows[0]:
             if not h:
-                raise Exception('Empty column header in CSV: %s' % rows[0])
+                raise Exception('Empty column header in CSV: %s'
+                                % rows[header_index])
+        if self.column_types is None and first_row_is_types:
+            self.column_types = HeaderResolver.get_column_types(rows[0])
+        log.debug('Column types: %r' % self.column_types)
         self.header_resolver = HeaderResolver(
-            self.target_object, rows[0], column_types=self.column_types)
+            self.target_object, rows[header_index],
+            column_types=self.column_types)
         self.columns = self.header_resolver.create_columns()
         log.debug('Columns: %r' % self.columns)
 
-        valuerows = rows[1:]
+        valuerows = rows[rows_index:]
         log.debug('Got %d rows', len(valuerows))
         if PlateI is self.value_resolver.target_class:
-            valuerows = self.subselect_plate(valuerows, rows[0])
+            valuerows = self.subselect_plate(valuerows, rows[header_index])
         self.populate(valuerows)
         self.post_process()
         log.debug('Column widths: %r' % self.get_column_widths())

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -418,20 +418,9 @@ class ValueResolver(object):
 
         self.images_by_id[self.target_object.id.val] = images_by_id
         self.images_by_name[self.target_object.id.val] = images_by_name
-        self.parse_dataset(
+        self.parse_by_name(
             self.target_name, images_by_id, images_by_name, data
         )
-
-    def parse_dataset(self, dname, images_by_id, images_by_name, data):
-        for iid, iname in data:
-            images_by_id[iid] = iname
-            if iname in images_by_name:
-                log.warn("Image named %s(id=%d) present. Skipping %s" % (
-                    iname, images_by_name[iname], iid
-                ))
-            else:
-                images_by_name[iname] = iid
-        log.debug('Completed parsing dataset: %s' % dname)
 
     def load_project(self):
         query_service = self.client.getSession().getQueryService()
@@ -471,20 +460,18 @@ class ValueResolver(object):
 
         self.images_by_id[self.target_object.id.val] = images_by_id
         self.images_by_name[self.target_object.id.val] = images_by_name
-        self.parse_project(
+        self.parse_by_name(
             self.target_name, images_by_id, images_by_name, data
         )
 
-    def parse_project(self, pname, images_by_id, images_by_name, data):
-        # TODO: idential to parse_dataset
+    def parse_by_name(self, name, images_by_id, images_by_name, data):
         for iid, iname in data:
             images_by_id[iid] = iname
             if iname in images_by_name:
-                log.warn("Image named %s(id=%d) present. Skipping %s" % (
+                raise Exception("Image named %s(id=%d) present. Skipping %s" % (
                     iname, images_by_name[iname], iid
                 ))
-            else:
-                images_by_name[iname] = iid
+            images_by_name[iname] = iid
         log.debug('Completed parsing dataset: %s' % pname)
 
     def resolve(self, column, value, row):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -932,9 +932,12 @@ class BulkToMapAnnotationContext(_QueryContext):
             for omerotype, n in idcols:
                 if row[n] > 0:
                     obj = omerotype(row[n], False)
-                    # Josh: disabling to prevent duplication in UI
-                    # targets.append(obj)
+                    additional = self._get_additional_targets(obj)
                     targets.extend(self._get_additional_targets(obj))
+                    # Josh: disabling to prevent duplication in UI
+                    # if there are other targets to be used. FIXME
+                    if not additional:
+                        targets.append(obj)
                 else:
                     log.warn("Invalid Id:%d found in row %s", row[n], row)
             if targets:
@@ -999,6 +1002,7 @@ class DeleteMapAnnotationContext(_QueryContext):
             "Well": None,
             "WellSample": None,
             "Image": None,
+            "Dataset": None,
         }
 
         target = self.target_object
@@ -1044,8 +1048,19 @@ class DeleteMapAnnotationContext(_QueryContext):
             q = "SELECT image.id FROM WellSample WHERE id IN (:ids)"
             parentids["Image"] = self.projection(q, parentids["WellSample"])
 
+        if isinstance(target, DatasetI):
+            parentids["Dataset"] = ids
+        if parentids["Dataset"]:
+            q = ("SELECT i.id FROM DatasetImageLink link "
+                 "join link.parent ds "
+                 "join link.child as i WHERE ds.id IN (:ids)")
+            parentids["Image"] = self.projection(q, parentids["Dataset"])
+
         if isinstance(target, ImageI):
             parentids["Image"] = ids
+
+        # TODO: This should really include:
+        #    raise Exception("Unknown target: %s" % target.__class__.__name__)
 
         log.debug("Parent IDs: %s", parentids)
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -67,17 +67,21 @@ Usage: %s [options] <target_object> <file>
 Runs metadata population code for a given object.
 
 Options:
-  -s    OMERO hostname to use [defaults to "localhost"]
-  -p    OMERO port to use [defaults to 4064]
-  -u    OMERO username to use
-  -w    OMERO password
-  -k    OMERO session key to use
-  -i    Dump measurement information and exit (no population)
-  -d    Print debug statements
-  -c    Use an alternative context (for expert users only)
+  -s            OMERO hostname to use [defaults to "localhost"]
+  -p            OMERO port to use [defaults to 4064]
+  -u            OMERO username to use
+  -w            OMERO password
+  -k            OMERO session key to use
+  --columns     Column configuration, Specify as comma separated list.
+                Supported types: plate, well, image, roi,
+                                 d (double), l (long), s (string), b (boolean)
+                Supported Boolean True Values: "yes", "true", "t", "1".
+  -i            Dump measurement information and exit (no population)
+  -d            Print debug statements
+  -c            Use an alternative context (for expert users only)
 
 Examples:
-  %s -s localhost -p 14064 -u bob Plate:6 metadata.csv
+  %s -s localhost -p 14064 -u bob --columns l,image,d,l Plate:6 metadata.csv
 
 Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd)
     sys.exit(2)
@@ -1008,7 +1012,7 @@ def parse_target_object(target_object):
 
 if __name__ == "__main__":
     try:
-        options, args = getopt(sys.argv[1:], "s:p:u:w:k:c:id")
+        options, args = getopt(sys.argv[1:], "s:p:u:w:k:c:id", ["columns="])
     except GetoptError, (msg, opt):
         usage(msg)
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -90,6 +90,8 @@ Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd)
 thread_pool = None
 
 # Special column names we may add depending on the data type
+BOOLEAN_TRUE = ["yes", "true", "t", "1"]
+
 PLATE_NAME_COLUMN = 'Plate Name'
 WELL_NAME_COLUMN = 'Well Name'
 IMAGE_NAME_COLUMN = 'Image Name'
@@ -435,6 +437,12 @@ class ValueResolver(object):
                 return long(self.AS_ALPHA.index(value.lower()))
         if StringColumn is column_class:
             return value
+        if LongColumn is column_class:
+            return int(value)
+        if DoubleColumn is column_class:
+            return float(value)
+        if BoolColumn is column_class:
+            return value.lower() in BOOLEAN_TRUE
         raise MetadataError('Unsupported column class: %s' % column_class)
 
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -31,6 +31,7 @@ import json
 from getpass import getpass
 from getopt import getopt, GetoptError
 from itertools import izip
+from collections import defaultdict
 
 import omero.clients
 from omero.callbacks import CmdCallbackI
@@ -283,18 +284,192 @@ class ValueResolver(object):
         self.client = client
         self.target_object = target_object
         self.target_class = self.target_object.__class__
+        self.target_type = self.target_object.ice_staticId().split('::')[-1]
+        self.target_id = self.target_object.id.val
+        q = "select x.details.group.id from %s x where x.id = %d " % (
+            self.target_type, self.target_id
+        )
+        self.target_group = unwrap(
+            self.client.sf.getQueryService().projection(q, None))
+        # The goal is to make this the only instance of
+        # a if/elif/else block on the target_class. All
+        # logic should be placed in a the concrete wrapper
+        # implementation
         if PlateI is self.target_class:
-            return self.load_plate()
+            self.wrapper = PlateWrapper(self)
         elif DatasetI is self.target_class:
-            return self.load_dataset()
+            self.wrapper = DatasetWrapper(self)
         elif ScreenI is self.target_class:
-            return self.load_screen()
+            self.wrapper = ScreenWrapper(self)
         elif ProjectI is self.target_class:
-            return self.load_project()
-        raise MetadataError(
-            'Unsupported target object class: %s' % self.target_class)
+            self.wrapper = ProjectWrapper(self)
+        else:
+            raise MetadataError(
+                'Unsupported target object class: %s' % self.target_class)
 
-    def load_screen(self):
+    def get_plate_name_by_id(self, plate):
+        return self.wrapper.get_plate_name_by_id(plate)
+
+    def get_well_name(self, well_id, plate=None):
+        well = self.wrapper.get_well_by_id(well_id, plate)
+        row = well.row.val
+        col = well.column.val
+        row = self.AS_ALPHA[row]
+        return '%s%d' % (row, col + 1)
+
+    def get_image_id_by_name(self, iname, dname=None):
+        return self.wrapper.get_image_id_by_name(iname, dname)
+
+    def subselect(self, valuerows, names):
+        return self.wrapper.subselect(valuerows, names)
+
+    def resolve(self, column, value, row):
+        column_class = column.__class__
+        column_as_lower = column.name.lower()
+        if ImageColumn is column_class:
+            if len(self.images_by_id) == 1:
+                images_by_id = self.images_by_id.values()[0]
+            else:
+                for column, plate in row:
+                    if column.__class__ is PlateColumn:
+                        images_by_id = self.images_by_id[
+                            self.plates_by_name[plate].id.val
+                        ]
+                        log.debug(
+                            "Got plate %i", self.plates_by_name[plate].id.val
+                        )
+                    break
+            if images_by_id is None:
+                raise MetadataError(
+                    'Unable to locate Plate column in Row: %r' % row
+                )
+            try:
+                return images_by_id[long(value)].id.val
+            except KeyError:
+                log.debug('Image Id: %i not found!' % (value))
+                return -1L
+            return
+        if WellColumn is column_class:
+            return self.wrapper.resolve_well(column, row, value)
+        if PlateColumn is column_class:
+            return self.wrapper.resolve_plate(column, row, value)
+        if column_as_lower in ('row', 'column') \
+           and column_class is LongColumn:
+            try:
+                # The value is not 0 offsetted
+                return long(value) - 1
+            except ValueError:
+                return long(self.AS_ALPHA.index(value.lower()))
+        if StringColumn is column_class:
+            return value
+        if LongColumn is column_class:
+            return long(value)
+        if DoubleColumn is column_class:
+            return float(value)
+        if BoolColumn is column_class:
+            return value.lower() in BOOLEAN_TRUE
+        raise MetadataError('Unsupported column class: %s' % column_class)
+
+
+class ValueWrapper(object):
+
+    def __init__(self, value_resolver):
+        self.resolver = value_resolver
+        self.client = value_resolver.client
+        self.target_object = value_resolver.target_object
+        self.target_class = value_resolver.target_class
+
+    def subselect(self, rows, names):
+        return rows
+
+
+class SPWWrapper(ValueWrapper):
+
+    def __init__(self, value_resolver):
+        super(SPWWrapper, self).__init__(value_resolver)
+        self.AS_ALPHA = value_resolver.AS_ALPHA
+        self.WELL_REGEX = value_resolver.WELL_REGEX
+
+    def get_well_by_id(self, well_id, plate=None):
+        raise Exception("to be implemented by subclasses")
+
+    def parse_plate(self, plate, wells_by_location, wells_by_id, images_by_id):
+        # TODO: This should use the PlateNamingConvention. We're assuming rows
+        # as alpha and columns as numeric.
+        for well in plate.copyWells():
+            wells_by_id[well.id.val] = well
+            row = well.row.val
+            # 0 offsetted is not what people use in reality
+            column = str(well.column.val + 1)
+            try:
+                columns = wells_by_location[self.AS_ALPHA[row]]
+            except KeyError:
+                wells_by_location[self.AS_ALPHA[row]] = columns = dict()
+            columns[column] = well
+
+            for well_sample in well.copyWellSamples():
+                image = well_sample.getImage()
+                images_by_id[image.id.val] = image
+        log.debug('Completed parsing plate: %s' % plate.name.val)
+        for row in wells_by_location:
+            log.debug('%s: %r' % (row, wells_by_location[row].keys()))
+
+    def resolve_well(self, column, row, value):
+            m = self.WELL_REGEX.match(value)
+            if m is None or len(m.groups()) != 2:
+                msg = 'Cannot parse well identifier "%s" from row: %r'
+                msg = msg % (value, [o[1] for o in row])
+                raise MetadataError(msg)
+            plate_row = m.group(1).lower()
+            plate_column = str(long(m.group(2)))
+            wells_by_location = None
+            if len(self.wells_by_location) == 1:
+                wells_by_location = self.wells_by_location.values()[0]
+                log.debug(
+                    'Parsed "%s" row: %s column: %s' % (
+                        value, plate_row, plate_column))
+            else:
+                for column, plate in row:
+                    if column.__class__ is PlateColumn:
+                        wells_by_location = self.wells_by_location[plate]
+                        log.debug(
+                            'Parsed "%s" row: %s column: %s plate: %s' % (
+                                value, plate_row, plate_column, plate))
+                        break
+            if wells_by_location is None:
+                raise MetadataError(
+                    'Unable to locate Plate column in Row: %r' % row
+                )
+            try:
+                return wells_by_location[plate_row][plate_column].id.val
+            except KeyError:
+                log.debug('Row: %s Column: %s not found!' % (
+                    plate_row, plate_column))
+                return -1L
+
+
+class ScreenWrapper(SPWWrapper):
+
+    def __init__(self, value_resolver):
+        super(ScreenWrapper, self).__init__(value_resolver)
+        self._load()
+
+    def get_plate_name_by_id(self, plate):
+        plate = self.plates_by_id[plate]
+        return plate.name.val
+
+    def get_well_by_id(self, well_id, plate=None):
+        wells = self.wells_by_id[plate]
+        return wells[well_id]
+
+    def resolve_plate(self, column, row, value):
+        try:
+            return self.plates_by_name[value].id.val
+        except KeyError:
+            log.warn('Screen is missing plate: %s' % value)
+            return Skip()
+
+    def _load(self):
         query_service = self.client.getSession().getQueryService()
         parameters = omero.sys.ParametersI()
         parameters.addId(self.target_object.id.val)
@@ -333,7 +508,34 @@ class ValueResolver(object):
                 plate, wells_by_location, wells_by_id, images_by_id
             )
 
-    def load_plate(self):
+
+class PlateWrapper(SPWWrapper):
+
+    def __init__(self, value_resolver):
+        super(PlateWrapper, self).__init__(value_resolver)
+        self._load()
+
+    def get_well_by_id(self, well_id, plate=None):
+        plate = self.target_object.id.val
+        wells = self.wells_by_id[plate]
+        return wells[well_id]
+
+    def subselect(self, rows, names):
+        """
+        If we're processing a plate but the bulk-annotations file contains
+        a plate column then select rows for this plate only
+        """
+        for i, name in enumerate(names):
+            if name.lower() == 'plate':
+                valuerows = [row for row in rows if row[i] ==
+                             self.value_resolver.target_name]
+                log.debug(
+                    'Selected %d/%d rows for plate "%s"', len(valuerows),
+                    len(rows), self.value_resolver.target_name)
+                return valuerows
+        return rows
+
+    def _load(self):
         query_service = self.client.getSession().getQueryService()
         parameters = omero.sys.ParametersI()
         parameters.addId(self.target_object.id.val)
@@ -362,28 +564,25 @@ class ValueResolver(object):
             self.target_object, wells_by_location, wells_by_id, images_by_id
         )
 
-    def parse_plate(self, plate, wells_by_location, wells_by_id, images_by_id):
-        # TODO: This should use the PlateNamingConvention. We're assuming rows
-        # as alpha and columns as numeric.
-        for well in plate.copyWells():
-            wells_by_id[well.id.val] = well
-            row = well.row.val
-            # 0 offsetted is not what people use in reality
-            column = str(well.column.val + 1)
-            try:
-                columns = wells_by_location[self.AS_ALPHA[row]]
-            except KeyError:
-                wells_by_location[self.AS_ALPHA[row]] = columns = dict()
-            columns[column] = well
 
-            for well_sample in well.copyWellSamples():
-                image = well_sample.getImage()
-                images_by_id[image.id.val] = image
-        log.debug('Completed parsing plate: %s' % plate.name.val)
-        for row in wells_by_location:
-            log.debug('%s: %r' % (row, wells_by_location[row].keys()))
+class PDIWrapper(ValueWrapper):
 
-    def load_dataset(self):
+    def get_image_id_by_name(self, iname, dname=None):
+        raise Exception("to be implemented by subclasses")
+
+
+class DatasetWrapper(PDIWrapper):
+
+    def __init__(self, value_resolver):
+        super(DatasetWrapper, self).__init__(value_resolver)
+        self.images_by_id = dict()
+        self.images_by_name = dict()
+        self._load()
+
+    def get_image_id_by_name(self, iname, dname=None):
+        return self.images_by_name[iname]
+
+    def _load(self):
         query_service = self.client.getSession().getQueryService()
         parameters = omero.sys.ParametersI()
         parameters.addId(self.target_object.id.val)
@@ -411,18 +610,28 @@ class ValueResolver(object):
         if not data:
             raise MetadataError('Could not find target object!')
 
-        self.images_by_id = dict()
-        self.images_by_name = dict()
-        images_by_id = dict()
-        images_by_name = dict()
+        for iid, iname in data:
+            self.images_by_id[iid] = iname
+            if iname in self.images_by_name:
+                raise Exception("Image named %s(id=%d) present. (id=%s)" % (
+                    iname, self.images_by_name[iname], iid
+                ))
+            self.images_by_name[iname] = iid
+        log.debug('Completed parsing dataset: %s' % self.target_name)
 
-        self.images_by_id[self.target_object.id.val] = images_by_id
-        self.images_by_name[self.target_object.id.val] = images_by_name
-        self.parse_by_name(
-            self.target_name, images_by_id, images_by_name, data
-        )
 
-    def load_project(self):
+class ProjectWrapper(PDIWrapper):
+
+    def __init__(self, value_resolver):
+        super(ProjectWrapper, self).__init__(value_resolver)
+        self.graph_by_id = defaultdict(lambda: dict())
+        self.graph_by_name = defaultdict(lambda: dict())
+        self._load()
+
+    def get_image_id_by_name(self, iname, dname=None):
+        return self.graph_by_name[dname][iname][2]
+
+    def _load(self):
         query_service = self.client.getSession().getQueryService()
         parameters = omero.sys.ParametersI()
         parameters.addId(self.target_object.id.val)
@@ -438,7 +647,7 @@ class ValueResolver(object):
         while True:
             parameters.page(len(data), 1000)
             rv = unwrap(query_service.projection((
-                'select distinct i.id, i.name '
+                'select distinct d.id, d.name, i.id, i.name '
                 'from Project p '
                 'join p.datasetLinks as pdl '
                 'join pdl.child as d '
@@ -453,107 +662,27 @@ class ValueResolver(object):
         if not data:
             raise MetadataError('Could not find target object!')
 
-        self.images_by_id = dict()
-        self.images_by_name = dict()
-        images_by_id = dict()
-        images_by_name = dict()
+        seen = dict()
+        for row in data:
+            did, dname, iid, iname = row
 
-        self.images_by_id[self.target_object.id.val] = images_by_id
-        self.images_by_name[self.target_object.id.val] = images_by_name
-        self.parse_by_name(
-            self.target_name, images_by_id, images_by_name, data
-        )
-
-    def parse_by_name(self, name, images_by_id, images_by_name, data):
-        for iid, iname in data:
-            images_by_id[iid] = iname
-            if iname in images_by_name:
-                raise Exception("Image named %s(id=%d) present. Skipping %s" % (
-                    iname, images_by_name[iname], iid
+            if dname in seen and seen[dname] != did:
+                raise Exception("Duplicate datasets: '%s' = %s, %s" % (
+                    dname, seen[dname], did
                 ))
-            images_by_name[iname] = iid
-        log.debug('Completed parsing dataset: %s' % pname)
+            else:
+                seen[dname] = did
 
-    def resolve(self, column, value, row):
-        column_class = column.__class__
-        column_as_lower = column.name.lower()
-        if ImageColumn is column_class:
-            if len(self.images_by_id) == 1:
-                images_by_id = self.images_by_id.values()[0]
+            ikey = (did, iname)
+            if ikey in seen and iid != seen[ikey]:
+                raise Exception("Duplicate image: '%s' = %s, %s (Dataset:%s)"
+                                % (iname, seen[ikey], iid, did))
             else:
-                for column, plate in row:
-                    if column.__class__ is PlateColumn:
-                        images_by_id = self.images_by_id[
-                            self.plates_by_name[plate].id.val
-                        ]
-                        log.debug(
-                            "Got plate %i", self.plates_by_name[plate].id.val
-                        )
-                    break
-            if images_by_id is None:
-                raise MetadataError(
-                    'Unable to locate Plate column in Row: %r' % row
-                )
-            try:
-                return images_by_id[long(value)].id.val
-            except KeyError:
-                log.error('Image Id: %s not found!' % (value))
-                return -1L
-            return
-        if WellColumn is column_class:
-            m = self.WELL_REGEX.match(value)
-            if m is None or len(m.groups()) != 2:
-                msg = 'Cannot parse well identifier "%s" from row: %r'
-                msg = msg % (value, [o[1] for o in row])
-                raise MetadataError(msg)
-            plate_row = m.group(1).lower()
-            plate_column = str(long(m.group(2)))
-            wells_by_location = None
-            if len(self.wells_by_location) == 1:
-                wells_by_location = self.wells_by_location.values()[0]
-                log.debug(
-                    'Parsed "%s" row: %s column: %s' % (
-                        value, plate_row, plate_column))
-            else:
-                for column, plate in row:
-                    if column.__class__ is PlateColumn:
-                        wells_by_location = self.wells_by_location[plate]
-                        log.debug(
-                            'Parsed "%s" row: %s column: %s plate: %s' % (
-                                value, plate_row, plate_column, plate))
-                        break
-            if wells_by_location is None:
-                raise MetadataError(
-                    'Unable to locate Plate column in Row: %r' % row
-                )
-            try:
-                return wells_by_location[plate_row][plate_column].id.val
-            except KeyError:
-                log.debug('Row: %s Column: %s not found!' % (
-                    plate_row, plate_column))
-                return -1L
-        if PlateColumn is column_class:
-            try:
-                return self.plates_by_name[value].id.val
-            except KeyError:
-                log.warn('Screen is missing plate: %s' % value)
-                return Skip()
-        if column_as_lower in ('row', 'column') \
-           and column_class is LongColumn:
-            try:
-                # The value is not 0 offsetted
-                return long(value) - 1
-            except ValueError:
-                return long(self.AS_ALPHA.index(value.lower()))
-        if StringColumn is column_class:
-            return value
-        if LongColumn is column_class:
-            return long(value)
-        if DoubleColumn is column_class:
-            return float(value)
-        if BoolColumn is column_class:
-            return value.lower() in BOOLEAN_TRUE
-        raise MetadataError('Unsupported column class: %s' % column_class)
+                seen[ikey] = iid
+
+            self.graph_by_id[did][iid] = row
+            self.graph_by_name[dname][iname] = row
+        log.debug('Completed parsing project: %s' % self.target_object.id.val)
 
 
 class ParsingContext(object):
@@ -602,21 +731,6 @@ class ParsingContext(object):
                 widths.append(None)
         return widths
 
-    def subselect_plate(self, rows, names):
-        """
-        If we're processing a plate but the bulk-annotations file contains
-        a plate column then select rows for this plate only
-        """
-        for i, name in enumerate(names):
-            if name.lower() == 'plate':
-                valuerows = [row for row in rows if row[i] ==
-                             self.value_resolver.target_name]
-                log.debug(
-                    'Selected %d/%d rows for plate "%s"', len(valuerows),
-                    len(rows), self.value_resolver.target_name)
-                return valuerows
-        return rows
-
     def parse_from_handle(self, data):
         rows = list(csv.reader(data, delimiter=','))
         first_row_is_types = HeaderResolver.is_row_column_types(rows[0])
@@ -641,8 +755,8 @@ class ParsingContext(object):
 
         valuerows = rows[rows_index:]
         log.debug('Got %d rows', len(valuerows))
-        if PlateI is self.value_resolver.target_class:
-            valuerows = self.subselect_plate(valuerows, rows[header_index])
+        valuerows = self.value_resolver.subselect(
+            valuerows, rows[header_index])
         self.populate(valuerows)
         self.post_process()
         log.debug('Column widths: %r' % self.get_column_widths())
@@ -725,18 +839,14 @@ class ParsingContext(object):
         sz = max([len(x.values) for x in self.columns])
         for i in range(0, sz):
             if well_name_column is not None:
-                if PlateI is self.value_resolver.target_class:
-                    plate = self.value_resolver.target_object.id.val
-                elif ScreenI is self.value_resolver.target_class:
-                    plate = columns_by_name['Plate'].values[i]
+
                 v = ''
                 try:
-                    well = self.value_resolver.wells_by_id[plate]
-                    well = well[well_column.values[i]]
-                    row = well.row.val
-                    col = well.column.val
-                    row = self.value_resolver.AS_ALPHA[row]
-                    v = '%s%d' % (row, col + 1)
+                    well_id = well_column.values[i]
+                    plate = None
+                    if "Plate" in columns_by_name:  # FIXME
+                        plate = columns_by_name["Plate"].values[i]
+                    v = self.value_resolver.get_well_name(well_id, plate)
                 except KeyError:
                     log.warn(
                         'Skipping table row %d! Missing well row or column '
@@ -748,30 +858,26 @@ class ParsingContext(object):
                 log.info('Missing well name column, skipping.')
 
             if image_name_column is not None:
-                # Josh: I understand here that an Image Name column
-                # was provided and therefore we need to find the image
-                # id for the given image_name
-                did = self.value_resolver.target_object.id.val
-                iname = image_name_column.values[i]
-                # TODO: This may throw!
                 try:
-                    images_by_name = self.value_resolver.images_by_name[did]
-                    iid = images_by_name[iname]
+                    iname = image_name_column.values[i]
+                    did = None
+                    if "Dataset Name" in columns_by_name:  # FIXME
+                        did = columns_by_name["Dataset Name"].values[i]
+                    iid = self.value_resolver.get_image_id_by_name(iname, did)
                     assert i == len(image_column.values)
                     image_column.values.append(iid)
                     image_name_column.size = max(
                         image_name_column.size, len(iname))
                 except KeyError:
-                    raise Exception(
-                        "%s not found in image names: %" % (
-                            iname, ", ".join(images_by_name.keys())))
+                    log.error(
+                        "%s not found in image names" % iname)
+                    raise
             else:
                 log.info('Missing image name column, skipping.')
 
             if plate_name_column is not None:
-                plate = columns_by_name['Plate'].values[i]
-                plate = self.value_resolver.plates_by_id[plate]
-                v = plate.name.val
+                plate = columns_by_name['Plate'].values[i]   # FIXME
+                v = self.value_resolver.get_plate_name_by_id(plate)
                 plate_name_column.size = max(plate_name_column.size, len(v))
                 plate_name_column.values.append(v)
             else:
@@ -779,7 +885,7 @@ class ParsingContext(object):
 
     def write_to_omero(self):
         sf = self.client.getSession()
-        group = str(self.value_resolver.target_object.details.group.id.val)
+        group = str(self.value_resolver.target_group)
         sr = sf.sharedResources()
         update_service = sf.getUpdateService()
         name = 'bulk_annotations'
@@ -1011,7 +1117,7 @@ class BulkToMapAnnotationContext(_QueryContext):
 
     def write_to_omero(self):
         sf = self.client.getSession()
-        group = str(self.target_object.details.group.id.val)
+        group = str(self.target_object.details.group.id)
         update_service = sf.getUpdateService()
         ids = update_service.saveAndReturnIds(
             self.mapannotations, {'omero.group': group})

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -38,6 +38,7 @@ from omero.rtypes import rstring, unwrap
 from omero.model import DatasetAnnotationLinkI, DatasetI, FileAnnotationI
 from omero.model import OriginalFileI, PlateI, PlateAnnotationLinkI, ScreenI
 from omero.model import PlateAcquisitionI, WellI, WellSampleI, ImageI
+from omero.model import ProjectAnnotationLinkI, ProjectI
 from omero.model import ScreenAnnotationLinkI
 from omero.model import MapAnnotationI, NamedValue
 from omero.grid import ImageColumn, LongColumn, PlateColumn, RoiColumn
@@ -94,6 +95,7 @@ BOOLEAN_TRUE = ["yes", "true", "t", "1"]
 
 PLATE_NAME_COLUMN = 'Plate Name'
 WELL_NAME_COLUMN = 'Well Name'
+DATASET_NAME_COLUMN = 'Dataset Name'
 IMAGE_NAME_COLUMN = 'Image Name'
 
 COLUMN_TYPES = {
@@ -126,14 +128,17 @@ class HeaderResolver(object):
 
     DEFAULT_COLUMN_SIZE = 1
 
-    plate_keys = {
+    dataset_keys = {
+        'image': ImageColumn,
+    }
+
+    plate_keys = dict({
         'well': WellColumn,
         'field': ImageColumn,
         'row': LongColumn,
         'column': LongColumn,
         'wellsample': ImageColumn,
-        'image': ImageColumn
-    }
+    }, **dataset_keys)
 
     screen_keys = dict({
         'plate': PlateColumn,
@@ -187,51 +192,15 @@ class HeaderResolver(object):
         log.debug('Sanity check passed')
 
     def create_columns_screen(self):
-        if self.types is not None and len(self.types) != len(self.headers):
-            message = "Number of columns and column types not equal."
-            raise MetadataError(message)
-        columns = list()
-        for i, header_as_lower in enumerate(self.headers_as_lower):
-            name = self.headers[i]
-            description = ""
-            if "%%" in name:
-                name, description = name.split("%%", 1)
-                name = name.strip()
-                # description is key=value. Convert to json
-                if "=" in description:
-                    k, v = description.split("=", 1)
-                    k = k.strip()
-                    description = json.dumps({k: v.strip()})
-            # HDF5 does not allow / in column names
-            name = name.replace('/', '\\')
-            if self.types is not None and \
-                    COLUMN_TYPES[self.types[i]] is StringColumn:
-                column = COLUMN_TYPES[self.types[i]](
-                    name, description, self.DEFAULT_COLUMN_SIZE, list())
-            elif self.types is not None:
-                column = COLUMN_TYPES[self.types[i]](name, description, list())
-            else:
-                try:
-                    column = self.screen_keys[header_as_lower](
-                        name, description, list())
-                except KeyError:
-                    column = StringColumn(
-                        name, description, self.DEFAULT_COLUMN_SIZE, list())
-            columns.append(column)
-        for column in columns:
-            if column.__class__ is PlateColumn:
-                columns.append(StringColumn(PLATE_NAME_COLUMN, '',
-                               self.DEFAULT_COLUMN_SIZE, list()))
-            if column.__class__ is WellColumn:
-                columns.append(StringColumn(WELL_NAME_COLUMN, '',
-                               self.DEFAULT_COLUMN_SIZE, list()))
-            if column.__class__ is ImageColumn:
-                columns.append(StringColumn(IMAGE_NAME_COLUMN, '',
-                               self.DEFAULT_COLUMN_SIZE, list()))
-        self.columns_sanity_check(columns)
-        return columns
+        return self._create_columns("screen")
 
     def create_columns_plate(self):
+        return self._create_columns("plate")
+
+    def create_columns_dataset(self):
+        return self._create_columns("dataset")
+
+    def _create_columns(self, klass):
         if self.types is not None and len(self.types) != len(self.headers):
             message = "Number of columns and column types not equal."
             raise MetadataError(message)
@@ -257,7 +226,8 @@ class HeaderResolver(object):
                 column = COLUMN_TYPES[self.types[i]](name, description, list())
             else:
                 try:
-                    column = self.plate_keys[header_as_lower](
+                    keys = getattr(self, "%s_keys" % klass)
+                    column = keys[header_as_lower](
                         name, description, list())
                 except KeyError:
                     column = StringColumn(
@@ -275,12 +245,6 @@ class HeaderResolver(object):
                                self.DEFAULT_COLUMN_SIZE, list()))
         self.columns_sanity_check(columns)
         return columns
-
-    def create_columns_dataset(self):
-        if self.types is not None and len(self.types) != len(self.headers):
-            message = "Number of columns and column types not equal."
-            raise MetadataError(message)
-        raise Exception('To be implemented!')
 
 
 class ValueResolver(object):
@@ -301,9 +265,9 @@ class ValueResolver(object):
         self.target_class = self.target_object.__class__
         if PlateI is self.target_class:
             return self.load_plate()
-        if DatasetI is self.target_class:
+        elif DatasetI is self.target_class:
             return self.load_dataset()
-        if ScreenI is self.target_class:
+        elif ScreenI is self.target_class:
             return self.load_screen()
         raise MetadataError(
             'Unsupported target object class: %s' % self.target_class)
@@ -398,7 +362,54 @@ class ValueResolver(object):
             log.debug('%s: %r' % (row, wells_by_location[row].keys()))
 
     def load_dataset(self):
-        raise Exception('To be implemented!')
+        query_service = self.client.getSession().getQueryService()
+        parameters = omero.sys.ParametersI()
+        parameters.addId(self.target_object.id.val)
+        log.debug('Loading Dataset:%d' % self.target_object.id.val)
+
+        parameters.page(0, 1)
+        self.target_object = unwrap(query_service.findByQuery(
+            'select d from Dataset d where d.id = :id',
+            parameters, {'omero.group': '-1'}))
+        self.target_name = self.target_object.name.val
+
+        data = list()
+        while True:
+            parameters.page(len(data), 1000)
+            rv = unwrap(query_service.projection((
+                'select distinct i.id, i.name from Dataset as d '
+                'join d.imageLinks as l '
+                'join l.child as i '
+                'where d.id = :id order by i.id desc'),
+                parameters, {'omero.group': '-1'}))
+            if len(rv) == 0:
+                break
+            else:
+                data.extend(rv)
+        if not data:
+            raise MetadataError('Could not find target object!')
+
+        self.images_by_id = dict()
+        self.images_by_name = dict()
+        images_by_id = dict()
+        images_by_name = dict()
+
+        self.images_by_id[self.target_object.id.val] = images_by_id
+        self.images_by_name[self.target_object.id.val] = images_by_name
+        self.parse_dataset(
+            self.target_name, images_by_id, images_by_name, data
+        )
+
+    def parse_dataset(self, dname, images_by_id, images_by_name, data):
+        for iid, iname in data:
+            images_by_id[iid] = iname
+            if iname in images_by_name:
+                log.warn("Image named %s(id=%d) present. Skipping %s" % (
+                    iname, images_by_name[iname], iid
+                ))
+            else:
+                images_by_name[iname] = iid
+        log.debug('Completed parsing dataset: %s' % dname)
 
     def resolve(self, column, value, row):
         column_class = column.__class__
@@ -514,6 +525,8 @@ class ParsingContext(object):
             return PlateAnnotationLinkI()
         if DatasetI is self.target_class:
             return DatasetAnnotationLinkI()
+        if ProjectI is self.target_class:
+            return ProjectAnnotationLinkI()
         raise MetadataError(
             'Unsupported target object class: %s' % self.target_class)
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -40,8 +40,8 @@ from omero.model import OriginalFileI, PlateI, PlateAnnotationLinkI, ScreenI
 from omero.model import PlateAcquisitionI, WellI, WellSampleI, ImageI
 from omero.model import ScreenAnnotationLinkI
 from omero.model import MapAnnotationI, NamedValue
-from omero.grid import ImageColumn, LongColumn, PlateColumn
-from omero.grid import StringColumn, WellColumn
+from omero.grid import ImageColumn, LongColumn, PlateColumn, RoiColumn
+from omero.grid import StringColumn, WellColumn, DoubleColumn, BoolColumn
 from omero.util.metadata_utils import KeyValueListPassThrough
 from omero.util.metadata_utils import KeyValueListTransformer
 from omero.util.metadata_utils import NSBULKANNOTATIONSCONFIG
@@ -93,6 +93,12 @@ thread_pool = None
 PLATE_NAME_COLUMN = 'Plate Name'
 WELL_NAME_COLUMN = 'Well Name'
 IMAGE_NAME_COLUMN = 'Image Name'
+
+COLUMN_TYPES = {
+    'plate': PlateColumn, 'well': WellColumn, 'image': ImageColumn,
+    'roi': RoiColumn, 'd': DoubleColumn, 'l': LongColumn, 's': StringColumn,
+    'b': BoolColumn
+}
 
 
 class Skip(object):
@@ -1010,6 +1016,20 @@ def parse_target_object(target_object):
         return ScreenI(long(id), False)
     raise ValueError('Unsupported target object: %s' % target_object)
 
+
+def parse_column_types(column_type_list):
+    column_types = []
+    for column_type in column_type_list:
+        if column_type.lower() in COLUMN_TYPES:
+            column_types.append(column_type.lower())
+        else:
+            column_types = []
+            message = "\nColumn type '%s' unknown.\nChoose from following: %s" \
+                % (column_type, ",".join(COLUMN_TYPES.keys()))
+            raise MetadataError(message)
+    return column_types
+
+
 if __name__ == "__main__":
     try:
         options, args = getopt(sys.argv[1:], "s:p:u:w:k:c:id", ["columns="])
@@ -1030,6 +1050,7 @@ if __name__ == "__main__":
     session_key = None
     logging_level = logging.INFO
     thread_count = 1
+    column_types = None
     context_class = ParsingContext
     for option, argument in options:
         if option == "-u":
@@ -1048,6 +1069,8 @@ if __name__ == "__main__":
             logging_level = logging.DEBUG
         if option == "-t":
             thread_count = int(argument)
+        if option == "--columns":
+            column_types = parse_column_types(argument.split(','))
         if option == "-c":
             try:
                 context_class = globals()[argument]

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -182,7 +182,11 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            if self.types is not None:
+            if self.types is not None and \
+                    COLUMN_TYPES[self.types[i]] is StringColumn:
+                column = COLUMN_TYPES[self.types[i]](
+                    name, description, self.DEFAULT_COLUMN_SIZE, list())
+            elif self.types is not None:
                 column = COLUMN_TYPES[self.types[i]](name, description, list())
             else:
                 try:
@@ -220,7 +224,11 @@ class HeaderResolver(object):
                     description = json.dumps({k: v.strip()})
             # HDF5 does not allow / in column names
             name = name.replace('/', '\\')
-            if self.types is not None:
+            if self.types is not None and \
+                    COLUMN_TYPES[self.types[i]] is StringColumn:
+                column = COLUMN_TYPES[self.types[i]](
+                    name, description, self.DEFAULT_COLUMN_SIZE, list())
+            elif self.types is not None:
                 column = COLUMN_TYPES[self.types[i]](name, description, list())
             else:
                 try:
@@ -548,7 +556,8 @@ class ParsingContext(object):
                     break
                 values.append(value)
                 try:
-                    if value.__class__ is not long:
+                    log.debug("Value's class: %s" % value.__class__)
+                    if value.__class__ is str:
                         column.size = max(column.size, len(value))
                 except TypeError:
                     log.error('Original value "%s" now "%s" of bad type!' % (

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -438,7 +438,7 @@ class ValueResolver(object):
         if StringColumn is column_class:
             return value
         if LongColumn is column_class:
-            return int(value)
+            return long(value)
         if DoubleColumn is column_class:
             return float(value)
         if BoolColumn is column_class:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -130,6 +130,7 @@ class HeaderResolver(object):
 
     dataset_keys = {
         'image': ImageColumn,
+        'image_name': StringColumn,
     }
 
     plate_keys = dict({
@@ -138,7 +139,7 @@ class HeaderResolver(object):
         'row': LongColumn,
         'column': LongColumn,
         'wellsample': ImageColumn,
-    }, **dataset_keys)
+    })
 
     screen_keys = dict({
         'plate': PlateColumn,
@@ -233,16 +234,21 @@ class HeaderResolver(object):
                     column = StringColumn(
                         name, description, self.DEFAULT_COLUMN_SIZE, list())
             columns.append(column)
+        append = []
         for column in columns:
             if column.__class__ is PlateColumn:
-                columns.append(StringColumn(PLATE_NAME_COLUMN, '',
-                               self.DEFAULT_COLUMN_SIZE, list()))
+                append.append(StringColumn(PLATE_NAME_COLUMN, '',
+                              self.DEFAULT_COLUMN_SIZE, list()))
             if column.__class__ is WellColumn:
-                columns.append(StringColumn(WELL_NAME_COLUMN, '',
-                               self.DEFAULT_COLUMN_SIZE, list()))
+                append.append(StringColumn(WELL_NAME_COLUMN, '',
+                              self.DEFAULT_COLUMN_SIZE, list()))
             if column.__class__ is ImageColumn:
-                columns.append(StringColumn(IMAGE_NAME_COLUMN, '',
-                               self.DEFAULT_COLUMN_SIZE, list()))
+                append.append(StringColumn(IMAGE_NAME_COLUMN, '',
+                              self.DEFAULT_COLUMN_SIZE, list()))
+            # Currently hard-coded, but "if image name, then add image id"
+            if column.name == IMAGE_NAME_COLUMN:
+                append.append(ImageColumn("image", '', list()))
+        columns.extend(append)
         self.columns_sanity_check(columns)
         return columns
 
@@ -595,7 +601,6 @@ class ParsingContext(object):
 
     def populate(self, rows):
         nrows = len(rows)
-
         for (r, row) in enumerate(rows):
             values = list()
             row = [(self.columns[i], value) for i, value in enumerate(row)]
@@ -618,15 +623,20 @@ class ParsingContext(object):
             if value.__class__ is not Skip:
                 values.reverse()
                 for column in self.columns:
-                    if column.name in (PLATE_NAME_COLUMN, WELL_NAME_COLUMN,
-                                       IMAGE_NAME_COLUMN):
-                        continue
-                    try:
+                    if not values:
+                        if isinstance(column, ImageColumn) or \
+                           column.name in (PLATE_NAME_COLUMN,
+                                           WELL_NAME_COLUMN,
+                                           IMAGE_NAME_COLUMN):
+                            # Then assume that the values will be calculated
+                            # later based on another column.
+                            continue
+                        else:
+                            msg = 'Column %s has no values.' % column.name
+                            log.error(msg)
+                            raise IndexError(msg)
+                    else:
                         column.values.append(values.pop())
-                    except IndexError:
-                        log.error(
-                            'Column %s has no values to pop.' % column.name)
-                        raise
 
     def post_process(self):
         columns_by_name = dict()
@@ -649,10 +659,14 @@ class ParsingContext(object):
                 image_name_column = column
             elif column.__class__ is ImageColumn:
                 image_column = column
+
         if well_name_column is None and plate_name_column is None \
                 and image_name_column is None:
             log.info('Nothing to do during post processing.')
-        for i in range(0, len(self.columns[0].values)):
+            return
+
+        sz = max([len(x.values) for x in self.columns])
+        for i in range(0, sz):
             if well_name_column is not None:
                 if PlateI is self.value_resolver.target_class:
                     plate = self.value_resolver.target_object.id.val
@@ -677,17 +691,23 @@ class ParsingContext(object):
                 log.info('Missing well name column, skipping.')
 
             if image_name_column is not None:
+                # Josh: I understand here that an Image Name column
+                # was provided and therefore we need to find the image
+                # id for the given image_name
+                did = self.value_resolver.target_object.id.val
+                iname = image_name_column.values[i]
+                # TODO: This may throw!
                 try:
-                    image = self.value_resolver.images_by_id[
-                        self.target_object.id.val]
-                    image = image[image_column.values[i]]
+                    images_by_name = self.value_resolver.images_by_name[did]
+                    iid = images_by_name[iname]
+                    assert i == len(image_column.values)
+                    image_column.values.append(iid)
+                    image_name_column.size = max(
+                        image_name_column.size, len(iname))
                 except KeyError:
-                    log.error(
-                        'Missing row or column for image name population!')
-                    raise
-                name = image.name.val
-                image_name_column.size = max(image_name_column.size, len(name))
-                image_name_column.values.append(name)
+                    raise Exception(
+                        "%s not found in image names: %" % (
+                            iname, ", ".join(images_by_name.keys())))
             else:
                 log.info('Missing image name column, skipping.')
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -450,7 +450,7 @@ class ParsingContext(object):
     """Generic parsing context for CSV files."""
 
     def __init__(self, client, target_object, file=None, fileid=None,
-                 cfg=None, cfgid=None, attach=False):
+                 cfg=None, cfgid=None, attach=False, column_types=None):
         '''
         This lines should be handled outside of the constructor:
 
@@ -467,6 +467,7 @@ class ParsingContext(object):
         self.client = client
         self.target_object = target_object
         self.file = file
+        self.column_types = column_types
         self.value_resolver = ValueResolver(self.client, self.target_object)
 
     def create_annotation_link(self):
@@ -510,7 +511,8 @@ class ParsingContext(object):
         for h in rows[0]:
             if not h:
                 raise Exception('Empty column header in CSV: %s' % rows[0])
-        self.header_resolver = HeaderResolver(self.target_object, rows[0])
+        self.header_resolver = HeaderResolver(
+            self.target_object, rows[0], column_types=self.column_types)
         self.columns = self.header_resolver.create_columns()
         log.debug('Columns: %r' % self.columns)
 
@@ -1111,7 +1113,8 @@ if __name__ == "__main__":
 
         log.debug('Creating pool of %d threads' % thread_count)
         thread_pool = ThreadPool(thread_count)
-        ctx = context_class(client, target_object, file)
+        ctx = context_class(
+            client, target_object, file, column_types=column_types)
         ctx.parse()
         if not info:
             ctx.write_to_omero()

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -106,7 +106,8 @@ class Fixture(object):
         prj.setName(rstring(name))
         for x in datasets:
             ds = self.createDataset(names=images)
-            prj.linkDataset(ds)
+            ds = self.setName(ds, x)
+            prj.linkDataset(ds.proxy())
         return self.test.client.sf.getUpdateService().saveAndReturnObject(prj)
 
     def createDataset(self, names=("A1", "A2")):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -389,7 +389,7 @@ class Project2Datasets(Fixture):
                 raise Exception("Unknown dataset: %s" % ds)
 
 
-class TestPopulateMetadata(lib.ITest):
+class TestPopulateMetadata(ITest):
 
     METADATA_FIXTURES = (
         Screen2Plates(),
@@ -626,7 +626,7 @@ class ROICSV(Fixture):
         return self.plate
 
 
-class TestPopulateRois(lib.ITest):
+class TestPopulateRois(ITest):
 
     def testPopulateRoisPlate(self):
         """

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -39,6 +39,7 @@ from omero.model import FileAnnotationI, MapAnnotationI, PlateAnnotationLinkI
 from omero.model import RoiAnnotationLinkI
 from omero.model import RoiI, PointI
 from omero.rtypes import rdouble, rint, rstring, unwrap
+from omero.sys import ParametersI
 
 from omero.util.populate_metadata import (
     ParsingContext, BulkToMapAnnotationContext, DeleteMapAnnotationContext)
@@ -51,6 +52,7 @@ from omero.constants.namespaces import NSMEASUREMENT
 from omero.util.temp_files import create_path
 
 from pytest import skip
+from pytest import mark
 
 
 def coord2offset(coord):
@@ -88,6 +90,19 @@ class BasePopulate(ITest):
             csvFile.close()
         return str(csvFileName)
 
+    def createDataset(self, names=("A1", "A2")):
+        q = self.client.sf.getQueryService()
+        up = self.client.sf.getUpdateService()
+        ds = self.make_dataset()
+        for name in names:
+            img = self.importSingleImage(name=name)
+            # Name must match exactly. No ".fake"
+            img = q.get("Image", img.id.val)
+            img.setName(rstring(name))
+            img = up.saveAndReturnObject(img)
+            self.link(ds, img)
+        return ds.proxy()
+
     def createPlate(self, rowCount, colCount):
         plates = self.import_plates(plate_rows=rowCount,
                                     plate_cols=colCount)
@@ -118,10 +133,36 @@ class BasePopulate(ITest):
 class TestPopulateMetadata(BasePopulate):
 
     def setup_method(self, method):
-        self.csvName = self.createCsv()
+        self.plate_csv = self.createCsv()
+        self.dataset_csv = self.createCsv(
+            colNames="Image Name,Type,Concentration",
+        )
         self.rowCount = 1
         self.colCount = 2
-        self.plate = self.createPlate(self.rowCount, self.colCount)
+        self.plate = None
+        self.dataset = None
+        self.images = []
+
+    def get_plate(self):
+        if not self.plate:
+            self.plate = self.createPlate(self.rowCount, self.colCount)
+        return self.plate
+
+    def get_dataset(self):
+        if not self.dataset:
+            self.dataset = self.createDataset()
+            self.images = self.get_dataset_images()
+        return self.dataset
+
+    def get_dataset_images(self):
+        if not self.dataset:
+            return []
+        query = """select i from Image i
+            left outer join fetch i.datasetLinks links
+            left outer join fetch links.parent d
+            where d.id=%s""" % self.dataset.id.val
+        qs = self.client.sf.getQueryService()
+        return qs.findAllByQuery(query, None)
 
     def get_plate_annotations(self):
         query = """select p from Plate p
@@ -133,7 +174,31 @@ class TestPopulateMetadata(BasePopulate):
         anns = plate.linkedAnnotationList()
         return anns
 
+    def get_dataset_annotations(self):
+        query = """select d from Dataset d
+            left outer join fetch d.annotationLinks links
+            left outer join fetch links.child
+            where d.id=%s""" % self.dataset.id.val
+        qs = self.client.sf.getQueryService()
+        ds = qs.findByQuery(query, None)
+        anns = ds.linkedAnnotationList()
+        return anns
+
+    def get_image_annotations(self):
+        if not self.images:
+            return []
+        params = ParametersI()
+        params.addIds([x.id for x in self.images])
+        query = """select a from Image i
+            left outer join i.annotationLinks links
+            left outer join links.child as a
+            where i.id in (:ids) and a <> null"""
+        qs = self.client.sf.getQueryService()
+        return qs.findAllByQuery(query, params)
+
     def get_well_annotations(self):
+        if not self.plate:
+            return []
         query = """
             SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
             FROM WellAnnotationLink wal
@@ -142,7 +207,14 @@ class TestPopulateMetadata(BasePopulate):
         was = unwrap(qs.projection(query, None))
         return was
 
-    def testPopulateMetadataPlate(self):
+    METADATA_TESTS = (
+        ("plate", 4, 2),
+        ("dataset", 4, 1)
+    )
+    METADATA_IDS = [x[0] for x in METADATA_TESTS]
+
+    @mark.parametrize("data", METADATA_TESTS, ids=METADATA_IDS)
+    def testPopulateMetadata(self, data):
         """
         We should really test each of the parsing contexts in separate tests
         but in practice each one uses data created by the others, so for
@@ -153,24 +225,25 @@ class TestPopulateMetadata(BasePopulate):
             print yaml, "found"
         except Exception:
             skip("PyYAML not installed.")
-        self._test_parsing_context()
-        # Adding map annotations to wells AND images is currently disabled
-        # in commit d3a0b362 because they are duplicated in UI.
-        # self._test_bulk_to_map_annotation_context()
-        # self._test_delete_map_annotation_context()
+        type, count, anns = data
+        self._test_parsing_context(type, count)
+        self._test_bulk_to_map_annotation_context(type, anns)
+        self._test_delete_map_annotation_context(type)
 
-    def _test_parsing_context(self):
+    def _test_parsing_context(self, type, count):
         """
             Create a small csv file, use populate_metadata.py to parse and
             attach to Plate. Then query to check table has expected content.
         """
 
-        ctx = ParsingContext(self.client, self.plate, file=self.csvName)
+        target = getattr(self, "get_%s" % type)()
+        csv = getattr(self, "%s_csv" % type)
+        ctx = ParsingContext(self.client, target, file=csv)
         ctx.parse()
         ctx.write_to_omero()
 
         # Get file annotations
-        anns = self.get_plate_annotations()
+        anns = getattr(self, "get_%s_annotations" % type)()
         # Only expect a single annotation which is a 'bulk annotation'
         assert len(anns) == 1
         tableFileAnn = anns[0]
@@ -186,30 +259,44 @@ class TestPopulateMetadata(BasePopulate):
         for hit in range(rows):
             rowValues = [col.values[0] for col in t.read(range(len(cols)),
                                                          hit, hit+1).columns]
-            assert len(rowValues) == 4
-            if "a1" in rowValues:
+            assert len(rowValues) == count
+            if "A1" in rowValues:
                 assert "Control" in rowValues
-            elif "a2" in rowValues:
+            elif "A2" in rowValues:
                 assert "Treatment" in rowValues
             else:
-                assert False, "Row does not contain 'a1' or 'a2'"
+                assert False, \
+                    "Row does not contain 'a1' or 'a2': %s" % rowValues
 
-    def _test_bulk_to_map_annotation_context(self):
+    def _test_bulk_to_map_annotation_context(self, type, ann_count):
         # self._testPopulateMetadataPlate()
         assert len(self.get_well_annotations()) == 0
+        assert len(self.get_image_annotations()) == 0
 
         cfg = os.path.join(
             os.path.dirname(__file__), 'bulk_to_map_annotation_context.yml')
 
-        fileid = self.get_plate_annotations()[0].file.id.val
+        target = getattr(self, "get_%s" % type)()
+        anns = getattr(self, "get_%s_annotations" % type)()
+        fileid = anns[0].file.id.val
         ctx = BulkToMapAnnotationContext(
-            self.client, self.plate, fileid=fileid, cfg=cfg)
+            self.client, target, fileid=fileid, cfg=cfg)
         ctx.parse()
         assert len(self.get_well_annotations()) == 0
+        assert len(self.get_image_annotations()) == 0
 
         ctx.write_to_omero()
         was = self.get_well_annotations()
-        assert len(was) == 2
+        ias = self.get_image_annotations()
+
+        if len(was) == ann_count:
+            assert len(ias) == 0
+            oas = was
+        elif len(ias) == ann_count:
+            assert len(was) == 0
+            oas = ias
+        else:
+            assert False, "W:%s & I:%s" % (len(was), len(ias))
 
         for ma, wid, wr, wc in was:
             assert isinstance(ma, MapAnnotationI)

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -37,7 +37,7 @@ from omero.grid import StringColumn
 from omero.model import PlateI, WellI, WellSampleI, OriginalFileI
 from omero.model import FileAnnotationI, MapAnnotationI, PlateAnnotationLinkI
 from omero.model import RoiAnnotationLinkI
-from omero.model import RoiI, PointI
+from omero.model import RoiI, PointI, ScreenI
 from omero.rtypes import rdouble, rint, rstring, unwrap
 from omero.sys import ParametersI
 
@@ -74,6 +74,13 @@ def coord2offset(coord):
 
 class BasePopulate(ITest):
 
+    def setName(self, obj, name):
+        q = self.client.sf.getQueryService()
+        up = self.client.sf.getUpdateService()
+        obj = q.get(obj.__class__.__name__, obj.id.val)
+        obj.setName(rstring(name))
+        return up.saveAndReturnObject(obj)
+
     def createCsv(
         self,
         colNames="Well,Well Type,Concentration",
@@ -91,17 +98,26 @@ class BasePopulate(ITest):
         return str(csvFileName)
 
     def createDataset(self, names=("A1", "A2")):
-        q = self.client.sf.getQueryService()
-        up = self.client.sf.getUpdateService()
         ds = self.make_dataset()
         for name in names:
             img = self.importSingleImage(name=name)
             # Name must match exactly. No ".fake"
-            img = q.get("Image", img.id.val)
-            img.setName(rstring(name))
-            img = up.saveAndReturnObject(img)
+            img = self.setName(img, name)
             self.link(ds, img)
         return ds.proxy()
+
+    def createScreen(self, rowCount, colCount):
+        plate1 = self.importPlates(plateRows=rowCount,
+                                   plateCols=colCount)[0]
+        plate2 = self.importPlates(plateRows=rowCount,
+                                   plateCols=colCount)[0]
+        plate1 = self.setName(plate1, "P001")
+        plate2 = self.setName(plate2, "P002")
+        screen = ScreenI()
+        screen.name = rstring("Screen")
+        screen.linkPlate(plate1.proxy())
+        screen.linkPlate(plate2.proxy())
+        return self.client.sf.getUpdateService().saveAndReturnObject(screen)
 
     def createPlate(self, rowCount, colCount):
         plates = self.import_plates(plate_rows=rowCount,
@@ -133,15 +149,25 @@ class BasePopulate(ITest):
 class TestPopulateMetadata(BasePopulate):
 
     def setup_method(self, method):
+        self.screen_csv = self.createCsv(
+            colNames="Plate,Well,Well Type,Concentration",
+            rowData=("P001,A1,Control,0", "P001,A2,Treatment,10",
+                     "P002,A1,Control,0", "P002,A2,Treatment,10"))
         self.plate_csv = self.createCsv()
         self.dataset_csv = self.createCsv(
             colNames="Image Name,Type,Concentration",
         )
         self.rowCount = 1
         self.colCount = 2
+        self.screen = None
         self.plate = None
         self.dataset = None
         self.images = []
+
+    def get_screen(self):
+        if not self.screen:
+            self.screen = self.createScreen(self.rowCount, self.colCount)
+        return self.screen
 
     def get_plate(self):
         if not self.plate:
@@ -163,6 +189,16 @@ class TestPopulateMetadata(BasePopulate):
             where d.id=%s""" % self.dataset.id.val
         qs = self.client.sf.getQueryService()
         return qs.findAllByQuery(query, None)
+
+    def get_screen_annotations(self):
+        query = """select s from Screen s
+            left outer join fetch s.annotationLinks links
+            left outer join fetch links.child
+            where s.id=%s""" % self.screen.id.val
+        qs = self.client.sf.getQueryService()
+        screen = qs.findByQuery(query, None)
+        anns = screen.linkedAnnotationList()
+        return anns
 
     def get_plate_annotations(self):
         query = """select p from Plate p
@@ -197,17 +233,28 @@ class TestPopulateMetadata(BasePopulate):
         return qs.findAllByQuery(query, params)
 
     def get_well_annotations(self):
-        if not self.plate:
+        if self.plate:
+            query = """
+                SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
+                FROM WellAnnotationLink wal
+                WHERE wal.parent.plate.id=%d""" % self.plate.id.val
+            qs = self.client.sf.getQueryService()
+            was = unwrap(qs.projection(query, None))
+            return was
+        elif self.screen:
+            query = """
+                SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
+                FROM WellAnnotationLink wal join wal.parent well
+                     join well.plate p join p.screenLinks l join l.parent s
+                WHERE s.id=%d""" % self.screen.id.val
+            qs = self.client.sf.getQueryService()
+            was = unwrap(qs.projection(query, None))
+            return was
+        else:
             return []
-        query = """
-            SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
-            FROM WellAnnotationLink wal
-            WHERE wal.parent.plate.id=%d""" % self.plate.id.val
-        qs = self.client.sf.getQueryService()
-        was = unwrap(qs.projection(query, None))
-        return was
 
     METADATA_TESTS = (
+        ("screen", 6, 4),
         ("plate", 4, 2),
         ("dataset", 4, 2)
     )
@@ -255,7 +302,10 @@ class TestPopulateMetadata(BasePopulate):
         t = r.openTable(OriginalFileI(fileid), None)
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
-        assert rows == self.rowCount * self.colCount
+        if self.screen:
+            assert rows == 2 * self.rowCount * self.colCount
+        else:
+            assert rows == self.rowCount * self.colCount
         for hit in range(rows):
             rowValues = [col.values[0] for col in t.read(range(len(cols)),
                                                          hit, hit+1).columns]
@@ -314,14 +364,14 @@ class TestPopulateMetadata(BasePopulate):
 
     def _test_delete_map_annotation_context(self, type, ann_count):
         # self._test_bulk_to_map_annotation_context()
-        assert len(self.get_well_annotations()) == 2 or \
-               len(self.get_image_annotations()) == 2
+        assert len(self.get_well_annotations()) == ann_count or \
+               len(self.get_image_annotations()) == ann_count
 
         target = getattr(self, type)
         ctx = DeleteMapAnnotationContext(self.client, target)
         ctx.parse()
-        assert len(self.get_well_annotations()) == 2 or \
-               len(self.get_image_annotations()) == 2
+        assert len(self.get_well_annotations()) == ann_count or \
+               len(self.get_image_annotations()) == ann_count
 
         ctx.write_to_omero()
         assert len(self.get_well_annotations()) == 0 and \

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -34,11 +34,11 @@ from omero.api import RoiOptions
 from omero.grid import ImageColumn
 from omero.grid import RoiColumn
 from omero.grid import StringColumn
-from omero.model import PlateI, WellI, WellSampleI, OriginalFileI
+from omero.model import OriginalFileI
 from omero.model import FileAnnotationI, MapAnnotationI, PlateAnnotationLinkI
 from omero.model import RoiAnnotationLinkI
 from omero.model import RoiI, PointI, ScreenI
-from omero.rtypes import rdouble, rint, rstring, unwrap
+from omero.rtypes import rdouble, rstring, unwrap
 from omero.sys import ParametersI
 
 from omero.util.populate_metadata import (
@@ -72,11 +72,14 @@ def coord2offset(coord):
     return r - 1, c - 1
 
 
-class BasePopulate(ITest):
+class Fixture(object):
+
+    def init(self, test):
+        self.test = test
 
     def setName(self, obj, name):
-        q = self.client.sf.getQueryService()
-        up = self.client.sf.getUpdateService()
+        q = self.test.client.sf.getQueryService()
+        up = self.test.client.sf.getUpdateService()
         obj = q.get(obj.__class__.__name__, obj.id.val)
         obj.setName(rstring(name))
         return up.saveAndReturnObject(obj)
@@ -98,83 +101,136 @@ class BasePopulate(ITest):
         return str(csvFileName)
 
     def createDataset(self, names=("A1", "A2")):
-        ds = self.make_dataset()
+        ds = self.test.make_dataset()
         for name in names:
-            img = self.importSingleImage(name=name)
+            img = self.test.importSingleImage(name=name)
             # Name must match exactly. No ".fake"
             img = self.setName(img, name)
-            self.link(ds, img)
+            self.test.link(ds, img)
         return ds.proxy()
 
     def createScreen(self, rowCount, colCount):
-        plate1 = self.importPlates(plateRows=rowCount,
-                                   plateCols=colCount)[0]
-        plate2 = self.importPlates(plateRows=rowCount,
-                                   plateCols=colCount)[0]
+        plate1 = self.test.importPlates(plateRows=rowCount,
+                                        plateCols=colCount)[0]
+        plate2 = self.test.importPlates(plateRows=rowCount,
+                                        plateCols=colCount)[0]
         plate1 = self.setName(plate1, "P001")
         plate2 = self.setName(plate2, "P002")
         screen = ScreenI()
         screen.name = rstring("Screen")
         screen.linkPlate(plate1.proxy())
         screen.linkPlate(plate2.proxy())
-        return self.client.sf.getUpdateService().saveAndReturnObject(screen)
+        return self.test.client.sf.getUpdateService().\
+            saveAndReturnObject(screen)
 
     def createPlate(self, rowCount, colCount):
-        plates = self.import_plates(plate_rows=rowCount,
-                                    plate_cols=colCount)
+        plates = self.test.import_plates(plate_rows=rowCount,
+                                         plate_cols=colCount)
         return plates[0]
 
-    def createPlate1(self, rowCount, colCount):
-        uuid = self.ctx.sessionUuid
+    def get_csv(self):
+        return self.csv
 
-        def createWell(row, column):
-            well = WellI()
-            well.row = rint(row)
-            well.column = rint(column)
-            ws = WellSampleI()
-            image = self.new_image(name=uuid)
-            ws.image = image
-            well.addWellSample(ws)
-            return well
-
-        plate = PlateI()
-        plate.name = rstring("TestPopulateMetadata%s" % uuid)
-        for row in range(rowCount):
-            for col in range(colCount):
-                well = createWell(row, col)
-                plate.addWell(well)
-        return self.client.sf.getUpdateService().saveAndReturnObject(plate)
+    def assert_rows(self, rows):
+        assert rows == self.rowCount * self.colCount
 
 
-class TestPopulateMetadata(BasePopulate):
+class Screen2Plates(Fixture):
 
-    def setup_method(self, method):
-        self.screen_csv = self.createCsv(
+    def __init__(self):
+        self.count = 6
+        self.annCount = 4
+        self.rowCount = 1
+        self.colCount = 2
+        self.csv = self.createCsv(
             colNames="Plate,Well,Well Type,Concentration",
             rowData=("P001,A1,Control,0", "P001,A2,Treatment,10",
                      "P002,A1,Control,0", "P002,A2,Treatment,10"))
-        self.plate_csv = self.createCsv()
-        self.dataset_csv = self.createCsv(
-            colNames="Image Name,Type,Concentration",
-        )
-        self.rowCount = 1
-        self.colCount = 2
         self.screen = None
-        self.plate = None
-        self.dataset = None
-        self.images = []
 
-    def get_screen(self):
+    def assert_rows(self, rows):
+        """
+        Double the number of rows due to 2 plates.
+        """
+        assert rows == 2 * self.rowCount * self.colCount
+
+    def get_target(self):
         if not self.screen:
             self.screen = self.createScreen(self.rowCount, self.colCount)
         return self.screen
 
-    def get_plate(self):
+    def get_annotations(self):
+        query = """select s from Screen s
+            left outer join fetch s.annotationLinks links
+            left outer join fetch links.child
+            where s.id=%s""" % self.screen.id.val
+        qs = self.test.client.sf.getQueryService()
+        screen = qs.findByQuery(query, None)
+        anns = screen.linkedAnnotationList()
+        return anns
+
+    def get_child_annotations(self):
+        query = """
+            SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
+            FROM WellAnnotationLink wal join wal.parent well
+                    join well.plate p join p.screenLinks l join l.parent s
+            WHERE s.id=%d""" % self.screen.id.val
+        qs = self.test.client.sf.getQueryService()
+        was = unwrap(qs.projection(query, None))
+        return was
+
+
+class Plate2Wells(Fixture):
+
+    def __init__(self):
+        self.count = 4
+        self.annCount = 2
+        self.rowCount = 1
+        self.colCount = 2
+        self.csv = self.createCsv()
+        self.plate = None
+
+    def get_target(self):
         if not self.plate:
             self.plate = self.createPlate(self.rowCount, self.colCount)
         return self.plate
 
-    def get_dataset(self):
+    def get_annotations(self):
+        query = """select p from Plate p
+            left outer join fetch p.annotationLinks links
+            left outer join fetch links.child
+            where p.id=%s""" % self.plate.id.val
+        qs = self.test.client.sf.getQueryService()
+        plate = qs.findByQuery(query, None)
+        anns = plate.linkedAnnotationList()
+        return anns
+
+    def get_child_annotations(self):
+        query = """
+            SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
+            FROM WellAnnotationLink wal
+            WHERE wal.parent.plate.id=%d""" % self.plate.id.val
+        qs = self.test.client.sf.getQueryService()
+        was = unwrap(qs.projection(query, None))
+        return was
+
+
+class Dataset2Images(Fixture):
+
+    def __init__(self):
+        self.count = 4
+        self.annCount = 2
+        self.csv = self.createCsv(
+            colNames="Image Name,Type,Concentration",
+        )
+        self.dataset = None
+        self.images = None
+
+    def assert_rows(self, rows):
+        # Hard-coded in createCsv's arguments
+        assert rows == 2
+
+    def get_target(self):
         if not self.dataset:
             self.dataset = self.createDataset()
             self.images = self.get_dataset_images()
@@ -187,40 +243,20 @@ class TestPopulateMetadata(BasePopulate):
             left outer join fetch i.datasetLinks links
             left outer join fetch links.parent d
             where d.id=%s""" % self.dataset.id.val
-        qs = self.client.sf.getQueryService()
+        qs = self.test.client.sf.getQueryService()
         return qs.findAllByQuery(query, None)
 
-    def get_screen_annotations(self):
-        query = """select s from Screen s
-            left outer join fetch s.annotationLinks links
-            left outer join fetch links.child
-            where s.id=%s""" % self.screen.id.val
-        qs = self.client.sf.getQueryService()
-        screen = qs.findByQuery(query, None)
-        anns = screen.linkedAnnotationList()
-        return anns
-
-    def get_plate_annotations(self):
-        query = """select p from Plate p
-            left outer join fetch p.annotationLinks links
-            left outer join fetch links.child
-            where p.id=%s""" % self.plate.id.val
-        qs = self.client.sf.getQueryService()
-        plate = qs.findByQuery(query, None)
-        anns = plate.linkedAnnotationList()
-        return anns
-
-    def get_dataset_annotations(self):
+    def get_annotations(self):
         query = """select d from Dataset d
             left outer join fetch d.annotationLinks links
             left outer join fetch links.child
             where d.id=%s""" % self.dataset.id.val
-        qs = self.client.sf.getQueryService()
+        qs = self.test.client.sf.getQueryService()
         ds = qs.findByQuery(query, None)
         anns = ds.linkedAnnotationList()
         return anns
 
-    def get_image_annotations(self):
+    def get_child_annotations(self):
         if not self.images:
             return []
         params = ParametersI()
@@ -229,39 +265,21 @@ class TestPopulateMetadata(BasePopulate):
             left outer join i.annotationLinks links
             left outer join links.child as a
             where i.id in (:ids) and a <> null"""
-        qs = self.client.sf.getQueryService()
+        qs = self.test.client.sf.getQueryService()
         return qs.findAllByQuery(query, params)
 
-    def get_well_annotations(self):
-        if self.plate:
-            query = """
-                SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
-                FROM WellAnnotationLink wal
-                WHERE wal.parent.plate.id=%d""" % self.plate.id.val
-            qs = self.client.sf.getQueryService()
-            was = unwrap(qs.projection(query, None))
-            return was
-        elif self.screen:
-            query = """
-                SELECT wal.child,wal.parent.id,wal.parent.row,wal.parent.column
-                FROM WellAnnotationLink wal join wal.parent well
-                     join well.plate p join p.screenLinks l join l.parent s
-                WHERE s.id=%d""" % self.screen.id.val
-            qs = self.client.sf.getQueryService()
-            was = unwrap(qs.projection(query, None))
-            return was
-        else:
-            return []
 
-    METADATA_TESTS = (
-        ("screen", 6, 4),
-        ("plate", 4, 2),
-        ("dataset", 4, 2)
+class TestPopulateMetadata(lib.ITest):
+
+    METADATA_FIXTURES = (
+        Screen2Plates(),
+        Plate2Wells(),
+        Dataset2Images(),
     )
-    METADATA_IDS = [x[0] for x in METADATA_TESTS]
+    METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
 
-    @mark.parametrize("data", METADATA_TESTS, ids=METADATA_IDS)
-    def testPopulateMetadata(self, data):
+    @mark.parametrize("fixture", METADATA_FIXTURES, ids=METADATA_IDS)
+    def testPopulateMetadata(self, fixture):
         """
         We should really test each of the parsing contexts in separate tests
         but in practice each one uses data created by the others, so for
@@ -272,25 +290,26 @@ class TestPopulateMetadata(BasePopulate):
             print yaml, "found"
         except Exception:
             skip("PyYAML not installed.")
-        type, count, anns = data
-        self._test_parsing_context(type, count)
-        self._test_bulk_to_map_annotation_context(type, anns)
-        self._test_delete_map_annotation_context(type, anns)
 
-    def _test_parsing_context(self, type, count):
+        fixture.init(self)
+        self._test_parsing_context(fixture)
+        self._test_bulk_to_map_annotation_context(fixture)
+        self._test_delete_map_annotation_context(fixture)
+
+    def _test_parsing_context(self, fixture):
         """
             Create a small csv file, use populate_metadata.py to parse and
             attach to Plate. Then query to check table has expected content.
         """
 
-        target = getattr(self, "get_%s" % type)()
-        csv = getattr(self, "%s_csv" % type)
+        target = fixture.get_target()
+        csv = fixture.get_csv()
         ctx = ParsingContext(self.client, target, file=csv)
         ctx.parse()
         ctx.write_to_omero()
 
         # Get file annotations
-        anns = getattr(self, "get_%s_annotations" % type)()
+        anns = fixture.get_annotations()
         # Only expect a single annotation which is a 'bulk annotation'
         assert len(anns) == 1
         tableFileAnn = anns[0]
@@ -302,14 +321,11 @@ class TestPopulateMetadata(BasePopulate):
         t = r.openTable(OriginalFileI(fileid), None)
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
-        if self.screen:
-            assert rows == 2 * self.rowCount * self.colCount
-        else:
-            assert rows == self.rowCount * self.colCount
+        fixture.assert_rows(rows)
         for hit in range(rows):
             rowValues = [col.values[0] for col in t.read(range(len(cols)),
                                                          hit, hit+1).columns]
-            assert len(rowValues) == count
+            assert len(rowValues) == fixture.count
             # Unsure where the lower-casing is happening
             if "A1" in rowValues or "a1" in rowValues:
                 assert "Control" in rowValues
@@ -319,37 +335,26 @@ class TestPopulateMetadata(BasePopulate):
                 assert False, \
                     "Row does not contain 'a1' or 'a2': %s" % rowValues
 
-    def _test_bulk_to_map_annotation_context(self, type, ann_count):
+    def _test_bulk_to_map_annotation_context(self, fixture):
         # self._testPopulateMetadataPlate()
-        assert len(self.get_well_annotations()) == 0
-        assert len(self.get_image_annotations()) == 0
+        assert len(fixture.get_child_annotations()) == 0
 
         cfg = os.path.join(
             os.path.dirname(__file__), 'bulk_to_map_annotation_context.yml')
 
-        target = getattr(self, "get_%s" % type)()
-        anns = getattr(self, "get_%s_annotations" % type)()
+        target = fixture.get_target()
+        anns = fixture.get_annotations()
         fileid = anns[0].file.id.val
         ctx = BulkToMapAnnotationContext(
             self.client, target, fileid=fileid, cfg=cfg)
         ctx.parse()
-        assert len(self.get_well_annotations()) == 0
-        assert len(self.get_image_annotations()) == 0
+        assert len(fixture.get_child_annotations()) == 0
 
         ctx.write_to_omero()
-        was = self.get_well_annotations()
-        ias = self.get_image_annotations()
+        oas = fixture.get_child_annotations()
+        assert len(oas) == fixture.annCount
 
-        if len(was) == ann_count:
-            assert len(ias) == 0
-            oas = was
-        elif len(ias) == ann_count:
-            assert len(was) == 0
-            oas = ias
-        else:
-            assert False, "W:%s & I:%s" % (len(was), len(ias))
-
-        for ma, wid, wr, wc in was:
+        for ma, wid, wr, wc in oas:
             assert isinstance(ma, MapAnnotationI)
             assert unwrap(ma.getNs()) == NSBULKANNOTATIONS
             mv = ma.getMapValueAsMap()
@@ -362,20 +367,17 @@ class TestPopulateMetadata(BasePopulate):
                 assert mv['Well Type'] == 'Treatment'
                 assert mv['Concentration'] == '10'
 
-    def _test_delete_map_annotation_context(self, type, ann_count):
+    def _test_delete_map_annotation_context(self, fixture):
         # self._test_bulk_to_map_annotation_context()
-        assert len(self.get_well_annotations()) == ann_count or \
-               len(self.get_image_annotations()) == ann_count
+        assert len(fixture.get_child_annotations()) == fixture.annCount
 
-        target = getattr(self, type)
+        target = fixture.get_target()
         ctx = DeleteMapAnnotationContext(self.client, target)
         ctx.parse()
-        assert len(self.get_well_annotations()) == ann_count or \
-               len(self.get_image_annotations()) == ann_count
+        assert len(fixture.get_child_annotations()) == fixture.annCount
 
         ctx.write_to_omero()
-        assert len(self.get_well_annotations()) == 0 and \
-               len(self.get_image_annotations()) == 0
+        assert len(fixture.get_child_annotations()) == 0
 
 
 class MockMeasurementCtx(AbstractMeasurementCtx):
@@ -495,7 +497,27 @@ class MockPlateAnalysisCtx(AbstractPlateAnalysisCtx):
         return 1
 
 
-class TestPopulateRois(BasePopulate):
+class ROICSV(Fixture):
+
+    def __init__(self):
+        self.count = 1
+        self.annCount = 2
+        self.csvName = self.createCsv(
+            colNames="Well,Field,X,Y,Type",
+            rowData=("A1,0,15,15,Test",))
+
+        self.rowCount = 1
+        self.colCount = 1
+        self.plate = None
+
+    def get_target(self):
+        if not self.plate:
+            self.plate = self.createPlate(
+                self.rowCount, self.colCount)
+        return self.plate
+
+
+class TestPopulateRois(lib.ITest):
 
     def testPopulateRoisPlate(self):
         """
@@ -503,17 +525,13 @@ class TestPopulateRois(BasePopulate):
             attach to Plate. Then query to check table has expected content.
         """
 
-        csvName = self.createCsv(
-            colNames="Well,Field,X,Y,Type",
-            rowData=("A1,0,15,15,Test",))
-
-        rowCount = 1
-        colCount = 1
-        plate = self.createPlate(rowCount, colCount)
+        fixture = ROICSV()
+        fixture.init(self)
+        plate = fixture.get_target()
 
         # As opposed to the ParsingContext, here we are expected
         # to link the file ourselves
-        ofile = self.client.upload(csvName).proxy()
+        ofile = self.client.upload(fixture.csvName).proxy()
         ann = FileAnnotationI()
         ann.file = ofile
         link = PlateAnnotationLinkI()


### PR DESCRIPTION

This is the same as gh-4637 but rebased onto metadata53.

----

This PR carries on from work by @emilroz  (PR 120) which makes it possible to specify the column types for OMERO.tables when using populate_metadata.py to parse the csv files and adds support for datasets and projects as the target object for a metadata table.


                