### PR TITLE
populate_metadata.py: add batches to write_to_omero (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -147,6 +147,11 @@ class MetadataControl(BaseControl):
         populate = parser.add(sub, self.populate)
         populateroi = parser.add(sub, self.populateroi)
 
+        populate.add_argument("--batch",
+                              type=long,
+                              default=1000,
+                              help="Number of objects to save at once")
+
         for x in (summary, original, bulkanns, measures, mapanns, allanns,
                   rois, populate, populateroi):
             x.add_argument("obj",
@@ -423,7 +428,7 @@ class MetadataControl(BaseControl):
                             cfg=args.cfg, cfgid=cfgid, attach=args.attach)
         ctx.parse()
         if not args.dry_run:
-            ctx.write_to_omero()
+            ctx.write_to_omero(batch_size=args.batch)
 
     def rois(self, args):
         "Manage ROIs"

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -150,7 +150,7 @@ class MetadataControl(BaseControl):
         populate.add_argument("--batch",
                               type=long,
                               default=1000,
-                              help="Number of objects to save at once")
+                              help="Number of objects to process at once")
 
         for x in (summary, original, bulkanns, measures, mapanns, allanns,
                   rois, populate, populateroi):

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -41,6 +41,7 @@ import omero
 import omero.gateway
 from omero_version import omero_version
 
+from collections import defaultdict
 from omero.cmd import DoAll, State, ERR, OK, Chmod2, Chgrp2, Delete2
 from omero.callbacks import CmdCallbackI
 from omero.model import DatasetI, DatasetImageLinkI, ImageI, ProjectI
@@ -1025,27 +1026,20 @@ class ITest(object):
             link.setChild(obj2.proxy())
         return client.sf.getUpdateService().saveAndReturnObject(link)
 
-    def delete(self, obj):
+    def delete(self, objs):
         """
-        Deletes a list of model entities (ProjectI, DatasetI or ImageI)
+        Deletes model entities (ProjectI, DatasetI, ImageI, etc)
         by creating Delete2 commands and calling
         :func:`~test.ITest.do_submit`.
 
         :param obj: a list of objects to be deleted
         """
-        if isinstance(obj[0], ProjectI):
-            t = "Project"
-        elif isinstance(obj[0], DatasetI):
-            t = "Dataset"
-        elif isinstance(obj[0], ImageI):
-            t = "Image"
-        else:
-            assert False, "Object type not supported."
-
-        ids = [i.id.val for i in obj]
-        command = Delete2(targetObjects={t: ids})
-
-        self.do_submit(command, self.client)
+        to_delete = defaultdict(list)
+        for obj in objs:
+            t = obj.__class__.__name__
+            to_delete[t].append(obj.id.val)
+        command = Delete2(targetObjects=to_delete)
+        self.doSubmit(command, self.client)
 
     def change_group(self, obj, target, client=None):
         """

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -674,7 +674,6 @@ class _QueryContext(object):
         for batch in (i[pos:pos + sz] for pos in xrange(0, len(i), sz)):
             yield batch
 
-
     def projection(self, q, ids, ns=None):
         """
         Run a projection query designed to return scalars only
@@ -1001,7 +1000,7 @@ class DeleteMapAnnotationContext(_QueryContext):
 
     def write_to_omero(self, batch_size=1000):
         combined = self.mapannids + self.fileannids
-        for batch in self._batch(self.mapannids + self.fileannids, sz=batch_size):
+        for batch in self._batch(combined, sz=batch_size):
             self._write_to_omero_batch(batch)
 
     def _write_to_omero_batch(self, batch):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -612,7 +612,7 @@ class ParsingContext(object):
             else:
                 log.info('Missing plate name column, skipping.')
 
-    def write_to_omero(self):
+    def write_to_omero(self, batch_size=1000):
         sf = self.client.getSession()
         group = str(self.value_resolver.target_object.details.group.id.val)
         sr = sf.sharedResources()
@@ -624,10 +624,29 @@ class ParsingContext(object):
                 "Unable to create table: %s" % name)
         original_file = table.getOriginalFile()
         log.info('Created new table OriginalFile:%d' % original_file.id.val)
+
+        columns = self.columns
+        values = []
+        length = -1
+        for x in columns:
+            if length < 0:
+                length = len(x.values)
+            else:
+                assert length == len(x.values)
+            values.append(x.values)
+            x.values = None
+
         table.initialize(self.columns)
         log.info('Table initialized with %d columns.' % (len(self.columns)))
-        table.addData(self.columns)
-        log.info('Added data column data.')
+
+        i = 0
+        for pos in xrange(0, length, batch_size):
+            i += 1
+            for idx, x in enumerate(values):
+                columns[idx].values = x[pos:pos+batch_size]
+            table.addData(self.columns)
+            log.info('Added %s rows of column data (batch %s)', batch_size, i)
+
         table.close()
         file_annotation = FileAnnotationI()
         file_annotation.ns = rstring(
@@ -850,12 +869,12 @@ class BulkToMapAnnotationContext(_QueryContext):
 
         self.mapannotations = mas
 
-    def write_to_omero(self):
+    def write_to_omero(self, batch_size=1000):
         sf = self.client.getSession()
         group = str(self.target_object.details.group.id.val)
         update_service = sf.getUpdateService()
         i = 0
-        for batch in self._batch(self.mapannotations):
+        for batch in self._batch(self.mapannotations, sz=batch_size):
             i += 1
             ids = update_service.saveAndReturnIds(
                 batch, {'omero.group': group})
@@ -980,8 +999,9 @@ class DeleteMapAnnotationContext(_QueryContext):
             log.info("Total: %d FileAnnotation(s) in %s",
                      len(set(self.fileannids)), ns)
 
-    def write_to_omero(self):
-        for batch in self._batch(self.mapannids + self.fileannids):
+    def write_to_omero(self, batch_size=1000):
+        combined = self.mapannids + self.fileannids
+        for batch in self._batch(self.mapannids + self.fileannids, sz=batch_size):
             self._write_to_omero_batch(batch)
 
     def _write_to_omero_batch(self, batch):

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -24,6 +24,7 @@ Populate bulk metadata tables from delimited text files.
 
 
 import logging
+import gzip
 import sys
 import csv
 import re
@@ -501,7 +502,11 @@ class ParsingContext(object):
             (o.name, len(o.values)) for o in self.columns])
 
     def parse(self):
-        data = open(self.file, 'U')
+        if self.file.endswith(".gz"):
+            data = gzip.open(self.file, "rb")
+        else:
+            data = open(self.file, 'U')
+
         try:
             return self.parse_from_handle(data)
         finally:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -647,6 +647,15 @@ class _QueryContext(object):
     def __init__(self, client):
         self.client = client
 
+    def _batch(self, i, sz=1000):
+        """
+        Generate batches of size sz (by default 1000) from the input
+        iterable `i`.
+        """
+        for batch in (i[pos:pos + sz] for pos in xrange(0, len(i), sz)):
+            yield batch
+
+
     def projection(self, q, ids, ns=None):
         """
         Run a projection query designed to return scalars only
@@ -845,9 +854,12 @@ class BulkToMapAnnotationContext(_QueryContext):
         sf = self.client.getSession()
         group = str(self.target_object.details.group.id.val)
         update_service = sf.getUpdateService()
-        ids = update_service.saveAndReturnIds(
-            self.mapannotations, {'omero.group': group})
-        log.info('Created %d MapAnnotations', len(ids))
+        i = 0
+        for batch in self._batch(self.mapannotations):
+            i += 1
+            ids = update_service.saveAndReturnIds(
+                batch, {'omero.group': group})
+            log.info('Created %d MapAnnotations (batch %s)', len(ids), i)
 
 
 class DeleteMapAnnotationContext(_QueryContext):
@@ -969,14 +981,18 @@ class DeleteMapAnnotationContext(_QueryContext):
                      len(set(self.fileannids)), ns)
 
     def write_to_omero(self):
-        to_delete = {"Annotation": self.mapannids + self.fileannids}
+        for batch in self._batch(self.mapannids + self.fileannids):
+            self._write_to_omero_batch(batch)
+
+    def _write_to_omero_batch(self, batch):
+        to_delete = {"Annotation": batch}
         delCmd = omero.cmd.Delete2(targetObjects=to_delete)
         handle = self.client.getSession().submit(delCmd)
 
         callback = None
         try:
             callback = CmdCallbackI(self.client, handle)
-            loops = max(10, len(self.mapannids) / 10)
+            loops = max(10, len(batch) / 10)
             delay = 500
             callback.loop(loops, delay)
             rsp = callback.getResponse()

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -674,7 +674,7 @@ class _QueryContext(object):
         for batch in (i[pos:pos + sz] for pos in xrange(0, len(i), sz)):
             yield batch
 
-    def projection(self, q, ids, ns=None):
+    def projection(self, q, ids, ns=None, batch_size=None):
         """
         Run a projection query designed to return scalars only
         :param q: The query to be projected, should contain either `:ids`
@@ -682,19 +682,40 @@ class _QueryContext(object):
         :param: ids: Either a list of IDs to be passed as `:ids` parameter or
                 a single scalar id to be passed as `:id` parameter in query
         :ns: Optional namespace to be passed as `:ns` parameter in query
+        :batch_size: Optional batch_size (default: all) defining the number
+                of IDs that will be queried at once. Methods that expect to
+                have more than several thousand input IDs should consider an
+                appropriate batch size. By default, however, no batch size is
+                applied since this could change the interpretation of the
+                query string (e.g. use of `distinct`).
         """
         qs = self.client.getSession().getQueryService()
         params = omero.sys.ParametersI()
+
         try:
             nids = len(ids)
-            params.addIds(ids)
+            single_id = None
         except TypeError:
             nids = 1
-            params.addId(ids)
+            single_id = ids
+
         if ns:
             params.addString("ns", ns)
+
         log.debug("Query: %s len(IDs): %d", q, nids)
-        rss = unwrap(qs.projection(q, params))
+
+        if single_id is not None:
+            params.addId(single_id)
+            rss = unwrap(qs.projection(q, params))
+        elif batch_size is None:
+            params.addIds(ids)
+            rss = unwrap(qs.projection(q, params))
+        else:
+            rss = []
+            for batch in self._batch(ids, sz=batch_size):
+                params.addIds(batch)
+                rss.extend(unwrap(qs.projection(q, params)))
+
         return [r for rs in rss for r in rs]
 
 
@@ -908,7 +929,8 @@ class DeleteMapAnnotationContext(_QueryContext):
             q = ("SELECT child.id FROM %sAnnotationLink WHERE "
                  "child.class=%s AND parent.id in (:ids) "
                  "AND child.ns=:ns")
-            r = self.projection(q % (objtype, anntype), objids, ns)
+            r = self.projection(q % (objtype, anntype), objids, ns,
+                                batch_size=10000)
             log.debug("%s: %d %s(s)", objtype, len(set(r)), anntype)
         return r
 
@@ -958,13 +980,15 @@ class DeleteMapAnnotationContext(_QueryContext):
             parentids["Well"] = ids
         if parentids["Well"]:
             q = "SELECT id FROM WellSample WHERE well.id IN (:ids)"
-            parentids["WellSample"] = self.projection(q, parentids["Well"])
+            parentids["WellSample"] = self.projection(
+                q, parentids["Well"], batch_size=10000)
 
         if isinstance(target, WellSampleI):
             parentids["WellSample"] = ids
         if parentids["WellSample"]:
             q = "SELECT image.id FROM WellSample WHERE id IN (:ids)"
-            parentids["Image"] = self.projection(q, parentids["WellSample"])
+            parentids["Image"] = self.projection(
+                q, parentids["WellSample"], batch_size=10000)
 
         if isinstance(target, ImageI):
             parentids["Image"] = ids

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -625,10 +625,9 @@ class ParsingContext(object):
         original_file = table.getOriginalFile()
         log.info('Created new table OriginalFile:%d' % original_file.id.val)
 
-        columns = self.columns
         values = []
         length = -1
-        for x in columns:
+        for x in self.columns:
             if length < 0:
                 length = len(x.values)
             else:
@@ -643,9 +642,10 @@ class ParsingContext(object):
         for pos in xrange(0, length, batch_size):
             i += 1
             for idx, x in enumerate(values):
-                columns[idx].values = x[pos:pos+batch_size]
+                self.columns[idx].values = x[pos:pos+batch_size]
             table.addData(self.columns)
-            log.info('Added %s rows of column data (batch %s)', batch_size, i)
+            count = min(batch_size, length - pos)
+            log.info('Added %s rows of column data (batch %s)', count, i)
 
         table.close()
         file_annotation = FileAnnotationI()

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1030,29 +1030,20 @@ class DeleteMapAnnotationContext(_QueryContext):
     def _write_to_omero_batch(self, batch):
         to_delete = {"Annotation": batch}
         delCmd = omero.cmd.Delete2(targetObjects=to_delete)
-        handle = self.client.getSession().submit(delCmd)
-
-        callback = None
-        try:
-            callback = CmdCallbackI(self.client, handle)
-            loops = max(10, len(batch) / 10)
-            delay = 500
-            callback.loop(loops, delay)
-            rsp = callback.getResponse()
-            if isinstance(rsp, omero.cmd.OK):
-                ndma = len(rsp.deletedObjects.get(
-                    "ome.model.annotations.MapAnnotation", []))
-                log.info("Deleted %d MapAnnotation(s)", ndma)
-                ndfa = len(rsp.deletedObjects.get(
-                    "ome.model.annotations.FileAnnotation", []))
-                log.info("Deleted %d FileAnnotation(s)", ndfa)
-            else:
-                log.error("Delete failed: %s", rsp)
-        finally:
-            if callback:
-                callback.close(True)
-            else:
-                handle.close()
+        callback = self.client.submit(
+            delCmd, loops=100, failontimeout=True)
+        # At this point, we're sure that there's a response OR
+        # an exception has been thrown (likely LockTimeout)
+        rsp = callback.getResponse()
+        if isinstance(rsp, omero.cmd.OK):
+            ndma = len(rsp.deletedObjects.get(
+                "ome.model.annotations.MapAnnotation", []))
+            log.info("Deleted %d MapAnnotation(s)", ndma)
+            ndfa = len(rsp.deletedObjects.get(
+                "ome.model.annotations.FileAnnotation", []))
+            log.info("Deleted %d FileAnnotation(s)", ndfa)
+        else:
+            log.error("Delete failed: %s", rsp)
 
 
 def parse_target_object(target_object):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -27,8 +27,10 @@
 from omero.testlib import ITest
 import string
 import csv
+import gzip
 import os.path
 import re
+import shutil
 
 from omero.api import RoiOptions
 from omero.grid import ImageColumn
@@ -276,6 +278,18 @@ class Dataset101Images(Dataset2Images):
         assert rows == 102
 
 
+class GZIP(Dataset2Images):
+
+    def createCsv(self, *args, **kwargs):
+        csvFileName = super(GZIP, self).createCsv(*args, **kwargs)
+        gzipFileName = "%s.gz" % csvFileName
+        with open(csvFileName, 'rb') as f_in, \
+            gzip.open(gzipFileName, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+
+        return gzipFileName
+
+
 class Project2Datasets(Fixture):
 
     def __init__(self):
@@ -362,6 +376,7 @@ class TestPopulateMetadata(lib.ITest):
         Dataset2Images(),
         Dataset101Images(),
         Project2Datasets(),
+        GZIP(),
     )
     METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
 

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -165,7 +165,12 @@ class TestPopulateMetadata(BasePopulate):
             attach to Plate. Then query to check table has expected content.
         """
 
-        ctx = ParsingContext(self.client, self.plate, file=self.csvName)
+        target = fixture.get_target()
+        # Deleting anns so that we can re-use the same user
+        self.delete(fixture.get_annotations())
+
+        csv = fixture.get_csv()
+        ctx = ParsingContext(self.client, target, file=csv)
         ctx.parse()
         ctx.write_to_omero()
 


### PR DESCRIPTION

This is the same as gh-4754 but rebased onto metadata53.

----

# What this PR does

The new `QueryContext` implementations in `populate_metadata.py` were not batching in their `write_to_omero` methods. For very large screens (e.g. idr0016):
- `BulkToMapAnnotationContext` tends to hit MESSAGESIZEMAX limits and
- `DeleteMapAnnotationContext` hits `Caused by: java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 109734`

Now both are done in batches of 1000.

_Note:_ projections are also causing issues so batching is being added to invocations of `projection` as well.
# Testing this PR
1. A bulk annotation YML configuration is required. This is minimal possible via `test/integration/metadata/test_populate.py`.
2. There should be no change in functionality and no overt slowdown in creation or deletion.
# Related reading
- https://trello.com/c/urQCwi0v/470-error-creating-map-annotations-in-demo2-for-idr0016
- https://trello.com/c/88jfqEem/469-error-deleting-map-annotations-for-idr0001-screena

cc: @eleanorwilliams 


                