### PR TITLE
Revert "Disable metadata.py with OMERO_DEV_PLUGINS" (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -500,8 +500,7 @@ class MetadataControl(BaseControl):
                 meas.parse_and_populate()
 
 try:
-    if "OMERO_DEV_PLUGINS" in os.environ:
-        register("metadata", MetadataControl, HELP)
+    register("metadata", MetadataControl, HELP)
 except NameError:
     if __name__ == "__main__":
         cli = CLI()


### PR DESCRIPTION

This is the same as gh-4765 but rebased onto metadata53.

----

# What this PR does

Reverts the requirement to set `OMERO_DEV_PLUGINS` when using the `omero metadata` plugin. This env-var makes sense on the mainline, but since this plugin is in integral part of the work in the `metadata52` development branch it should be enabled by default.
# Testing this PR
1. Check `OMERO_DEV_PLUGINS` isn't set: `$ set | grep OMERO_DEV_PLUGINS`
2. Run `omero metadata ...`, the plugin should be enabled
# Related reading
- Original `develop` PR: https://github.com/openmicroscopy/openmicroscopy/pull/4426


                