### PR TITLE
Mapr annotations: query database for existing map-annotations (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
@@ -195,7 +195,7 @@ class MapAnnotationManager(object):
     def get_map_annotations(self):
         return self.mapanns.values() + self.nokey
 
-    def add_from_namespace_query(self, session, ns, primary_keys):
+    def add_from_namespace_query(self, session, ns, primary_keys, unique_keys):
         """
         Fetches all map-annotations with the given namespace
         This will only work if there are no duplicates, otherwise an
@@ -210,6 +210,7 @@ class MapAnnotationManager(object):
         :param session: An OMERO session
         :param ns: The namespace
         :param primary_keys: Primary keys
+        :param unique_keys: Whether keys have to be unique in a map
         """
         qs = session.getQueryService()
         q = 'FROM MapAnnotation WHERE ns=:ns ORDER BY id DESC'
@@ -218,7 +219,7 @@ class MapAnnotationManager(object):
         results = qs.findAllByQuery(q, p)
         log.debug('Found %d MapAnnotations in ns:%s', len(results), ns)
         for ma in results:
-            cma = CanonicalMapAnnotation(ma, primary_keys)
+            cma = CanonicalMapAnnotation(ma, primary_keys, unique_keys)
             r = self.add(cma)
             if r:
                 raise Exception(

--- a/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Utilities for manipulating map-annotations used as metadata
+"""
+
+import logging
+from omero.model import NamedValue
+from omero.rtypes import rstring, unwrap
+from omero.sys import ParametersI
+
+
+log = logging.getLogger("omero.util.metadata_mapannotations")
+
+
+class MapAnnotationPrimaryKeyException(Exception):
+
+    def __init__(self, message):
+        super(MapAnnotationPrimaryKeyException, self).__init__(message)
+
+
+class CanonicalMapAnnotation(object):
+    """
+    A canonical representation of a map-annotation for metadata use
+    This is based around the idea of a primary key derived from the
+    combination of the namespace with 1+ keys-value pairs. A null
+    namespace is treated as an empty string (''), but still forms part
+    of the primary key.
+
+    ma: The omero.model.MapAnnotation object
+    primary_keys: Keys from key-value pairs that will be used to form the
+        primary key.
+    unique_keys: If False duplicate keys (with different values) aren't
+        allowed, default True (allowed)
+    """
+
+    def __init__(self, ma, primary_keys=None, unique_keys=True):
+        # TODO: should we consider data and description
+        self.ma = ma
+        ns = unwrap(ma.getNs())
+        self.ns = ns if ns else ''
+        try:
+            mapvalue = [(kv.name, kv.value) for kv in ma.getMapValue()]
+        except TypeError:
+            mapvalue = []
+        self.kvpairs, self.primary = self.process_keypairs(
+            mapvalue, primary_keys, unique_keys)
+        self.parents = set()
+
+    def process_keypairs(self, kvpairs, primary_keys, unique_keys):
+        if len(set(kvpairs)) != len(kvpairs):
+            raise ValueError('Duplicate key-value pairs found: %s' % kvpairs)
+
+        if unique_keys:
+            u_keys = [k for (k, v) in kvpairs]
+            if len(set(u_keys)) != len(u_keys):
+                raise ValueError('Duplicate keys found: %s' % u_keys)
+
+        if primary_keys:
+            primary_keys = set(primary_keys)
+            missing = primary_keys.difference(kv[0] for kv in kvpairs)
+            if missing:
+                raise MapAnnotationPrimaryKeyException(
+                    'Missing primary key fields: %s' % missing)
+            # ns is always part of the primary key
+            primary = (
+                self.ns,
+                frozenset((k, v) for (k, v) in kvpairs if k in primary_keys))
+        else:
+            primary = None
+
+        return kvpairs, primary
+
+    def merge(self, other):
+        """
+        Adds any key/value pairs from other that aren't in self
+        Adds parents from other
+        Does not update primary key
+        """
+        if self.kvpairs != other.kvpairs:
+            kvpairsset = set(self.kvpairs)
+            for okv in other.kvpairs:
+                if okv not in kvpairsset:
+                    self.kvpairs.append(okv)
+        self.merge_parents(other)
+
+    def merge_parents(self, other):
+        self.parents.update(other.parents)
+
+    def add_parent(self, parenttype, parentid):
+        """
+        Add a parent descriptor
+        Parameter types are important because they are used in a set
+
+        parenttype: An OMERO type string
+        parentid: An OMERO object ID (integer)
+        """
+        if not isinstance(parenttype, str) or not isinstance(
+                parentid, (int, long)):
+            raise ValueError('Expected parenttype:str parentid:integer')
+        self.parents.add((parenttype, parentid))
+
+    def get_mapann(self):
+        """
+        Update and return an omero.model.MapAnnotation with merged/combined
+        fields
+        """
+        mv = [NamedValue(*kv) for kv in self.kvpairs]
+        self.ma.setMapValue(mv)
+        self.ma.setNs(rstring(self.ns))
+        return self.ma
+
+    def get_parents(self):
+        return self.parents
+
+    def __str__(self):
+        return 'primary:%s keyvalues:%s parents:%s' % (
+            self.primary, self.kvpairs, self.parents)
+
+
+class MapAnnotationManager(object):
+    """
+    Handles creation and de-duplication of MapAnnotations
+    """
+    # Policies for combining/replacing MapAnnotations
+    MA_APPEND, MA_OLD, MA_NEW = range(3)
+
+    def __init__(self, combine=MA_APPEND):
+        """
+        Ensure you understand the doc string for init_from_namespace_query
+        if not using MA_APPEND
+        """
+        self.mapanns = {}
+        self.nokey = []
+        self.combine = combine
+
+    def add(self, cma):
+        """
+        Adds a CanonicalMapAnnotation to the managed list.
+
+        Returns any CanonicalMapAnnotation that are no longer required,
+        this may be cma or it may be a previously added annotation.
+        The idea is that this can be used to de-duplicate existing OMERO
+        MapAnnotations by calling add() on all MapAnnotations and deleting
+        those which are returned
+
+        If MapAnnotations are combined the parents of the unwanted
+        MapAnnotations are appended to the one that is kept by the manager.
+
+        :param cma: A CanonicalMapAnnotation
+        """
+
+        if cma.primary is None:
+            self.nokey.append(cma)
+            return
+
+        try:
+            current = self.mapanns[cma.primary]
+            if current.ma is cma.ma:
+                # Don't re-add an identical object
+                return
+            if self.combine == self.MA_APPEND:
+                current.merge(cma)
+                return cma
+            if self.combine == self.MA_NEW:
+                self.mapanns[cma.primary] = cma
+                cma.merge_parents(current)
+                return current
+            if self.combine == self.MA_OLD:
+                current.merge_parents(cma)
+                return cma
+            raise ValueError('Invalid combine policy')
+        except KeyError:
+            self.mapanns[cma.primary] = cma
+
+    def get_map_annotations(self):
+        return self.mapanns.values() + self.nokey
+
+    def add_from_namespace_query(self, session, ns, primary_keys):
+        """
+        Fetches all map-annotations with the given namespace
+        This will only work if there are no duplicates, otherwise an
+        exception will be thrown
+
+        WARNING: You should probably only use this in MA_APPEND mode since
+        the parents of existing annotations aren't fetched (requires a query
+        for each parent type)
+        WARNING: This may be resource intensive
+        TODO: Use omero.utils.populate_metadata._QueryContext for batch queries
+
+        :param session: An OMERO session
+        :param ns: The namespace
+        :param primary_keys: Primary keys
+        """
+        qs = session.getQueryService()
+        q = 'FROM MapAnnotation WHERE ns=:ns ORDER BY id DESC'
+        p = ParametersI()
+        p.addString('ns', ns)
+        results = qs.findAllByQuery(q, p)
+        log.debug('Found %d MapAnnotations in ns:%s', len(results), ns)
+        for ma in results:
+            cma = CanonicalMapAnnotation(ma, primary_keys)
+            r = self.add(cma)
+            if r:
+                raise Exception(
+                    'Duplicate MapAnnotation primary key (%s, %s): id:%s',
+                    ns, primary_keys, unwrap(ma.getId()))

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -730,7 +730,7 @@ class BulkToMapAnnotationContext(_QueryContext):
 
                 self.pkmap[gns] = keys
                 self.mapannotations.add_from_namespace_query(
-                    self.client.getSession(), gns, keys, False)
+                    self.client.getSession(), gns, keys)
                 log.debug('Loaded ns:%s primary-keys:%s', gns, keys)
 
     def _get_ns_primary_keys(self, ns):
@@ -763,6 +763,14 @@ class BulkToMapAnnotationContext(_QueryContext):
             mv.extend(NamedValue(k, str(v)) for v in vs)
         ma.setMapValue(mv)
 
+        log.debug('Creating CanonicalMapAnnotation ns:%s pks:%s kvs:%s',
+                  ns, pks, rowkvs)
+        cma = CanonicalMapAnnotation(ma, primary_keys=pks)
+        for (otype, oid) in targets:
+            cma.add_parent(otype, oid)
+        return cma
+
+    def _create_map_annotation_links(self, cma):
         links = []
         for target in targets:
             otype = target.ice_staticId().split('::')[-1]

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -718,7 +718,7 @@ class BulkToMapAnnotationContext(_QueryContext):
 
         for pk in pkcfg:
             try:
-                gns = pk['groupname']
+                gns = pk['namespace']
                 keys = pk['keys']
             except KeyError:
                 raise Exception('Invalid primary_group_keys: %s' % pk)
@@ -901,6 +901,17 @@ class DeleteMapAnnotationContext(_QueryContext):
             r = self.projection(q % (objtype, anntype), objids, ns)
             log.debug("%s: %d %s(s)", objtype, len(set(r)), anntype)
         return r
+
+    def _get_configured_namespaces(self):
+        nss = set([omero.constants.namespaces.NSBULKANNOTATIONS])
+        if self.column_cfgs:
+            for c in self.column_cfgs:
+                try:
+                    ns = c['group']['namespace']
+                    nss.add(ns)
+                except KeyError:
+                    continue
+        return list(nss)
 
     def populate(self):
         # Hierarchy: Screen, Plate, {PlateAcquistion, Well}, WellSample, Image

--- a/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns.yml
+++ b/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns.yml
@@ -1,0 +1,30 @@
+---
+name: test_bulk_to_map_annotation_context_ns
+version: 2
+
+defaults:
+    include: yes
+
+columns:
+- name: Gene
+- name: FlyBase
+  clientname: FlyBase URL
+  clientvalue: http://flybase.org/reports/{{ value }}.html
+  omitempty: yes
+- name: Well
+  include: no
+  includeclient: no
+- name: Well Name
+  include: no
+  includeclient: no
+- group:
+    namespace: openmicroscopy.org/mapr/gene
+    columns:
+    # Intentionally duplicate a column in a different group
+    - name: Gene
+    - name: Gene Names
+      clientname: Gene name
+      split: ;
+
+advanced:
+#    well_to_images: yes

--- a/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2.yml
+++ b/components/tools/OmeroPy/test/integration/metadata/bulk_to_map_annotation_context_ns2.yml
@@ -1,0 +1,34 @@
+---
+name: test_bulk_to_map_annotation_context_ns2
+version: 2
+
+defaults:
+    include: yes
+
+columns:
+- name: Gene
+- name: FlyBase
+  clientname: FlyBase URL
+  clientvalue: http://flybase.org/reports/{{ value }}.html
+  omitempty: yes
+- name: Well
+  include: no
+  includeclient: no
+- name: Well Name
+  include: no
+  includeclient: no
+- group:
+    namespace: openmicroscopy.org/mapr/gene
+    columns:
+    # Intentionally duplicate a column in a different group
+    - name: Gene
+    - name: Gene Names
+      clientname: Gene name
+      split: ;
+
+advanced:
+#    well_to_images: yes
+    primary_group_keys:
+    - namespace: openmicroscopy.org/mapr/gene
+      keys:
+      - Gene

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -63,7 +63,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
+        mgr.add_from_namespace_query(self.sf, ns1, pks)
 
         assert len(mgr.mapanns) == 2
         pk1 = (ns1, frozenset([('a', '1')]))
@@ -88,7 +88,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
+        mgr.add_from_namespace_query(self.sf, ns1, pks)
 
         ma4 = MapAnnotationI()
         ma4 = MapAnnotationI()

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Integration test of metadata_mapannotation
+"""
+
+
+import library as lib
+from omero.model import MapAnnotationI, NamedValue
+from omero.rtypes import wrap
+from omero.util.metadata_mapannotations import MapAnnotationManager
+
+
+def assert_equal_name_value(a, b):
+    assert isinstance(a, NamedValue)
+    assert isinstance(b, NamedValue)
+    assert a.name == b.name
+    assert a.value == b.value
+
+
+class TestMapAnnotationManager(lib.ITest):
+
+    def create_mas(self):
+        ns1 = self.uuid()
+        ns3 = self.uuid()
+        ma1 = MapAnnotationI()
+        ma1.setNs(wrap(ns1))
+        ma1.setMapValue([NamedValue('a', '1')])
+        ma2 = MapAnnotationI()
+        ma2.setNs(wrap(ns1))
+        ma2.setMapValue([NamedValue('a', '2')])
+        ma3 = MapAnnotationI()
+        ma3.setNs(wrap(ns3))
+        ma3.setMapValue([NamedValue('a', '1')])
+
+        mids = self.update.saveAndReturnIds([ma1, ma2, ma3])
+        print ns1, ns3, mids
+        return ns1, ns3, mids
+
+    def test_add_from_namespace_query(self):
+        ns1, ns3, mids = self.create_mas()
+        pks = ['a']
+        mgr = MapAnnotationManager()
+        mgr.add_from_namespace_query(self.sf, ns1, pks)
+
+        assert len(mgr.mapanns) == 2
+        pk1 = (ns1, frozenset([('a', '1')]))
+        pk2 = (ns1, frozenset([('a', '2')]))
+        assert len(mgr.mapanns) == 2
+        assert pk1 in mgr.mapanns
+        assert pk2 in mgr.mapanns
+
+        cma1 = mgr.mapanns[pk1]
+        assert cma1.kvpairs == [('a', '1')]
+        assert cma1.parents == set()
+        mv1 = cma1.get_mapann().getMapValue()
+        assert len(mv1) == 1
+        assert_equal_name_value(mv1[0], NamedValue('a', '1'))
+
+        cma2 = mgr.mapanns[pk2]
+        assert cma2.kvpairs == [('a', '2')]
+        assert cma2.parents == set()
+        mv2 = cma2.get_mapann().getMapValue()
+        assert len(mv2) == 1
+        assert_equal_name_value(mv2[0], NamedValue('a', '2'))

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -63,7 +63,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks)
+        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
 
         assert len(mgr.mapanns) == 2
         pk1 = (ns1, frozenset([('a', '1')]))
@@ -88,7 +88,7 @@ class TestMapAnnotationManager(lib.ITest):
         ns1, ns3, mids = self.create_mas()
         pks = ['a']
         mgr = MapAnnotationManager()
-        mgr.add_from_namespace_query(self.sf, ns1, pks)
+        mgr.add_from_namespace_query(self.sf, ns1, pks, False)
 
         ma4 = MapAnnotationI()
         ma4 = MapAnnotationI()

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -37,8 +37,9 @@ from omero.grid import StringColumn
 from omero.model import PlateI, WellI, WellSampleI, OriginalFileI
 from omero.model import FileAnnotationI, MapAnnotationI, PlateAnnotationLinkI
 from omero.model import RoiAnnotationLinkI
-from omero.model import RoiI, PointI
-from omero.rtypes import rdouble, rint, rstring, unwrap
+from omero.model import RoiI, PointI, ProjectI, ScreenI
+from omero.rtypes import rdouble, rlist, rstring, unwrap
+from omero.sys import ParametersI
 
 from omero.util.populate_metadata import (
     ParsingContext, BulkToMapAnnotationContext, DeleteMapAnnotationContext)
@@ -93,8 +94,60 @@ class BasePopulate(ITest):
                                     plate_cols=colCount)
         return plates[0]
 
-    def createPlate1(self, rowCount, colCount):
-        uuid = self.ctx.sessionUuid
+    def get_csv(self):
+        return self.csv
+
+    def get_cfg(self):
+        return os.path.join(
+            os.path.dirname(__file__), 'bulk_to_map_annotation_context.yml')
+
+    def get_namespaces(self):
+        return NSBULKANNOTATIONS
+
+    def assert_rows(self, rows):
+        assert rows == self.rowCount * self.colCount
+
+    def assert_child_annotations(self, oas):
+        for ma, wid, wr, wc in oas:
+            assert isinstance(ma, MapAnnotationI)
+            assert unwrap(ma.getNs()) == NSBULKANNOTATIONS
+            mv = ma.getMapValueAsMap()
+            assert mv['Well'] == str(wid)
+            assert coord2offset(mv['Well Name']) == (wr, wc)
+            if (wr, wc) == (0, 0):
+                assert mv['Well Type'] == 'Control'
+                assert mv['Concentration'] == '0'
+            else:
+                assert mv['Well Type'] == 'Treatment'
+                assert mv['Concentration'] == '10'
+
+    def get_all_map_annotations(self):
+        qs = self.test.client.sf.getQueryService()
+        q = "FROM MapAnnotation WHERE ns in (:nss)"
+        p = ParametersI()
+        p.map['nss'] = rlist(rstring(ns) for ns in self.get_namespaces())
+        r = qs.findAllByQuery(q, p)
+        return r
+
+
+class Screen2Plates(Fixture):
+
+    def __init__(self):
+        self.count = 6
+        self.annCount = 4
+        self.rowCount = 1
+        self.colCount = 2
+        self.csv = self.createCsv(
+            colNames="Plate,Well,Well Type,Concentration",
+            rowData=("P001,A1,Control,0", "P001,A2,Treatment,10",
+                     "P002,A1,Control,0", "P002,A2,Treatment,10"))
+        self.screen = None
+
+    def assert_rows(self, rows):
+        """
+        Double the number of rows due to 2 plates.
+        """
+        assert rows == 2 * self.rowCount * self.colCount
 
         def createWell(row, column):
             well = WellI()
@@ -142,7 +195,442 @@ class TestPopulateMetadata(BasePopulate):
         was = unwrap(qs.projection(query, None))
         return was
 
-    def testPopulateMetadataPlate(self):
+
+class Plate2WellsNs(Plate2Wells):
+    # For this test use explicit files instead of generating them as an
+    # additional safeguard against changes in the test code
+
+    def __init__(self):
+        self.count = 6
+        self.annCount = 6 * 2  # Two namespaces
+        self.rowCount = 2
+        self.colCount = 3
+        d = os.path.dirname(__file__)
+        self.csv = os.path.join(d, 'bulk_to_map_annotation_context_ns.csv')
+        self.plate = None
+
+    def get_cfg(self):
+        return os.path.join(os.path.dirname(__file__),
+                            'bulk_to_map_annotation_context_ns.yml')
+
+    def get_namespaces(self):
+        return [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
+
+    def assert_row_values(self, rowvalues):
+        # First column is the WellID
+        assert rowvalues[0][1:] == (
+            "FBgn0004644", "hh", "hedgehog;bar-3;CG4637", "a1")
+        assert rowvalues[1][1:] == (
+            "FBgn0003656", "sws", "swiss cheese;olfE;CG2212", "a2")
+        assert rowvalues[2][1:] == (
+            "FBgn0011236", "ken", "ken and barbie;CG5575", "a3")
+        assert rowvalues[3][1:] == (
+            "", "hh",
+            "DHH;IHH;SHH;Desert hedgehog;Indian hedgehog;Sonic hedgehog", "b1")
+        assert rowvalues[4][1:] == (
+            "", "sws",
+            "PNPLA6;patatin like phospholipase domain containing 6", "b2")
+        assert rowvalues[5][1:] == (
+            "", "ken", "BCL6;B-cell lymphoma 6 protein", "b3")
+
+    def assert_child_annotations(self, oas):
+        wellrcs = [coord2offset(c) for c in (
+            'a1', 'a2', 'a3', 'b1', 'b2', 'b3')]
+        nss = [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
+        wellrc_ns = [(wrc, ns) for wrc in wellrcs for ns in nss]
+        check = dict((k, None) for k in wellrc_ns)
+        annids = []
+
+        for ma, wid, wr, wc in oas:
+            assert isinstance(ma, MapAnnotationI)
+            annids.append(unwrap(ma.getId()))
+            ns = unwrap(ma.getNs())
+            wrc = (wr, wc)
+
+            # Well names/ids aren't included in this test, because this also
+            # test that annotations are combined by primary key
+            assert (wrc, ns) in check, 'Unexpected well/namespace'
+            assert check[(wrc, ns)] is None, 'Duplicate annotation'
+
+            # Use getMapValue to check ordering and duplicates
+            check[(wrc, ns)] = [(p.name, p.value) for p in ma.getMapValue()]
+
+        # Row a
+
+        assert check[(wellrcs[0], nss[0])] == [
+            ('Gene', 'hh'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0004644.html'),
+        ]
+        assert check[(wellrcs[0], nss[1])] == [
+            ('Gene', 'hh'),
+            ('Gene name', 'hedgehog'),
+            ('Gene name', 'bar-3'),
+            ('Gene name', 'CG4637'),
+        ]
+
+        assert check[(wellrcs[1], nss[0])] == [
+            ('Gene', 'sws'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0003656.html'),
+        ]
+        assert check[(wellrcs[1], nss[1])] == [
+            ('Gene', 'sws'),
+            ('Gene name', 'swiss cheese'),
+            ('Gene name', 'olfE'),
+            ('Gene name', 'CG2212'),
+        ]
+
+        assert check[(wellrcs[2], nss[0])] == [
+            ('Gene', 'ken'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0011236.html'),
+        ]
+        assert check[(wellrcs[2], nss[1])] == [
+            ('Gene', 'ken'),
+            ('Gene name', 'ken and barbie'),
+            ('Gene name', 'CG5575'),
+        ]
+
+        # Row b
+
+        assert check[(wellrcs[3], nss[0])] == [
+            ('Gene', 'hh'),
+        ]
+        assert check[(wellrcs[3], nss[1])] == [
+            ('Gene', 'hh'),
+            ('Gene name', 'DHH'),
+            ('Gene name', 'IHH'),
+            ('Gene name', 'SHH'),
+            ('Gene name', 'Desert hedgehog'),
+            ('Gene name', 'Indian hedgehog'),
+            ('Gene name', 'Sonic hedgehog'),
+        ]
+        assert check[(wellrcs[4], nss[0])] == [
+            ('Gene', 'sws'),
+        ]
+        assert check[(wellrcs[4], nss[1])] == [
+            ('Gene', 'sws'),
+            ('Gene name', 'PNPLA6'),
+            ('Gene name', 'patatin like phospholipase domain containing 6'),
+        ]
+
+        assert check[(wellrcs[5], nss[0])] == [
+            ('Gene', 'ken'),
+        ]
+        assert check[(wellrcs[5], nss[1])] == [
+            ('Gene', 'ken'),
+            ('Gene name', 'BCL6'),
+            ('Gene name', 'B-cell lymphoma 6 protein'),
+        ]
+
+        assert len(annids) == 12
+        assert len(set(annids)) == 12
+
+
+class Plate2WellsNs2(Plate2WellsNs):
+    # For this test use explicit files instead of generating them as an
+    # additional safeguard against changes in the test code
+
+    def __init__(self):
+        super(Plate2WellsNs2, self).__init__()
+
+    def get_cfg(self):
+        return os.path.join(os.path.dirname(__file__),
+                            'bulk_to_map_annotation_context_ns2.yml')
+
+    def assert_child_annotations(self, oas):
+        wellrcs = [coord2offset(c) for c in (
+            'a1', 'a2', 'a3', 'b1', 'b2', 'b3')]
+        nss = [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
+        wellrc_ns = [(wrc, ns) for wrc in wellrcs for ns in nss]
+        check = dict((k, None) for k in wellrc_ns)
+        annids = []
+
+        for ma, wid, wr, wc in oas:
+            assert isinstance(ma, MapAnnotationI)
+            annids.append(unwrap(ma.getId()))
+            ns = unwrap(ma.getNs())
+            wrc = (wr, wc)
+
+            # Well names/ids aren't included in this test, because this also
+            # test that annotations are combined by primary key
+            assert (wrc, ns) in check, 'Unexpected well/namespace'
+            assert check[(wrc, ns)] is None, 'Duplicate annotation'
+
+            # Use getMapValue to check ordering and duplicates
+            check[(wrc, ns)] = [(p.name, p.value) for p in ma.getMapValue()]
+
+        # Row a
+
+        assert check[(wellrcs[0], nss[0])] == [
+            ('Gene', 'hh'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0004644.html'),
+        ]
+        assert check[(wellrcs[0], nss[1])] == [
+            ('Gene', 'hh'),
+            ('Gene name', 'hedgehog'),
+            ('Gene name', 'bar-3'),
+            ('Gene name', 'CG4637'),
+            ('Gene name', 'DHH'),
+            ('Gene name', 'IHH'),
+            ('Gene name', 'SHH'),
+            ('Gene name', 'Desert hedgehog'),
+            ('Gene name', 'Indian hedgehog'),
+            ('Gene name', 'Sonic hedgehog'),
+        ]
+        assert check[(wellrcs[1], nss[0])] == [
+            ('Gene', 'sws'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0003656.html'),
+        ]
+        assert check[(wellrcs[1], nss[1])] == [
+            ('Gene', 'sws'),
+            ('Gene name', 'swiss cheese'),
+            ('Gene name', 'olfE'),
+            ('Gene name', 'CG2212'),
+            ('Gene name', 'PNPLA6'),
+            ('Gene name', 'patatin like phospholipase domain containing 6'),
+        ]
+
+        assert check[(wellrcs[2], nss[0])] == [
+            ('Gene', 'ken'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0011236.html'),
+        ]
+        assert check[(wellrcs[2], nss[1])] == [
+            ('Gene', 'ken'),
+            ('Gene name', 'ken and barbie'),
+            ('Gene name', 'CG5575'),
+            ('Gene name', 'BCL6'),
+            ('Gene name', 'B-cell lymphoma 6 protein'),
+        ]
+
+        # Row b
+
+        assert check[(wellrcs[3], nss[0])] == [
+            ('Gene', 'hh'),
+        ]
+        assert check[(wellrcs[3], nss[1])] == check[(wellrcs[0], nss[1])]
+
+        assert check[(wellrcs[4], nss[0])] == [
+            ('Gene', 'sws'),
+        ]
+        assert check[(wellrcs[4], nss[1])] == check[(wellrcs[1], nss[1])]
+
+        assert check[(wellrcs[5], nss[0])] == [
+            ('Gene', 'ken'),
+        ]
+        assert check[(wellrcs[5], nss[1])] == check[(wellrcs[2], nss[1])]
+
+        assert len(annids) == 12
+        assert len(set(annids)) == 9
+
+
+class Dataset2Images(Fixture):
+
+    def __init__(self):
+        self.count = 4
+        self.annCount = 2
+        self.csv = self.createCsv(
+            colNames="Image Name,Type,Concentration",
+        )
+        self.dataset = None
+        self.images = None
+        self.names = ("A1", "A2")
+
+    def assert_rows(self, rows):
+        # Hard-coded in createCsv's arguments
+        assert rows == 2
+
+    def get_target(self):
+        if not self.dataset:
+            self.dataset = self.createDataset(self.names)
+            self.images = self.get_dataset_images()
+        return self.dataset
+
+    def get_dataset_images(self):
+        if not self.dataset:
+            return []
+        query = """select i from Image i
+            left outer join fetch i.datasetLinks links
+            left outer join fetch links.parent d
+            where d.id=%s""" % self.dataset.id.val
+        qs = self.test.client.sf.getQueryService()
+        return qs.findAllByQuery(query, None)
+
+    def get_annotations(self):
+        query = """select d from Dataset d
+            left outer join fetch d.annotationLinks links
+            left outer join fetch links.child
+            where d.id=%s""" % self.dataset.id.val
+        qs = self.test.client.sf.getQueryService()
+        ds = qs.findByQuery(query, None)
+        anns = ds.linkedAnnotationList()
+        return anns
+
+    def get_child_annotations(self):
+        if not self.images:
+            return []
+        params = ParametersI()
+        params.addIds([x.id for x in self.images])
+        query = """ select a, i.id, 'NA', 'NA'
+            from Image i
+            left outer join i.annotationLinks links
+            left outer join links.child as a
+            where i.id in (:ids) and a <> null"""
+        qs = self.test.client.sf.getQueryService()
+        return unwrap(qs.projection(query, params))
+
+    def assert_child_annotations(self, oas):
+        for ma, iid, na1, na2 in oas:
+            assert isinstance(ma, MapAnnotationI)
+            assert unwrap(ma.getNs()) == NSBULKANNOTATIONS
+            mv = ma.getMapValueAsMap()
+            img = mv['Image Name']
+            con = mv['Concentration']
+            typ = mv['Type']
+            assert img[0] in ("A", "a")
+            which = long(img[1:])
+            if which % 2 == 1:
+                assert con == '0'
+                assert typ == 'Control'
+            elif which % 2 == 0:
+                assert con == '10'
+                assert typ == 'Treatment'
+
+
+class Dataset101Images(Dataset2Images):
+
+    def __init__(self):
+        self.count = 4
+        self.annCount = 102
+        self.names = []
+        rowData = []
+        for x in range(0, 101, 2):
+            name = "A%s" % (x+1)
+            self.names.append(name)
+            rowData.append("%s,Control,0" % name)
+            name = "A%s" % (x+2)
+            self.names.append(name)
+            rowData.append("A%s,Treatment,10" % (x+2))
+        self.csv = self.createCsv(
+            colNames="Image Name,Type,Concentration",
+            rowData=rowData,
+        )
+        self.dataset = None
+        self.images = None
+
+    def assert_rows(self, rows):
+        assert rows == 102
+
+
+class GZIP(Dataset2Images):
+
+    def createCsv(self, *args, **kwargs):
+        csvFileName = super(GZIP, self).createCsv(*args, **kwargs)
+        gzipFileName = "%s.gz" % csvFileName
+        with open(csvFileName, 'rb') as f_in, \
+                gzip.open(gzipFileName, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+        return gzipFileName
+
+
+class Project2Datasets(Fixture):
+
+    def __init__(self):
+        self.count = 5
+        self.annCount = 4
+        self.csv = self.createCsv(
+            colNames="Dataset Name,Image Name,Type,Concentration",
+            rowData=("D001,A1,Control,0", "D001,A2,Treatment,10",
+                     "D002,A1,Control,0", "D002,A2,Treatment,10"))
+        self.project = None
+
+    def assert_rows(self, rows):
+        # Hard-coded in createCsv's arguments
+        assert rows == 4
+
+    def get_target(self):
+        if not self.project:
+            self.project = self.createProject("P123")
+            self.images = self.get_project_images()
+        return self.project
+
+    def get_project_images(self):
+        if not self.project:
+            return []
+        query = """select i from Image i
+            left outer join fetch i.datasetLinks dil
+            left outer join fetch dil.parent d
+            left outer join fetch d.projectLinks pdl
+            left outer join fetch pdl.parent p
+            where p.id=%s""" % self.project.id.val
+        qs = self.test.client.sf.getQueryService()
+        return qs.findAllByQuery(query, None)
+
+    def get_annotations(self):
+        query = """select p from Project p
+            left outer join fetch p.annotationLinks links
+            left outer join fetch links.child
+            where p.id=%s""" % self.project.id.val
+        qs = self.test.client.sf.getQueryService()
+        ds = qs.findByQuery(query, None)
+        anns = ds.linkedAnnotationList()
+        return anns
+
+    def get_child_annotations(self):
+        if not self.images:
+            return []
+        params = ParametersI()
+        params.addIds([x.id for x in self.images])
+        query = """ select a, i.id, 'NA', 'NA'
+            from Image i
+            left outer join i.annotationLinks links
+            left outer join links.child as a
+            where i.id in (:ids) and a <> null"""
+        qs = self.test.client.sf.getQueryService()
+        return unwrap(qs.projection(query, params))
+
+    def assert_child_annotations(self, oas):
+        for ma, iid, na1, na2 in oas:
+            assert isinstance(ma, MapAnnotationI)
+            assert unwrap(ma.getNs()) == NSBULKANNOTATIONS
+            mv = ma.getMapValueAsMap()
+            ds = mv['Dataset Name']
+            img = mv['Image Name']
+            con = mv['Concentration']
+            typ = mv['Type']
+            if ds == 'D001' or ds == 'D002':
+                if img == "A1":
+                    assert con == '0'
+                    assert typ == 'Control'
+                elif img == "A2":
+                    assert con == '10'
+                    assert typ == 'Treatment'
+                else:
+                    raise Exception("Unknown img: %s" % img)
+            else:
+                raise Exception("Unknown dataset: %s" % ds)
+
+
+class TestPopulateMetadata(lib.ITest):
+
+    METADATA_FIXTURES = (
+        Screen2Plates(),
+        Plate2Wells(),
+        Dataset2Images(),
+        Dataset101Images(),
+        Project2Datasets(),
+        GZIP(),
+    )
+    METADATA_IDS = [x.__class__.__name__ for x in METADATA_FIXTURES]
+
+    METADATA_NS_FIXTURES = (
+        Plate2WellsNs(),
+        Plate2WellsNs2(),
+    )
+    METADATA_NS_IDS = [x.__class__.__name__ for x in METADATA_NS_FIXTURES]
+
+    @mark.parametrize("fixture", METADATA_FIXTURES, ids=METADATA_IDS)
+    @mark.parametrize("batch_size", (None, 10, 1000))
+    def testPopulateMetadata(self, fixture, batch_size):
         """
         We should really test each of the parsing contexts in separate tests
         but in practice each one uses data created by the others, so for
@@ -203,15 +691,15 @@ class TestPopulateMetadata(BasePopulate):
         except Exception:
             skip("PyYAML not installed.")
 
-        fixture = Plate2WellsNs2()
-        fixture.init(self)
-        self._test_parsing_context(fixture, 2)
-        self._test_bulk_to_map_annotation_context(fixture, 2)
+        fixture1 = Plate2WellsNs2()
+        fixture1.init(self)
+        self._test_parsing_context(fixture1, 2)
+        self._test_bulk_to_map_annotation_context(fixture1, 2)
 
         fixture2 = Plate2WellsNs2()
         fixture2.init(self)
         self._test_parsing_context(fixture2, 2)
-        self._test_bulk_to_map_annotation_dedup(fixture, fixture2, 2)
+        self._test_bulk_to_map_annotation_dedup(fixture1, fixture2)
 
     def _test_parsing_context(self, fixture, batch_size):
         """
@@ -250,7 +738,8 @@ class TestPopulateMetadata(BasePopulate):
 
     def _test_bulk_to_map_annotation_context(self):
         # self._testPopulateMetadataPlate()
-        assert len(self.get_well_annotations()) == 0
+        assert len(fixture.get_all_map_annotations()) == 0
+        assert len(fixture.get_child_annotations()) == 0
 
         cfg = os.path.join(
             os.path.dirname(__file__), 'bulk_to_map_annotation_context.yml')
@@ -265,8 +754,7 @@ class TestPopulateMetadata(BasePopulate):
         was = self.get_well_annotations()
         assert len(was) == 2
 
-    def _test_bulk_to_map_annotation_dedup(
-            self, fixture1, fixture2, batch_size):
+    def _test_bulk_to_map_annotation_dedup(self, fixture1, fixture2):
         ann_count = fixture1.annCount
         assert fixture2.annCount == ann_count
         assert len(fixture1.get_child_annotations()) == ann_count
@@ -283,10 +771,7 @@ class TestPopulateMetadata(BasePopulate):
         assert len(fixture1.get_child_annotations()) == ann_count
         assert len(fixture2.get_child_annotations()) == 0
 
-        if batch_size is None:
-            ctx.write_to_omero()
-        else:
-            ctx.write_to_omero(batch_size=batch_size)
+        ctx.write_to_omero()
 
         oas1 = fixture1.get_child_annotations()
         oas2 = fixture2.get_child_annotations()
@@ -312,8 +797,12 @@ class TestPopulateMetadata(BasePopulate):
         ctx.parse()
         assert len(self.get_well_annotations()) == 2
 
-        ctx.write_to_omero()
-        assert len(self.get_well_annotations()) == 0
+        if batch_size is None:
+            ctx.write_to_omero()
+        else:
+            ctx.write_to_omero(batch_size=batch_size)
+        assert len(fixture.get_child_annotations()) == 0
+        assert len(fixture.get_all_map_annotations()) == 0
 
 
 class MockMeasurementCtx(AbstractMeasurementCtx):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -700,6 +700,9 @@ class TestPopulateMetadata(lib.ITest):
         fixture2.init(self)
         self._test_parsing_context(fixture2, 2)
         self._test_bulk_to_map_annotation_dedup(fixture1, fixture2)
+        # TODO: This will currently fail because the MapAnnotations are
+        # deleted even if they're multiply linked
+        # self._test_delete_map_annotation_context_dedup(fixture1, fixture2)
 
     def _test_parsing_context(self, fixture, batch_size):
         """
@@ -803,6 +806,25 @@ class TestPopulateMetadata(lib.ITest):
             ctx.write_to_omero(batch_size=batch_size)
         assert len(fixture.get_child_annotations()) == 0
         assert len(fixture.get_all_map_annotations()) == 0
+
+    def _test_delete_map_annotation_context_dedup(self, fixture1, fixture2):
+        assert len(fixture1.get_child_annotations()) == fixture1.annCount
+        assert len(fixture2.get_child_annotations()) == fixture2.annCount
+
+        ctx = DeleteMapAnnotationContext(
+            self.client, fixture1.get_target(), cfg=fixture1.get_cfg())
+        ctx.parse()
+        ctx.write_to_omero()
+        assert len(fixture1.get_child_annotations()) == 0
+        assert len(fixture2.get_child_annotations()) == fixture2.annCount
+
+        ctx = DeleteMapAnnotationContext(
+            self.client, fixture2.get_target(), cfg=fixture2.get_cfg())
+        ctx.parse()
+        ctx.write_to_omero()
+        assert len(fixture2.get_child_annotations()) == 0
+        assert len(fixture1.get_all_map_annotations()) == 0
+        assert len(fixture2.get_all_map_annotations()) == 0
 
 
 class MockMeasurementCtx(AbstractMeasurementCtx):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -192,8 +192,26 @@ class TestPopulateMetadata(BasePopulate):
         self._test_bulk_to_map_annotation_context(fixture, 2)
         self._test_delete_map_annotation_context(fixture, 2)
 
-    # TODO: testPopulateMetadataNsAnns with multiple separate Plates
-    # to check duplicate map-annotations aren't created
+    def testPopulateMetadataNsAnnsDedup(self):
+        """
+        Similar to testPopulateMetadataNsAnns but use two plates and check
+        MapAnnotations aren't duplicated
+        """
+        try:
+            import yaml
+            print yaml, "found"
+        except Exception:
+            skip("PyYAML not installed.")
+
+        fixture = Plate2WellsNs2()
+        fixture.init(self)
+        self._test_parsing_context(fixture, 2)
+        self._test_bulk_to_map_annotation_context(fixture, 2)
+
+        fixture2 = Plate2WellsNs2()
+        fixture2.init(self)
+        self._test_parsing_context(fixture2, 2)
+        self._test_bulk_to_map_annotation_dedup(fixture, fixture2, 2)
 
     def _test_parsing_context(self, fixture, batch_size):
         """
@@ -247,18 +265,44 @@ class TestPopulateMetadata(BasePopulate):
         was = self.get_well_annotations()
         assert len(was) == 2
 
-        for ma, wid, wr, wc in was:
-            assert isinstance(ma, MapAnnotationI)
-            assert unwrap(ma.getNs()) == NSBULKANNOTATIONS
-            mv = ma.getMapValueAsMap()
-            assert mv['Well'] == str(wid)
-            assert coord2offset(mv['Well Name']) == (wr, wc)
-            if (wr, wc) == (0, 0):
-                assert mv['Well Type'] == 'Control'
-                assert mv['Concentration'] == '0'
-            else:
-                assert mv['Well Type'] == 'Treatment'
-                assert mv['Concentration'] == '10'
+    def _test_bulk_to_map_annotation_dedup(
+            self, fixture1, fixture2, batch_size):
+        ann_count = fixture1.annCount
+        assert fixture2.annCount == ann_count
+        assert len(fixture1.get_child_annotations()) == ann_count
+        assert len(fixture2.get_child_annotations()) == 0
+
+        cfg = fixture2.get_cfg()
+
+        target = fixture2.get_target()
+        anns = fixture2.get_annotations()
+        fileid = anns[0].file.id.val
+        ctx = BulkToMapAnnotationContext(
+            self.client, target, fileid=fileid, cfg=cfg)
+        ctx.parse()
+        assert len(fixture1.get_child_annotations()) == ann_count
+        assert len(fixture2.get_child_annotations()) == 0
+
+        if batch_size is None:
+            ctx.write_to_omero()
+        else:
+            ctx.write_to_omero(batch_size=batch_size)
+
+        oas1 = fixture1.get_child_annotations()
+        oas2 = fixture2.get_child_annotations()
+        assert len(oas1) == ann_count
+        assert len(oas2) == ann_count
+        fixture1.assert_child_annotations(oas1)
+        fixture2.assert_child_annotations(oas2)
+
+        # 6 of the mapannotations should be common
+        ids1 = set(unwrap(o[0].getId()) for o in oas1)
+        ids2 = set(unwrap(o[0].getId()) for o in oas2)
+        assert len(ids1.intersection(ids2)) == 3
+
+    def _test_delete_map_annotation_context(self, fixture, batch_size):
+        # self._test_bulk_to_map_annotation_context()
+        assert len(fixture.get_child_annotations()) == fixture.annCount
 
     def _test_delete_map_annotation_context(self):
         # self._test_bulk_to_map_annotation_context()

--- a/components/tools/OmeroPy/test/unit/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/unit/test_metadata_mapannotations.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Test of metadata_mapannotation classes
+"""
+
+
+import pytest
+
+from omero.model import MapAnnotationI, NamedValue
+from omero.rtypes import rstring
+from omero.util.metadata_mapannotations import (
+    CanonicalMapAnnotation, MapAnnotationPrimaryKeyException,
+    MapAnnotationManager)
+
+
+def assert_equal_name_value(a, b):
+    assert isinstance(a, NamedValue)
+    assert isinstance(b, NamedValue)
+    assert a.name == b.name
+    assert a.value == b.value
+
+
+class TestCanonicalMapAnnotation(object):
+
+    # test_init_* methods test process_keypairs
+
+    @pytest.mark.parametrize('ns', [None, '', 'NS'])
+    def test_init_defaults_empty(self, ns):
+        ma = MapAnnotationI(1)
+        if ns is not None:
+            ma.setNs(rstring(ns))
+
+        cma = CanonicalMapAnnotation(ma)
+        assert cma.ma is ma
+        expectedns = ns if ns else ''
+        assert cma.ns == expectedns
+        assert cma.kvpairs == []
+        assert cma.primary is None
+        assert cma.parents == set()
+
+    @pytest.mark.parametrize('ns', [None, '', 'NS'])
+    def test_init_defaults_kvpairs(self, ns):
+        ma = MapAnnotationI(1)
+        ma.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
+        if ns is not None:
+            ma.setNs(rstring(ns))
+
+        cma = CanonicalMapAnnotation(ma)
+        assert cma.ma is ma
+        expectedns = ns if ns else ''
+        assert cma.ns == expectedns
+        assert cma.kvpairs == [('b', '2'), ('a', '1')]
+        assert cma.primary is None
+        assert cma.parents == set()
+
+    def test_init_defaults_duplicates(self):
+        ma = MapAnnotationI(1)
+        ma.setMapValue([NamedValue('a', '1'), NamedValue('a', '1')])
+
+        with pytest.raises(ValueError) as excinfo:
+            CanonicalMapAnnotation(ma)
+        assert str(excinfo.value).startswith('Duplicate ')
+
+    @pytest.mark.parametrize('ns', [None, '', 'NS'])
+    @pytest.mark.parametrize('primary_keys', [[], ['a'], ['a', 'b']])
+    def test_init_primary_keys(self, ns, primary_keys):
+        ma = MapAnnotationI(1)
+        ma.setNs(rstring(ns))
+        ma.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
+
+        cma = CanonicalMapAnnotation(ma, primary_keys=primary_keys)
+        assert cma.ma is ma
+        expectedns = ns if ns else ''
+        assert cma.ns == expectedns
+        assert cma.kvpairs == [('b', '2'), ('a', '1')]
+        expectedpks = [('a', '1'), ('b', '2')][:len(primary_keys)]
+        if primary_keys:
+            expectedpri = (expectedns, frozenset(expectedpks))
+        else:
+            expectedpri = None
+        assert cma.primary == expectedpri
+        assert cma.parents == set()
+
+    def test_init_missing_primary_key(self):
+        ma = MapAnnotationI(1)
+        ma.setMapValue([NamedValue('b', '2')])
+
+        with pytest.raises(MapAnnotationPrimaryKeyException) as excinfo:
+            CanonicalMapAnnotation(ma, primary_keys=['a', 'b'])
+        assert str(excinfo.value).startswith('Missing ')
+
+    @pytest.mark.parametrize('reverse', [True, False])
+    def test_merge(self, reverse):
+        ma1 = MapAnnotationI(1)
+        ma1.setMapValue([NamedValue('a', '1')])
+        cma1 = CanonicalMapAnnotation(ma1, primary_keys=['a'])
+        cma1.add_parent('Parent', 1)
+        ma2 = MapAnnotationI(2)
+        ma2.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
+        cma2 = CanonicalMapAnnotation(ma2, primary_keys=['b'])
+        cma2.add_parent('Parent', 1)
+        cma2.add_parent('Parent', 2)
+
+        if reverse:
+            cma2.merge(cma1)
+            assert cma2.kvpairs == [('b', '2'), ('a', '1')]
+            assert cma2.parents == set([('Parent', 1), ('Parent', 2)])
+            assert cma2.primary == ('', frozenset([('b', '2')]))
+        else:
+            cma1.merge(cma2)
+            assert cma1.kvpairs == [('a', '1'), ('b', '2')]
+            assert cma1.parents == set([('Parent', 1), ('Parent', 2)])
+            assert cma1.primary == ('', frozenset([('a', '1')]))
+
+    def test_add_parent(self):
+        ma = MapAnnotationI(1)
+        cma = CanonicalMapAnnotation(ma)
+        assert cma.parents == set()
+        cma.add_parent('A', 1)
+        assert cma.parents == set([('A', 1)])
+        cma.add_parent('B', 2)
+        assert cma.parents == set([('A', 1), ('B', 2)])
+
+        with pytest.raises(ValueError) as excinfo:
+            cma.add_parent('C', '3')
+        assert str(excinfo.value).startswith('Expected parent')
+
+    def test_get_mapann(self):
+        ma = MapAnnotationI(1)
+        ma.setMapValue([NamedValue('a', '1')])
+        cma = CanonicalMapAnnotation(ma, primary_keys=['a'])
+        cma.add_parent('Parent', 1)
+        cma.kvpairs.append(('b', '2'))
+        newma = cma.get_mapann()
+
+        assert newma is ma
+        mv = newma.getMapValue()
+        assert len(mv) == 2
+        assert_equal_name_value(mv[0], NamedValue('a', '1'))
+        assert_equal_name_value(mv[1], NamedValue('b', '2'))
+
+
+class TestMapAnnotationManager(object):
+
+    def create_cmas(self, pk2):
+        ma1 = MapAnnotationI(1)
+        ma1.setMapValue([NamedValue('a', '1')])
+        cma1 = CanonicalMapAnnotation(ma1, primary_keys=['a'])
+        cma1.add_parent('Parent', 1)
+
+        ma2 = MapAnnotationI(2)
+        ma2.setMapValue([NamedValue('b', '2'), NamedValue('a', '1')])
+        cma2 = CanonicalMapAnnotation(ma2, primary_keys=[pk2])
+        cma2.add_parent('Parent', 1)
+        cma2.add_parent('Parent', 2)
+
+        return cma1, cma2
+
+    @pytest.mark.parametrize('combine', [
+        None, MapAnnotationManager.MA_APPEND, MapAnnotationManager.MA_OLD,
+        MapAnnotationManager.MA_NEW])
+    def test_add_samepk(self, combine):
+        cma1, cma2 = self.create_cmas('a')
+        pk1 = ('', frozenset([('a', '1')]))
+        parents12 = set([('Parent', 1), ('Parent', 2)])
+
+        if combine:
+            mgr = MapAnnotationManager(combine)
+        else:
+            mgr = MapAnnotationManager()
+        assert mgr.mapanns == {}
+
+        # These tests all make use of object identity
+        # Sanity check:
+        assert cma1 != cma2
+
+        r = mgr.add(cma1)
+        assert mgr.mapanns == {pk1: cma1}
+        assert r is None
+
+        # Duplicate add should have no effect
+        r = mgr.add(cma1)
+        assert mgr.mapanns == {pk1: cma1}
+        assert r is None
+
+        r = mgr.add(cma2)
+        if combine == MapAnnotationManager.MA_OLD:
+            assert mgr.mapanns == {pk1: cma1}
+            assert cma1.kvpairs == [('a', '1')]
+            assert cma1.parents == parents12
+            assert r is cma2
+        elif combine == MapAnnotationManager.MA_NEW:
+            assert mgr.mapanns == {pk1: cma2}
+            assert cma2.kvpairs == [('b', '2'), ('a', '1')]
+            assert cma2.parents == parents12
+            assert r is cma1
+        else:  # None or MA_APPEND
+            assert mgr.mapanns == {pk1: cma1}
+            assert cma1.kvpairs == [('a', '1'), ('b', '2')]
+            assert cma1.parents == parents12
+            assert r is cma2
+
+    @pytest.mark.parametrize('combine', [
+        MapAnnotationManager.MA_APPEND, MapAnnotationManager.MA_OLD,
+        MapAnnotationManager.MA_NEW])
+    def test_add_diffpk(self, combine):
+        cma1, cma2 = self.create_cmas('b')
+        pk1 = ('', frozenset([('a', '1')]))
+        pk2 = ('', frozenset([('b', '2')]))
+
+        mgr = MapAnnotationManager(combine)
+        r = mgr.add(cma1)
+        assert r is None
+
+        r = mgr.add(cma2)
+        assert mgr.mapanns == {pk1: cma1, pk2: cma2}
+        assert cma1.kvpairs == [('a', '1')]
+        assert cma1.parents == set([('Parent', 1)])
+        assert cma2.kvpairs == [('b', '2'), ('a', '1')]
+        assert cma2.parents == set([('Parent', 1), ('Parent', 2)])
+        assert r is None


### PR DESCRIPTION

This is the same as gh-4786 but rebased onto metadata53.

----

# What this PR does

This is a follow-up to https://github.com/openmicroscopy/openmicroscopy/pull/4775 to use/update existing map-annotations in the database instead of creating duplicates.

There are several limitations which is why I've kept this as a separate PR:
- De-duplication only occurs between different screens/projects. This mean you can't re-run `metadata populate` on the same screen with the same `bulkmap-config.yml` file unless you first delete the map-annotations on the target.
- The database query loads all map-annotations in the given namespace, this is potentially resource intensive on both server and client
- Haven't figured out proper deletion semantics yet
  - Can you delete only annotation links, unless it's the last one in which case also delete the annotation?
# Testing this PR
1. Setup is similar to https://github.com/openmicroscopy/openmicroscopy/pull/4775, but this time create two screens with at least one overlapping primary key
2. `populate metadata` both screens.
3. Only one map-annotation for each primary key should exist, regardless of how many screens it is found in
# For discussion: upsert

There's two use cases here:
1. CreateIfNotExist: Create XxxAnnotationLink(parent,chlid) only if that link doesn't already exist. This would help fix the current lack of implementation for modifying annotations on existing screens. Example:
   - A screen contains `Images 1-10`. All of the images are linked to `MapAnnotation A`.
   - `Images 11-100` are subsequently added to the screen, and also need to be linked to `MapAnnotation A`.
   - The easiest way is to create 100 ImageAnnotationLinks with the same child, and use `UpdateServer.saveAndReturnArray`. This will fail because some of the `ImageAnnotationLink` already exist
   - In practice the Images to be annotated are filtered according to some other criteria, so the existence of the link would have to be checked for each image
2. Creating/merging mMapAnnotations. In #4775 I added support for deduplicating MapAnnotations before they were saved. This PR now takes existing MapAnnotations into account. Most of the merging logic is handled by `components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py`
# TODO:
- [x] Rename `groupname` to `namespace`
- [ ] Maybe delete?


                