### PR TITLE
Api rois

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5488,7 +5488,7 @@ class _RoiWrapper (BlitzObjectWrapper):
         Extend base query to handle loading of Shapes.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'load_shapes': boolean.
-                        'image': <imgae_id> to filter by Image
+                        'image': <image_id> to filter by Image
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5474,6 +5474,44 @@ class MapAnnotationWrapper (AnnotationWrapper):
 AnnotationWrapper._register(MapAnnotationWrapper)
 
 
+class _RoiWrapper (BlitzObjectWrapper):
+    """
+    omero_model_ExperimenterI class wrapper extends BlitzObjectWrapper.
+    """
+    OMERO_CLASS = 'Roi'
+    # TODO: test listChildren() to use ShapeWrapper? or remove?
+    CHILD_WRAPPER_CLASS = 'ShapeWrapper'
+
+    @classmethod
+    def _getQueryString(cls, opts=None):
+        """
+        Extend base query to handle loading of Shapes.
+        Returns a tuple of (query, clauses, params).
+        Supported opts: 'load_shapes': boolean.
+
+        :param opts:        Dictionary of optional parameters.
+        :return:            Tuple of string, list, ParametersI
+        """
+        query, clauses, params = super(
+            _RoiWrapper, cls)._getQueryString(opts)
+        if opts is None:
+            opts = {}
+        if opts.get('load_shapes'):
+            query += ' left outer join fetch obj.shapes'
+        return (query, clauses, params)
+
+RoiWrapper = _RoiWrapper
+
+
+class _ShapeWrapper (BlitzObjectWrapper):
+    """
+    omero_model_ShapeI class wrapper extends BlitzObjectWrapper.
+    """
+    OMERO_CLASS = 'Shape'
+
+ShapeWrapper = _ShapeWrapper
+
+
 class _EnumerationWrapper (BlitzObjectWrapper):
 
     def getType(self):
@@ -6298,7 +6336,9 @@ class _WellWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Extend base query to handle filtering of Wells by Plate.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'plate': <plate_id> to filter by Plate
-                        'load_images': <bool> to load wellSamples and images
+                        'load_images': <bool> to load WellSamples and Images
+                        'load_pixels': <bool> to load Image Pixels
+                        'load_channels': <bool> to load Pixels and Channels
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
@@ -10348,6 +10388,8 @@ def refreshWrappers():
                            "plateacquisition": PlateAcquisitionWrapper,
                            "acquisition": PlateAcquisitionWrapper,
                            "well": WellWrapper,
+                           "roi": RoiWrapper,
+                           "shape": ShapeWrapper,
                            "experimenter": ExperimenterWrapper,
                            "experimentergroup": ExperimenterGroupWrapper,
                            "originalfile": OriginalFileWrapper,

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5488,6 +5488,7 @@ class _RoiWrapper (BlitzObjectWrapper):
         Extend base query to handle loading of Shapes.
         Returns a tuple of (query, clauses, params).
         Supported opts: 'load_shapes': boolean.
+                        'image': <imgae_id> to filter by Image
 
         :param opts:        Dictionary of optional parameters.
         :return:            Tuple of string, list, ParametersI
@@ -5498,6 +5499,9 @@ class _RoiWrapper (BlitzObjectWrapper):
             opts = {}
         if opts.get('load_shapes'):
             query += ' left outer join fetch obj.shapes'
+        if 'image' in opts:
+            clauses.append('obj.image.id = :image_id')
+            params.add('image_id', rlong(opts['image']))
         return (query, clauses, params)
 
 RoiWrapper = _RoiWrapper

--- a/components/tools/OmeroWeb/omeroweb/api/api_settings.py
+++ b/components/tools/OmeroWeb/omeroweb/api/api_settings.py
@@ -56,4 +56,5 @@ report_settings(sys.modules[__name__])
 # TODO - need to decide how this is configured, strategy for extending etc.
 API_VERSIONS = ('0',)
 
-API_VERSION = '0.0'
+# Current major.minor version number
+API_VERSION = '0.1'

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -276,6 +276,13 @@ api_plate_screens = url(
 GET Screens that contain a Plate, using omero-marshal to generate json
 """
 
+api_rois = url(r'^v(?P<api_version>%s)/m/rois/$' % versions,
+                views.RoisView.as_view(),
+                name='api_rois')
+"""
+GET all rois, using omero-marshal to generate json
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -309,4 +316,5 @@ urlpatterns = patterns(
     api_plateacquisition_wells,
     api_well,
     api_plate_screens,
+    api_rois,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -283,6 +283,15 @@ api_rois = url(r'^v(?P<api_version>%s)/m/rois/$' % versions,
 GET all rois, using omero-marshal to generate json
 """
 
+api_image_rois = url(
+    r'^v(?P<api_version>%s)/m/images/'
+    '(?P<image_id>[0-9]+)/rois/$' % versions,
+    views.RoisView.as_view(),
+    name='api_image_rois')
+"""
+GET ROIs that belong to an Image, using omero-marshal to generate json
+"""
+
 urlpatterns = patterns(
     '',
     api_versions,
@@ -317,4 +326,5 @@ urlpatterns = patterns(
     api_well,
     api_plate_screens,
     api_rois,
+    api_image_rois,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -277,8 +277,8 @@ GET Screens that contain a Plate, using omero-marshal to generate json
 """
 
 api_rois = url(r'^v(?P<api_version>%s)/m/rois/$' % versions,
-                views.RoisView.as_view(),
-                name='api_rois')
+               views.RoisView.as_view(),
+               name='api_rois')
 """
 GET all rois, using omero-marshal to generate json
 """

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -673,6 +673,8 @@ class RoisView(ObjectsView):
         """Add extra parameters to the opts dict."""
         opts = super(RoisView, self).get_opts(request, **kwargs)
         opts['load_shapes'] = True
+        # order_by ID simply for consistency & paging
+        opts['order_by'] = 'obj.id'
 
         # at /images/:image_id/rois/ we have 'image_id' in kwargs
         if 'image_id' in kwargs:

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -661,6 +661,18 @@ class WellsView(ObjectsView):
         return marshalled
 
 
+class RoisView(ObjectsView):
+    """Handles GET for /rois/ to list available ROIs with Shapes."""
+
+    OMERO_TYPE = 'Roi'
+
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(RoisView, self).get_opts(request, **kwargs)
+        opts['load_shapes'] = True
+        return opts
+
+
 class SaveView(View):
     """
     This view provides 'Save' functionality for all types of objects.

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -83,6 +83,7 @@ def api_base(request, api_version=None, **kwargs):
           'url:images': build_url(request, 'api_images', v),
           'url:screens': build_url(request, 'api_screens', v),
           'url:plates': build_url(request, 'api_plates', v),
+          'url:rois': build_url(request, 'api_rois', v),
           'url:token': build_url(request, 'api_token', v),
           'url:servers': build_url(request, 'api_servers', v),
           'url:login': build_url(request, 'api_login', v),

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -240,6 +240,8 @@ class ImageView(ObjectView):
     urls = {
         'url:datasets': {'name': 'api_image_datasets',
                          'kwargs': {'image_id': 'OBJECT_ID'}},
+        'url:rois': {'name': 'api_image_rois',
+                     'kwargs': {'image_id': 'OBJECT_ID'}},
     }
 
     def get_opts(self, request):
@@ -670,6 +672,16 @@ class RoisView(ObjectsView):
         """Add extra parameters to the opts dict."""
         opts = super(RoisView, self).get_opts(request, **kwargs)
         opts['load_shapes'] = True
+
+        # at /images/:image_id/rois/ we have 'image_id' in kwargs
+        if 'image_id' in kwargs:
+            opts['image'] = long(kwargs['image_id'])
+        else:
+            # filter by query /rois/?image=:id
+            image = getIntOrDefault(request, 'image', None)
+            if image is not None:
+                opts['image'] = image
+
         return opts
 
 

--- a/components/tools/OmeroWeb/test/integration/test_api_rois.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_rois.py
@@ -48,6 +48,7 @@ def build_url(client, url_name, url_kwargs):
     url = webclient_url.replace('/webclient/', url)
     return url
 
+
 def rgba_to_int(red, green, blue, alpha=255):
     """Return the color as an Integer in RGBA encoding."""
     r = red << 24
@@ -158,9 +159,10 @@ class TestContainers(IWebTest):
         # List ALL rois
         rois_url = reverse('api_rois', kwargs={'api_version': version})
         rsp = _get_response_json(client, rois_url, {})
-        assert_objects(conn, rsp['data'], rois, dtype="Roi", opts={'load_shapes': True})
+        assert_objects(conn, rsp['data'], rois, dtype="Roi",
+                       opts={'load_shapes': True})
 
         # ROIs on the image
         rsp = _get_response_json(client, rois_url, {'image': image.id.val})
-        assert_objects(conn, rsp['data'], rois[:2], dtype="Roi", opts={'load_shapes': True})
-
+        assert_objects(conn, rsp['data'], rois[:2], dtype="Roi",
+                       opts={'load_shapes': True})

--- a/components/tools/OmeroWeb/test/integration/test_api_rois.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_rois.py
@@ -79,19 +79,18 @@ class TestContainers(IWebTest):
         rect.y = rdouble(20)
         rect.width = rdouble(30)
         rect.height = rdouble(40)
-        rect.theZ = rint(0)
+        # Only save theT, not theZ
         rect.theT = rint(0)
         rect.textValue = rstring("test-Rectangle")
         rect.fillColor = rint(rgba_to_int(255, 255, 255, 255))
         rect.strokeColor = rint(rgba_to_int(255, 255, 0, 255))
 
+        # ellipse without saving theZ & theT
         ellipse = EllipseI()
         ellipse.x = rdouble(33)
         ellipse.y = rdouble(44)
         ellipse.radiusX = rdouble(55)
         ellipse.radiusY = rdouble(66)
-        ellipse.theZ = rint(1)
-        ellipse.theT = rint(20)
         ellipse.textValue = rstring("test-Ellipse")
 
         line = LineI()

--- a/components/tools/OmeroWeb/test/integration/test_api_rois.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_rois.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests querying of ROIs and Shapes with json api."""
+
+from omeroweb.testlib import IWebTest, _get_response_json
+from django.core.urlresolvers import reverse
+from omeroweb.api import api_settings
+import pytest
+from test_api_projects import get_update_service, \
+    get_connection
+from test_api_images import assert_objects
+from omero.model import EllipseI, \
+    ImageI, \
+    LengthI, \
+    LineI, \
+    PointI, \
+    PolygonI, \
+    RectangleI, \
+    RoiI
+
+from omero.model.enums import UnitsLength
+from omero.rtypes import rstring, rint, rdouble
+
+
+def build_url(client, url_name, url_kwargs):
+    """Build an absolute url using client response url."""
+    response = client.request()
+    # http://testserver/webclient/
+    webclient_url = response.url
+    url = reverse(url_name, kwargs=url_kwargs)
+    url = webclient_url.replace('/webclient/', url)
+    return url
+
+def rgba_to_int(red, green, blue, alpha=255):
+    """Return the color as an Integer in RGBA encoding."""
+    r = red << 24
+    g = green << 16
+    b = blue << 8
+    a = alpha
+    rgba_int = r+g+b+a
+    if (rgba_int > (2**31-1)):       # convert to signed 32-bit int
+        rgba_int = rgba_int - 2**32
+    return rgba_int
+
+
+class TestContainers(IWebTest):
+    """Tests querying & editing Datasets, Screens etc."""
+
+    @pytest.fixture()
+    def user1(self):
+        """Return a new user in a read-annotate group."""
+        group = self.new_group(perms='rwra--')
+        user = self.new_client_and_user(group=group)
+        return user
+
+    @pytest.fixture()
+    def shapes(self):
+        """Create a bunch of unsaved Shapes."""
+        rect = RectangleI()
+        rect.x = rdouble(10)
+        rect.y = rdouble(20)
+        rect.width = rdouble(30)
+        rect.height = rdouble(40)
+        rect.theZ = rint(0)
+        rect.theT = rint(0)
+        rect.textValue = rstring("test-Rectangle")
+        rect.fillColor = rint(rgba_to_int(255, 255, 255, 255))
+        rect.strokeColor = rint(rgba_to_int(255, 255, 0, 255))
+
+        ellipse = EllipseI()
+        ellipse.x = rdouble(33)
+        ellipse.y = rdouble(44)
+        ellipse.radiusX = rdouble(55)
+        ellipse.radiusY = rdouble(66)
+        ellipse.theZ = rint(1)
+        ellipse.theT = rint(20)
+        ellipse.textValue = rstring("test-Ellipse")
+
+        line = LineI()
+        line.x1 = rdouble(200)
+        line.x2 = rdouble(300)
+        line.y1 = rdouble(400)
+        line.y2 = rdouble(500)
+        line.textValue = rstring("test-Line")
+
+        point = PointI()
+        point.x = rdouble(1)
+        point.y = rdouble(1)
+        point.theZ = rint(1)
+        point.theT = rint(1)
+        point.textValue = rstring("test-Point")
+
+        polygon = PolygonI()
+        polygon.theZ = rint(5)
+        polygon.theT = rint(5)
+        polygon.fillColor = rint(rgba_to_int(255, 0, 255, 50))
+        polygon.strokeColor = rint(rgba_to_int(255, 255, 0))
+        polygon.strokeWidth = LengthI(10, UnitsLength.PIXEL)
+        points = "10,20, 50,150, 200,200, 250,75"
+        polygon.points = rstring(points)
+
+        return [rect, ellipse, line, point, polygon]
+
+    @pytest.fixture()
+    def image_rois(self, user1, shapes):
+        """Return Image with ROIs."""
+        image = ImageI()
+        image.name = rstring('Image for ROIs')
+        image = get_update_service(user1).saveAndReturnObject(image)
+
+        # ROI with all but one shapes
+        rois = []
+        roi = RoiI()
+        for shape in shapes[:-1]:
+            roi.addShape(shape)
+        roi.setImage(image)
+        rois.append(roi)
+
+        # roi without shapes
+        roi = RoiI()
+        roi.setImage(image)
+        rois.append(roi)
+
+        # roi without image
+        roi = RoiI()
+        roi.addShape(shapes[-1])
+        rois.append(roi)
+
+        rois = get_update_service(user1).saveAndReturnArray(rois)
+        rois.sort(key=lambda x: x.id.val)
+        return image, rois
+
+    def test_image_rois(self, user1, image_rois):
+        """Test listing ROIs and filtering by Image."""
+        image, rois = image_rois
+        conn = get_connection(user1)
+        user_name = conn.getUser().getName()
+        client = self.new_django_client(user_name, user_name)
+        version = api_settings.API_VERSIONS[-1]
+
+        # List ALL rois
+        rois_url = reverse('api_rois', kwargs={'api_version': version})
+        rsp = _get_response_json(client, rois_url, {})
+        assert_objects(conn, rsp['data'], rois, dtype="Roi", opts={'load_shapes': True})
+
+        # ROIs on the image
+        rsp = _get_response_json(client, rois_url, {'image': image.id.val})
+        assert_objects(conn, rsp['data'], rois[:2], dtype="Roi", opts={'load_shapes': True})
+


### PR DESCRIPTION
# What this PR does:

Adds support for GET of ROIs to the JSON API.
cc @waxenegger 

# Testing this PR

1. Check test is green.

1. Add ROIs to an Image or find an Image with ROIs

2. Browse from ```/api/```, follow link to ```/api/v0/m/rois/``` to show all available ROIs. ROIs should have their Shapes loaded. Test  ```/api/v0/m/rois/?image={imageId}``` to only show ROIs for that image.

3. For chosen Image, go to ```/api/v0/m/images/{imageId}/``` and follow ```url:rois``` link to ```/api/v0/m/images/{imageId}/rois/``` to see ROIs for that image.

4. Add ```?owner={owner_id}``` to filter by ROI owner.

# Related reading

https://trello.com/c/wOznF1W8/66-roi-shapes-support
