### PR TITLE
allow creation of thumbnails in all-groups context (rebased onto metadata53)

### DIFF
--- a/components/server/src/ome/services/PerGroupActor.java
+++ b/components/server/src/ome/services/PerGroupActor.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ome.api.IQuery;
+import ome.model.core.Pixels;
+import ome.parameters.Parameters;
+import ome.services.messages.ContextMessage;
+import ome.system.OmeroContext;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+
+/**
+ * Perform an operation on {@link Pixels} in contexts corresponding to the {@link Pixels}' group.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.3.1
+ */
+abstract class PerGroupActor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PerGroupActor.class);
+
+    private final OmeroContext applicationContext;
+    private final IQuery queryService;
+    private final long currentGroupId;
+
+    /**
+     * Create a new per-group actor.
+     * @param applicationContext the OMERO application context
+     * @param queryService the query service for retrieving the pixels' groups
+     * @param currentGroupId the current group ID, may be {@code -1}
+     */
+    PerGroupActor(OmeroContext applicationContext, IQuery queryService, long currentGroupId) {
+        this.applicationContext = applicationContext;
+        this.queryService = queryService;
+        this.currentGroupId = currentGroupId;
+    }
+
+    /**
+     * Act on the {@link Pixels} by setting the group context and calling {@link #actOnOneGroup(Set)} as necessary.
+     * @param pixelsIds the IDs of the {@link Pixels} on which to act
+     */
+    void actOnByGroup(Collection<Long> pixelsIds) {
+        if (pixelsIds.isEmpty()) {
+            return;
+        }
+        final SetMultimap<Long, Long> pixelsByGroup = HashMultimap.create();
+        for (final Object[] resultRow : queryService.projection("SELECT id, details.group.id FROM Pixels WHERE id IN (:ids)",
+                new Parameters().addIds(pixelsIds))) {
+            final Long pixelsId = (Long) resultRow[0];
+            final Long groupId  = (Long) resultRow[1];
+            pixelsByGroup.put(groupId, pixelsId);
+        }
+        for (final Map.Entry<Long, Collection<Long>> pixelsOneGroup : pixelsByGroup.asMap().entrySet()) {
+            final long groupId = pixelsOneGroup.getKey();
+            if (groupId == currentGroupId) {
+                actOnOneGroup((Set<Long>) pixelsOneGroup.getValue());
+            } else {
+                final Map<String, String> groupContext = new HashMap<>();
+                groupContext.put("omero.group", Long.toString(groupId));
+                try {
+                    try {
+                        applicationContext.publishMessage(new ContextMessage.Push(this, groupContext));
+                    } catch (Throwable t) {
+                        LOGGER.error("could not publish context change push", t);
+                    }
+                    actOnOneGroup((Set<Long>) pixelsOneGroup.getValue());
+                } finally {
+                    try {
+                        applicationContext.publishMessage(new ContextMessage.Pop(this, groupContext));
+                    } catch (Throwable t) {
+                        LOGGER.error("could not publish context change pop", t);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Act on the {@link Pixels}. Called within a context corresponding to the {@link Pixels}' group.
+     * @param pixelsIds the IDs of the {@link Pixels} on which to act
+     */
+    abstract protected void actOnOneGroup(Set<Long> pixelsIds);
+}

--- a/components/server/src/ome/services/PerGroupActor.java
+++ b/components/server/src/ome/services/PerGroupActor.java
@@ -47,15 +47,15 @@ abstract class PerGroupActor {
 
     private final OmeroContext applicationContext;
     private final IQuery queryService;
-    private final long currentGroupId;
+    private final Long currentGroupId;
 
     /**
      * Create a new per-group actor.
      * @param applicationContext the OMERO application context
      * @param queryService the query service for retrieving the pixels' groups
-     * @param currentGroupId the current group ID, may be {@code -1}
+     * @param currentGroupId the current group ID, may be {@code null}
      */
-    PerGroupActor(OmeroContext applicationContext, IQuery queryService, long currentGroupId) {
+    PerGroupActor(OmeroContext applicationContext, IQuery queryService, Long currentGroupId) {
         this.applicationContext = applicationContext;
         this.queryService = queryService;
         this.currentGroupId = currentGroupId;
@@ -77,7 +77,7 @@ abstract class PerGroupActor {
             pixelsByGroup.put(groupId, pixelsId);
         }
         for (final Map.Entry<Long, Collection<Long>> pixelsOneGroup : pixelsByGroup.asMap().entrySet()) {
-            final long groupId = pixelsOneGroup.getKey();
+            final Long groupId = pixelsOneGroup.getKey();
             if (groupId == currentGroupId) {
                 actOnOneGroup((Set<Long>) pixelsOneGroup.getValue());
             } else {

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1007,8 +1007,11 @@ public class ThumbnailBean extends AbstractLevel2Service
     private Map<Long, byte[]> retrieveThumbnailSet(Set<Long> pixelsIds)
     {
         // Our return value HashMap
-        Map<Long, byte[]> toReturn = new HashMap<Long, byte[]>();
+        final Map<Long, byte[]> toReturn = new HashMap<Long, byte[]>();
 
+        new PerGroupActor(applicationContext, iQuery, -1) {
+            @Override
+            protected void actOnOneGroup(Set<Long> pixelsIds) {
         List<Thumbnail> toSave = new ArrayList<Thumbnail>();
         for (Long pixelsId : pixelsIds)
         {
@@ -1076,6 +1079,8 @@ public class ThumbnailBean extends AbstractLevel2Service
         // around in the Hibernate session cache.
         iQuery.clear();
         iUpdate.flush();
+            }
+        }.actOnByGroup(pixelsIds);
         return toReturn;
     }
 

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1009,7 +1009,7 @@ public class ThumbnailBean extends AbstractLevel2Service
         // Our return value HashMap
         final Map<Long, byte[]> toReturn = new HashMap<Long, byte[]>();
 
-        new PerGroupActor(applicationContext, iQuery, -1) {
+        new PerGroupActor(applicationContext, iQuery, null) {
             @Override
             protected void actOnOneGroup(Set<Long> pixelsIds) {
                 final List<Thumbnail> toSave = new ArrayList<Thumbnail>();

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -865,7 +865,9 @@ public class ThumbnailBean extends AbstractLevel2Service
                 try {
                     applicationContext.publishMessage(new ContextMessage.Push(this, groupContext));
                 } catch (Throwable t) {
-                    log.error("could not publish context change push", t);
+                    final String errorMessage = "could not publish context change push";
+                    log.error(errorMessage, t);
+                    throw new InternalException(errorMessage + ": " + t);
                 }
                 if (rndOwnerId.equals(ownerId)) {
                     final Pixels unloadedPixels = new Pixels(pixels.getId(), false);
@@ -885,7 +887,9 @@ public class ThumbnailBean extends AbstractLevel2Service
                 try {
                     applicationContext.publishMessage(new ContextMessage.Pop(this, groupContext));
                 } catch (Throwable t) {
-                    log.error("could not publish context change pop", t);
+                    final String errorMessage = "could not publish context change pop";
+                    log.error(errorMessage, t);
+                    throw new InternalException(errorMessage + ": " + t);
                 }
             }
         }

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -844,7 +844,7 @@ public class ThumbnailBean extends AbstractLevel2Service
         }
     }
 
-    /** Actually does the work specified by {@link createThumbnail()}.*/
+    /** Actually does the work specified by {@link #createThumbnail(Integer, Integer)}. */
     private Thumbnail _createThumbnail() {
         StopWatch s1 = new Slf4JStopWatch("omero._createThumbnail");
         if (thumbnailMetadata == null) {
@@ -868,14 +868,14 @@ public class ThumbnailBean extends AbstractLevel2Service
                     log.error("could not publish context change push", t);
                 }
                 if (rndOwnerId.equals(ownerId)) {
-                    Pixels unloadedPixels = new Pixels(pixels.getId(), false);
+                    final Pixels unloadedPixels = new Pixels(pixels.getId(), false);
                     thumbnailMetadata.setPixels(unloadedPixels);
                     _setMetadataVersion(thumbnailMetadata, inProgress);
                     dirtyMetadata = true;
                 } else {
                     //new one for owner of the settings.
-                    Dimension d = new Dimension(thumbnailMetadata.getSizeX(),
-                            thumbnailMetadata.getSizeY());
+                    final Dimension d = new Dimension(thumbnailMetadata.getSizeX(),
+                                                      thumbnailMetadata.getSizeY());
                     thumbnailMetadata = ctx.createThumbnailMetadata(pixels, d);
                     _setMetadataVersion(thumbnailMetadata, inProgress);
                     thumbnailMetadata = iUpdate.saveAndReturnObject(thumbnailMetadata);

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -524,10 +524,15 @@ public class ThumbnailCtx
         return settingsLastUpdated.after(metadataLastUpdated);
     }
 
-    class ExtendedGraphCriticalCheck extends ActPerGroup {
-        boolean isCritical;
+    /**
+     * Check if a {@link Pixels} is extended graph critical in its own group's context.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.3.1
+     */
+    private class ExtendedGraphCriticalCheck extends ActPerGroup {
+        private boolean isCritical;
 
-        ExtendedGraphCriticalCheck(long pixelsId) {
+        private ExtendedGraphCriticalCheck(long pixelsId) {
             actOnByGroup(Collections.singleton(pixelsId));
         }
 
@@ -1140,8 +1145,17 @@ public class ThumbnailCtx
         return thumb;
     }
 
+    /**
+     * Perform an operation on {@link Pixels} in contexts corresponding to the {@link Pixels}' group.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.3.1
+     */
     private abstract class ActPerGroup {
 
+        /**
+         * Act on the {@link Pixels} by setting the group context and calling {@link #actOnOneGroup(Set)} as necessary.
+         * @param pixelsIds the IDs of the {@link Pixels} on which to act
+         */
         void actOnByGroup(Collection<Long> pixelsIds) {
             if (pixelsIds.isEmpty()) {
                 return;
@@ -1179,6 +1193,10 @@ public class ThumbnailCtx
             }
         }
 
+        /**
+         * Act on the {@link Pixels}. Called within a context corresponding to the {@link Pixels}' group.
+         * @param pixelsIds the IDs of the {@link Pixels} on which to act
+         */
         abstract protected void actOnOneGroup(Set<Long> pixelsIds);
         }
 }

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -643,7 +643,7 @@ public class ThumbnailCtx
      * dimension pools. We're extended graph critical if:
      * <ul>
      *   <li>
-     *      <code>isGraphGritical() == true</code> and the Pixels set does not
+     *      <code>isGraphCritical() == true</code> and the Pixels set does not
      *      belong to us.
      *   </li>
      *   <li>

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2010-2014 University of Dundee. All rights reserved.
+ *   Copyright 2010-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -661,7 +661,7 @@ public class ThumbnailCtx
         Permissions currentGroupPermissions = ec.getCurrentGroupPermissions();
         Permissions readOnly = Permissions.parseString("rwr---");
 
-        if (ec.getCurrentShareId() != null)
+        if (ec.getCurrentShareId() != null || ec.getCurrentGroupId() < 0)
         {
             return true;
         }

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -526,7 +526,12 @@ public class ThumbnailCtx
 
         private ExtendedGraphCriticalCheck(long pixelsId) {
             super(applicationContext, queryService, securitySystem.getEventContext().getCurrentEventId());
-            actOnByGroup(Collections.singleton(pixelsId));
+            if (securitySystem.getEventContext().getCurrentShareId() == null) {
+                actOnByGroup(Collections.singleton(pixelsId));
+            } else {
+                /* in a share */
+                isCritical = true;
+            }
         }
 
         @Override

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -661,7 +661,7 @@ public class ThumbnailCtx
         Permissions currentGroupPermissions = ec.getCurrentGroupPermissions();
         Permissions readOnly = Permissions.parseString("rwr---");
 
-        if (ec.getCurrentShareId() != null || ec.getCurrentGroupId() < 0)
+        if (ec.getCurrentShareId() != null)
         {
             return true;
         }

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -245,6 +245,7 @@ public class ThumbnailStoreTest extends AbstractServerTest {
         ThumbnailStorePrx svc = factory.createThumbnailStore();
         svc.setPixelsId(pixelsIdα);
         final byte[] thumbnailα = svc.getThumbnailByLongestSide(null);
+        Assert.assertTrue(thumbnailα.length > 0);
         svc.close();
 
         /* import the image as another user in another group and get its thumbnail */
@@ -253,6 +254,7 @@ public class ThumbnailStoreTest extends AbstractServerTest {
         svc = factory.createThumbnailStore();
         svc.setPixelsId(pixelsIdβ);
         final byte[] thumbnailβ = svc.getThumbnailByLongestSide(null);
+        Assert.assertTrue(thumbnailβ.length > 0);
 
         /* have that other user use all-groups context to fetch both thumbnails at once */
         final List<Long> pixelsIdsαβ = ImmutableList.of(pixelsIdα, pixelsIdβ);

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -260,22 +260,9 @@ public class ThumbnailStoreTest extends AbstractServerTest {
             }
         }
 
+        /* import the image as another user in another group */
         setUpNewUserWithImporter();
-
-        try {
-            /* import the image as another user in another group and get its thumbnail */
-            pixelsIdβ = importFile(importer, file, "fake", false).get(0).getId().getValue();
-            svc = factory.createThumbnailStore();
-            svc.setPixelsId(pixelsIdβ);
-            Assert.assertEquals(svc.getThumbnailByLongestSide(null), thumbnail);
-        } finally {
-            if (svc != null) {
-                {
-                    svc.close();
-                    svc = null;
-                }
-            }
-        }
+        pixelsIdβ = importFile(importer, file, "fake", false).get(0).getId().getValue();
 
         final Map<Long, byte[]> thumbnails;
 

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -283,7 +283,7 @@ public class ThumbnailStoreTest extends AbstractServerTest {
 
         /* check that the thumbnails are as expected */
         Assert.assertTrue(thumbnail.length > 0);
-        Assert.assertEquals(thumbnail, thumbnails.get(pixelsIdα));
-        Assert.assertEquals(thumbnail, thumbnails.get(pixelsIdβ));
+        Assert.assertEquals(thumbnails.get(pixelsIdα), thumbnail);
+        Assert.assertEquals(thumbnails.get(pixelsIdβ), thumbnail);
     }
 }

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -1,7 +1,7 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
  *
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,8 +32,11 @@ import omero.api.ThumbnailStorePrx;
 import omero.model.Pixels;
 
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Collections of tests for the <code>ThumbnailStore</code> service.
@@ -52,14 +55,12 @@ public class ThumbnailStoreTest extends AbstractServerTest {
     private OMEROMetadataStoreClient importer;
 
     /**
-     * Overridden to initialize the list.
-     *
-     * @see AbstractServerTest#setUp()
+     * Set up a new user in a new group and set the local {@code importer} field.
+     * @throws Exception unexpected
      */
-    @Override
-    @BeforeClass
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeMethod
+    protected void setUpNewUserWithImporter() throws Exception {
+        newUserAndGroup("rwr-r-");
         importer = new OMEROMetadataStoreClient();
         importer.initialize(factory);
     }
@@ -228,5 +229,42 @@ public class ThumbnailStoreTest extends AbstractServerTest {
             Assert.assertTrue(values.length > 0);
         }
         svc.close();
+    }
+
+    /**
+     * Test that thumbnails can be retrieved from multiple groups at once.
+     * @throws Throwable unexpected
+     */
+    @Test
+    public void testGetThumbnailsMultipleGroups() throws Throwable {
+        /* create a fake image file */
+        final File file = File.createTempFile(getClass().getSimpleName(), ".fake");
+
+        /* import the image as one user in one group and get its thumbnail */
+        final long pixelsIdα = importFile(importer, file, "fake", false).get(0).getId().getValue();
+        ThumbnailStorePrx svc = factory.createThumbnailStore();
+        svc.setPixelsId(pixelsIdα);
+        final byte[] thumbnailα = svc.getThumbnailByLongestSide(null);
+        svc.close();
+
+        /* import the image as another user in another group and get its thumbnail */
+        setUpNewUserWithImporter();
+        final long pixelsIdβ = importFile(importer, file, "fake", false).get(0).getId().getValue();
+        svc = factory.createThumbnailStore();
+        svc.setPixelsId(pixelsIdβ);
+        final byte[] thumbnailβ = svc.getThumbnailByLongestSide(null);
+
+        /* have that other user use all-groups context to fetch both thumbnails at once */
+        final List<Long> pixelsIdsαβ = ImmutableList.of(pixelsIdα, pixelsIdβ);
+        final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
+        final Map<Long, byte[]> thumbs = svc.getThumbnailByLongestSideSet(null, pixelsIdsαβ, allGroupsContext);
+
+        /* check that the thumbnails are as before */
+        Assert.assertEquals(thumbnailα, thumbs.get(pixelsIdα));
+        Assert.assertEquals(thumbnailβ, thumbs.get(pixelsIdβ));
+
+        /* clean up */
+        svc.close();
+        file.delete();
     }
 }


### PR DESCRIPTION

This is the same as gh-5207 but rebased onto metadata53.

----

# What this PR does

Adjusts the heart of the server's thumbnail generation so that in a `omero.group: -1` context thumbnails can still be generated, by grouping the pixels objects by group and creating their thumbnails in the corresponding group context.

# Testing this PR

Experiment with the thumbnail service to ensure that this PR does not cause any regressions.

Check if the new https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/ThumbnailStoreTest/testGetThumbnailsMultipleGroups/ test passes and looks to relate to what this PR does.

# Related reading

https://trello.com/c/bJqd3SkJ/39-getthumbnailbylongestsideset-doesn-t-accept-ctx

                