### PR TITLE
Fix render py (rebased onto metadata53) 

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -803,6 +803,12 @@ class BaseControl(object):
             break
         return root_pass
 
+    def _add_wait(self, parser, default=-1):
+        parser.add_argument(
+            "--wait", type=long,
+            help="Number of seconds to wait for the processing to complete "
+            "(Indefinite < 0; No wait=0).", default=default)
+
     def get_subcommands(self):
         """Return a list of subcommands"""
         parser = Parser()
@@ -1600,10 +1606,7 @@ class CmdControl(BaseControl):
 
     def _configure(self, parser):
         parser.set_defaults(func=self.main_method)
-        parser.add_argument(
-            "--wait", type=long,
-            help="Number of seconds to wait for the processing to complete "
-            "(Indefinite < 0; No wait=0).", default=-1)
+        self._add_wait(parser, default=-1)
 
     def main_method(self, args):
         client = self.ctx.conn(args)
@@ -1716,10 +1719,7 @@ class GraphControl(CmdControl):
 
     def _configure(self, parser):
         parser.set_defaults(func=self.main_method)
-        parser.add_argument(
-            "--wait", type=long,
-            help="Number of seconds to wait for the processing to complete "
-            "(Indefinite < 0; No wait=0).", default=-1)
+        self._add_wait(parser, default=-1)
         parser.add_argument(
             "--include",
             help="Modifies the given option by including a list of objects")

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1370,7 +1370,17 @@ class CLI(cmd.Cmd, Context):
         in the parser
         """
 
-        for plugin_path in self._plugin_paths:
+        paths = set(self._plugin_paths)
+        for x in sys.path:
+            x = path(x)
+            if x.isdir():
+                x = x / "omero" / "plugins"
+                if x.exists():
+                    paths.add(x)
+            else:
+                if self.isdebug:
+                    print "Can't load %s" % x
+        for plugin_path in paths:
             self.loadpath(path(plugin_path))
 
         self.configure_plugins()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7613,7 +7613,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 self._re = self._prepareRE(rdid=rdid)
             except omero.ValidationException:
                 logger.debug('on _prepareRE()', exc_info=True)
-                self._re = None
+                self._closeRE()
         return self._re is not None
 
     def resetRDefs(self):
@@ -8192,8 +8192,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             rv[i] = float(level)/sizeXList[0]
         return rv
 
+    @assert_re()
     def setActiveChannels(self, channels, windows=None, colors=None,
-                          reverseMaps=None):
+                          reverseMaps=None, noRE=False):
         """
         Sets the active channels on the rendering engine.
         Also sets rendering windows and channel colors
@@ -8222,7 +8223,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         abs_channels = [abs(c) for c in channels]
         idx = 0     # index of windows/colors args above
-        for c in range(len(self.getChannels())):
+        for c in range(len(self.getChannels(noRE=noRE))):
             self._re.setActive(c, (c+1) in channels, self._conn.SERVICE_OPTS)
             if (c+1) in channels:
                 if (reverseMaps is not None and
@@ -8601,43 +8602,46 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         # Prepare the rendering engine parameters on the ImageWrapper.
         re = self._prepareRE()
-        z = re.getDefaultZ()
-        t = re.getDefaultT()
-        x = 0
-        y = 0
-        size_x = self.getSizeX()
-        size_y = self.getSizeY()
-        tile_width, tile_height = re.getTileSize()
-        tiles_wide = math.ceil(float(size_x) / tile_width)
-        tiles_high = math.ceil(float(size_y) / tile_height)
-        # Since the JPEG 2000 algorithm is iterative and rounds pixel counts
-        # at each resolution level we're doing the resulting tile size
-        # calculations in a loop. Also, since the image is physically tiled
-        # the resulting size is a multiple of the tile size and not the
-        # iterative quotient of a 2**(resolutionLevels - 1).
-        for i in range(1, re.getResolutionLevels()):
-            tile_width = round(tile_width / 2.0)
-            tile_height = round(tile_height / 2.0)
-        width = int(tiles_wide * tile_width)
-        height = int(tiles_high * tile_height)
-        jpeg_data = self.renderJpegRegion(z, t, x, y, width, height, level=0)
-        if size is None:
-            return jpeg_data
-        # We've been asked to scale the image by its longest side so we'll
-        # perform that operation until the server has the capability of
-        # doing so.
-        ratio = float(size) / max(width, height)
-        if width > height:
-            size = (int(size), int(height * ratio))
-        else:
-            size = (int(width * ratio), int(size))
-        jpeg_data = Image.open(StringIO(jpeg_data))
-        jpeg_data.thumbnail(size, Image.ANTIALIAS)
-        ImageDraw.Draw(jpeg_data)
-        f = StringIO()
-        jpeg_data.save(f, "JPEG")
-        f.seek(0)
-        return f.read()
+        try:
+            z = re.getDefaultZ()
+            t = re.getDefaultT()
+            x = 0
+            y = 0
+            size_x = self.getSizeX()
+            size_y = self.getSizeY()
+            tile_width, tile_height = re.getTileSize()
+            tiles_wide = math.ceil(float(size_x) / tile_width)
+            tiles_high = math.ceil(float(size_y) / tile_height)
+            # Since the JPEG 2000 algorithm is iterative and rounds pixel counts
+            # at each resolution level we're doing the resulting tile size
+            # calculations in a loop. Also, since the image is physically tiled
+            # the resulting size is a multiple of the tile size and not the
+            # iterative quotient of a 2**(resolutionLevels - 1).
+            for i in range(1, re.getResolutionLevels()):
+                tile_width = round(tile_width / 2.0)
+                tile_height = round(tile_height / 2.0)
+            width = int(tiles_wide * tile_width)
+            height = int(tiles_high * tile_height)
+            jpeg_data = self.renderJpegRegion(z, t, x, y, width, height, level=0)
+            if size is None:
+                return jpeg_data
+            # We've been asked to scale the image by its longest side so we'll
+            # perform that operation until the server has the capability of
+            # doing so.
+            ratio = float(size) / max(width, height)
+            if width > height:
+                size = (int(size), int(height * ratio))
+            else:
+                size = (int(width * ratio), int(size))
+            jpeg_data = Image.open(StringIO(jpeg_data))
+            jpeg_data.thumbnail(size, Image.ANTIALIAS)
+            ImageDraw.Draw(jpeg_data)
+            f = StringIO()
+            jpeg_data.save(f, "JPEG")
+            f.seek(0)
+            return f.read()
+        finally:
+            re.close()
 
     @assert_re()
     def renderJpegRegion(self, z, t, x, y, width, height, level=None,
@@ -8674,7 +8678,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 except omero.SecurityViolation:  # pragma: no cover
                     self._obj.clearPixels()
                     self._obj.pixelsLoaded = False
-                    self._re = None
+                    self._closeRE()
                     return self.renderJpeg(z, t, None)
             rv = self._re.renderCompressed(self._pd, self._conn.SERVICE_OPTS)
             return rv
@@ -8687,8 +8691,17 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             # hangs
             self._obj.clearPixels()
             self._obj.pixelsLoaded = False
-            self._re = None
+            self._closeRE()
             raise
+
+    def _closeRE(self):
+        try:
+            if self._re:
+                self._re.close()
+        except Exception, e:
+            logger.warn("Failed to close " + self._re)
+        finally:
+            self._re = None  # This should be the ONLY location to null _re!
 
     @assert_re()
     def renderJpeg(self, z=None, t=None, compression=0.9):
@@ -8717,7 +8730,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 except omero.SecurityViolation:  # pragma: no cover
                     self._obj.clearPixels()
                     self._obj.pixelsLoaded = False
-                    self._re = None
+                    self._closeRE()
                     return self.renderJpeg(z, t, None)
             projection = self.PROJECTIONS.get(self._pr, -1)
             if not isinstance(
@@ -8743,7 +8756,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             # hangs
             self._obj.clearPixels()
             self._obj.pixelsLoaded = False
-            self._re = None
+            self._closeRE()
             raise
 
     def exportOmeTiff(self, bufsize=0):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1540,6 +1540,7 @@ class _BlitzGateway (object):
         self._user = None
         self._userid = None
         self._proxies = NoProxies()
+        self._tracked_services = dict()
         if self.c is None:
             self._resetOmeroClient()
         else:
@@ -1556,6 +1557,51 @@ class _BlitzGateway (object):
 
         # The properties we are setting through the interface
         self.setIdentity(username, passwd, not clone)
+
+    def _register_service(self, service_string, stack):
+        """
+        Register the results of traceback.extract_stack() at the time
+        that a service was created.
+        """
+        service_string = str(service_string)
+        self._tracked_services[service_string] = stack
+        logger.info("Registered %s" % service_string)
+
+    def _unregister_service(self, service_string):
+        """
+        Called on close of a service.
+        """
+        service_string = str(service_string)
+        if service_string in self._tracked_services:
+            del self._tracked_services[service_string]
+            logger.info("Unregistered %s" % service_string)
+        else:
+            logger.warn("Cannot find registered service %s" % service_string)
+
+    def _assert_unregistered(self, prefix="Service left open!"):
+        """
+        Log an ERROR for every stateful service that is open
+        and was registered by this BlitzGateway instance.
+
+        Return the number of unclosed services found.
+        """
+
+        try:
+            stateful_services = self.c.getStatefulServices()
+        except Exception, e:
+            logger.warn("No services could be found.", e)
+            stateful_services = []
+
+        count = 0
+        for s in stateful_services:
+            service_string = str(s)
+            stack_list = self._tracked_services.get(service_string, [])
+            if stack_list:
+                count += 1
+                stack_msg = "".join(traceback.format_list(stack_list))
+                logger.error("%s - %s\n%s" % (
+                    prefix, service_string, stack_msg))
+        return count
 
     def createServiceOptsDict(self):
         serviceOpts = ServiceOptsDict(self.c.getImplicitContext().getContext())
@@ -1864,8 +1910,9 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-#    def __del__ (self):
-#        logger.debug("##GARBAGE COLLECTOR KICK IN")
+    def __del__ (self):
+        logger.debug("##GARBAGE COLLECTOR KICK IN")
+        self._assert_unregistered()
 
     def _createProxies(self):
         """
@@ -4592,6 +4639,7 @@ class ProxyObjectWrapper (object):
 
         if self._obj and isinstance(
                 self._obj, omero.api.StatefulServiceInterfacePrx):
+            self._conn._unregister_service(str(self._obj))
             self._obj.close(*args, **kwargs)
         self._obj = None
 
@@ -4612,7 +4660,10 @@ class ProxyObjectWrapper (object):
             if self._func_str is None:
                 return self._cast_to(self._sf.getByName(self._service_name))
             else:
-                return getattr(self._sf, self._func_str)()
+                obj = getattr(self._sf, self._func_str)()
+                if isinstance(obj, omero.api.StatefulServiceInterfacePrx):
+                    conn._register_service(str(obj), traceback.extract_stack())
+                return obj
         self._create_func = cf
         if self._obj is not None:
             try:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1910,7 +1910,7 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-    def __del__ (self):
+    def __del__(self):
         logger.debug("##GARBAGE COLLECTOR KICK IN")
         self._assert_unregistered()
 
@@ -8663,17 +8663,18 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             tile_width, tile_height = re.getTileSize()
             tiles_wide = math.ceil(float(size_x) / tile_width)
             tiles_high = math.ceil(float(size_y) / tile_height)
-            # Since the JPEG 2000 algorithm is iterative and rounds pixel counts
-            # at each resolution level we're doing the resulting tile size
-            # calculations in a loop. Also, since the image is physically tiled
-            # the resulting size is a multiple of the tile size and not the
-            # iterative quotient of a 2**(resolutionLevels - 1).
+            # Since the JPEG 2000 algorithm is iterative and rounds pixel
+            # counts at each resolution level we're doing the resulting tile
+            # size calculations in a loop. Also, since the image is physically
+            # tiled the resulting size is a multiple of the tile size and not
+            # the iterative quotient of a 2**(resolutionLevels - 1).
             for i in range(1, re.getResolutionLevels()):
                 tile_width = round(tile_width / 2.0)
                 tile_height = round(tile_height / 2.0)
             width = int(tiles_wide * tile_width)
             height = int(tiles_high * tile_height)
-            jpeg_data = self.renderJpegRegion(z, t, x, y, width, height, level=0)
+            jpeg_data = self.renderJpegRegion(
+                z, t, x, y, width, height, level=0)
             if size is None:
                 return jpeg_data
             # We've been asked to scale the image by its longest side so we'll
@@ -8738,8 +8739,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             logger.debug(traceback.format_exc())
             return None
         except Ice.MemoryLimitException:  # pragma: no cover
-            # Make sure renderCompressed isn't called again on this re, as it
-            # hangs
+            # Make sure renderCompressed isn't called again on this re,
+            # as it hangs
             self._obj.clearPixels()
             self._obj.pixelsLoaded = False
             self._closeRE()
@@ -8747,10 +8748,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
     def _closeRE(self):
         try:
-            if self._re:
+            if self._re is not None:
                 self._re.close()
         except Exception, e:
             logger.warn("Failed to close " + self._re)
+            logger.debug(e)
         finally:
             self._re = None  # This should be the ONLY location to null _re!
 

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -151,6 +151,7 @@ class MetadataControl(BaseControl):
                               type=long,
                               default=1000,
                               help="Number of objects to process at once")
+        self._add_wait(populate)
 
         for x in (summary, original, bulkanns, measures, mapanns, allanns,
                   rois, populate, populateroi):
@@ -428,7 +429,14 @@ class MetadataControl(BaseControl):
                             cfg=args.cfg, cfgid=cfgid, attach=args.attach)
         ctx.parse()
         if not args.dry_run:
-            ctx.write_to_omero(batch_size=args.batch)
+            wait = args.wait
+            if not wait:
+                loops = 0
+                ms = 0
+            else:
+                ms = 5000
+                loops = int((wait * 1000) / ms) + 1
+            ctx.write_to_omero(batch_size=args.batch, loops=loops, ms=ms)
 
     def rois(self, args):
         "Manage ROIs"

--- a/components/tools/OmeroPy/src/omero/plugins/render.py
+++ b/components/tools/OmeroPy/src/omero/plugins/render.py
@@ -197,28 +197,6 @@ class RenderObject(object):
             self.levels = image._re.getResolutionLevels()
             self.zoomLevelScaling = image.getZoomLevelScaling()
 
-        """
-        self.nominalMagnification = \
-            image.getObjectiveSettings() is not None \
-            and image.getObjectiveSettings() \
-            .getObjective().getNominalMagnification() \
-        or None
-
-
-    try:
-        rv.update({
-            'interpolate': interpolate,
-            'size': {'width': image.getSizeX(),
-                     'height': image.getSizeY(),
-                     'z': image.getSizeZ(),
-                     't': image.getSizeT(),
-                     'c': image.getSizeC()},
-            'pixel_size': {'x': image.getPixelSizeX(),
-                           'y': image.getPixelSizeY(),
-                           'z': image.getPixelSizeZ()},
-            })
-        """
-
         self.range = image.getPixelRange()
         self.channels = map(lambda x: ChannelObject(x), image.getChannels())
         self.model = image.isGreyscaleRenderingModel() and \

--- a/components/tools/OmeroPy/src/omero/plugins/render.py
+++ b/components/tools/OmeroPy/src/omero/plugins/render.py
@@ -287,12 +287,6 @@ class RenderControl(BaseControl):
             "channels",
             help="Rendering definition, local file or OriginalFile:ID")
 
-    def _check_services(self, client):
-        for s in client.getStatefulServices():
-            # FIXME: it's not currently clear if these services
-            # were created by the current process
-            self.ctx.err("Service left open! - %s" % s)
-
     def _lookup(self, gateway, type, oid):
         # TODO: move _lookup to a _configure type
         obj = gateway.getObject(type, oid)
@@ -352,13 +346,13 @@ class RenderControl(BaseControl):
                     first = False
             finally:
                 ro.close()
-        self._check_services(client)
+        gateway._assert_unregistered("info")
 
     def copy(self, args):
         client = self.ctx.conn(args)
         gateway = BlitzGateway(client_obj=client)
         self._copy(gateway, args.object, args.target, args.skipthumbs)
-        self._check_services(client)
+        gateway._assert_unregistered("copy")
 
     def _copy(self, gateway, obj, target, skipthumbs, close=True):
         """
@@ -491,7 +485,7 @@ class RenderControl(BaseControl):
         if namedict:
             self._update_channel_names(gateway, iids, namedict)
 
-        self._check_services(client)
+        gateway._assert_unregistered("edit")
 
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/render.py
+++ b/components/tools/OmeroPy/src/omero/plugins/render.py
@@ -469,7 +469,8 @@ class RenderControl(BaseControl):
                         img.setColorRenderingModel()
 
                 img.saveDefaults()
-                self.ctx.dbg("Updated rendering settings for Image:%s" % img.id)
+                self.ctx.dbg(
+                    "Updated rendering settings for Image:%s" % img.id)
                 if not args.skipthumbs:
                     self._generate_thumbs([img])
 
@@ -477,7 +478,9 @@ class RenderControl(BaseControl):
                     # Edit first image only, copy to rest
                     # Don't close source image until outer
                     # loop is done.
-                    self._copy_single(gateway, img, args.object, args.skipthumbs)
+                    self._copy_single(gateway,
+                                      img, args.object,
+                                      args.skipthumbs)
                     break
             finally:
                 img._closeRE()

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -352,14 +352,14 @@ class ITest(object):
         return images
 
     def import_plates(self, client=None, plates=1, plate_acqs=1, plate_cols=1,
-                      plate_rows=1, fields=1, **kwargs):
+                      plate_rows=1, fields=1, screens=0, **kwargs):
         """
         Creates fake plates and imports them.
         """
-
         if client is None:
             client = self.client
 
+        kwargs["screens"] = screens
         kwargs["plates"] = plates
         kwargs["plateAcqs"] = plate_acqs
         kwargs["plateCols"] = plate_cols

--- a/components/tools/OmeroPy/test/integration/clitest/test_render.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_render.py
@@ -67,6 +67,7 @@ class TestRender(CLITest):
                         size=(96,), direct=False)
                     img._closeRE()
         self.imgobj._closeRE()
+        assert not self.gw._assert_unregistered("create_image")
 
     def get_target_imageids(self, target):
         if target in (self.idonly, self.imageid):
@@ -193,6 +194,7 @@ class TestRender(CLITest):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
             img._closeRE()
+        assert not gw._assert_unregistered("testEdit")
 
     # Once testEdit is no longer broken testEditSingleC could be merged into
     # it with sizec and greyscale parameters
@@ -217,9 +219,14 @@ class TestRender(CLITest):
         for iid in iids:
             # Get the updated object
             img = gw.getObject('Image', iid)
+            # Note: calling _prepareRE below does NOT suffice!
+            img._prepareRenderingEngine()  # Call *before* getChannels
+            # Passing noRE to getChannels below also prevents leaking
+            # the RenderingEngine but then Nones are returned later.
             channels = img.getChannels()
             assert len(channels) == sizec
             for c in xrange(len(channels)):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
             img._closeRE()
+        assert not gw._assert_unregistered("testEditSingleC")

--- a/components/tools/OmeroPy/test/integration/clitest/test_render.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_render.py
@@ -62,8 +62,11 @@ class TestRender(CLITest):
         for p in self.plates:
             for w in p.listChildren():
                 for i in range(w.countWellSample()):
-                    w.getImage(index=i).getThumbnail(
+                    img = w.getImage(index=i)
+                    img.getThumbnail(
                         size=(96,), direct=False)
+                    img._closeRE()
+        self.imgobj._closeRE()
 
     def get_target_imageids(self, target):
         if target in (self.idonly, self.imageid):
@@ -189,6 +192,7 @@ class TestRender(CLITest):
             for c in xrange(len(channels)):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
+            img._closeRE()
 
     # Once testEdit is no longer broken testEditSingleC could be merged into
     # it with sizec and greyscale parameters
@@ -218,3 +222,4 @@ class TestRender(CLITest):
             for c in xrange(len(channels)):
                 self.assert_channel_rdef(channels[c], rd['channels'][c + 1])
             self.assert_image_rmodel(img, expected_greyscale)
+            img._closeRE()

--- a/components/tools/OmeroPy/test/integration/clitest/test_render.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_render.py
@@ -47,7 +47,7 @@ class TestRender(CLITest):
     def create_image(self, sizec=4):
         self.gw = BlitzGateway(client_obj=self.client)
         self.plates = []
-        for plate in self.importPlates(fields=2, sizeC=sizec):
+        for plate in self.importPlates(fields=2, sizeC=sizec, screens=1):
             self.plates.append(self.gw.getObject("Plate", plate.id.val))
         # Now pick the first Image
         self.imgobj = list(self.plates[0].listChildren())[0].getImage(index=0)

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -961,7 +961,7 @@ class TestPopulateMetadata(ITest):
         if batch_size is None:
             ctx.write_to_omero()
         else:
-            ctx.write_to_omero(batch_size=batch_size)
+            ctx.write_to_omero(batch_size=batch_size, loops=10, ms=250)
 
         # Get file annotations
         anns = fixture.get_annotations()
@@ -1069,14 +1069,14 @@ class TestPopulateMetadata(ITest):
         ctx = DeleteMapAnnotationContext(
             self.client, fixture1.get_target(), cfg=fixture1.get_cfg())
         ctx.parse()
-        ctx.write_to_omero()
+        ctx.write_to_omero(loops=10, ms=250)
         assert len(fixture1.get_child_annotations()) == 0
         assert len(fixture2.get_child_annotations()) == fixture2.annCount
 
         ctx = DeleteMapAnnotationContext(
             self.client, fixture2.get_target(), cfg=fixture2.get_cfg())
         ctx.parse()
-        ctx.write_to_omero()
+        ctx.write_to_omero(loops=10, ms=250)
         assert len(fixture2.get_child_annotations()) == 0
         assert len(fixture1.get_all_map_annotations()) == 0
         assert len(fixture2.get_all_map_annotations()) == 0


### PR DESCRIPTION
This is the same as gh-4872 but rebased onto metadata53 and #4988 #5053 #5163

----

See https://github.com/jburel/openmicroscopy/pull/11

This should fix the currently failing metadata52 tests.


                