### PR TITLE
Add optional args param to build_url, make api_version optional

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -40,7 +40,7 @@ from omeroweb.api.decorators import login_required, json_response
 from omeroweb.webgateway.util import getIntOrDefault
 
 
-def build_url(request, name, api_version, **kwargs):
+def build_url(request, name, api_version, *args, **kwargs):
     """
     Helper for generating urls within /api json responses.
 
@@ -52,8 +52,9 @@ def build_url(request, name, api_version, **kwargs):
     @param name:            Name of the url
     @param api_version      Version string
     """
-    kwargs['api_version'] = api_version
-    url = reverse(name, kwargs=kwargs)
+    if api_version:
+        kwargs['api_version'] = api_version
+    url = reverse(name, args=args, kwargs=kwargs)
     if api_settings.API_ABSOLUTE_URL is None:
         return request.build_absolute_uri(url)
     else:


### PR DESCRIPTION
# What this PR does

Allows non-keyword args to be passed to `api.build_url` so absolute URLs can be constructed by omeroweb. In conjunction with https://github.com/openmicroscopy/openmicroscopy/pull/5245 this includes all required changes from https://github.com/openmicroscopy/openmicroscopy/pull/4744 (some commits were already rebased to develop, others are unnecessary following the addition of `omero.web.api.absolute_url` in mainline.

# Testing this PR
See https://github.com/openmicroscopy/openmicroscopy/pull/5245

# Related reading
There was some discussion in Slack about how best to fix `build_url`.
@aleksandra-tarkowska @will-moore 