### PR TITLE
Social media absolute url config

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -35,6 +35,7 @@ from omero_version import build_year
 from marshal import imageMarshal, shapeMarshal, rgb_int2rgba
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.views.generic import View
+from omeroweb.api.views import build_url
 from omeroweb.webadmin.forms import LoginForm
 from omeroweb.decorators import get_client_ip
 from omeroweb.webadmin.webadmin_utils import upgradeCheck
@@ -2137,13 +2138,9 @@ def full_viewer(request, iid, conn=None, **kwargs):
         if opengraph or twitter:
             prefix = kwargs.get(
                 'thumbprefix', 'webgateway.views.render_thumbnail')
-
-            def urlprefix(iid):
-                return reverse(prefix, args=(iid,))
-
-            image_preview = request.build_absolute_uri(urlprefix(iid))
-            page_url = request.build_absolute_uri(reverse(
-                'webgateway.views.full_viewer', args=(iid,)))
+            image_preview = build_url(request, prefix, None, iid)
+            page_url = build_url(
+                request, 'webgateway.views.full_viewer', None, iid)
 
         d = {'blitzcon': conn,
              'image': image,


### PR DESCRIPTION
# What this PR does

Allows absolute URL for social media to be overriden by the OMERO.web administrator, the default is to use Django's `build_absolute_uri` which probably uses the `Host` header sent by the client.

--depends-on https://github.com/openmicroscopy/openmicroscopy/pull/5244

In conjunction with https://github.com/openmicroscopy/openmicroscopy/pull/5244 this includes all required changes from https://github.com/openmicroscopy/openmicroscopy/pull/4744 (some commits were already rebased to develop, others are unnecessary following the addition of `omero.web.api.absolute_url` in mainline.


# Testing this PR

1. Configure a public web user, enable social media options, e.g. https://github.com/manics/deployment/blob/9bba3a5c7223acb6b9f01c16fc5435778796d2e8/ansible/group_vars/omero-hosts.yml#L109
2. Check the twitter and opengraph metadata is present in the HTML source of the full image viewer
3. Set a custom value for `omero.web.api.absolute_url`, check this is reflected in the hard-coded URL.

# Related reading

https://trello.com/c/z2U5K6ht/1-omero-5-3-migration

@aleksandra-tarkowska 