### PR TITLE
Delete and create bulk-map-annotations by namespace (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -410,7 +410,8 @@ class MetadataControl(BaseControl):
         context_class = dict(self.POPULATE_CONTEXTS)[args.context]
 
         if args.localcfg:
-            localcfg = pydict_text_io.load(args.localcfg)
+            localcfg = pydict_text_io.load(
+                args.localcfg, session=client.getSession())
         else:
             localcfg = {}
 

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -20,7 +20,7 @@ from omero.cli import CLI
 from omero.cli import ProxyStringType
 from omero.constants import namespaces
 from omero.gateway import BlitzGateway
-from omero.util import populate_metadata, populate_roi
+from omero.util import populate_metadata, populate_roi, pydict_text_io
 from omero.util.metadata_utils import NSBULKANNOTATIONSCONFIG
 from omero.util.metadata_utils import NSBULKANNOTATIONSRAW
 
@@ -201,6 +201,9 @@ class MetadataControl(BaseControl):
 
         populate.add_argument("--attach", action="store_true", help=(
             "Upload input or configuration files and attach to parent object"))
+
+        populate.add_argument("--localcfg", help=(
+            "Local configuration file or a JSON object string"))
 
         populateroi.add_argument(
             "--measurement", type=int, default=None,
@@ -406,6 +409,11 @@ class MetadataControl(BaseControl):
 
         context_class = dict(self.POPULATE_CONTEXTS)[args.context]
 
+        if args.localcfg:
+            localcfg = pydict_text_io.load(args.localcfg)
+        else:
+            localcfg = {}
+
         fileid = args.fileid
         cfgid = args.cfgid
 
@@ -426,7 +434,8 @@ class MetadataControl(BaseControl):
 
         # Note some contexts only support a subset of these args
         ctx = context_class(client, args.obj, file=args.file, fileid=fileid,
-                            cfg=args.cfg, cfgid=cfgid, attach=args.attach)
+                            cfg=args.cfg, cfgid=cfgid, attach=args.attach,
+                            options=localcfg)
         ctx.parse()
         if not args.dry_run:
             wait = args.wait

--- a/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
@@ -26,8 +26,8 @@ Utilities for manipulating map-annotations used as metadata
 import logging
 from omero.model import NamedValue
 from omero.rtypes import rstring, unwrap
-from omero.sys import ParametersI
-
+# For complicated reasons `from omero.sys import ParametersI` doesn't work
+from omero_sys_ParametersI import ParametersI
 
 log = logging.getLogger("omero.util.metadata_mapannotations")
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1084,7 +1084,8 @@ class _QueryContext(object):
 
 def get_config(session, cfg=None, cfgid=None):
     if cfgid:
-        cfgdict = pydict_text_io.load('OriginalFile:%d' % cfgid)
+        cfgdict = pydict_text_io.load(
+            'OriginalFile:%d' % cfgid, session=session)
     elif cfg:
         cfgdict = pydict_text_io.load(cfg)
     else:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1480,7 +1480,10 @@ class DeleteMapAnnotationContext(_QueryContext):
         except KeyError:
             pass
 
-        nss = set([omero.constants.namespaces.NSBULKANNOTATIONS])
+        nss = set([
+            omero.constants.namespaces.NSBULKANNOTATIONS,
+            NSBULKANNOTATIONSCONFIG,
+        ])
         if self.column_cfgs:
             for c in self.column_cfgs:
                 try:
@@ -1599,17 +1602,19 @@ class DeleteMapAnnotationContext(_QueryContext):
                  nss, sum(len(v) for v in self.mapannids.values()))
         log.debug("MapAnnotationLinks in %s: %s", nss, self.mapannids)
 
-        if self.attach:
-            nss = [NSBULKANNOTATIONSCONFIG]
+        if self.attach and NSBULKANNOTATIONSCONFIG in nss:
             for objtype, objids in parentids.iteritems():
                 if objtype in not_annotatable:
                     continue
                 r = self._get_annotations_for_deletion(
-                    objtype, objids, 'FileAnnotation', nss)
+                    objtype, objids, 'FileAnnotation',
+                    [NSBULKANNOTATIONSCONFIG])
                 self.fileannids.update(r)
 
-            log.info("Total: %d FileAnnotation(s) in %s",
-                     len(set(self.fileannids)), nss)
+            log.info("Total FileAnnotations in %s: %d",
+                     [NSBULKANNOTATIONSCONFIG], len(set(self.fileannids)))
+            log.debug("FileAnnotations in %s: %s",
+                      [NSBULKANNOTATIONSCONFIG], self.fileannids)
 
     def write_to_omero(self, batch_size=1000, loops=10, ms=500):
         for objtype, maids in self.mapannids.iteritems():

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1084,7 +1084,7 @@ class _QueryContext(object):
 
 def get_config(session, cfg=None, cfgid=None):
     if cfgid:
-        cfgdict = pydict_text_io.load(cfgid)
+        cfgdict = pydict_text_io.load('OriginalFile:%d' % cfgid)
     elif cfg:
         cfgdict = pydict_text_io.load(cfg)
     else:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1595,7 +1595,9 @@ class DeleteMapAnnotationContext(_QueryContext):
                 except KeyError:
                     self.mapannids[objtype] = set(r)
 
-        log.info("Total: [%s] MapAnnotationLink(s) in %s", self.mapannids, nss)
+        log.info("Total MapAnnotationLinks in %s: %d",
+                 nss, sum(len(v) for v in self.mapannids.values()))
+        log.debug("MapAnnotationLinks in %s: %s", nss, self.mapannids)
 
         if self.attach:
             nss = [NSBULKANNOTATIONSCONFIG]
@@ -1630,20 +1632,12 @@ class DeleteMapAnnotationContext(_QueryContext):
         # At this point, we're sure that there's a response OR
         # an exception has been thrown (likely LockTimeout)
         rsp = callback.getResponse()
-        if isinstance(rsp, omero.cmd.OK):
-            ndal = len(rsp.deletedObjects.get(
-                "ome.model.annotations.AnnotationLink", []))
-            ndma = len(rsp.deletedObjects.get(
-                "ome.model.annotations.MapAnnotation", []))
-            ndfa = len(rsp.deletedObjects.get(
-                "ome.model.annotations.FileAnnotation", []))
-            if ndal:
-                log.info("Deleted %d AnnotationLink(s)", ndal)
-            if ndma:
-                log.info("Deleted %d MapAnnotation(s)", ndma)
-            if ndfa:
-                log.info("Deleted %d FileAnnotation(s)", ndfa)
-        else:
+        try:
+            deleted = rsp.deletedObjects
+            for k, v in deleted.iteritems():
+                log.info("Deleted: %s %d", k, len(v))
+                log.debug("Deleted: %s %s", k, v)
+        except AttributeError:
             log.error("Delete failed: %s", rsp)
 
 

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -747,7 +747,8 @@ class ParsingContext(object):
     """Generic parsing context for CSV files."""
 
     def __init__(self, client, target_object, file=None, fileid=None,
-                 cfg=None, cfgid=None, attach=False, column_types=None):
+                 cfg=None, cfgid=None, attach=False, column_types=None,
+                 options=None):
         '''
         This lines should be handled outside of the constructor:
 
@@ -1104,7 +1105,7 @@ class BulkToMapAnnotationContext(_QueryContext):
     """
 
     def __init__(self, client, target_object, file=None, fileid=None,
-                 cfg=None, cfgid=None, attach=False):
+                 cfg=None, cfgid=None, attach=False, options=None):
         """
         :param client: OMERO client object
         :param target_object: The object to be annotated
@@ -1408,7 +1409,7 @@ class DeleteMapAnnotationContext(_QueryContext):
     """
 
     def __init__(self, client, target_object, file=None, fileid=None,
-                 cfg=None, cfgid=None, attach=False):
+                 cfg=None, cfgid=None, attach=False, options=None):
         """
         :param client: OMERO client object
         :param target_object: The object to be processed
@@ -1428,6 +1429,10 @@ class DeleteMapAnnotationContext(_QueryContext):
             self.default_cfg = None
             self.column_cfgs = None
             self.advanced_cfgs = None
+
+        self.options = {}
+        if options:
+            self.options = options
 
     def parse(self):
         return self.populate()
@@ -1449,6 +1454,14 @@ class DeleteMapAnnotationContext(_QueryContext):
         return r
 
     def _get_configured_namespaces(self):
+        try:
+            nss = self.options['ns']
+            if isinstance(nss, list):
+                return nss
+            return [nss]
+        except KeyError:
+            pass
+
         nss = set([omero.constants.namespaces.NSBULKANNOTATIONS])
         if self.column_cfgs:
             for c in self.column_cfgs:

--- a/components/tools/OmeroPy/src/omero/util/pydict_text_io.py
+++ b/components/tools/OmeroPy/src/omero/util/pydict_text_io.py
@@ -137,7 +137,10 @@ def get_format_originalfileid(originalfileid, filetype, session):
             'OMERO session required: OriginalFile:%d' % originalfileid)
     f = session.getQueryService().get('OriginalFile', originalfileid)
     if not filetype:
-        mt = unwrap(f.getMimetype()).lower()
+        try:
+            mt = unwrap(f.getMimetype()).lower()
+        except AttributeError:
+            mt = ''
         if mt == 'application/x-yaml':
             filetype = 'yaml'
         if mt == 'application/json':

--- a/components/tools/OmeroPy/src/omero/util/pydict_text_io.py
+++ b/components/tools/OmeroPy/src/omero/util/pydict_text_io.py
@@ -54,6 +54,10 @@ def load(fileobj, filetype=None, single=True, session=None):
     session: If fileobj is an OriginalFile:ID a valid session is required
     """
 
+    if not isinstance(fileobj, basestring):
+        raise Exception(
+            'Invalid type: fileobj must be a filename or json string')
+
     try:
         data = json.loads(fileobj)
         if isinstance(data, dict):

--- a/components/tools/OmeroPy/src/omero/util/pydict_text_io.py
+++ b/components/tools/OmeroPy/src/omero/util/pydict_text_io.py
@@ -47,11 +47,21 @@ def load(fileobj, filetype=None, single=True, session=None):
     """
     Try and load a file in a format that is convertible to a Python dictionary
 
-    fileobj: Either a file-path or OriginalFile:ID
+    fileobj: Either a single json object string, file-path, or OriginalFile:ID
     single: If True file should only contain a single document, otherwise a
-        list of documents will always be returned.
+        list of documents will always be returned. Multiple documents are not
+        supported for JSON strings.
     session: If fileobj is an OriginalFile:ID a valid session is required
     """
+
+    try:
+        data = json.loads(fileobj)
+        if isinstance(data, dict):
+            if single:
+                return data
+            return [data]
+    except ValueError:
+        pass
 
     m = re.match('originalfile:(\d+)$', fileobj, re.I)
     if m:

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -241,7 +241,6 @@ class Plate2Wells(Fixture):
     def get_target(self):
         if not self.plate:
             self.plate = self.createPlate(self.rowCount, self.colCount)
-        print self.plate.id.val
         return self.plate
 
     def get_annotations(self):
@@ -961,12 +960,6 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         but in practice each one uses data created by the others, so for
         now just run them all together
         """
-        try:
-            import yaml
-            print yaml, "found"
-        except Exception:
-            skip("PyYAML not installed.")
-
         fixture.init(self)
         t = self._test_parsing_context(fixture, batch_size)
         self._assert_parsing_context_values(t, fixture)
@@ -980,12 +973,6 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         data type, as opposed to testPopulateMetadata which tests simple
         annotations on multiple OMERO data types
         """
-        try:
-            import yaml
-            print yaml, "found"
-        except Exception:
-            skip("PyYAML not installed.")
-
         fixture.init(self)
         t = self._test_parsing_context(fixture, 2)
 
@@ -1005,12 +992,6 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         Similar to testPopulateMetadataNsAnns but use two plates and check
         MapAnnotations aren't duplicated
         """
-        try:
-            import yaml
-            print yaml, "found"
-        except Exception:
-            skip("PyYAML not installed.")
-
         fixture_empty = Plate2WellsNs2UnavailableHeader()
         fixture_empty.init(self)
         self._test_parsing_context(fixture_empty, 2)
@@ -1021,12 +1002,6 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         Similar to testPopulateMetadataNsAnns but use two plates and check
         MapAnnotations aren't duplicated
         """
-        try:
-            import yaml
-            print yaml, "found"
-        except Exception:
-            skip("PyYAML not installed.")
-
         fixture_fail = Plate2WellsNs2Fail()
         fixture_fail.init(self)
         self._test_parsing_context(fixture_fail, 2)
@@ -1173,12 +1148,6 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
         Similar to testPopulateMetadataNsAnns but use two plates, check
         MapAnnotations aren't duplicated, and filter by namespace
         """
-        try:
-            import yaml
-            print yaml, "found"
-        except Exception:
-            skip("PyYAML not installed.")
-
         fixture1 = Plate2WellsNs2()
         fixture1.init(self)
         self._test_parsing_context(fixture1, 2)
@@ -1195,12 +1164,6 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
         Similar to testPopulateMetadataNsAnns but use two plates, check
         MapAnnotations aren't duplicated, and delete by namespace
         """
-        try:
-            import yaml
-            print yaml, "found"
-        except Exception:
-            skip("PyYAML not installed.")
-
         fixture1 = Plate2WellsNs2()
         fixture1.init(self)
         self._test_parsing_context(fixture1, 2)

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -905,9 +905,7 @@ class TestPopulateMetadata(ITest):
         fixture2.init(self)
         self._test_parsing_context(fixture2, 2)
         self._test_bulk_to_map_annotation_dedup(fixture1, fixture2)
-        # TODO: This will currently fail because the MapAnnotations are
-        # deleted even if they're multiply linked
-        # self._test_delete_map_annotation_context_dedup(fixture1, fixture2)
+        self._test_delete_map_annotation_context_dedup(fixture1, fixture2)
 
     def testPopulateMetadataNsAnnsUnavailableHeader(self):
         """

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -840,6 +840,21 @@ class TestPopulateMetadata(ITest):
     )
     METADATA_NS_IDS = [x.__class__.__name__ for x in METADATA_NS_FIXTURES]
 
+    # This class includes counting map-annotations, so create a clean
+    # environment
+
+    def setup_class(cls):
+        pass
+
+    def teardown_class(cls):
+        pass
+
+    def setup_method(self, method):
+        super(TestPopulateMetadata, self).setup_class()
+
+    def teardown_method(self, method):
+        super(TestPopulateMetadata, self).teardown_class()
+
     @mark.parametrize("fixture", METADATA_FIXTURES, ids=METADATA_IDS)
     @mark.parametrize("batch_size", (None, 1, 10))
     def testPopulateMetadata(self, fixture, batch_size):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -55,7 +55,6 @@ from omero.util.temp_files import create_path
 
 from omero.util.metadata_mapannotations import MapAnnotationPrimaryKeyException
 
-from pytest import skip
 from pytest import mark
 from pytest import raises
 

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -59,6 +59,8 @@ from pytest import skip
 from pytest import mark
 from pytest import raises
 
+MAPR_NS_GENE = 'openmicroscopy.org/mapr/gene'
+
 
 def coord2offset(coord):
     """
@@ -282,7 +284,7 @@ class Plate2WellsNs(Plate2Wells):
                             'bulk_to_map_annotation_context_ns.yml')
 
     def get_namespaces(self):
-        return [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
+        return [NSBULKANNOTATIONS, MAPR_NS_GENE]
 
     def assert_row_values(self, rowvalues):
         # First column is the WellID
@@ -308,7 +310,7 @@ class Plate2WellsNs(Plate2Wells):
     def assert_child_annotations(self, oas):
         wellrcs = [coord2offset(c) for c in (
             'a1', 'a2', 'a3', 'a4', 'b1', 'b2', 'b3', 'b4')]
-        nss = [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
+        nss = [NSBULKANNOTATIONS, MAPR_NS_GENE]
         wellrc_ns = [(wrc, ns) for wrc in wellrcs for ns in nss]
         check = dict((k, None) for k in wellrc_ns)
         annids = []
@@ -428,7 +430,7 @@ class Plate2WellsNs2(Plate2WellsNs):
     def assert_child_annotations(self, oas):
         wellrcs = [coord2offset(c) for c in (
             'a1', 'a2', 'a3', 'a4', 'b1', 'b2', 'b3', 'b4')]
-        nss = [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
+        nss = [NSBULKANNOTATIONS, MAPR_NS_GENE]
         wellrc_ns = [(wrc, ns) for wrc in wellrcs for ns in nss]
         check = dict((k, None) for k in wellrc_ns)
         annids = []
@@ -551,7 +553,7 @@ class Plate2WellsNs2UnavailableHeader(Plate2WellsNs2):
     def assert_child_annotations(self, oas):
         wellrcs = [coord2offset(c) for c in (
             'a1', 'a2', 'b1', 'b2')]
-        nss = [NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene']
+        nss = [NSBULKANNOTATIONS, MAPR_NS_GENE]
         wellrc_ns = [(wrc, ns) for wrc in wellrcs for ns in nss]
         check = dict((k, None) for k in wellrc_ns)
         annids = []
@@ -1075,7 +1077,6 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
         if ns:
             options['ns'] = ns
 
-        MAPR_NS_GENE = 'openmicroscopy.org/mapr/gene'
         assert len(fixture1.get_child_annotations()) == 16
         assert len(fixture1.get_child_annotations(NSBULKANNOTATIONS)) == 8
         assert len(fixture1.get_child_annotations(MAPR_NS_GENE)) == 8
@@ -1128,8 +1129,7 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
             assert len(fixture2.get_child_annotations()) == 0
             assert len(fixture2.get_all_map_annotations()) == 0
 
-    @mark.parametrize("ns", [
-        None, NSBULKANNOTATIONS, 'openmicroscopy.org/mapr/gene'])
+    @mark.parametrize("ns", [None, NSBULKANNOTATIONS, MAPR_NS_GENE])
     def testPopulateMetadataNsAnnsDedup(self, ns):
         """
         Similar to testPopulateMetadataNsAnns but use two plates, check

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -427,10 +427,15 @@ class Plate2WellsNs2(Plate2WellsNs):
         return os.path.join(os.path.dirname(__file__),
                             'bulk_to_map_annotation_context_ns2.yml')
 
-    def assert_child_annotations(self, oas):
+    def assert_child_annotations(self, oas, onlyns=None):
+        """
+        Pass onlyns to check that only annotations in that namespace exist
+        """
         wellrcs = [coord2offset(c) for c in (
             'a1', 'a2', 'a3', 'a4', 'b1', 'b2', 'b3', 'b4')]
         nss = [NSBULKANNOTATIONS, MAPR_NS_GENE]
+        if onlyns:
+            nss = [onlyns]
         wellrc_ns = [(wrc, ns) for wrc in wellrcs for ns in nss]
         check = dict((k, None) for k in wellrc_ns)
         annids = []
@@ -449,13 +454,55 @@ class Plate2WellsNs2(Plate2WellsNs):
             # Use getMapValue to check ordering and duplicates
             check[(wrc, ns)] = [(p.name, p.value) for p in ma.getMapValue()]
 
-        # Row a
+        if onlyns == NSBULKANNOTATIONS:
+            self._assert_nsbulkann(check, wellrcs)
+            assert len(annids) == 8
+            assert len(set(annids)) == 8
+        if onlyns == MAPR_NS_GENE:
+            self._assert_nsgeneann(check, wellrcs)
+            assert len(annids) == 8
+            assert len(set(annids)) == 4
+        if not onlyns:
+            self._assert_nsgeneann(check, wellrcs)
+            assert len(annids) == 16
+            assert len(set(annids)) == 12
 
-        assert check[(wellrcs[0], nss[0])] == [
+    def _assert_nsbulkann(self, check, wellrcs):
+        # Row a
+        assert check[(wellrcs[0], NSBULKANNOTATIONS)] == [
             ('Gene', 'hh'),
             ('FlyBase URL', 'http://flybase.org/reports/FBgn0004644.html'),
         ]
-        assert check[(wellrcs[0], nss[1])] == [
+        assert check[(wellrcs[1], NSBULKANNOTATIONS)] == [
+            ('Gene', 'sws'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0003656.html'),
+        ]
+        assert check[(wellrcs[2], NSBULKANNOTATIONS)] == [
+            ('Gene', 'ken'),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0011236.html'),
+        ]
+        assert check[(wellrcs[3], NSBULKANNOTATIONS)] == [
+            ('Gene', ''),
+            ('FlyBase URL', 'http://flybase.org/reports/FBgn0086378.html'),
+        ]
+
+        # Row b
+        assert check[(wellrcs[4], NSBULKANNOTATIONS)] == [
+            ('Gene', 'hh'),
+        ]
+        assert check[(wellrcs[5], NSBULKANNOTATIONS)] == [
+            ('Gene', 'sws'),
+        ]
+        assert check[(wellrcs[6], NSBULKANNOTATIONS)] == [
+            ('Gene', 'ken'),
+        ]
+        assert check[(wellrcs[7], NSBULKANNOTATIONS)] == [
+            ('Gene', ''),
+        ]
+
+    def _assert_nsgeneann(self, check, wellrcs):
+        # Row a
+        assert check[(wellrcs[0], MAPR_NS_GENE)] == [
             ('Gene', 'hh'),
             ('Gene name', 'hedgehog'),
             ('Gene name', 'bar-3'),
@@ -467,11 +514,7 @@ class Plate2WellsNs2(Plate2WellsNs):
             ('Gene name', 'Indian hedgehog'),
             ('Gene name', 'Sonic hedgehog'),
         ]
-        assert check[(wellrcs[1], nss[0])] == [
-            ('Gene', 'sws'),
-            ('FlyBase URL', 'http://flybase.org/reports/FBgn0003656.html'),
-        ]
-        assert check[(wellrcs[1], nss[1])] == [
+        assert check[(wellrcs[1], MAPR_NS_GENE)] == [
             ('Gene', 'sws'),
             ('Gene name', 'swiss cheese'),
             ('Gene name', 'olfE'),
@@ -480,11 +523,7 @@ class Plate2WellsNs2(Plate2WellsNs):
             ('Gene name', 'patatin like phospholipase domain containing 6'),
         ]
 
-        assert check[(wellrcs[2], nss[0])] == [
-            ('Gene', 'ken'),
-            ('FlyBase URL', 'http://flybase.org/reports/FBgn0011236.html'),
-        ]
-        assert check[(wellrcs[2], nss[1])] == [
+        assert check[(wellrcs[2], MAPR_NS_GENE)] == [
             ('Gene', 'ken'),
             ('Gene name', 'ken and barbie'),
             ('Gene name', 'CG5575'),
@@ -492,42 +531,22 @@ class Plate2WellsNs2(Plate2WellsNs):
             ('Gene name', 'B-cell lymphoma 6 protein'),
         ]
 
-        assert check[(wellrcs[3], nss[0])] == [
-            ('Gene', ''),
-            ('FlyBase URL', 'http://flybase.org/reports/FBgn0086378.html'),
-        ]
-        assert check[(wellrcs[3], nss[1])] == [
+        assert check[(wellrcs[3], MAPR_NS_GENE)] == [
             ('Gene', ''),
             ('Gene name', 'Alg-2'),
         ]
 
         # Row b
-
-        assert check[(wellrcs[4], nss[0])] == [
-            ('Gene', 'hh'),
-        ]
-        assert check[(wellrcs[4], nss[1])] == check[(wellrcs[0], nss[1])]
-
-        assert check[(wellrcs[5], nss[0])] == [
-            ('Gene', 'sws'),
-        ]
-        assert check[(wellrcs[5], nss[1])] == check[(wellrcs[1], nss[1])]
-
-        assert check[(wellrcs[6], nss[0])] == [
-            ('Gene', 'ken'),
-        ]
-        assert check[(wellrcs[6], nss[1])] == check[(wellrcs[2], nss[1])]
-
-        assert check[(wellrcs[7], nss[0])] == [
-            ('Gene', ''),
-        ]
-        assert check[(wellrcs[7], nss[1])] == [
+        assert check[(wellrcs[4], MAPR_NS_GENE)] == check[
+            (wellrcs[0], MAPR_NS_GENE)]
+        assert check[(wellrcs[5], MAPR_NS_GENE)] == check[
+            (wellrcs[1], MAPR_NS_GENE)]
+        assert check[(wellrcs[6], MAPR_NS_GENE)] == check[
+            (wellrcs[2], MAPR_NS_GENE)]
+        assert check[(wellrcs[7], MAPR_NS_GENE)] == [
             ('Gene', ''),
             ('Gene name', 'Alg-2'),
         ]
-
-        assert len(annids) == 16
-        assert len(set(annids)) == 12
 
 
 class Plate2WellsNs2UnavailableHeader(Plate2WellsNs2):
@@ -1032,7 +1051,15 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
     def teardown_method(self, method):
         super(TestPopulateMetadataDedup, self).teardown_class()
 
-    def _test_bulk_to_map_annotation_dedup(self, fixture1, fixture2):
+    # Hard-code the number of expected map-annotations in these tests
+    # since the code in this file is complicated enough without trying
+    # to parameterise this
+
+    def _test_bulk_to_map_annotation_dedup(self, fixture1, fixture2, ns):
+        options = {}
+        if ns:
+            options['ns'] = ns
+
         ann_count = fixture1.annCount
         assert fixture2.annCount == ann_count
         assert len(fixture1.get_child_annotations()) == ann_count
@@ -1044,7 +1071,7 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
         anns = fixture2.get_annotations()
         fileid = anns[0].file.id.val
         ctx = BulkToMapAnnotationContext(
-            self.client, target, fileid=fileid, cfg=cfg)
+            self.client, target, fileid=fileid, cfg=cfg, options=options)
         ctx.parse()
         assert len(fixture1.get_child_annotations()) == ann_count
         assert len(fixture2.get_child_annotations()) == 0
@@ -1054,20 +1081,31 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
         oas1 = fixture1.get_child_annotations()
         oas2 = fixture2.get_child_annotations()
         assert len(oas1) == ann_count
-        assert len(oas2) == ann_count
-        fixture1.assert_child_annotations(oas1)
-        fixture2.assert_child_annotations(oas2)
 
-        # 4 of the mapannotations should be common
+        if ns == NSBULKANNOTATIONS:
+            assert len(oas2) == 8
+            fixture1.assert_child_annotations(oas1)
+            fixture2.assert_child_annotations(oas2, ns)
+        if ns == MAPR_NS_GENE:
+            assert len(oas2) == 8
+            fixture1.assert_child_annotations(oas1)
+            fixture2.assert_child_annotations(oas2, ns)
+        if ns is None:
+            assert len(oas2) == ann_count
+            fixture1.assert_child_annotations(oas1)
+            fixture2.assert_child_annotations(oas2)
+
+        # The gene mapannotations should be common
         ids1 = set(unwrap(o[0].getId()) for o in oas1)
         ids2 = set(unwrap(o[0].getId()) for o in oas2)
-        assert len(ids1.intersection(ids2)) == 4
+        common = ids1.intersection(ids2)
+        if ns == NSBULKANNOTATIONS:
+            assert len(common) == 0
+        else:
+            assert len(common) == 4
 
     def _test_delete_map_annotation_context_dedup(
             self, fixture1, fixture2, ns):
-        # Hard-code the number of expected map-annotations in the asserts
-        # since the code in this file is complicated enough without trying
-        # to parameterise this
 
         # Sanity checks in case the test code or fixtures are modified
         assert fixture1.annCount == 16
@@ -1134,7 +1172,6 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
         """
         Similar to testPopulateMetadataNsAnns but use two plates, check
         MapAnnotations aren't duplicated, and filter by namespace
-        TODO: Only delete by namespace is currently implemented
         """
         try:
             import yaml
@@ -1150,7 +1187,29 @@ class TestPopulateMetadataDedup(TestPopulateMetadataHelper):
         fixture2 = Plate2WellsNs2()
         fixture2.init(self)
         self._test_parsing_context(fixture2, 2)
-        self._test_bulk_to_map_annotation_dedup(fixture1, fixture2)
+        self._test_bulk_to_map_annotation_dedup(fixture1, fixture2, ns)
+
+    @mark.parametrize("ns", [None, NSBULKANNOTATIONS, MAPR_NS_GENE])
+    def testPopulateMetadataNsAnnsDedupDelete(self, ns):
+        """
+        Similar to testPopulateMetadataNsAnns but use two plates, check
+        MapAnnotations aren't duplicated, and delete by namespace
+        """
+        try:
+            import yaml
+            print yaml, "found"
+        except Exception:
+            skip("PyYAML not installed.")
+
+        fixture1 = Plate2WellsNs2()
+        fixture1.init(self)
+        self._test_parsing_context(fixture1, 2)
+        self._test_bulk_to_map_annotation_context(fixture1, 2)
+
+        fixture2 = Plate2WellsNs2()
+        fixture2.init(self)
+        self._test_parsing_context(fixture2, 2)
+        self._test_bulk_to_map_annotation_dedup(fixture1, fixture2, None)
         self._test_delete_map_annotation_context_dedup(
             fixture1, fixture2, ns)
 

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -153,7 +153,7 @@ class Fixture(object):
             os.path.dirname(__file__), 'bulk_to_map_annotation_context.yml')
 
     def get_namespaces(self):
-        return NSBULKANNOTATIONS
+        return [NSBULKANNOTATIONS]
 
     def assert_rows(self, rows):
         assert rows == self.rowCount * self.colCount

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -44,7 +44,11 @@ from omero.rtypes import rdouble, rlist, rstring, unwrap
 from omero.sys import ParametersI
 
 from omero.util.populate_metadata import (
-    ParsingContext, BulkToMapAnnotationContext, DeleteMapAnnotationContext)
+    get_config,
+    ParsingContext,
+    BulkToMapAnnotationContext,
+    DeleteMapAnnotationContext,
+)
 from omero.util.populate_roi import AbstractMeasurementCtx
 from omero.util.populate_roi import AbstractPlateAnalysisCtx
 from omero.util.populate_roi import MeasurementParsingResult
@@ -838,6 +842,30 @@ class Project2Datasets(Fixture):
                     raise Exception("Unknown img: %s" % img)
             else:
                 raise Exception("Unknown dataset: %s" % ds)
+
+
+class TestPopulateMetadataConfigLoad(ITest):
+
+    def get_cfg_filepath(self):
+        return os.path.join(os.path.dirname(__file__),
+                            'bulk_to_map_annotation_context.yml')
+
+    def _assert_configs(self, default_cfg, column_cfgs, advanced_cfgs):
+        assert default_cfg == {"include": True}
+        assert column_cfgs is None
+        assert advanced_cfgs == {}
+
+    def test_get_config_local(self):
+        default_cfg, column_cfgs, advanced_cfgs = get_config(
+            None, cfg=self.get_cfg_filepath())
+        self._assert_configs(default_cfg, column_cfgs, advanced_cfgs)
+
+    def test_get_config_remote(self):
+        ofile = self.client.upload(self.get_cfg_filepath()).proxy()
+        cfgid = unwrap(ofile.getId())
+        default_cfg, column_cfgs, advanced_cfgs = get_config(
+            self.client.getSession(), cfgid=cfgid)
+        self._assert_configs(default_cfg, column_cfgs, advanced_cfgs)
 
 
 class TestPopulateMetadataHelper(ITest):

--- a/components/tools/OmeroPy/test/integration/metadata/test_pydict_text.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_pydict_text.py
@@ -111,6 +111,11 @@ class TestPydictTextIo(lib.ITest):
             fileobj, session=self.client.getSession())
         assert data == {'a': 2}
 
+    def test_load_fromstring(self):
+        content = self.getTestJson()
+        data = pydict_text_io.load(content)
+        assert data == {'a': 2}
+
     @pytest.mark.parametrize('format', ['json', 'yaml'])
     def test_dump(data, tmpdir, format):
         d = {'a': 2}

--- a/components/tools/OmeroPy/test/integration/metadata/test_pydict_text.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_pydict_text.py
@@ -116,6 +116,11 @@ class TestPydictTextIo(lib.ITest):
         data = pydict_text_io.load(content)
         assert data == {'a': 2}
 
+    def test_load_invalidtype(self):
+        with pytest.raises(Exception) as excinfo:
+            pydict_text_io.load(123)
+        assert str(excinfo.value).startswith('Invalid type: ')
+
     @pytest.mark.parametrize('format', ['json', 'yaml'])
     def test_dump(data, tmpdir, format):
         d = {'a': 2}


### PR DESCRIPTION

This is the same as gh-5074 but rebased onto metadata53.

----

# What this PR does

Adds infrastructure and tests for creating and deleting bulk-map-annotations with a namespace limit. At the moment I've added an extensible way of passing additional parameters, but I haven't added a dedicated CLI flag.

--depends-on https://github.com/openmicroscopy/openmicroscopy/pull/5068

Todo:
- [x] Check if https://github.com/openmicroscopy/openmicroscopy/pull/5074/commits/a73689b729412bb998a6a9b2de850d689db93dcb works as expected

# Testing this PR

Run the integration tests

Run `omero metadata populate ... --localcfg <cfg>` where `<cfg>` is something that can be read by `omero.utils.pydict_text_utils`. For example, to limit by namespace any of the following should work:

`--localcfg localcfg.yml` or `--localcfg OriginalFile:123`:
```
ns: openmicroscopy/mapr/gene
```
`--localcfg localcfg.json` or `--localcfg OriginalFile:123`:
```
{
  "ns": "openmicroscopy/mapr/gene"
}
```
`--localcfg '{"ns":"openmicroscopy/mapr/gene"}'`

# Related reading

- https://trello.com/c/e1OTY56t/96-annotate-delete-per-namespace

                