### PR TITLE
Print more info if a duplicate map-ann is detected in the database (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
+++ b/components/tools/OmeroPy/src/omero/util/metadata_mapannotations.py
@@ -216,5 +216,5 @@ class MapAnnotationManager(object):
             r = self.add(cma)
             if r:
                 raise Exception(
-                    'Duplicate MapAnnotation primary key (%s, %s): id:%s',
-                    ns, primary_keys, unwrap(ma.getId()))
+                    'Duplicate MapAnnotation primary key: id:%s %s' % (
+                        unwrap(ma.getId()), str(r)))

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -29,6 +29,7 @@ from omero.model import MapAnnotationI, NamedValue
 from omero.rtypes import unwrap, wrap
 from omero.util.metadata_mapannotations import (
     CanonicalMapAnnotation, MapAnnotationManager)
+import pytest
 
 
 def assert_equal_map_value(mva, mvb):
@@ -83,6 +84,16 @@ class TestMapAnnotationManager(lib.ITest):
         assert cma2.parents == set()
         mv2 = cma2.get_mapann().getMapValue()
         assert_equal_map_value(mv2, [NamedValue('a', '2')])
+
+    def test_add_from_namespace_query_duplicate(self):
+        ns1, ns3, mids = self.create_mas()
+        pks = ['a']
+        mgr = MapAnnotationManager()
+        mgr.add_from_namespace_query(self.sf, ns1, pks)
+        with pytest.raises(Exception) as exc_info:
+            mgr.add_from_namespace_query(self.sf, ns1, pks)
+        assert exc_info.value.message.startswith(
+            'Duplicate MapAnnotation primary key')
 
     def test_update_existing_mapann(self):
         ns1, ns3, mids = self.create_mas()


### PR DESCRIPTION

This is the same as gh-5085 but rebased onto metadata53.

----

# What this PR does

If multiple map-annotations with the same primary key are found in the database this prints out the whole map instead of just the namespace and id to assist with debugging the underlying cause.

# Testing this PR

See new test in `integration/metadata/test_metadata_mapannotations.py` `TestMapAnnotationManager.test_add_from_namespace_query_duplicate`


# Related reading

Link to cards, tickets, other PRs:

- Trello card: ~(to be found)~ https://trello.com/c/vz46CiaB/74-improve-metadata-mapr-annotations-error-message

                