### PR TITLE
can* tests checks

### DIFF
--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -434,12 +434,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        Dataset dat = mmFactory.simpleDataset();
        Project sentProj = null;
        Dataset sentDat = null;
-       try {
-           sentProj = (Project) iUpdate.saveAndReturnObject(proj);
-           sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
-       } catch (ServerError se) {
-           throw se;
-       }
+       sentProj = (Project) iUpdate.saveAndReturnObject(proj);
+       sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
        /* import an image for the normalUser into the normalUser's default group 
         * and target it into the created Dataset*/
        final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1374,6 +1374,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         loginUser(lightAdmin);
         client.getImplicitContext().put("omero.group", "-1");
         /* transfer can proceed only if chownPassing boolean is true */
+        /* Check on one selected object only (sentProj1OtherGroup) the value
+         * of canChown. The value must match the chownPassing boolean.*/
+        Assert.assertEquals(getCurrentPermissions(sentProj1OtherGroup).canChown(), chownPassing);
         doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), chownPassing);
         if (!chownPassing) {
             return;

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -107,7 +107,6 @@ import com.google.common.collect.ImmutableSet;
  * @author p.walczysko@dundee.ac.uk
  * @since 5.4.0
  */
-
 public class LightAdminRolesTest extends AbstractServerImportTest {
 
     private static final TempFileManager TEMPORARY_FILE_MANAGER = new TempFileManager(

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -375,8 +375,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
         /* check that the light admin when sudoed, can link the created Dataset
          * to the created Project, check the ownership of the links
-         * is of the simple user */
+         * is of the simple user.*/
 
+        /* check that the canLink() method is delivering true on both the Dataset
+         * and Project to be linked. As the cases where the light admin was not sudoing
+         * are not tested in this part of the test, the canLink() is always true
+         * for the owner of the objects (the normalUser as who the light admin is
+         * sudoed for) */
+        Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), true);
+        Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), true);
         ProjectDatasetLink projectDatasetLink = linkProjectDataset(sentProj, sentDat);
 
         /* Now check the ownership of image and links

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1144,6 +1144,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * which should succeed in case the light admin has Chgrp permissions
          */
         doChange(client, factory, Requests.chgrp().target(sentDat).toGroup(normalUser.groupId).build(), permChgrp);
+        /* Check that the value of canChgrp on the dataset is true.
+         * Note that although the chgrp action into the group of normalUser will fail,
+         * the light admin could be chgrp the dataset into a group where he is a member,
+         * and thus the canChgrp must be "true".*/
+        Assert.assertEquals(getCurrentPermissions(sentDat).canChgrp(), true);
+
         /* retrieve again the image, dataset and link */
         long datasetGroupId =((RLong) iQuery.projection(
                 "SELECT details.group.id FROM Dataset d WHERE d.id = :id",
@@ -1184,6 +1190,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * A successful chowning of the dataset will chown the linked image
          * and the link too.*/
         if (importYourGroupAndChgrpAndChownExpectSuccess) {/* whole workflow2 succeeded */
+            /* Check the value of canChown on the dataset is true in this case.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), true);
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1211,6 +1219,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(datasetImageLinkGroupId, normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
+            /* Check the value of canChown on the dataset is true in this case.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), true);
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1239,6 +1249,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
+            /* Check the value of canChown on the dataset is false in this case.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), false);
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1266,6 +1278,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(datasetImageLinkGroupId, normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
+            /* Check the value of canChown on the dataset is false in this case.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), false);
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -575,6 +575,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         final String changedName = "ChangedNameOfLightAdmin";
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         long id = sentProj.getId().getValue();
+        /* check that the canEdit flag on the created project is as expected */
+        Assert.assertEquals(getCurrentPermissions(sentProj).canEdit(), isExpectSuccess);
         final Project retrievedUnrenamedProject = (Project) iQuery.get("Project", id);
         retrievedUnrenamedProject.setName(omero.rtypes.rstring(changedName));
         if (isExpectSuccess) {/* in case no WriteOwned permission is given to light admin, and he/she is

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1026,9 +1026,18 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         DatasetImageLink linkOfDatasetImage = new DatasetImageLinkI();
         ProjectDatasetLink linkOfProjectDataset = new ProjectDatasetLinkI();
         if (isExpectLinkingSuccess) {
+            /*Check that the canLink value on all the objects to be linked is true,
+             * then create the links.*/
+            Assert.assertEquals(getCurrentPermissions(sentImage).canLink(), true);
+            Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), true);
+            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), true);
             linkOfDatasetImage = linkDatasetImage(sentDat, sentImage);
             linkOfProjectDataset = linkProjectDataset(sentProj, sentDat);
         } else {
+            /*Check that the canLink value on all the objects to be linked is false.*/
+            Assert.assertEquals(getCurrentPermissions(sentImage).canLink(), false);
+            Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), false);
+            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), false);
             return; /*links could not be created, finish the test */
         }
 
@@ -1037,9 +1046,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * needs additonally the Chown permission. Note that the links
          * have to be transferred step by step, as the Chown feature
          * of whole hierarchy does not transfer links owned by non-owners
-         * of the P/D?I objects. */
+         * of the P/D?I objects. Also check that the canChown value on all
+         * the objects to be chowned is matching the isExpectSuccessLinkAndChown.*/
+        Assert.assertEquals(getCurrentPermissions(linkOfDatasetImage).canChown(), isExpectSuccessLinkAndChown);
         Chown2 chown = Requests.chown().target(linkOfDatasetImage).toUser(normalUser.userId).build();
         doChange(client, factory, chown, isExpectSuccessLinkAndChown);
+        Assert.assertEquals(getCurrentPermissions(linkOfProjectDataset).canChown(), isExpectSuccessLinkAndChown);
         chown = Requests.chown().target(linkOfProjectDataset).toUser(normalUser.userId).build();
         doChange(client, factory, chown, isExpectSuccessLinkAndChown);
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -392,8 +392,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * are not tested in this part of the test, the canLink() is always true
          * for the owner of the objects (the normalUser as who the light admin is
          * sudoed for) */
-        Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), true);
-        Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), true);
+        Assert.assertTrue(getCurrentPermissions(sentProj).canLink());
+        Assert.assertTrue(getCurrentPermissions(sentDat).canLink());
         ProjectDatasetLink projectDatasetLink = linkProjectDataset(sentProj, sentDat);
 
         /* Now check the ownership of image and links
@@ -489,8 +489,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         * would delete the whole hierarchy, which was successfully tested
         * during writing of this test. The order of the below delete() commands
         * is intentional, as the ability to delete the links and P/D/I separately is
-        * tested in this way.Also check that the canDelete boolean
-        * on the object retreived by the light admin matches the deletePassing
+        * tested in this way. Also check that the canDelete boolean
+        * on the object retrieved by the light admin matches the deletePassing
         * boolean.*/
        Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
        doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
@@ -808,7 +808,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * in such case.*/
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         if (isSudoing) {
-            Assert.assertEquals(getCurrentPermissions(image).canChown(), false);
+            Assert.assertFalse(getCurrentPermissions(image).canChown());
             doChange(client, factory, Requests.chown().target(image).toUser(anotherUser.userId).build(), false);
             long imageGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM Image i WHERE i.id = :id",
@@ -938,7 +938,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * captured in the boolean importNotYourGroupAndChownExpectSuccess */
         if (createDatasetImportNotYourGroupAndChownExpectSuccess) {
             /* Also check that the canChown value on the dataset is true in these cases.*/
-            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), true);
+            Assert.assertTrue(getCurrentPermissions(sentDat).canChown());
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             final long remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -965,7 +965,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             Assert.assertEquals(remoteFileGroupId, normalUser.groupId);
         } else {
             /* Also check that the canChown value on the dataset is false in these cases.*/
-            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), false);
+            Assert.assertFalse(getCurrentPermissions(sentDat).canChown());
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             final long remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1036,18 +1036,18 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         DatasetImageLink linkOfDatasetImage = new DatasetImageLinkI();
         ProjectDatasetLink linkOfProjectDataset = new ProjectDatasetLinkI();
         if (isExpectLinkingSuccess) {
-            /*Check that the canLink value on all the objects to be linked is true,
+            /* Check that the canLink value on all the objects to be linked is true,
              * then create the links.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canLink(), true);
-            Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), true);
-            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), true);
+            Assert.assertTrue(getCurrentPermissions(sentImage).canLink());
+            Assert.assertTrue(getCurrentPermissions(sentDat).canLink());
+            Assert.assertTrue(getCurrentPermissions(sentProj).canLink());
             linkOfDatasetImage = linkDatasetImage(sentDat, sentImage);
             linkOfProjectDataset = linkProjectDataset(sentProj, sentDat);
         } else {
-            /*Check that the canLink value on all the objects to be linked is false.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canLink(), false);
-            Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), false);
-            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), false);
+            /* Check that the canLink value on all the objects to be linked is false.*/
+            Assert.assertFalse(getCurrentPermissions(sentImage).canLink());
+            Assert.assertFalse(getCurrentPermissions(sentDat).canLink());
+            Assert.assertFalse(getCurrentPermissions(sentProj).canLink());
             return; /*links could not be created, finish the test */
         }
 
@@ -1056,7 +1056,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * needs additonally the Chown permission. Note that the links
          * have to be transferred step by step, as the Chown feature
          * of whole hierarchy does not transfer links owned by non-owners
-         * of the P/D?I objects. Also check that the canChown value on all
+         * of the P/D/I objects. Also check that the canChown value on all
          * the objects to be chowned is matching the isExpectSuccessLinkAndChown.*/
         Assert.assertEquals(getCurrentPermissions(linkOfDatasetImage).canChown(), isExpectSuccessLinkAndChown);
         Chown2 chown = Requests.chown().target(linkOfDatasetImage).toUser(normalUser.userId).build();
@@ -1158,7 +1158,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * Note that although the chgrp action into the group of normalUser will fail,
          * the light admin could be chgrp the dataset into a group where he is a member,
          * and thus the canChgrp must be "true".*/
-        Assert.assertEquals(getCurrentPermissions(sentDat).canChgrp(), true);
+        Assert.assertTrue(getCurrentPermissions(sentDat).canChgrp());
 
         /* retrieve again the image, dataset and link */
         long datasetGroupId =((RLong) iQuery.projection(
@@ -1201,7 +1201,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * and the link too.*/
         if (importYourGroupAndChgrpAndChownExpectSuccess) {/* whole workflow2 succeeded */
             /* Check the value of canChown on the dataset is true in this case.*/
-            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), true);
+            Assert.assertTrue(getCurrentPermissions(sentDat).canChown());
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1230,7 +1230,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
             /* Check the value of canChown on the dataset is true in this case.*/
-            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), true);
+            Assert.assertTrue(getCurrentPermissions(sentDat).canChown());
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1260,7 +1260,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
             /* Check the value of canChown on the dataset is false in this case.*/
-            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), false);
+            Assert.assertFalse(getCurrentPermissions(sentDat).canChown());
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1289,7 +1289,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
             /* Check the value of canChown on the dataset is false in this case.*/
-            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), false);
+            Assert.assertFalse(getCurrentPermissions(sentDat).canChown());
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -1399,7 +1399,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         assertOwnedBy(sentImage1, recipient);
         assertOwnedBy(linkOfDatasetImage1, recipient);
         assertOwnedBy(linkOfProjectDataset1, recipient);
-        /*check ownership of the second hierarchy set*/
+        /* Check ownership of the second hierarchy set*/
         assertOwnedBy(sentProj2, recipient);
         assertOwnedBy(sentDat2, recipient);
         assertOwnedBy(sentImage2, recipient);
@@ -1466,13 +1466,13 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             roi = (Roi) iUpdate.saveAndReturnObject(roi);
             /* Check the value of canAnnotate on the sentImage.
              * The value must be true as the ROI can be saved.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canAnnotate(), true);
+            Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
         } catch (SecurityViolation sv) {
             /* will not work in private group or when the permissions are insufficient */
             /* Check the value of canAnnotate on the sentImage.
              * The value must be false as the ROI cannot be saved.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canAnnotate(), false);
+            Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertFalse(isExpectSuccessCreateROIRndSettings);
         }
 
@@ -1483,13 +1483,13 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                     Arrays.asList(pixelsOfImage.getId().getValue()));
             /* Check the value of canAnnotate on the sentImage.
              * The value must be true as the Rnd settings can be saved.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canAnnotate(), true);
+            Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
         } catch (SecurityViolation sv) {
             /* will not work in private group or when the permissions are insufficient */
             /* Check the value of canAnnotate on the sentImage.
              * The value must be false as the Rnd settings cannot be saved.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canAnnotate(), false);
+            Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertFalse(isExpectSuccessCreateROIRndSettings);
         }
         /* retrieve the image corresponding to the roi and Rnd settings
@@ -1602,11 +1602,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         try {
             link = (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
             /* Check the value of canAnnotate on the image is true in this case.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canAnnotate(), true);
+            Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertTrue(isExpectSuccessLinkFileAttachemnt);
         } catch (SecurityViolation sv) {
             /* Check the value of canAnnotate on the image is false in this case.*/
-            Assert.assertEquals(getCurrentPermissions(sentImage).canAnnotate(), false);
+            Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertFalse(isExpectSuccessLinkFileAttachemnt);
             return; /* finish the test in case we have no Link */
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -681,7 +681,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* try to move the image into another group of the normalUser
          * which should succeed if sudoing and also in case
          * the light admin has Chgrp permissions
-         * (i.e. isExpectSuccessInMemberGroup is true) */
+         * (i.e. isExpectSuccessInMemberGroup is true). Also check that
+         * the canChgrp boolean delivers true in accordance with the
+         * isExpectSuccessInMemberGroup boolean value */
+        Assert.assertEquals(getCurrentPermissions(image).canChgrp(), isExpectSuccessInMemberGroup);
         doChange(client, factory, Requests.chgrp().target(image).toGroup(normalUsersOtherGroupId).build(), isExpectSuccessInMemberGroup);
         /* note in which group the image and the original file are now */
         long afterFirstChgrpImageGroupId = ((RLong) iQuery.projection(
@@ -703,7 +706,13 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* try to move into another group the normalUser
          * is not a member of, which should fail in all cases
          * except the light admin has Chgrp permission and is not sudoing
-         * (i.e. chgrpNoSudoExpectSuccessAnyGroup is true) */
+         * (i.e. chgrpNoSudoExpectSuccessAnyGroup is true). Also check that
+         * the canChgrp boolean delivers true in accordance with the
+         * isExpectSuccessInMemberGroup boolean value. Note that the
+         * canChgrp boolean is true in case the object can be moved into
+         * SOME group, and thus it cannot match (in cases where light admin
+         * is sudoed in) with the chgrpNoSudoExpectSuccessAnyGroup boolean.*/
+        Assert.assertEquals(getCurrentPermissions(image).canChgrp(), isExpectSuccessInMemberGroup);
         doChange(client, factory, Requests.chgrp().target(image).toGroup(anotherGroupId).build(),
                 chgrpNoSudoExpectSuccessAnyGroup);
         long afterSecondChgrpImageGroupId = ((RLong) iQuery.projection(

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -924,9 +924,11 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         /* now, having the image linked to the dataset in the group of normalUser already,
          * try to change the ownership of the dataset to the normalUser */
         /* Chowning the dataset should fail in case you have not all of
-         * isAdmin & Chown & WriteOwned & WriteFile permissions which are
+         * Chown & WriteOwned & WriteFile permissions which are
          * captured in the boolean importNotYourGroupAndChownExpectSuccess */
         if (createDatasetImportNotYourGroupAndChownExpectSuccess) {
+            /* Also check that the canChown value on the dataset is true in these cases.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), true);
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             final long remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",
@@ -952,6 +954,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             assertOwnedBy(remoteFile, normalUser);
             Assert.assertEquals(remoteFileGroupId, normalUser.groupId);
         } else {
+            /* Also check that the canChown value on the dataset is false in these cases.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), false);
             doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             final long remoteFileGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM OriginalFile o WHERE o.id = :id",

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -320,13 +320,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
-        if (isSudoing) {
-            try {
-                sudo(new ExperimenterI(normalUser.userId, false));
-            } catch (SecurityViolation sv) {
-                /* sudo expected to fail if the user is not in system group */
-            }
-        }
+        if (isSudoing) sudo(new ExperimenterI(normalUser.userId, false));
 
         /* First, check that the light admin (=importer As)
          * can create Project and Dataset on behalf of the normalUser
@@ -433,11 +427,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
        final EventContext lightAdmin;
        lightAdmin = loginNewAdmin(true, permissions);
-       try {
-           sudo(new ExperimenterI(normalUser.userId, false));
-           }catch (SecurityViolation sv) {
-               throw sv;
-           }
+       sudo(new ExperimenterI(normalUser.userId, false));
        /* create a Dataset and Project being sudoed as normalUser */
        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
        Project proj = mmFactory.simpleProject();
@@ -574,12 +564,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         String savedOriginalName = sentProj.getName().getValue().toString();
         loginUser(lightAdmin);
         /* being the light admin, sudo as the normalUser if this should be the case */
-        if (isSudoing) {
-            try {
-                sudo(new ExperimenterI(normalUser.userId, false));
-            } catch (SecurityViolation sv) {
-            }
-        }
+        if (isSudoing) sudo(new ExperimenterI(normalUser.userId, false));
         /* try to rename the Project as the light admin, either sudoed as normalUser or not */
         final String changedName = "ChangedNameOfLightAdmin";
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
@@ -676,10 +661,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
-        try {
-            sudo(new ExperimenterI(normalUser.userId, false));
-            }catch (SecurityViolation sv) {
-            }
+        sudo(new ExperimenterI(normalUser.userId, false));
+
         /* take care of workflows which do not use sudo */
         if (!isSudoing) {
             loginUser(lightAdmin);
@@ -793,10 +776,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
 
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
-        try {
-            sudo(new ExperimenterI(normalUser.userId, false));
-            }catch (SecurityViolation sv) {
-        }
+        sudo(new ExperimenterI(normalUser.userId, false));
+
         /* take care of workflows which do not use sudo */
         if (!isSudoing) {
             loginUser(lightAdmin);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -793,9 +793,12 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             loginUser(lightAdmin);
         }
         /* light admin tries to chown the image of the normalUser whilst sudoed,
-         * which should fail whether they have a Chown permissions or not */
+         * which should fail whether they have a Chown permissions or not
+         * Also check that the value of canChown boolean on the image is false
+         * in such case.*/
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         if (isSudoing) {
+            Assert.assertEquals(getCurrentPermissions(image).canChown(), false);
             doChange(client, factory, Requests.chown().target(image).toUser(anotherUser.userId).build(), false);
             long imageGroupId = ((RLong) iQuery.projection(
                     "SELECT details.group.id FROM Image i WHERE i.id = :id",
@@ -806,7 +809,10 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         } else {
             /* chowning the image NOT being sudoed,
              * should pass only in case you have Chown
-             * privilege, captured in "chownPassingWhenNotSudoing" boolean */
+             * privilege, captured in "chownPassingWhenNotSudoing" boolean.
+             * Also check that the value of canChown boolean matches chownPassingWhenNotSudoing
+             * boolean in such case.*/
+            Assert.assertEquals(getCurrentPermissions(image).canChown(), chownPassingWhenNotSudoing);
             doChange(client, factory, Requests.chown().target(image).toUser(anotherUser.userId).build(), chownPassingWhenNotSudoing);
             if (chownPassingWhenNotSudoing) {
                 assertOwnedBy(image, anotherUser);


### PR DESCRIPTION
This PR adds tests for can* (canDelete, canEdit etc.) methods which tell the clients the permissions on a particular objects. These methods have been fixed by @mtbc 's PR #5204.

Note that the tests which are being adjusted by this PR were merged with #5159 , but the improvements asked for during the review of #5159 are not included here, because this present PR is older than the review of #5159 . The merging of this PR should allow me to rebase #5275 where all the improvements are going to be (for the list of improvements in #5275 see https://trello.com/c/ygDN23CC/41-new-role-integration-tests-petr

See also
https://trello.com/c/ENmwK2ru/16-can-methods-on-client-side-object-permissions


