### PR TITLE
correct codomain map join for security filter

### DIFF
--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -719,8 +719,9 @@ implements java.io.Serializable, IObject
             "channelbinding.renderingdef = renderingdef.id AND renderingdef.pixels = pixels.id AND pixels.image IN (:images)))"),
 #elseif($prop.type.equals("ome.model.display.CodomainMapContext"))
         @org.hibernate.annotations.Filter(name="SharingSecurityFilter", condition="(:is_admin = 1 OR :is_share = 0 OR " +
-            "id IN (SELECT codomainmapcontext.id FROM codomainmapcontext*, renderingdef*, pixels* WHERE " +
-            "codomainmapcontext.renderingdef = renderingdef.id AND renderingdef.pixels = pixels.id AND pixels.image IN (:images)))"),
+            "id IN (SELECT codomainmapcontext.id FROM channelbinding*, codomainmapcontext*, renderingdef*, pixels* WHERE " +
+            "codomainmapcontext.channelbinding = channelbinding.id AND channelbinding.renderingdef = renderingdef.id AND " +
+            "renderingdef.pixels = pixels.id AND pixels.image IN (:images)))"),
 #elseif($prop.type.equals("ome.model.display.ProjectionDef"))
         @org.hibernate.annotations.Filter(name="SharingSecurityFilter", condition="(:is_admin = 1 OR :is_share = 0 OR " +
             "id IN (SELECT projectiondef.id FROM projectiondef*, renderingdef*, pixels* WHERE " +

--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -188,8 +188,9 @@ import ome.model.*;
         "channelbinding.renderingdef = renderingdef.id AND renderingdef.pixels = pixels.id AND pixels.image IN (:images)))")
 #elseif($type.id.equals("ome.model.display.CodomainMapContext"))
     @org.hibernate.annotations.Filter(name="SharingSecurityFilter", condition="(:is_admin = 1 OR :is_share = 0 OR " +
-        "id IN (SELECT codomainmapcontext.id FROM codomainmapcontext*, renderingdef*, pixels* WHERE " +
-        "codomainmapcontext.renderingdef = renderingdef.id AND renderingdef.pixels = pixels.id AND pixels.image IN (:images)))")
+        "id IN (SELECT codomainmapcontext.id FROM channelbinding*, codomainmapcontext*, renderingdef*, pixels* WHERE " +
+        "codomainmapcontext.channelbinding = channelbinding.id AND channelbinding.renderingdef = renderingdef.id AND " +
+        "renderingdef.pixels = pixels.id AND pixels.image IN (:images)))")
 #elseif($type.id.equals("ome.model.display.ProjectionDef"))
     @org.hibernate.annotations.Filter(name="SharingSecurityFilter", condition="(:is_admin = 1 OR :is_share = 0 OR " +
         "id IN (SELECT projectiondef.id FROM projectiondef*, renderingdef*, pixels* WHERE " +

--- a/components/server/src/ome/services/sharing/BlobShareStore.java
+++ b/components/server/src/ome/services/sharing/BlobShareStore.java
@@ -40,6 +40,7 @@ import ome.model.core.LogicalChannel;
 import ome.model.core.Pixels;
 import ome.model.core.PlaneInfo;
 import ome.model.display.ChannelBinding;
+import ome.model.display.CodomainMapContext;
 import ome.model.display.QuantumDef;
 import ome.model.display.RenderingDef;
 import ome.model.display.Thumbnail;
@@ -311,6 +312,10 @@ public class BlobShareStore extends ShareStore implements
             ChannelBinding obj = (ChannelBinding) s.get(ChannelBinding.class,
                     objId);
             return imagesContainsPixels(s, images, obj.getRenderingDef()
+                    .getPixels(), pixToImageCache);
+        } else if (CodomainMapContext.class.isAssignableFrom(kls)) {
+            final CodomainMapContext obj = (CodomainMapContext) s.get(CodomainMapContext.class, objId);
+            return imagesContainsPixels(s, images, obj.getChannelBinding().getRenderingDef()
                     .getPixels(), pixToImageCache);
         } else if (Thumbnail.class.isAssignableFrom(kls)) {
             Thumbnail obj = (Thumbnail) s.get(Thumbnail.class, objId);


### PR DESCRIPTION
# What this PR does

Adjust the security filter for reading codomain map context instances in shares.

# Testing this PR

@pwalczysko has the relevant share workflows.

# Related reading

https://github.com/openmicroscopy/openmicroscopy/pull/4793
https://trello.com/c/sMxu4Rwi/73-codomain-map-context-in-shares-and-public-user