### PR TITLE
Cors headers

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -692,6 +692,22 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " 'webtest/webclient_plugins/center_plugin.overlay.js.html',"
           " 'channel_overlay_panel']``. "
           "The javascript loads data into ``$('#div_id')``.")],
+
+    # CORS
+    "omero.web.cors_origin_whitelist":
+        ["CORS_ORIGIN_WHITELIST",
+         '[]',
+         json.loads,
+         ("A list of origin hostnames that are authorized to make cross-site "
+          "HTTP requests."
+          "Used by the django-cors-headers app as described at "
+          "https://github.com/ottoyiu/django-cors-headers")],
+    "omero.web.cors_origin_allow_all":
+        ["CORS_ORIGIN_ALLOW_ALL",
+         "false",
+         parse_boolean,
+         ("If True, cors_origin_whitelist will not be used and all origins "
+          "will be authorized to make cross-site HTTP requests.")],
 }
 
 DEPRECATED_SETTINGS_MAPPINGS = {
@@ -1194,17 +1210,13 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
-# Or use CORS_ORIGIN_WHITELIST below
-CORS_ORIGIN_ALLOW_ALL = True
-
+# Configuration for django-cors-headers app
+# See https://github.com/ottoyiu/django-cors-headers
+# Configration of allowed origins is handled by custom settings above
 CORS_ALLOW_CREDENTIALS = True
-
 # Needed for Django <1.9 since CSRF_TRUSTED_ORIGINS not supported
 CORS_REPLACE_HTTPS_REFERER = True
 
-# CORS_ORIGIN_WHITELIST = (
-#     'localhost:8000',
-# )
 
 # Load server list and freeze
 from connector import Server

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -971,6 +971,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'corsheaders.middleware.CorsPostCsrfMiddleware',
 )
 
 
@@ -1193,7 +1194,17 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
+# Or use CORS_ORIGIN_WHITELIST below
 CORS_ORIGIN_ALLOW_ALL = True
+
+CORS_ALLOW_CREDENTIALS = True
+
+# Needed for Django <1.9 since CSRF_TRUSTED_ORIGINS not supported
+CORS_REPLACE_HTTPS_REFERER = True
+
+# CORS_ORIGIN_WHITELIST = (
+#     'localhost:8000',
+# )
 
 # Load server list and freeze
 from connector import Server

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -1193,6 +1193,8 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
+CORS_ORIGIN_ALLOW_ALL = True
+
 # Load server list and freeze
 from connector import Server
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -965,6 +965,7 @@ USE_I18N = True
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
 # See https://docs.djangoproject.com/en/1.8/topics/http/middleware/.
 MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.BrokenLinkEmailsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -1033,6 +1034,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'corsheaders',
 )
 
 # ADDITONAL_APPS: We import any settings.py from apps. This allows them to

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -7,6 +7,7 @@
 zeroc-ice>3.5,<3.7
 Django>=1.8,<1.9
 django-pipeline==1.3.20
+django-cors-headers>=2.0.2
 gunicorn>=19.3
 
 omero-marshal==0.5.1

--- a/examples/Training/javascript/index.html
+++ b/examples/Training/javascript/index.html
@@ -1,0 +1,280 @@
+
+<!DOCTYPE html>
+
+<!--
+  Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+  All rights reserved.
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!-- Example file for connecting and logging in to the JSON api -->
+
+<html>
+
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+<style>
+
+#base_url_container {
+  z-index: 100;
+}
+
+#login_container {
+  display: none;
+}
+
+.full_page {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  top: 0;
+  z-index: 0;
+  background-color: #eee;
+}
+
+.full_page input {
+  margin-bottom: 20px;
+  padding: 10px;
+  font-size: 16px;
+  height: auto;
+}
+
+.navbar {
+  z-index: 0;
+}
+
+#username {
+  margin-bottom: 5px;
+}
+
+body {
+  background-color: #eee;
+}
+
+#server_form, #login_form {
+  max-width: 430px;
+  padding-top: 55px;
+  margin: 0 auto;
+
+}
+
+</style>
+
+<body>
+
+  <div id="base_url_container" class="full_page container">
+    <form id="server_form">
+      <h2>Enter OMERO.web url</h2>
+      <input id="base_url" type="text" class="form-control" placeholder="e.g. http://localhost:4080/" required autofocus>
+      <button class="btn btn-lg btn-primary btn-block" type="submit">Connect</button>
+    </form>
+  </div>
+
+  <div id="login_container" class="full_page container">
+    <form id="login_form">
+      <h2>Login to OMERO</h2>
+      <select id="server"></select>
+      <label for="username" class="sr-only">Username</label>
+      <input id="username" type="text" class="form-control" name="username" placeholder="Username">
+      <label for="password" class="sr-only">Password</label>
+      <input id="password" type="text" class="form-control" name="password" placeholder="Password">
+      <button class="btn btn-lg btn-primary btn-block" type="submit">Login</button>
+    </form>
+  </div>
+
+
+  <nav class="navbar navbar-inverse navbar-fixed-top">
+    <div class="container">
+      <div class="navbar-header">
+        <a class="navbar-brand" href="#">OMERO</a>
+      </div>
+      <div id="navbar" class="collapse navbar-collapse">
+        <form class="navbar-form navbar-right" >
+          <button id="logout_button" type="submit" class="btn btn-link">Log out</button>
+        </form>
+        <ul class="nav navbar-nav navbar-right">
+          <li><a id="logged_in_user" href="#"></a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container" style="margin-top: 50px">
+    <div class="starter-template">
+      <h1>Projects</h1>
+      <div id="projects">
+      </div>
+    </div>
+  </div>
+
+<script>
+
+var omeroweb_url;
+var latest_base_url;
+var base_urls;
+var csrf_token;
+
+
+function createCORSRequest(method, url) {
+  var xhr = new XMLHttpRequest();
+  if ("withCredentials" in xhr) {
+    xhr.withCredentials = true;
+    xhr.open(method, url, true);
+  } else if (typeof XDomainRequest != "undefined") {
+    xhr = new XDomainRequest();
+    xhr.open(method, url);
+  } else {
+    // CORS is not supported by the browser.
+    xhr = null;
+  }
+
+  xhr.onerror = function() {
+    console.log('There was an error!');
+  };
+  return xhr;
+}
+
+function makeJSONRequest(method, url, callback, data) {
+  var xhr = createCORSRequest(method, url);
+
+  xhr.onload = function() {
+    console.log(xhr);
+    // handle the response (assumes we're getting JSON data)
+    var responseText = xhr.responseText;
+    var jsonResponse = JSON.parse(responseText);
+    // If not logged-in, show login form
+    if (xhr.status === 403 && jsonResponse.message === "Not logged in") {
+      prepareLogin();
+    }
+    // status OK - call the callback()
+    else if (xhr.status === 200) {
+      if (callback) {
+        callback(jsonResponse);
+      }
+    } else {
+      console.log("Error:", xhr)
+    }
+  };
+
+  if (method !== 'GET') {
+    xhr.setRequestHeader('x-csrftoken', csrf_token);
+  }
+
+  if (data) {
+    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+    xhr.send(data);
+  } else {
+    xhr.send();
+  }
+}
+
+function loadBaseUrls(callback) {
+  makeJSONRequest('GET', latest_base_url, function(rsp) {
+    base_urls = rsp;
+    callback();
+  });
+}
+
+function prepareLogin() {
+  // show login form
+  document.getElementById('login_container').style.display = 'block';
+  // Get available servers
+  var servers_url = base_urls['url:servers'];
+  makeJSONRequest('GET', servers_url, function(rsp) {
+    var serversHtml = rsp.data.map(function(s){
+      return '<option value="' + s.id + '">' + s.server + ':' + s.port + '</option>';
+    });
+    document.getElementById('server').innerHTML = serversHtml.join("");
+  });
+
+  // Also get CSRF token needed for login and other POST requests
+  var token_url = base_urls['url:token'];
+  makeJSONRequest('GET', token_url, function(rsp) {
+    csrf_token = rsp.data;
+  });
+}
+
+function loadProjects() {
+  var projects_url = base_urls['url:projects'];
+  makeJSONRequest('GET', projects_url, function(rsp) {
+    // hide login form
+    document.getElementById('login_container').style.display = 'none';
+    var projectsHtml = rsp.data.map(function(p){
+      return '<p>' + p['@id'] + ':' + p.Name + '</p>';
+    });
+    document.getElementById('projects').innerHTML = projectsHtml.join("");
+  });
+}
+
+document.getElementById('server_form').addEventListener('submit', function(event) {
+  event.preventDefault();
+
+  omeroweb_url = document.getElementById('base_url').value;
+  // hide form
+  document.getElementById('base_url_container').style.display = 'none';
+  makeJSONRequest('GET', omeroweb_url + 'api/', function(rsp) {
+    // List of supported versions
+    var versions = rsp.data;
+    // Get base_url from last version in the list
+    latest_base_url = versions[versions.length-1]["url:base"];
+
+    // Get the list of top-level urls as starting points,
+    // then load Projects (will show Login form if we're not logged in)
+    loadBaseUrls(loadProjects);
+  });
+
+  return false;
+});
+
+
+document.getElementById('login_form').addEventListener('submit', function(event) {
+  event.preventDefault();
+
+  var login_url = base_urls['url:login'];
+
+  var fields = ['username', 'password', 'server'];
+  var data = fields.map(function(f){
+    return f + '=' + document.getElementById(f).value
+  });
+  data = data.join('&');
+  console.log(data);
+
+  makeJSONRequest('POST', login_url, function(rsp) {
+    // Will get eventContext if login OK
+    console.log(rsp);
+
+    // Show username in top header
+    var ctx = rsp['eventContext'];
+    document.getElementById('logged_in_user').innerHTML = ctx['userName'];
+
+    loadProjects();
+  }, data);
+
+  return false;
+});
+
+document.getElementById('logout_button').addEventListener('click', function(event) {
+  event.preventDefault()
+  var logout_url = omeroweb_url + 'webclient/logout/';
+  makeJSONRequest('POST', logout_url, function(rsp) {
+    console.log("LOGGED OUT")
+  });
+  return false;
+})
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
# What this PR does

Adds CORS support to OMERO.web. See https://trello.com/c/HHVTF2l8/20-integration-cors-etc
This installs https://github.com/ottoyiu/django-cors-headers (added to requirements.txt).

We allow setting of origins that are authorised to make CORS requests:

```
$ bin/omero config append omero.web.cors_origin_whitelist '"localhost:8000"'
```
OR to allow ALL origins
```
$ bin/omero config set omero.web.cors_origin_allow_all True
```
By default these configs are empty/False, so that cors functionality is disabled by default.

# Testing this PR

1. Should be built and deployed by devspace at http://10.0.51.146/web/api/

2. Go to https://github.com/will-moore/openmicroscopy/blob/cors_headers/examples/Training/javascript/index.html save the raw html file locally then
```
cd path/to/dir/
```
or if you've checked out this branch:
```
$ cd openmicroscopy/examples/Training/javascript/
```
And then:
```
python -m SimpleHTTPServer
```
3. Go to http://localhost:8000/, open devtools and follow the Network tab to see what is happening.

4. Enter the url http://10.0.51.146/web/ and click "Connect" (this devspace deploy has been configured to accept ```"localhost:8000"``` as shown above)

5. This will GET available servers, CSRF token and login url and show a login screen.

6. Login uses POST (should see the pre-flight OPTIONS request) and then lists Projects.

7. Connecting from origins other than ```"localhost:8000"``` should fail.

![screen shot 2017-04-20 at 16 27 58](https://cloud.githubusercontent.com/assets/900055/25239272/7675fdd4-25e7-11e7-96d7-7b3558df30ab.png)

![screen shot 2017-04-20 at 16 28 58](https://cloud.githubusercontent.com/assets/900055/25239283/8011d458-25e7-11e7-9776-9b0d472b2f1e.png)


# Related reading

This is built by devspace including this PR (and ignoring the exclude flag) using 
```
scc merge develop -Dnone -Icors --no-ask --reset --update-gitmodules
```
As things stand in this PR, we require install of ```django-cors-headers``` and it's configured in ```INSTALLED_APPS``` and in ```MIDDLEWARE_CLASSES```.
To enable it, you simply have to configure the allowed origins (see above).
An alternative is that we don't specify it in requirements.txt and users have to install it as needed.
This would also mean that they'd also have to configure ```INSTALLED_APPS``` and ```MIDDLEWARE_CLASSES``` (see @manics PR) but we'd have to be sure that ```'corsheaders.middleware.CorsMiddleware'``` comes *before* ```'django.middleware.csrf.CsrfViewMiddleware',``` (and others?) and ```'corsheaders.middleware.CorsPostCsrfMiddleware'``` comes at the end.

Thoughts?
cc @chris-allan @aleksandra-tarkowska 

Would be nice to support ```https``` at ```https://10.0.51.146/web/``` so that we can host the example on gh-pages which uses ```https```.
Could maybe use the same sslcert that is used by https://10.0.51.146:8443/ See:
https://github.com/openmicroscopy/devspace/blob/master/sslcert