### PR TITLE
CLI tests for PR5205

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -114,3 +114,13 @@ class TestFS(CLITest):
             self.cli.invoke(self.args, strict=True)
         out, err = capsys.readouterr()
         assert err.endswith("SecurityViolation: Admins only!\n")
+
+    def testMkdirAdminOnly(self, capsys):
+        """Test fs mkdir is admin-only"""
+
+        directory_name = self.uuid()
+        self.args += ["mkdir", directory_name]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
+        out, err = capsys.readouterr()
+        assert err.endswith("SecurityViolation: Admins only!\n")

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -19,11 +19,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from test.integration.clitest.cli import CLITest
+from test.integration.clitest.cli import CLITest, RootCLITest
 from omero.cli import NonZeroReturnCode
 from omero.plugins.fs import FsControl
 
 import pytest
+import omero
 
 transfers = ['ln_s', 'ln', 'ln_rm', 'cp', 'cp_rm']
 repos = ['Managed', 'Public', 'Script']
@@ -124,3 +125,75 @@ class TestFS(CLITest):
             self.cli.invoke(self.args, strict=True)
         out, err = capsys.readouterr()
         assert err.endswith("SecurityViolation: Admins only!\n")
+
+
+class TestFsRoot(RootCLITest):
+
+    def setup_method(self, method):
+        super(TestFsRoot, self).setup_method(method)
+        self.cli.register("fs", FsControl, "TEST")
+        self.args += ["fs", "mkdir"]
+
+    def testMkdirAsAdminSimpleDirCreation(self, capsys):
+        """Test fs mkdir simple directory creation workflows"""
+
+        args_hierarchy = list(self.args)
+        top_directory_name = self.uuid()
+        self.args += [top_directory_name]
+        """mkdir of simple non-existing directory succeeds"""
+        self.cli.invoke(self.args, strict=True)
+        """mkdir of pre-existing simple directory directory fails"""
+        with pytest.raises(omero.ResourceError) as exc_info:
+            self.cli.invoke(self.args, strict=True)
+        assert "Path exists on disk" in exc_info.value.message
+        """mkdir passes with --parents flag even when directory exists"""
+        self.args += ["--parents"]
+        self.cli.invoke(self.args, strict=True)
+        """mkdir of directory within preexisting directory succeeds"""
+        subdirectory_name = self.uuid()
+        args_hierarchy += [top_directory_name + "/" + subdirectory_name]
+        self.cli.invoke(args_hierarchy, strict=True)
+        """Second mkdir of a subdirectory fails as the subdirectory exists"""
+        with pytest.raises(omero.ResourceError) as exc_info:
+            self.cli.invoke(args_hierarchy, strict=True)
+        assert "Path exists on disk" in exc_info.value.message
+
+    def testMkdirAsAdminHierarchyOnlyPreexisting(self, capsys):
+        """Test fs mkdir hierarchy is pre-existing only"""
+
+        args_hierarchy = list(self.args)
+        top_directory_name = self.uuid()
+        subdirectory_name = self.uuid()
+        args_hierarchy += [top_directory_name + "/" + subdirectory_name]
+        """mkdir of non-existing top_directory/subdirectory hierarchy fails"""
+        with pytest.raises(omero.SecurityViolation) as exc_info:
+            self.cli.invoke(args_hierarchy, strict=True)
+        assert "Cannot find parent directory" in exc_info.value.message
+
+    def testMkdirAsAdminHierarchyParents(self, capsys):
+        """Test fs mkdir hierarchy with --parents workflows"""
+
+        args_hierarchy = list(self.args)
+        args_hierarchy_parents = list(self.args)
+        top_directory_name = self.uuid()
+        subdirectory_name = self.uuid()
+        """mkdir of a non-existing top_directory/subdirectory
+        hierarchy passes with --parents"""
+        args_hierarchy_parents += [top_directory_name + "/" +
+                                   subdirectory_name, "--parents"]
+        self.cli.invoke(args_hierarchy_parents, strict=True)
+        """mkdir of pre-existing (top) directory fails"""
+        self.args += ["top_directory_name"]
+        with pytest.raises(omero.ResourceError) as exc_info:
+            self.cli.invoke(self.args, strict=True)
+        assert "Path exists on disk" in exc_info.value.message
+        """mkdir of pre-existing top_directory/subdirectory hierarchy fails"""
+        args_hierarchy += [top_directory_name + "/" + subdirectory_name]
+        with pytest.raises(omero.ResourceError) as exc_info:
+            self.cli.invoke(args_hierarchy, strict=True)
+        assert "Path exists on disk" in exc_info.value.message
+        """mkdir of pre-existing top directory with --parents succeeds"""
+        self.args += ["--parents"]
+        self.cli.invoke(self.args, strict=True)
+        """mkdir of pre-existing hierarchy with --parents succeeds"""
+        self.cli.invoke(args_hierarchy_parents, strict=True)

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -150,7 +150,8 @@ class TestFsRoot(RootCLITest):
         self.cli.invoke(args_simple_parents, strict=True)
         """mkdir of directory within preexisting directory succeeds"""
         subdirectory_name = self.uuid()
-        args_hierarchy = self.args + [top_directory_name + "/" + subdirectory_name]
+        args_hierarchy = self.args + [top_directory_name + "/" +
+                                      subdirectory_name]
         self.cli.invoke(args_hierarchy, strict=True)
         """Second mkdir of a subdirectory fails as the subdirectory exists"""
         with pytest.raises(omero.ResourceError) as exc_info:
@@ -162,8 +163,8 @@ class TestFsRoot(RootCLITest):
 
         top_directory_name = self.uuid()
         subdirectory_name = self.uuid()
-        args_hierarchy = self.args + [top_directory_name
-                                      + "/" + subdirectory_name]
+        args_hierarchy = self.args + [top_directory_name + "/" +
+                                      subdirectory_name]
         """mkdir of non-existing top_directory/subdirectory hierarchy fails"""
         with pytest.raises(omero.SecurityViolation) as exc_info:
             self.cli.invoke(args_hierarchy, strict=True)
@@ -185,7 +186,8 @@ class TestFsRoot(RootCLITest):
             self.cli.invoke(args_simple, strict=True)
         assert "Path exists on disk" in exc_info.value.message
         """mkdir of pre-existing top_directory/subdirectory hierarchy fails"""
-        args_hierarchy = self.args + [top_directory_name + "/" + subdirectory_name]
+        args_hierarchy = self.args + [top_directory_name + "/" +
+                                      subdirectory_name]
         with pytest.raises(omero.ResourceError) as exc_info:
             self.cli.invoke(args_hierarchy, strict=True)
         assert "Path exists on disk" in exc_info.value.message

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -181,7 +181,7 @@ class TestFsRoot(RootCLITest):
                                               subdirectory_name, "--parents"]
         self.cli.invoke(args_hierarchy_parents, strict=True)
         """mkdir of pre-existing (top) directory fails"""
-        args_simple = self.args + ["top_directory_name"]
+        args_simple = self.args + [top_directory_name]
         with pytest.raises(omero.ResourceError) as exc_info:
             self.cli.invoke(args_simple, strict=True)
         assert "Path exists on disk" in exc_info.value.message

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -137,21 +137,20 @@ class TestFsRoot(RootCLITest):
     def testMkdirAsAdminSimpleDirCreation(self, capsys):
         """Test fs mkdir simple directory creation workflows"""
 
-        args_hierarchy = list(self.args)
         top_directory_name = self.uuid()
-        self.args += [top_directory_name]
+        args_simple = self.args + [top_directory_name]
         """mkdir of simple non-existing directory succeeds"""
-        self.cli.invoke(self.args, strict=True)
-        """mkdir of pre-existing simple directory directory fails"""
+        self.cli.invoke(args_simple, strict=True)
+        """mkdir of pre-existing simple directory fails"""
         with pytest.raises(omero.ResourceError) as exc_info:
-            self.cli.invoke(self.args, strict=True)
+            self.cli.invoke(args_simple, strict=True)
         assert "Path exists on disk" in exc_info.value.message
         """mkdir passes with --parents flag even when directory exists"""
-        self.args += ["--parents"]
-        self.cli.invoke(self.args, strict=True)
+        args_simple_parents = args_simple + ["--parents"]
+        self.cli.invoke(args_simple_parents, strict=True)
         """mkdir of directory within preexisting directory succeeds"""
         subdirectory_name = self.uuid()
-        args_hierarchy += [top_directory_name + "/" + subdirectory_name]
+        args_hierarchy = self.args + [top_directory_name + "/" + subdirectory_name]
         self.cli.invoke(args_hierarchy, strict=True)
         """Second mkdir of a subdirectory fails as the subdirectory exists"""
         with pytest.raises(omero.ResourceError) as exc_info:
@@ -161,10 +160,10 @@ class TestFsRoot(RootCLITest):
     def testMkdirAsAdminHierarchyOnlyPreexisting(self, capsys):
         """Test fs mkdir hierarchy is pre-existing only"""
 
-        args_hierarchy = list(self.args)
         top_directory_name = self.uuid()
         subdirectory_name = self.uuid()
-        args_hierarchy += [top_directory_name + "/" + subdirectory_name]
+        args_hierarchy = self.args + [top_directory_name
+                                      + "/" + subdirectory_name]
         """mkdir of non-existing top_directory/subdirectory hierarchy fails"""
         with pytest.raises(omero.SecurityViolation) as exc_info:
             self.cli.invoke(args_hierarchy, strict=True)
@@ -173,27 +172,25 @@ class TestFsRoot(RootCLITest):
     def testMkdirAsAdminHierarchyParents(self, capsys):
         """Test fs mkdir hierarchy with --parents workflows"""
 
-        args_hierarchy = list(self.args)
-        args_hierarchy_parents = list(self.args)
         top_directory_name = self.uuid()
         subdirectory_name = self.uuid()
         """mkdir of a non-existing top_directory/subdirectory
         hierarchy passes with --parents"""
-        args_hierarchy_parents += [top_directory_name + "/" +
-                                   subdirectory_name, "--parents"]
+        args_hierarchy_parents = self.args + [top_directory_name + "/" +
+                                              subdirectory_name, "--parents"]
         self.cli.invoke(args_hierarchy_parents, strict=True)
         """mkdir of pre-existing (top) directory fails"""
-        self.args += ["top_directory_name"]
+        args_simple = self.args + ["top_directory_name"]
         with pytest.raises(omero.ResourceError) as exc_info:
-            self.cli.invoke(self.args, strict=True)
+            self.cli.invoke(args_simple, strict=True)
         assert "Path exists on disk" in exc_info.value.message
         """mkdir of pre-existing top_directory/subdirectory hierarchy fails"""
-        args_hierarchy += [top_directory_name + "/" + subdirectory_name]
+        args_hierarchy = self.args + [top_directory_name + "/" + subdirectory_name]
         with pytest.raises(omero.ResourceError) as exc_info:
             self.cli.invoke(args_hierarchy, strict=True)
         assert "Path exists on disk" in exc_info.value.message
         """mkdir of pre-existing top directory with --parents succeeds"""
-        self.args += ["--parents"]
-        self.cli.invoke(self.args, strict=True)
+        args_simple_parents = args_simple + ["--parents"]
+        self.cli.invoke(args_simple_parents, strict=True)
         """mkdir of pre-existing hierarchy with --parents succeeds"""
         self.cli.invoke(args_hierarchy_parents, strict=True)


### PR DESCRIPTION
# What this PR does
Adds CLI tests for the ``omero fs mkdir ...`` functionality introduced in https://github.com/openmicroscopy/openmicroscopy/pull/5205.

Give this PR a descriptive title then expand on that here.
The python CLI tests are added to check that:
  - the non-admin cannot execute the ``omero fs mkdir <directory_name>`` command
  - that the admin can successfully execute ``omero fs mkdir <directory_name>.`` command when the directory with ``idrectory_name`` does not exist
  - that the admin cannot execute  ``omero fs mkdir <directory_name>`` if the directory with `idrectory_name`` already exists
   - that the admin can execute ``omero fs mkdir <directory_name>  --parents`` even if the directory with `idrectory_name`` already exists

# Testing this PR

Check that the tests under ``tools/components/OmeroPy/test/integration/clitest/test_fs.py`` pass.
Check the sanity of the tests in the code.

See also https://trello.com/c/aKMV6KJI/24-bug-fs-symlink-strategy-fails

--depends-on #5205

