### PR TITLE
Configure django middleware

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -373,6 +373,23 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["APPLICATION_SERVER_MAX_REQUESTS", 0, int,
          ("The maximum number of requests a worker will process before "
           "restarting.")],
+    "omero.web.middleware":
+        ["MIDDLEWARE_CLASSES_LIST",
+         ('['
+          '{"index": 1, '
+          '"class": "django.middleware.common.BrokenLinkEmailsMiddleware"},'
+          '{"index": 2, '
+          '"class": "django.middleware.common.CommonMiddleware"},'
+          '{"index": 3, '
+          '"class": "django.contrib.sessions.middleware.SessionMiddleware"},'
+          '{"index": 4, '
+          '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
+          '{"index": 5, '
+          '"class": "django.contrib.messages.middleware.MessageMiddleware"}'
+          ']'),
+         json.loads,
+         ("The maximum number of requests a worker will process before "
+          "restarting.")],
     "omero.web.prefix":
         ["FORCE_SCRIPT_NAME",
          None,
@@ -978,17 +995,6 @@ except NameError:
 # internationalization machinery.
 USE_I18N = True
 
-# MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
-# See https://docs.djangoproject.com/en/1.8/topics/http/middleware/.
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.BrokenLinkEmailsMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-)
-
-
 # ROOT_URLCONF: A string representing the full Python import path to your root
 # URLconf.
 # For example: "mydjangoapps.urls". Can be overridden on a per-request basis
@@ -1206,6 +1212,14 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # JSON serializer, which is now the default, cannot handle
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+
+# MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
+# See https://docs.djangoproject.com/en/1.6/topics/http/middleware/.
+MIDDLEWARE_CLASSES = \
+    tuple(
+        map(lambda d: str(d.get('class')),
+        sorted(MIDDLEWARE_CLASSES_LIST, key=lambda k: k['index']))  # noqa
+    )
 
 # Load server list and freeze
 from connector import Server

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -388,8 +388,10 @@ CUSTOM_SETTINGS_MAPPINGS = {
           '"class": "django.contrib.messages.middleware.MessageMiddleware"}'
           ']'),
          json.loads,
-         ("The maximum number of requests a worker will process before "
-          "restarting.")],
+         ('List of Django middleware classes in the form '
+          '[{"class": "class.name", "index": FLOAT}]. '
+          'See https://docs.djangoproject.com/en/1.8/topics/http/middleware/. '
+          'Classes will be ordered by increasing index')],
     "omero.web.prefix":
         ["FORCE_SCRIPT_NAME",
          None,
@@ -1214,12 +1216,8 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
-# See https://docs.djangoproject.com/en/1.6/topics/http/middleware/.
-MIDDLEWARE_CLASSES = \
-    tuple(
-        map(lambda d: str(d.get('class')),
-        sorted(MIDDLEWARE_CLASSES_LIST, key=lambda k: k['index']))  # noqa
-    )
+MIDDLEWARE_CLASSES = tuple(e['class'] for e in sorted(
+    MIDDLEWARE_CLASSES_LIST, key=lambda k: k['index']))  # noqa
 
 # Load server list and freeze
 from connector import Server

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -1215,9 +1215,12 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
+
+# Load server list and freeze
+from utils import sort_properties_to_tuple
+
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
-MIDDLEWARE_CLASSES = tuple(e['class'] for e in sorted(
-    MIDDLEWARE_CLASSES_LIST, key=lambda k: k['index']))  # noqa
+MIDDLEWARE_CLASSES = sort_properties_to_tuple(MIDDLEWARE_CLASSES_LIST)  # noqa
 
 # Load server list and freeze
 from connector import Server

--- a/components/tools/OmeroWeb/omeroweb/utils.py
+++ b/components/tools/OmeroWeb/omeroweb/utils.py
@@ -43,3 +43,8 @@ def reverse_with_params(*args, **kwargs):
     if qs:
         url += '?' + urlencode(qs)
     return url
+
+
+def sort_properties_to_tuple(input_list, index="index", element="class"):
+    return tuple(e[element] for e in sorted(
+                 input_list, key=lambda k: k[index]))

--- a/components/tools/OmeroWeb/test/unit/test_util.py
+++ b/components/tools/OmeroWeb/test/unit/test_util.py
@@ -27,7 +27,7 @@ import json
 
 from django.core.urlresolvers import reverse
 
-from omeroweb.utils import reverse_with_params
+from omeroweb.utils import reverse_with_params, sort_properties_to_tuple
 from omeroweb.webclient.webclient_utils import formatPercentFraction
 from omeroweb.webclient.webclient_utils import getDateTime
 
@@ -93,3 +93,33 @@ class TestUtil(object):
         assert ('reverse_with_params() argument after ** must'
                 ' be a mapping, not %s') % top_links[1] \
             in str(excinfo.value)
+
+    @pytest.mark.parametrize('params', [
+        ([], ()),
+        ([{"index": 1, "class": "abc"}], ('abc',)),
+        ([{"index": 1, "class": "abc"}, {"index": 1, "class": "cde"}],
+         ('abc', 'cde')),
+        ([{"index": 2, "class": "abc"}, {"index": 1, "class": "cde"}],
+         ('cde', 'abc')),
+        (({"index": 1, "class": "abc"},), ('abc',)),
+    ])
+    def test_sort_properties_to_tuple(self, params):
+        assert sort_properties_to_tuple(params[0]) == params[1]
+
+    @pytest.mark.parametrize('params', [
+        ([{"foo": 1, "bar": "abc"}], ('abc',)),
+    ])
+    def test_sort_properties_to_tuple_custom(self, params):
+        assert sort_properties_to_tuple(
+            params[0], params[0][0].keys()[0],
+            params[0][0].keys()[1]) == params[1]
+
+    @pytest.mark.parametrize('bad_params', [
+        ([{}], KeyError, "'index'"),
+        ([{"foo": 1}], KeyError, "'index'"),
+        ([{"index": 1}], KeyError, "'class'"),
+    ])
+    def test_sort_properties_to_tuple_keyerror(self, bad_params):
+        with pytest.raises(bad_params[1]) as excinfo:
+            sort_properties_to_tuple(bad_params[0])
+        assert bad_params[2] in str(excinfo.value)


### PR DESCRIPTION
# What this PR does

Makes the Django middleware classes configurable using a new property `omero.web.middleware`

# Testing this PR

This PR should have no change on existing configurations.

To test the new property add a new middleware class. For example, you can serve static files directly in Django using [whitenoise](https://devcenter.heroku.com/articles/django-assets#whitenoise) which should be production quality in contrast to the built-in development server:

    pip install whitenoise
    OMERO.web/bin/omero config append omero.web.middleware '{"index":0, "class":"whitenoise.middleware.WhiteNoiseMiddleware"}'
    OMERO.web/bin/omero web start

OMERO.web should be running on http://localhost:4080

# Related reading

- https://trello.com/c/cWcsQClq/42-public-url-filter-vv-post-urls
- https://github.com/openmicroscopy/openmicroscopy/pull/4876 for a PR with a similar configuration property
- openmicroscopy docker slack channel for discussion of another use case (horizontally scaling OMERO.web docker)
- this will conflict with https://github.com/openmicroscopy/openmicroscopy/pull/5252 if it is rebased @will-moore