### PR TITLE
for light admin restrictions, clean up server code and improve performance

### DIFF
--- a/components/blitz/resources/omero/Collections.ice
+++ b/components/blitz/resources/omero/Collections.ice
@@ -10,8 +10,8 @@
 #define OMERO_COLLECTIONS_ICE
 
 #include <omero/ModelF.ice>
+#include <omero/SystemF.ice>
 #include <omero/RTypes.ice>
-#include <omero/System.ice>
 #include <Ice/BuiltinSequences.ice>
 
 /*

--- a/components/blitz/resources/omero/System.ice
+++ b/components/blitz/resources/omero/System.ice
@@ -6,9 +6,8 @@
 #ifndef OMERO_SYSTEM_ICE
 #define OMERO_SYSTEM_ICE
 
-#include <omero/RTypes.ice>
 #include <omero/ModelF.ice>
-#include <Ice/BuiltinSequences.ice>
+#include <omero/SystemF.ice>
 
 /*
  * The omero::system module combines the ome.system and ome.parameters
@@ -17,40 +16,6 @@
  */
 module omero {
   module sys {
-
-    // START: TRANSFERRED FROM COLLECTIONS
-
-    /*
-     * Some collections were initially defined under omero::sys
-     */
-
-        ["java:type:java.util.ArrayList<Long>:java.util.List<Long>"]
-            sequence<long> LongList;
-
-        ["java:type:java.util.ArrayList<Integer>:java.util.List<Integer>"]
-            sequence<int> IntList;
-
-        ["java:type:java.util.ArrayList<String>:java.util.List<String>"]
-            sequence<string> StringSet;
-
-        ["java:type:java.util.HashMap<Long,Long>:java.util.Map<Long,Long>"]
-            dictionary<long, long> CountMap;
-
-        /**
-         * ParamMap replaces the ome.parameters.QueryParam
-         * type, since the use of varargs is not possible.
-         **/
-        ["java:type:java.util.HashMap"]
-            dictionary<string,omero::RType> ParamMap;
-
-        /**
-         * IdByteMap is used by the ThumbnailService for the multiple thumbnail
-         * retrieval methods.
-         **/
-        ["java:type:java.util.HashMap"]
-            dictionary<long,Ice::ByteSeq> IdByteMap;
-
-    // END: TRANSFERRED FROM COLLECTIONS
 
     /**
      * Maps the ome.system.EventContext interface. Represents the

--- a/components/blitz/resources/omero/System.ice
+++ b/components/blitz/resources/omero/System.ice
@@ -8,6 +8,7 @@
 
 #include <omero/ModelF.ice>
 #include <omero/SystemF.ice>
+#include <omero/Collections.ice>
 
 /*
  * The omero::system module combines the ome.system and ome.parameters
@@ -34,7 +35,7 @@ module omero {
       long   groupId;
       string groupName;
       bool   isAdmin;
-      StringSet  adminPrivileges;
+      omero::api::StringSet  adminPrivileges;
       long   eventId;
       string eventType;
       LongList memberOfGroups;

--- a/components/blitz/resources/omero/System.ice
+++ b/components/blitz/resources/omero/System.ice
@@ -1,9 +1,6 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
- *
  */
 
 #ifndef OMERO_SYSTEM_ICE
@@ -32,6 +29,9 @@ module omero {
 
         ["java:type:java.util.ArrayList<Integer>:java.util.List<Integer>"]
             sequence<int> IntList;
+
+        ["java:type:java.util.ArrayList<String>:java.util.List<String>"]
+            sequence<string> StringSet;
 
         ["java:type:java.util.HashMap<Long,Long>:java.util.Map<Long,Long>"]
             dictionary<long, long> CountMap;
@@ -64,9 +64,12 @@ module omero {
       string sessionUuid;
       long   userId;
       string userName;
+      omero::RLong   sudoerId;
+      omero::RString sudoerName;
       long   groupId;
       string groupName;
       bool   isAdmin;
+      StringSet  adminPrivileges;
       long   eventId;
       string eventType;
       LongList memberOfGroups;

--- a/components/blitz/resources/omero/SystemF.ice
+++ b/components/blitz/resources/omero/SystemF.ice
@@ -1,0 +1,57 @@
+/*
+ *   Copyright 2017 Glencoe Software, Inc. All rights reserved.
+ *   Use is subject to license terms supplied in LICENSE.txt
+ *
+ */
+
+#include <omero/RTypes.ice>
+#include <Ice/BuiltinSequences.ice>
+
+#ifndef OMERO_SYSTEMF_ICE
+#define OMERO_SYSTEMF_ICE
+
+/*
+ * Defines various classes for more simplified imports.
+ */
+module omero {
+
+    module sys {
+
+        // START: TRANSFERRED FROM COLLECTIONS
+        // Some collections were initially defined under omero::sys
+
+        ["java:type:java.util.ArrayList<Long>:java.util.List<Long>"]
+            sequence<long> LongList;
+
+        ["java:type:java.util.ArrayList<Integer>:java.util.List<Integer>"]
+            sequence<int> IntList;
+
+        ["java:type:java.util.ArrayList<String>:java.util.List<String>"]
+            sequence<string> StringSet;
+
+        ["java:type:java.util.HashMap<Long,Long>:java.util.Map<Long,Long>"]
+            dictionary<long, long> CountMap;
+
+        /**
+         * ParamMap replaces the ome.parameters.QueryParam
+         * type, since the use of varargs is not possible.
+         **/
+        ["java:type:java.util.HashMap"]
+            dictionary<string,omero::RType> ParamMap;
+
+        /**
+         * IdByteMap is used by the ThumbnailService for the multiple thumbnail
+         * retrieval methods.
+         **/
+        ["java:type:java.util.HashMap"]
+            dictionary<long,Ice::ByteSeq> IdByteMap;
+
+        // END: TRANSFERRED FROM COLLECTIONS
+
+        class EventContext;
+
+    };
+
+};
+
+#endif

--- a/components/blitz/resources/omero/SystemF.ice
+++ b/components/blitz/resources/omero/SystemF.ice
@@ -26,9 +26,6 @@ module omero {
         ["java:type:java.util.ArrayList<Integer>:java.util.List<Integer>"]
             sequence<int> IntList;
 
-        ["java:type:java.util.ArrayList<String>:java.util.List<String>"]
-            sequence<string> StringSet;
-
         ["java:type:java.util.HashMap<Long,Long>:java.util.Map<Long,Long>"]
             dictionary<long, long> CountMap;
 

--- a/components/blitz/src/omero/cmd/graphs/GraphHelper.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphHelper.java
@@ -35,18 +35,15 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.SetMultimap;
 
-import ome.api.IQuery;
 import ome.conditions.InternalException;
 import ome.model.IObject;
 import ome.model.enums.AdminPrivilege;
-import ome.model.meta.Session;
 import ome.security.ACLVoter;
 import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
-import ome.system.EventContext;
 import ome.services.messages.EventLogMessage;
 import omero.cmd.ERR;
 import omero.cmd.Helper;
@@ -80,14 +77,7 @@ public class GraphHelper {
      * @return if the current user is an administrator
      */
     public boolean checkIsAdministrator(AdminPrivilege requiredPrivilege) {
-        final EventContext eventContext = helper.getEventContext();
-        if (!eventContext.isCurrentUserAdmin()) {
-            return false;
-        }
-        final IQuery iQuery = helper.getServiceFactory().getQueryService();
-        final Session session = iQuery.get(Session.class, eventContext.getCurrentSessionId());
-        final Set<AdminPrivilege> privileges = adminPrivileges.getSessionPrivileges(session);
-        return privileges.contains(requiredPrivilege);
+        return helper.getEventContext().getCurrentAdminPrivileges().contains(requiredPrivilege);
     }
 
     /**

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import ome.conditions.InternalException;
 import ome.model.IObject;
 import ome.model.ModelBased;
+import ome.model.enums.AdminPrivilege;
 import ome.services.blitz.util.ConvertToBlitzExceptionMessage;
 import ome.system.OmeroContext;
 import ome.system.Principal;
@@ -547,9 +548,15 @@ public class IceMapper extends ome.util.ModelMapper implements
         ec.groupName = ctx.getCurrentGroupName();
         ec.userId = ctx.getCurrentUserId();
         ec.userName = ctx.getCurrentUserName();
+        ec.sudoerId = ctx.getCurrentSudoerId() == null ? null : rlong(ctx.getCurrentSudoerId());
+        ec.sudoerName = ctx.getCurrentSudoerName() == null ? null : rstring(ctx.getCurrentSudoerName());
         ec.leaderOfGroups = ctx.getLeaderOfGroupsList();
         ec.memberOfGroups = ctx.getMemberOfGroupsList();
         ec.isAdmin = ctx.isCurrentUserAdmin();
+        ec.adminPrivileges = new ArrayList<>(ctx.getCurrentAdminPrivileges().size());
+        for (final AdminPrivilege privilege : ctx.getCurrentAdminPrivileges()) {
+            ec.adminPrivileges.add(privilege.getValue());
+        }
         // ticket:2265 Removing from public interface
         // ec.isReadOnly = ctx.isReadOnly();
         ec.groupPermissions = convert(ctx.getCurrentGroupPermissions());

--- a/components/blitz/test/ome/services/blitz/test/utests/IceMethodInvokerUnitTest.java
+++ b/components/blitz/test/ome/services/blitz/test/utests/IceMethodInvokerUnitTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -42,6 +42,7 @@ import ome.api.ThumbnailStore;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
 import ome.model.acquisition.Objective;
+import ome.model.enums.AdminPrivilege;
 import ome.model.enums.Family;
 import ome.model.enums.FilterType;
 import ome.model.internal.Permissions;
@@ -534,6 +535,16 @@ public class IceMethodInvokerUnitTest extends MockObjectTestCase {
                 return "user";
             }
 
+            @Override
+            public Long getCurrentSudoerId() {
+                return null;
+            }
+
+            @Override
+            public String getCurrentSudoerName() {
+                return null;
+            }
+
             public List<Long> getLeaderOfGroupsList() {
                 return Arrays.asList(4L);
             }
@@ -544,6 +555,11 @@ public class IceMethodInvokerUnitTest extends MockObjectTestCase {
 
             public boolean isCurrentUserAdmin() {
                 return true;
+            }
+
+            @Override
+            public Set<AdminPrivilege> getCurrentAdminPrivileges() {
+                return Collections.emptySet();
             }
 
             public boolean isReadOnly() {

--- a/components/common/src/ome/system/EventContext.java
+++ b/components/common/src/ome/system/EventContext.java
@@ -1,14 +1,14 @@
 /*
- * ome.system.EventContext
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
 package ome.system;
 
 import java.util.List;
+import java.util.Set;
 
+import ome.model.enums.AdminPrivilege;
 import ome.model.internal.Permissions;
 
 /**
@@ -17,7 +17,6 @@ import ome.model.internal.Permissions;
  * order), they also take place within an Event.
  * 
  * @author Josh Moore, josh.moore at gmx.de
- * @version $Revision$, $Date$
  * @see ome.model.meta.Experimenter
  * @see ome.model.meta.ExperimenterGroup
  * @since 3.0
@@ -34,11 +33,17 @@ public interface EventContext {
 
     String getCurrentUserName();
 
+    Long getCurrentSudoerId();
+
+    String getCurrentSudoerName();
+
     Long getCurrentGroupId();
 
     String getCurrentGroupName();
 
     boolean isCurrentUserAdmin();
+
+    Set<AdminPrivilege> getCurrentAdminPrivileges();
 
     boolean isReadOnly();
 

--- a/components/common/src/ome/system/SimpleEventContext.java
+++ b/components/common/src/ome/system/SimpleEventContext.java
@@ -1,7 +1,5 @@
 /*
- *   $Id$
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -10,15 +8,15 @@ package ome.system;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import ome.model.enums.AdminPrivilege;
 import ome.model.internal.Permissions;
 
 /**
  * simple, non-thread-safe, serializable {@link ome.system.EventContext}
  * 
  * @author Josh Moore, josh.moore at gmx.de
- * @version $Revision: 1167 $, $Date: 2006-12-15 11:39:34 +0100 (Fri, 15 Dec
- *          2006) $
  * @see EventContext
  * @since 3.0
  */
@@ -34,6 +32,8 @@ public class SimpleEventContext implements EventContext, Serializable {
 
     protected Long cuId;
 
+    protected Long csuId;
+
     protected Long ceId;
 
     protected String csName;
@@ -42,9 +42,13 @@ public class SimpleEventContext implements EventContext, Serializable {
 
     protected String cuName;
 
+    protected String csuName;
+
     protected String ceType;
 
     protected boolean isAdmin;
+
+    protected Set<AdminPrivilege> adminPrivileges;
 
     protected boolean isReadOnly;
 
@@ -80,15 +84,18 @@ public class SimpleEventContext implements EventContext, Serializable {
         this.csId = ec.getCurrentSessionId();
         this.cgId = ec.getCurrentGroupId();
         this.cuId = ec.getCurrentUserId();
+        this.csuId = ec.getCurrentSudoerId();
         this.csName = ec.getCurrentSessionUuid();
         this.cgName = ec.getCurrentGroupName();
         this.cuName = ec.getCurrentUserName();
+        this.csuName = ec.getCurrentSudoerName();
         this.ceType = ec.getCurrentEventType();
         this.memberOfGroups = new ArrayList<Long>(ec.getMemberOfGroupsList());
         this.leaderOfGroups = new ArrayList<Long>(ec.getLeaderOfGroupsList());
         setGroupPermissions(ec.getCurrentGroupPermissions());
         try {
             this.isAdmin = ec.isCurrentUserAdmin();
+            this.adminPrivileges = ec.getCurrentAdminPrivileges();
             this.isReadOnly = ec.isReadOnly();
             this.ceId = ec.getCurrentEventId();
         } catch (UnsupportedOperationException e) {
@@ -124,8 +131,23 @@ public class SimpleEventContext implements EventContext, Serializable {
         return cuName;
     }
 
+    @Override
+    public Long getCurrentSudoerId() {
+        return csuId;
+    }
+
+    @Override
+    public String getCurrentSudoerName() {
+        return csuName;
+    }
+
     public boolean isCurrentUserAdmin() {
         return isAdmin;
+    }
+
+    @Override
+    public Set<AdminPrivilege> getCurrentAdminPrivileges() {
+        return adminPrivileges;
     }
 
     public boolean isReadOnly() {

--- a/components/server/resources/ome/services/sec-system.xml
+++ b/components/server/resources/ome/services/sec-system.xml
@@ -100,7 +100,7 @@
 
   <bean id="adminPrivilegesCleanup" class="ome.security.basic.LightAdminPrivilegesCleanup" destroy-method="close">
     <constructor-arg ref="simpleSqlAction"/>
-    <constructor-arg value="100"></constructor-arg>  <!-- seconds -->
+    <constructor-arg value="10"></constructor-arg>  <!-- seconds -->
   </bean>
 
 </beans>

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -1592,13 +1592,6 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
      * @return the light administrator privileges that apply to the current session
      */
     private Set<AdminPrivilege> getCurrentAdminPrivilegesForSession() {
-        if (isAdmin()) {
-            final String hql = "FROM Session s LEFT OUTER JOIN FETCH s.sudoer WHERE s.id = :id";
-            final Parameters params = new Parameters().addId(getEventContext().getCurrentSessionId());
-            final ome.model.meta.Session session = iQuery.findByQuery(hql, params);
-            return adminPrivileges.getSessionPrivileges(session);
-        } else {
-            return ImmutableSet.of();
-        }
+        return isAdmin() ? getEventContextQuiet().getCurrentAdminPrivileges() : Collections.<AdminPrivilege>emptySet();
     }
 }

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -647,7 +647,7 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
     public long createLightSystemUser(Experimenter newSystemUser, List<AdminPrivilege> privileges) {
         assertKnownPrivileges(privileges);
         final List<NamedValue> userConfig = new ArrayList<>();
-        for (final AdminPrivilege privilege : adminPrivileges.getAllPrivileges()) {
+        for (final AdminPrivilege privilege : LightAdminPrivileges.getAllPrivileges()) {
             if (!privileges.contains(privilege)) {
                 userConfig.add(new NamedValue(adminPrivileges.getConfigNameForPrivilege(privilege), Boolean.toString(false)));
             }
@@ -1282,7 +1282,7 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
             return Collections.emptyList();
         }
         final List<NamedValue> userConfig = userProxy(user.getId()).getConfig();
-        final List<AdminPrivilege> privileges = new ArrayList<AdminPrivilege>(adminPrivileges.getAllPrivileges());
+        final List<AdminPrivilege> privileges = new ArrayList<AdminPrivilege>(LightAdminPrivileges.getAllPrivileges());
         if (CollectionUtils.isNotEmpty(userConfig)) {
             for (final NamedValue configProperty : userConfig) {
                 if (!Boolean.parseBoolean(configProperty.getValue())) {
@@ -1300,7 +1300,7 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
         assertKnownPrivileges(privileges);
         final Set<AdminPrivilege> targetUserPrivilegesBefore = ImmutableSet.copyOf(getAdminPrivileges(user));
 
-        final Set<AdminPrivilege> privilegesToRemove = new HashSet<AdminPrivilege>(adminPrivileges.getAllPrivileges());
+        final Set<AdminPrivilege> privilegesToRemove = new HashSet<AdminPrivilege>(LightAdminPrivileges.getAllPrivileges());
         privilegesToRemove.removeAll(privileges);
 
         if (user.getId() == getSecurityRoles().getRootId() && !privilegesToRemove.isEmpty()) {

--- a/components/server/src/ome/security/ACLVoter.java
+++ b/components/server/src/ome/security/ACLVoter.java
@@ -186,17 +186,6 @@ public interface ACLVoter {
     void setPermittedClasses(Map<Integer, Set<Class<? extends IObject>>> objectClassesPermitted);
 
     /**
-     * Note the light admin privileges for post-processing before the event context is invalidated.
-     * @param session the session for which privileges should be noted
-     */
-    void noteAdminPrivileges(ome.model.meta.Session session);
-
-    /**
-     * Clear note of the light admin privileges now post-processing is done.
-     */
-    void clearAdminPrivileges();
-
-    /**
      * Gives the {@link ACLVoter} instance a chance to act on the {@link IObject}
      * <em>after</em> the transaction but before finishing the AOP stack.
      * @param obj a model object

--- a/components/server/src/ome/security/CompositeACLVoter.java
+++ b/components/server/src/ome/security/CompositeACLVoter.java
@@ -106,16 +106,6 @@ public class CompositeACLVoter implements ACLVoter {
         basic.setPermittedClasses(objectClassesPermitted);
     }
 
-    @Override
-    public void noteAdminPrivileges(ome.model.meta.Session session) {
-        choose().noteAdminPrivileges(session);
-    }
-
-    @Override
-    public void clearAdminPrivileges() {
-        choose().clearAdminPrivileges();
-    }
-
     public void postProcess(IObject object) {
         choose().postProcess(object);
     }

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -221,6 +221,10 @@ public class BasicACLVoter implements ACLVoter {
             if (sessionOwnerQueried == null) {
                 sessionOwnerQueried = queriedSession.getOwner();
             }
+            /* can read sessions for which "real" owner matches */
+            if (sessionOwnerCurrent.getId().equals(sessionOwnerQueried.getId())) {
+                return true;
+            }
             /* determine if the "real" owner is an administrator */
             final Object systemMembership = session.createQuery(
                     "FROM GroupExperimenterMap WHERE parent.id = :group AND child.id = :user")
@@ -233,8 +237,8 @@ public class BasicACLVoter implements ACLVoter {
                     return true;
                 }
             }
-            /* without ReadSession privilege may read only those sessions for which "real" owner matches */
-            return sessionOwnerCurrent.getId() == sessionOwnerQueried.getId();
+            /* non-administrators may not load others' sessions */
+            return false;
         }
 
         if (d == null || sysTypes.isSystemType(klass)) {

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -312,7 +312,7 @@ public class BasicACLVoter implements ACLVoter {
             final Set<AdminPrivilege> privileges;
             final Event event = currentUser.current().getEvent();
             if (event == null || !event.isLoaded()) {
-                privileges = adminPrivileges.getAllPrivileges();
+                privileges = LightAdminPrivileges.getAllPrivileges();
             } else {
                 privileges = adminPrivileges.getSessionPrivileges(event.getSession());
             }
@@ -470,7 +470,7 @@ public class BasicACLVoter implements ACLVoter {
         }
 
         final Set<AdminPrivilege> privileges = c.getCurrentAdminPrivileges();
-        if (adminPrivileges.getAllPrivileges().equals(privileges)) {
+        if (LightAdminPrivileges.getAllPrivileges().equals(privileges)) {
             for (int i = 0; i < scopes.length; i++) {
                 if (scopes[i] != null) {
                     rv |= (1<<i);

--- a/components/server/src/ome/security/basic/BasicEventContext.java
+++ b/components/server/src/ome/security/basic/BasicEventContext.java
@@ -47,7 +47,7 @@ public class BasicEventContext extends SimpleEventContext {
     // =========================================================================
 
     /**
-     * Prinicpal should only be set once (on
+     * Principal should be set only once (on
      * {@link PrincipalHolder#login(Principal)}.
      */
     private final Principal p;

--- a/components/server/src/ome/security/basic/BasicEventContext.java
+++ b/components/server/src/ome/security/basic/BasicEventContext.java
@@ -1,7 +1,5 @@
 /*
- *   $Id$
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -20,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import ome.api.local.LocalAdmin;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
+import ome.model.enums.AdminPrivilege;
 import ome.model.internal.Permissions;
 import ome.model.meta.Event;
 import ome.model.meta.EventLog;
@@ -66,6 +65,8 @@ public class BasicEventContext extends SimpleEventContext {
 
     private Experimenter owner;
 
+    private Experimenter sudoer;
+
     private ExperimenterGroup group;
 
     private Map<String, String> callContext;
@@ -92,6 +93,7 @@ public class BasicEventContext extends SimpleEventContext {
 
     void invalidate() {
         owner = null;
+        sudoer = null;
         group = null;
         event = null;
     }
@@ -204,6 +206,14 @@ public class BasicEventContext extends SimpleEventContext {
         this.isAdmin = admin;
     }
 
+    public void setAdminPrivileges(Set<AdminPrivilege> adminPrivileges) {
+        this.adminPrivileges = adminPrivileges;
+    }
+
+    public Set<AdminPrivilege> getAdminPrivileges() {
+        return adminPrivileges;
+    }
+
     public void setReadOnly(boolean readOnly) {
         this.isReadOnly = readOnly;
     }
@@ -246,6 +256,23 @@ public class BasicEventContext extends SimpleEventContext {
         this.cuId = owner.getId();
         if (owner.isLoaded()) {
             this.cuName = owner.getOmeName();
+        }
+    }
+
+    public Experimenter getSudoer() {
+        return sudoer;
+    }
+
+    public void setSudoer(Experimenter sudoer) {
+        this.sudoer = sudoer;
+        if (sudoer == null) {
+            this.csuId = null;
+            this.csuName = null;
+        } else {
+            this.csuId = sudoer.getId();
+            if (sudoer.isLoaded()) {
+                this.csuName = sudoer.getOmeName();
+            }
         }
     }
 
@@ -379,6 +406,8 @@ public class BasicEventContext extends SimpleEventContext {
         sb.append(";");
         sb.append(this.owner);
         sb.append(";");
+        sb.append(this.sudoer);
+        sb.append(';');
         sb.append(this.group);
         sb.append(";");
         sb.append(this.event);

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import ome.api.IQuery;
 import ome.api.local.LocalAdmin;
 import ome.api.local.LocalQuery;
 import ome.api.local.LocalUpdate;
@@ -33,6 +34,7 @@ import ome.model.meta.EventLog;
 import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
 import ome.model.meta.GroupExperimenterMap;
+import ome.model.meta.Share;
 import ome.parameters.Parameters;
 import ome.security.ACLVoter;
 import ome.security.AdminAction;
@@ -448,9 +450,11 @@ public class BasicSecuritySystem implements SecuritySystem,
         if (isReadOnly) {
             sess = new ome.model.meta.Session(sessionId, false);
         } else {
-            final String hql = "FROM Session s LEFT OUTER JOIN FETCH s.sudoer WHERE s.id = :id";
+            final IQuery iQuery = sf.getQueryService();
+            final String sessionClass = iQuery.find(Share.class, sessionId) == null ? "Session" : "Share";
+            final String hql = "FROM " + sessionClass + " s LEFT OUTER JOIN FETCH s.sudoer WHERE s.id = :id";
             final Parameters params = new Parameters().addId(sessionId);
-            sess = sf.getQueryService().findByQuery(hql, params);
+            sess = iQuery.findByQuery(hql, params);
         }
 
         tokenHolder.setToken(callGroup.getGraphHolder());

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -647,10 +647,12 @@ public class BasicSecuritySystem implements SecuritySystem,
 
                 BasicEventContext c = cd.current();
                 boolean wasAdmin = c.isCurrentUserAdmin();
+                final Set<AdminPrivilege> oldAdminPrivileges = c.getAdminPrivileges();
                 ExperimenterGroup oldGroup = c.getGroup();
 
                 try {
                     c.setAdmin(true);
+                    c.setAdminPrivileges(LightAdminPrivileges.getAllPrivileges());
                     if (group != null) {
                         c.setGroup(group, group.getDetails().getPermissions());
                     }
@@ -659,6 +661,7 @@ public class BasicSecuritySystem implements SecuritySystem,
                     action.runAsAdmin();
                 } finally {
                     c.setAdmin(wasAdmin);
+                    c.setAdminPrivileges(oldAdminPrivileges);
                     if (group != null) {
                         c.setGroup(oldGroup, oldGroup.getDetails().getPermissions());
                     }

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -397,12 +397,7 @@ public class BasicSecuritySystem implements SecuritySystem,
         }
 
         // admin privileges
-        final Set<AdminPrivilege> adminPrivileges;
-        if (isAdmin) {
-            adminPrivileges = ec.getCurrentAdminPrivileges();
-        } else {
-            adminPrivileges = Collections.<AdminPrivilege>emptySet();
-        }
+        final Set<AdminPrivilege> adminPrivileges = ec.getCurrentAdminPrivileges();
 
         // Active group - starting with #3529, the current group and the current
         // share values should be definitive as setting the context on

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -547,20 +547,6 @@ public class BasicSecuritySystem implements SecuritySystem,
         cd.clearLogs();
     }
 
-    /**
-     * Note the light admin privileges for post-processing before the event context is invalidated.
-     */
-    public void noteAdminPrivileges() {
-        if (aclVoter == null) {
-            /* probably in pixel data or indexer thread */
-            return;
-        }
-        final Parameters params = new Parameters().addId(cd.getCurrentEventContext().getCurrentSessionId());
-        final String hql = "FROM Session s LEFT OUTER JOIN FETCH s.sudoer WHERE s.id = :id";
-        final ome.model.meta.Session session = sf.getQueryService().findByQuery(hql, params);
-        aclVoter.noteAdminPrivileges(session);
-    }
-
     public void invalidateEventContext() {
         if (log.isDebugEnabled()) {
             log.debug("Invalidating current EventContext.");

--- a/components/server/src/ome/security/basic/CurrentDetails.java
+++ b/components/server/src/ome/security/basic/CurrentDetails.java
@@ -1,7 +1,5 @@
 /*
- *   $Id$
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -26,6 +24,7 @@ import ome.conditions.ApiUsageException;
 import ome.conditions.InternalException;
 import ome.conditions.SecurityViolation;
 import ome.model.IObject;
+import ome.model.enums.AdminPrivilege;
 import ome.model.enums.EventType;
 import ome.model.internal.Details;
 import ome.model.internal.Permissions;
@@ -430,8 +429,16 @@ public class CurrentDetails implements PrincipalHolder {
         return current().getOwner();
     }
 
+    public Experimenter getSudoer() {
+        return current().getSudoer();
+    }
+
     public ExperimenterGroup getGroup() {
         return current().getGroup();
+    }
+
+    public Set<AdminPrivilege> getAdminPrivileges() {
+        return current().getAdminPrivileges();
     }
 
     public Event getEvent() {
@@ -443,13 +450,15 @@ public class CurrentDetails implements PrincipalHolder {
      * during {@link #newEvent(long, EventType, TokenHolder)} and possibly
      * updated via {@link #updateEvent(Event)}.
      */
-    void setValues(Experimenter owner, ExperimenterGroup group,
+    void setValues(Experimenter owner, Experimenter sudoer, ExperimenterGroup group,
             Permissions perms,
-            boolean isAdmin, boolean isReadOnly, Long shareId) {
+            boolean isAdmin, Set<AdminPrivilege> adminPrivileges, boolean isReadOnly, Long shareId) {
         BasicEventContext c = current();
         c.setOwner(owner);
+        c.setSudoer(sudoer);
         c.setGroup(group, perms);
         c.setAdmin(isAdmin);
+        c.setAdminPrivileges(adminPrivileges);
         c.setReadOnly(isReadOnly);
         c.setShareId(shareId);
     }

--- a/components/server/src/ome/security/basic/EventHandler.java
+++ b/components/server/src/ome/security/basic/EventHandler.java
@@ -1,9 +1,8 @@
 /*
- *   $Id$
- *
  *   Copyright 2006 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package ome.security.basic;
 
 import java.util.ArrayList;
@@ -151,7 +150,6 @@ public class EventHandler implements MethodInterceptor, ApplicationListener<Cont
         Object retVal = null;
         try {
             secSys.enableReadFilter(session);
-            secSys.noteAdminPrivileges();
             retVal = arg0.proceed();
             saveLogs(readOnly, session);
             secSys.cd.loadPermissions(session);

--- a/components/server/src/ome/security/basic/LightAdminPrivileges.java
+++ b/components/server/src/ome/security/basic/LightAdminPrivileges.java
@@ -90,7 +90,7 @@ public class LightAdminPrivileges {
     /**
      * @return all the light administrator privileges
      */
-    public ImmutableSet<AdminPrivilege> getAllPrivileges() {
+    public static ImmutableSet<AdminPrivilege> getAllPrivileges() {
         return ADMIN_PRIVILEGES;
     }
 

--- a/components/server/src/ome/security/basic/LightAdminPrivileges.java
+++ b/components/server/src/ome/security/basic/LightAdminPrivileges.java
@@ -151,7 +151,7 @@ public class LightAdminPrivileges {
      * @param isCache if newly fetched privileges should be cached for future lookups
      * @return the light administrator privileges associated with the session
      */
-    public ImmutableSet<AdminPrivilege> getSessionPrivileges(Session session, boolean isCache) {
+    private ImmutableSet<AdminPrivilege> getSessionPrivileges(Session session, boolean isCache) {
         final SessionEqualById wrappedSession = new SessionEqualById(session);
         try {
             if (isCache) {

--- a/components/server/src/ome/security/basic/LightAdminPrivileges.java
+++ b/components/server/src/ome/security/basic/LightAdminPrivileges.java
@@ -207,27 +207,35 @@ public class LightAdminPrivileges {
      */
     private ImmutableSet<AdminPrivilege> getPrivileges(Session session) {
         final Set<AdminPrivilege> privileges = new HashSet<>(getAllPrivileges());
-        final Experimenter user;
-        if (session.getSudoer() == null) {
-            user = session.getOwner();
-        } else {
-            user = session.getSudoer();
+        removeUserPrivileges(session.getSudoer(), privileges);
+        removeUserPrivileges(session.getOwner(), privileges);
+        return ImmutableSet.copyOf(privileges);
+    }
+
+    /**
+     * Remove from the given light administrator privileges those not shared by the given user.
+     * Does <em>not</em> take account of if the user is a member of <tt>system</tt>:
+     * calculates assuming that the user is an administrator.
+     * Assumes that <tt>root</tt> has all light administrator privileges.
+     * @param user a user, may be {@code null}
+     * @param privileges a set of light administrator privileges
+     */
+    private void removeUserPrivileges(Experimenter user, Set<AdminPrivilege> privileges) {
+        if (user == null || user.getId() == rootId) {
+            return;
         }
-        if (user != null && user.getId() != rootId) {
-            final List<NamedValue> config = user.getConfig();
-            if (CollectionUtils.isNotEmpty(config)) {
-                for (final NamedValue configProperty : config) {
-                    if (!Boolean.parseBoolean(configProperty.getValue())) {
-                        final String configPropertyName = configProperty.getName();
-                        if (configPropertyName.startsWith(USER_CONFIG_NAME_PREFIX)) {
-                            final String adminPrivilegeName = configPropertyName.substring(USER_CONFIG_NAME_PREFIX.length());
-                            privileges.remove(ADMIN_PRIVILEGES_BY_VALUE.get(adminPrivilegeName));
-                        }
+        final List<NamedValue> config = user.getConfig();
+        if (CollectionUtils.isNotEmpty(config)) {
+            for (final NamedValue configProperty : config) {
+                if (!Boolean.parseBoolean(configProperty.getValue())) {
+                    final String configPropertyName = configProperty.getName();
+                    if (configPropertyName.startsWith(USER_CONFIG_NAME_PREFIX)) {
+                        final String adminPrivilegeName = configPropertyName.substring(USER_CONFIG_NAME_PREFIX.length());
+                        privileges.remove(ADMIN_PRIVILEGES_BY_VALUE.get(adminPrivilegeName));
                     }
                 }
             }
         }
-        return ImmutableSet.copyOf(privileges);
     }
 
     /**

--- a/components/server/src/ome/security/basic/LightAdminPrivilegesSecurityFilter.java
+++ b/components/server/src/ome/security/basic/LightAdminPrivilegesSecurityFilter.java
@@ -79,17 +79,13 @@ public class LightAdminPrivilegesSecurityFilter extends AbstractSecurityFilter {
 
     @Override
     public void enable(Session session, EventContext ec) {
-        final ome.model.meta.Session omeroSession = (ome.model.meta.Session)
-                session.get(ome.model.meta.Session.class, ec.getCurrentSessionId());
         final List<String> privilegeValues = new ArrayList<String>();
-        for (final AdminPrivilege adminPrivilege : adminPrivileges.getSessionPrivileges(omeroSession)) {
+        for (final AdminPrivilege adminPrivilege : ec.getCurrentAdminPrivileges()) {
             privilegeValues.add(adminPrivilege.getValue());
         }
-        final Long realOwner;
-        if (omeroSession.getSudoer() != null) {
-            realOwner = omeroSession.getSudoer().getId();
-        } else {
-            realOwner = omeroSession.getOwner().getId();
+        Long realOwner = ec.getCurrentSudoerId();
+        if (realOwner == null) {
+            realOwner = ec.getCurrentUserId();
         }
 
         final int isAdmin01 = ec.isCurrentUserAdmin() ? 1 : 0;

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -29,7 +29,6 @@ import org.hibernate.type.Type;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.base.Splitter;
 
 import ome.conditions.ApiUsageException;
@@ -54,7 +53,6 @@ import ome.model.internal.NamedValue;
 import ome.model.internal.Permissions;
 import ome.model.internal.Permissions.Right;
 import ome.model.internal.Permissions.Role;
-import ome.model.meta.Event;
 import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
 import ome.model.meta.ExternalInfo;
@@ -360,8 +358,9 @@ public class OmeroInterceptor implements Interceptor {
         } else if (sqlAction != null) {
             /* read-write transactions may trigger checks */
             debug("updating current light administrator privileges");
+            final Set<AdminPrivilege> privileges = currentUser.current().getCurrentAdminPrivileges();
             sqlAction.deleteCurrentAdminPrivileges();
-            sqlAction.insertCurrentAdminPrivileges(getAdminPrivileges());
+            sqlAction.insertCurrentAdminPrivileges(privileges);
         }
     }
 
@@ -658,24 +657,6 @@ public class OmeroInterceptor implements Interceptor {
         return neededRight;
     }
 
-    /**
-     * Determine the light administrator privileges associated with the current event.
-     * If the event is {@code null} but the user is an administrator then return the full set of privileges.
-     * @return the light administrator privileges associated with the current event
-     */
-    private ImmutableSet<AdminPrivilege> getAdminPrivileges() {
-        if (currentUser.getCurrentEventContext().isCurrentUserAdmin()) {
-            final Event event = currentUser.current().getEvent();
-            if (event == null || !event.isLoaded()) {
-                return LightAdminPrivileges.getAllPrivileges();
-            } else {
-                return adminPrivileges.getSessionPrivileges(event.getSession());
-            }
-        } else {
-            return ImmutableSet.of();
-        }
-    }
-
     // TODO is this natural? perhaps permissions don't belong in details
     // details are the only thing that users can change the rest is
     // read only...
@@ -713,7 +694,7 @@ public class OmeroInterceptor implements Interceptor {
         final boolean isPrivilegedCreator;
         final boolean sysType = sysTypes.isSystemType(obj.getClass())
                 || sysTypes.isInSystemGroup(obj.getDetails());
-        final Set<AdminPrivilege> privileges = getAdminPrivileges();
+        final Set<AdminPrivilege> privileges = bec.getCurrentAdminPrivileges();
 
         if (!bec.isCurrentUserAdmin()) {
             isPrivilegedCreator = false;
@@ -1039,7 +1020,7 @@ public class OmeroInterceptor implements Interceptor {
             IObject obj, Details previousDetails, Details currentDetails,
             Details newDetails, final BasicEventContext bec) {
 
-        final Set<AdminPrivilege> privileges = getAdminPrivileges();
+        final Set<AdminPrivilege> privileges = bec.getCurrentAdminPrivileges();
 
         if (!HibernateUtils.idEqual(previousDetails.getOwner(), currentDetails
                 .getOwner())) {
@@ -1092,7 +1073,7 @@ public class OmeroInterceptor implements Interceptor {
             }
         }
 
-        final Set<AdminPrivilege> privileges = getAdminPrivileges();
+        final Set<AdminPrivilege> privileges = bec.getCurrentAdminPrivileges();
 
         // previous and current have different ids. either change it and return
         // true if permitted, or throw an exception.

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -349,6 +349,11 @@ public class OmeroInterceptor implements Interceptor {
     // =========================================================================
     public void preFlush(Iterator entities) throws CallbackException {
         debug("Intercepted preFlush.");
+        EMPTY.preFlush(entities);
+    }
+
+    public void postFlush(Iterator entities) throws CallbackException {
+        debug("Intercepted postFlush.");
 
         if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
             debug("detected read-only transaction");
@@ -358,11 +363,6 @@ public class OmeroInterceptor implements Interceptor {
             sqlAction.deleteCurrentAdminPrivileges();
             sqlAction.insertCurrentAdminPrivileges(getAdminPrivileges());
         }
-    }
-
-    public void postFlush(Iterator entities) throws CallbackException {
-        debug("Intercepted postFlush.");
-        EMPTY.postFlush(entities);
     }
 
     // ~ Serialization

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -667,7 +667,7 @@ public class OmeroInterceptor implements Interceptor {
         if (currentUser.getCurrentEventContext().isCurrentUserAdmin()) {
             final Event event = currentUser.current().getEvent();
             if (event == null || !event.isLoaded()) {
-                return adminPrivileges.getAllPrivileges();
+                return LightAdminPrivileges.getAllPrivileges();
             } else {
                 return adminPrivileges.getSessionPrivileges(event.getSession());
             }

--- a/components/server/src/ome/security/sharing/SharingACLVoter.java
+++ b/components/server/src/ome/security/sharing/SharingACLVoter.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -126,14 +124,6 @@ public class SharingACLVoter implements ACLVoter {
 
     @Override
     public void setPermittedClasses(Map<Integer, Set<Class<? extends IObject>>> objectClassesPermitted) {
-    }
-
-    @Override
-    public void noteAdminPrivileges(ome.model.meta.Session session) {
-    }
-
-    @Override
-    public void clearAdminPrivileges() {
     }
 
     @Override

--- a/components/server/src/ome/services/sessions/InternalSessionContext.java
+++ b/components/server/src/ome/services/sessions/InternalSessionContext.java
@@ -1,13 +1,15 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package ome.services.sessions;
 
 import java.util.Arrays;
 
+import com.google.common.collect.ImmutableSet;
+
+import ome.model.enums.AdminPrivilege;
 import ome.model.internal.Permissions;
 import ome.model.meta.Session;
 import ome.services.sessions.stats.NullSessionStats;
@@ -24,9 +26,9 @@ class InternalSessionContext extends SessionContextImpl {
 
     Roles roles;
 
-    InternalSessionContext(Session s, Roles roles) {
-        super(s, Arrays.asList(roles.getSystemGroupId()), Arrays.asList(roles
-                .getSystemGroupId()),
+    InternalSessionContext(Session s, ImmutableSet<AdminPrivilege> adminPrivileges, Roles roles) {
+        super(s, adminPrivileges, Arrays.asList(roles.getSystemGroupId()),
+                Arrays.asList(roles.getSystemGroupId()),
                 Arrays.asList(roles.getSystemGroupName()),
                 new NullSessionStats(), roles, null);
         this.roles = roles;

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -201,7 +201,7 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
         try {
             asroot = new Principal(internal_uuid, "system", "Sessions");
             final Session session = executeInternalSession();
-            internalSession = new InternalSessionContext(session, adminPrivileges.getAllPrivileges(), roles);
+            internalSession = new InternalSessionContext(session, LightAdminPrivileges.getAllPrivileges(), roles);
             cache.putSession(internal_uuid, internalSession);
         } catch (UncategorizedSQLException uncat) {
             log.warn("Assuming that this is read-only");

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Future;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 
+import ome.api.IQuery;
 import ome.api.local.LocalAdmin;
 import ome.conditions.ApiUsageException;
 import ome.conditions.AuthenticationException;
@@ -1465,9 +1466,10 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             final List<Long> memberOfGroupsIds = admin.getMemberOfGroupIds(exp);
             final List<Long> leaderOfGroupsIds = admin.getLeaderOfGroupIds(exp);
             final List<String> userRoles = admin.getUserRoles(exp);
-            final Session reloaded = (Session)
-                    sf.getQueryService().findByQuery(
-                            "select s from Session s "
+            final IQuery iQuery = sf.getQueryService();
+            final String sessionClass = iQuery.find(Share.class, session.getId()) == null ? "Session" : "Share";
+            final Session reloaded = (Session) iQuery.findByQuery(
+                            "select s from " + sessionClass + " s "
                             + "left outer join fetch s.sudoer "
                             + "left outer join fetch s.annotationLinks l "
                             + "left outer join fetch l.child a where s.id = :id",

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -596,7 +596,9 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
                 "SELECT id FROM GroupExperimenterMap WHERE parent.id = :group AND child.id = :user",
                 new Parameters().addLong("group", roles.getSystemGroupId()).addLong("user", realOwner.getId()));
         final Set<AdminPrivilege> privileges;
-        if (realOwner.getId() == roles.getRootId() || CollectionUtils.isEmpty(results)) {
+        if (realOwner.getId() == roles.getRootId()) {
+            privileges = LightAdminPrivileges.getAllPrivileges();
+        } else if (CollectionUtils.isEmpty(results)) {
             privileges = Collections.emptySet();
         } else {
             privileges = adminPrivileges.getSessionPrivileges(session);

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -1472,9 +1472,15 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
                             + "left outer join fetch s.annotationLinks l "
                             + "left outer join fetch l.child a where s.id = :id",
                             new Parameters().addId(session.getId()));
+            final List<Long> realOwnerGroupsIds;
+            if (reloaded.getSudoer() != null) {
+                realOwnerGroupsIds = admin.getMemberOfGroupIds(reloaded.getSudoer());
+            } else {
+                realOwnerGroupsIds = memberOfGroupsIds;
+            }
             list.add(exp);
             list.add(grp);
-            if (memberOfGroupsIds.contains(roles.getSystemGroupId())) {
+            if (realOwnerGroupsIds.contains(roles.getSystemGroupId())) {
                 list.add(adminPrivileges.getSessionPrivileges(reloaded));
             } else {
                 list.add(Collections.emptySet());

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -587,22 +587,20 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
     }
 
     public List<Session> findSameUser(String uuid, String... agents) {
-        /* determine the true originator of the current session and that user's privileges */
+        /* determine the light administrator privileges associated with the given session */
         final Session session = find(uuid);
-        Experimenter realOwner = session.getSudoer();
-        if (realOwner == null) {
-            realOwner = session.getOwner();
+        final String membershipQuery = "SELECT id FROM GroupExperimenterMap WHERE parent.id = :group AND child.id = :user";
+        boolean hasAdminPrivileges = CollectionUtils.isNotEmpty(executeProjection(membershipQuery,
+                new Parameters().addLong("group", roles.getSystemGroupId()).addLong("user", session.getOwner().getId())));
+        if (session.getSudoer() != null) {
+            hasAdminPrivileges = hasAdminPrivileges && CollectionUtils.isNotEmpty(executeProjection(membershipQuery,
+                    new Parameters().addLong("group", roles.getSystemGroupId()).addLong("user", session.getSudoer().getId())));
         }
-        final List<Object[]> results = executeProjection(
-                "SELECT id FROM GroupExperimenterMap WHERE parent.id = :group AND child.id = :user",
-                new Parameters().addLong("group", roles.getSystemGroupId()).addLong("user", realOwner.getId()));
         final Set<AdminPrivilege> privileges;
-        if (realOwner.getId() == roles.getRootId()) {
-            privileges = LightAdminPrivileges.getAllPrivileges();
-        } else if (CollectionUtils.isEmpty(results)) {
-            privileges = Collections.emptySet();
-        } else {
+        if (hasAdminPrivileges) {
             privileges = adminPrivileges.getSessionPrivileges(session);
+        } else {
+            privileges = Collections.emptySet();
         }
         /* determine which agent values should filter results */
         final Set<String> agentSet = new HashSet<>();
@@ -615,17 +613,17 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             }
         }
         /* construct and perform the query */
-        final StringBuilder hql = new StringBuilder();
+        final StringBuilder sessionQuery = new StringBuilder();
         final Parameters params = new Parameters();
-        hql.append("SELECT id, uuid FROM Session WHERE closed IS NULL");
-        hql.append(" AND owner.id = :owner");
+        sessionQuery.append("SELECT id, uuid FROM Session WHERE closed IS NULL");
+        sessionQuery.append(" AND owner.id = :owner");
         params.addLong("owner", session.getOwner().getId());
         if (!privileges.contains(adminPrivileges.getPrivilege(AdminPrivilege.VALUE_READ_SESSION))) {
             /* user is not privileged so is limited to where sudoer is the same as their current session */
             if (session.getSudoer() == null) {
-                hql.append(" AND sudoer IS NULL");
+                sessionQuery.append(" AND sudoer IS NULL");
             } else {
-                hql.append(" AND sudoer.id = :sudoer");
+                sessionQuery.append(" AND sudoer.id = :sudoer");
                 params.addLong("sudoer", session.getSudoer().getId());
             }
         }
@@ -638,10 +636,10 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             agentClauses.add("userAgent IS NULL");
         }
         if (!agentClauses.isEmpty()) {
-            hql.append(" AND (" + Joiner.on(" OR ").join(agentClauses) + ")");
+            sessionQuery.append(" AND (" + Joiner.on(" OR ").join(agentClauses) + ")");
         }
-        hql.append(" ORDER BY started DESC");
-        return findByQuery(hql.toString(), params);
+        sessionQuery.append(" ORDER BY started DESC");
+        return findByQuery(sessionQuery.toString(), params);
     }
 
     public int getReferenceCount(String uuid) {
@@ -1474,19 +1472,14 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
                             + "left outer join fetch s.annotationLinks l "
                             + "left outer join fetch l.child a where s.id = :id",
                             new Parameters().addId(session.getId()));
-            final List<Long> realOwnerGroupsIds;
-            if (reloaded.getSudoer() != null) {
-                realOwnerGroupsIds = admin.getMemberOfGroupIds(reloaded.getSudoer());
-            } else {
-                realOwnerGroupsIds = memberOfGroupsIds;
+            final Experimenter sudoer = reloaded.getSudoer();
+            boolean hasAdminPrivileges = memberOfGroupsIds.contains(roles.getSystemGroupId());
+            if (sudoer != null) {
+                hasAdminPrivileges = hasAdminPrivileges && admin.getMemberOfGroupIds(sudoer).contains(roles.getSystemGroupId());
             }
             list.add(exp);
             list.add(grp);
-            if (realOwnerGroupsIds.contains(roles.getSystemGroupId())) {
-                list.add(adminPrivileges.getSessionPrivileges(reloaded));
-            } else {
-                list.add(Collections.emptySet());
-            }
+            list.add(hasAdminPrivileges ? adminPrivileges.getSessionPrivileges(reloaded) : Collections.emptySet());
             list.add(memberOfGroupsIds);
             list.add(leaderOfGroupsIds);
             list.add(userRoles);

--- a/components/server/src/ome/tools/hibernate/ProxyCleanupFilter.java
+++ b/components/server/src/ome/tools/hibernate/ProxyCleanupFilter.java
@@ -251,7 +251,6 @@ public class ProxyCleanupFilter extends ContextFilter {
                         .getThis().getClass())) {
                     result = new ProxyCleanupFilter(acl, current)
                         .filter(null, result);
-                    acl.clearAdminPrivileges();
                 }
             } finally {
                 d--;

--- a/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 import ome.api.ITypes;
 import ome.api.local.LocalAdmin;
@@ -53,6 +54,8 @@ public abstract class AbstractBasicSecuritySystemTest extends
         MockObjectTestCase {
 
     private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    protected final Set<AdminPrivilege> allAdminPrivileges = new LightAdminPrivileges(new Roles()).getAllPrivileges();
 
     MockServiceFactory sf;
 
@@ -206,9 +209,9 @@ public abstract class AbstractBasicSecuritySystemTest extends
         mockEc.expects(atLeastOnce()).method("isReadOnly").will(
                 returnValue(readOnly));
         mockEc.expects(atLeastOnce()).method("isCurrentUserAdmin").will(
-                returnValue(false));
+                returnValue(true));
         mockEc.expects(atLeastOnce()).method("getCurrentAdminPrivileges").will(
-                returnValue(Collections.emptySet()));
+                returnValue(allAdminPrivileges));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupPermissions").will(
                 returnValue(Permissions.WORLD_WRITEABLE));
         mockEc.expects(atLeastOnce()).method("getCurrentEventType").will(

--- a/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 import ome.api.ITypes;
 import ome.api.local.LocalAdmin;
@@ -54,8 +53,6 @@ public abstract class AbstractBasicSecuritySystemTest extends
         MockObjectTestCase {
 
     private final Logger log = LoggerFactory.getLogger(this.getClass());
-
-    protected final Set<AdminPrivilege> allAdminPrivileges = new LightAdminPrivileges(new Roles()).getAllPrivileges();
 
     MockServiceFactory sf;
 
@@ -106,7 +103,7 @@ public abstract class AbstractBasicSecuritySystemTest extends
         final Roles roles = new Roles();
         final LightAdminPrivileges mockAdminPrivileges = new LightAdminPrivileges(roles) {
             @Override
-            public ImmutableSet<AdminPrivilege> getSessionPrivileges(Session session, boolean isCache) {
+            public ImmutableSet<AdminPrivilege> getSessionPrivileges(Session session) {
                 return getAllPrivileges();
             }
         };
@@ -211,7 +208,7 @@ public abstract class AbstractBasicSecuritySystemTest extends
         mockEc.expects(atLeastOnce()).method("isCurrentUserAdmin").will(
                 returnValue(true));
         mockEc.expects(atLeastOnce()).method("getCurrentAdminPrivileges").will(
-                returnValue(allAdminPrivileges));
+                returnValue(LightAdminPrivileges.getAllPrivileges()));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupPermissions").will(
                 returnValue(Permissions.WORLD_WRITEABLE));
         mockEc.expects(atLeastOnce()).method("getCurrentEventType").will(

--- a/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -246,6 +246,7 @@ public abstract class AbstractBasicSecuritySystemTest extends
         sf.mockAdmin.expects(once()).method("groupProxy").will(
                 returnValue(group));
         if (!readOnly) {
+            sf.mockQuery.expects(once()).method("find").will(returnValue(event.getSession()));
             sf.mockQuery.expects(once()).method("findByQuery").will(returnValue(event.getSession()));
             sf.mockAdmin.expects(once()).method("userProxy").will(
                     returnValue(user));

--- a/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -146,6 +146,8 @@ public abstract class AbstractBasicSecuritySystemTest extends
                 returnValue(readOnly));
         mockEc.expects(atLeastOnce()).method("isCurrentUserAdmin").will(
                 returnValue(false));
+        mockEc.expects(atLeastOnce()).method("getCurrentAdminPrivileges").will(
+                returnValue(Collections.emptySet()));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupPermissions").will(
                 returnValue(Permissions.WORLD_WRITEABLE));
         mockEc.expects(atLeastOnce()).method("getCurrentEventType").will(
@@ -160,6 +162,10 @@ public abstract class AbstractBasicSecuritySystemTest extends
                 returnValue(1L));
         mockEc.expects(atLeastOnce()).method("getCurrentUserName").will(
                 returnValue("some-user"));
+        mockEc.expects(atLeastOnce()).method("getCurrentSudoerId").will(
+                returnValue(null));
+        mockEc.expects(atLeastOnce()).method("getCurrentSudoerName").will(
+                returnValue(null));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupName").will(
                 returnValue("test"));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupId").will(
@@ -201,12 +207,16 @@ public abstract class AbstractBasicSecuritySystemTest extends
                 returnValue(readOnly));
         mockEc.expects(atLeastOnce()).method("isCurrentUserAdmin").will(
                 returnValue(false));
+        mockEc.expects(atLeastOnce()).method("getCurrentAdminPrivileges").will(
+                returnValue(Collections.emptySet()));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupPermissions").will(
                 returnValue(Permissions.WORLD_WRITEABLE));
         mockEc.expects(atLeastOnce()).method("getCurrentEventType").will(
                 returnValue("Test"));
         mockEc.expects(atLeastOnce()).method("getCurrentUserName").will(
                 returnValue("some-user"));
+        mockEc.expects(atLeastOnce()).method("getCurrentSudoerName").will(
+                returnValue(null));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupName").will(
                 returnValue("test"));
         mockEc.expects(atLeastOnce()).method("getCurrentShareId").will(
@@ -217,6 +227,8 @@ public abstract class AbstractBasicSecuritySystemTest extends
                 returnValue(1L));
         mockEc.expects(atLeastOnce()).method("getCurrentUserId").will(
                 returnValue(0L));
+        mockEc.expects(atLeastOnce()).method("getCurrentSudoerId").will(
+                returnValue(null));
         mockEc.expects(atLeastOnce()).method("getCurrentGroupId").will(
                 returnValue(0L));
         mockEc.expects(atLeastOnce()).method("getMemberOfGroupsList").will(

--- a/components/server/test/ome/server/utests/sec/WritePermissionsTest.java
+++ b/components/server/test/ome/server/utests/sec/WritePermissionsTest.java
@@ -8,9 +8,11 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import ome.model.core.Image;
+import ome.model.enums.AdminPrivilege;
 import ome.model.internal.Details;
 import ome.model.internal.Permissions;
 import ome.model.meta.Experimenter;
@@ -20,6 +22,7 @@ import ome.security.SystemTypes;
 import ome.security.basic.BasicACLVoter;
 import ome.security.basic.BasicEventContext;
 import ome.security.basic.CurrentDetails;
+import ome.security.basic.LightAdminPrivileges;
 import ome.security.basic.TokenHolder;
 import ome.security.policy.DefaultPolicyService;
 import ome.services.sessions.SessionContext;
@@ -27,6 +30,7 @@ import ome.services.sessions.SessionContextImpl;
 import ome.services.sessions.state.SessionCache;
 import ome.services.sessions.stats.NullSessionStats;
 import ome.system.Principal;
+import ome.system.Roles;
 
 import org.jmock.MockObjectTestCase;
 import org.testng.annotations.Test;
@@ -57,6 +61,8 @@ public class WritePermissionsTest extends MockObjectTestCase {
     final BasicACLVoter voter = new BasicACLVoter(cd, new SystemTypes(),
             new TokenHolder(), null, new DefaultPolicyService());
 
+    final Set<AdminPrivilege> allAdminPrivileges = new LightAdminPrivileges(new Roles()).getAllPrivileges();
+
     protected Session login(String perms, long user, boolean leader) {
 
         Session s = sess(perms, user, THE_GROUP);
@@ -64,6 +70,9 @@ public class WritePermissionsTest extends MockObjectTestCase {
         cache.putSession(s.getUuid(), sc);
         BasicEventContext bec = new BasicEventContext(new Principal(s.getUuid()),
                 new NullSessionStats(), sc);
+        if (user == ROOT) {
+            bec.setAdminPrivileges(allAdminPrivileges);
+        }
         ExperimenterGroup g = s.getDetails().getGroup();
         bec.setGroup(g, g.getDetails().getPermissions());
         bec.setOwner(s.getDetails().getOwner());

--- a/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
+++ b/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
@@ -1,9 +1,8 @@
 /*
- *   $Id$
- *
  *   Copyright 2007-2014 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package ome.server.utests.sessions;
 
 import java.util.Arrays;
@@ -28,6 +27,7 @@ import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
 import ome.model.meta.Node;
 import ome.model.meta.Session;
+import ome.model.meta.Share;
 import ome.security.basic.CurrentDetails;
 import ome.server.utests.DummyExecutor;
 import ome.services.sessions.SessionContext;
@@ -47,6 +47,7 @@ import org.jmock.MockObjectTestCase;
 import org.jmock.core.Constraint;
 import org.jmock.core.Invocation;
 import org.jmock.core.Stub;
+import org.jmock.core.constraint.IsEqual;
 import org.jmock.core.constraint.StringContains;
 import org.springframework.context.event.ApplicationEventMulticaster;
 import org.testng.annotations.AfterMethod;
@@ -352,6 +353,9 @@ public class SessMgrUnitTest extends MockObjectTestCase {
         sf.mockAdmin.expects(once()).method("checkPassword").will(
                 returnValue(true));
         // execute lookup user
+        sf.mockQuery.expects(atLeastOnce()).method("find")
+            .with(new IsEqual(Share.class), new IsEqual(session.getId()))
+            .will(returnValue(null));
         sf.mockQuery.expects(atLeastOnce()).method("findByQuery")
             .with(new StringContains("Session"), ANYTHING)
             .will(returnValue(session));

--- a/components/server/test/ome/server/utests/sessions/SessionBeanUnitTest.java
+++ b/components/server/test/ome/server/utests/sessions/SessionBeanUnitTest.java
@@ -5,6 +5,7 @@
 package ome.server.utests.sessions;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -14,6 +15,7 @@ import java.util.concurrent.TimeoutException;
 
 import ome.conditions.AuthenticationException;
 import ome.conditions.SessionException;
+import ome.model.enums.AdminPrivilege;
 import ome.model.internal.Permissions;
 import ome.model.meta.ExperimenterGroup;
 import ome.model.meta.Session;
@@ -98,7 +100,7 @@ public class SessionBeanUnitTest extends MockObjectTestCase {
     public void testProperIsAdminImplementation() throws Exception {
         List<Long> leaderOfGroupsIds = Arrays.asList(1L);
         List<Long> memberOfGroupsIds = Arrays.asList(0L, 1L);
-        SessionContextImpl sessionContext = new SessionContextImpl(session,
+        SessionContextImpl sessionContext = new SessionContextImpl(session, Collections.<AdminPrivilege>emptySet(),
                 leaderOfGroupsIds, memberOfGroupsIds, Arrays.asList("user"),
                 null, new Roles(), null);
         assertTrue(sessionContext.isCurrentUserAdmin());

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -2365,6 +2365,38 @@ public class LightAdminPrivilegesTest extends AbstractServerImportTest {
     }
 
     /**
+     * Test that {@link omero.api.IAdminPrx#getEventContext()} has the expected sudo status and list of privileges.
+     * @param isAdmin if to test a member of the <tt>system</tt> group
+     * @param isRestricted if to test a user who does <em>not</em> have the <tt>ReadSession</tt> privilege
+     * @param isSudo if to test attempt to subvert privilege by sudo to an unrestricted member of the <tt>system</tt> group
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "light administrator privilege test cases")
+    public void testGetEventContext(boolean isAdmin, boolean isRestricted, boolean isSudo) throws Exception {
+        loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
+                isRestricted ? AdminPrivilegeReadSession.value : null);
+        final EventContext eventContext = iAdmin.getEventContext();
+        if (isSudo) {
+            Assert.assertNotNull(eventContext.sudoerId);
+            Assert.assertNotNull(eventContext.sudoerName);
+        } else {
+            Assert.assertNull(eventContext.sudoerId);
+            Assert.assertNull(eventContext.sudoerName);
+        }
+        final List<String> privileges =  eventContext.adminPrivileges;
+        if (isAdmin) {
+            Assert.assertFalse(privileges.isEmpty());
+            if (isRestricted) {
+                Assert.assertFalse(privileges.contains(AdminPrivilegeReadSession.value));
+            } else {
+                Assert.assertTrue(privileges.contains(AdminPrivilegeReadSession.value));
+            }
+        } else {
+            Assert.assertTrue(privileges.isEmpty());
+        }
+    }
+
+    /**
      * @return a variety of test cases for light administrator privileges
      */
     @DataProvider(name = "light administrator privilege test cases")

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -1392,11 +1392,8 @@ public class LightAdminPrivilegesTest extends AbstractServerImportTest {
         }
         Assert.assertFalse(sessionUuids.contains(actor.sessionUuid));
         Assert.assertTrue(sessionUuids.contains(actorAsNormalUser.sessionUuid));
-        if (isExpectSuccess) {
-            Assert.assertTrue(sessionUuids.contains(normalUser.sessionUuid));
-        } else {
-            Assert.assertFalse(sessionUuids.contains(normalUser.sessionUuid));
-        }
+        /* can never succeed because privileges are not preserved through sudo */
+        Assert.assertFalse(sessionUuids.contains(normalUser.sessionUuid));
         normalUserClient.__del__();
     }
 
@@ -1436,11 +1433,8 @@ public class LightAdminPrivilegesTest extends AbstractServerImportTest {
         }
         Assert.assertFalse(sessionUuids.contains(actor.sessionUuid));
         Assert.assertTrue(sessionUuids.contains(actorAsNormalUser.sessionUuid));
-        if (isExpectSuccess) {
-            Assert.assertTrue(sessionUuids.contains(normalUser.sessionUuid));
-        } else {
-            Assert.assertFalse(sessionUuids.contains(normalUser.sessionUuid));
-        }
+        /* can never succeed because privileges are not preserved through sudo */
+        Assert.assertFalse(sessionUuids.contains(normalUser.sessionUuid));
         normalUserClient.__del__();
     }
 


### PR DESCRIPTION
# What this PR does

Adjusts the server component to improve performance without changing behavior. Brings sudoer and current light admin privileges into `EventContext` and `CurrentDetails`.

# Testing this PR

Check with https://10.0.51.154:8443/job/OMERO-test-integration/ that there are no new test failures and that the test running time is improved.

# Related reading

https://trello.com/c/ToMbDClf/26-improve-performance