### PR TITLE
Import into other groups

### DIFF
--- a/components/blitz/src/ome/services/blitz/fire/Registry.java
+++ b/components/blitz/src/ome/services/blitz/fire/Registry.java
@@ -52,7 +52,6 @@ public interface Registry {
      * create sessions for accessing the database.
      * 
      *<pre>
-     * communicator := Ice.Communicator used to find the registry
      * user         := Username which should have a session created
      * groupId      := Group into which the session should be logged
      * retries      := Number of session creation retries before throwing

--- a/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
+++ b/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
@@ -904,19 +904,15 @@ public class RepositoryDaoImpl implements RepositoryDao {
     }
 
     public omero.sys.EventContext getEventContext(Ice.Current curr) {
-        EventContext ec = this.currentContext(new Principal(curr.ctx.get(
-                omero.constants.SESSIONUUID.value)));
-        return IceMapper.convert(ec);
-    }
-
-    protected EventContext currentContext(Principal currentUser) {
-        return (EventContext) executor.execute(currentUser,
+        final Principal currentUser = new Principal(curr.ctx.get(omero.constants.SESSIONUUID.value));
+        final EventContext ec = (EventContext) executor.execute(curr.ctx, currentUser,
                 new Executor.SimpleWork(this, "getEventContext") {
             @Transactional(readOnly = true)
             public Object doWork(Session session, ServiceFactory sf) {
                 return ((LocalAdmin) sf.getAdminService()).getEventContextQuiet();
             }
         });
+        return IceMapper.convert(ec);
     }
 
     public String getUserInstitution(final long userId, Ice.Current current) {

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -564,6 +565,27 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
             assertFileExists("Delete failed. File deleted!: ",
                     pathToUsedFile(data2, index));
         }
+    }
+
+    /**
+     * Test that an administrator can import into a group of which they are not a member.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testAdminImportIntoAnotherGroup() throws Exception {
+        /* prepare as admin to import into another group */
+        final long targetGroup = newUserAndGroup("rw----").groupId;
+        newUserInGroup(iAdmin.lookupGroup(SYSTEM_GROUP), false);
+        client.getImplicitContext().put("omero.group", Long.toString(targetGroup));
+
+        /* create and import a fake image */
+        final File localPath = tempFileManager.createPath(UUID.randomUUID().toString(), null, true);
+        final File localFile = ensureFileExists(localPath, UUID.randomUUID().toString() + ".fake");
+        importFileset(Collections.singletonList(localFile.toString()));
+
+        /* check that the import was into the intended group */
+        final OriginalFile remoteFile = (OriginalFile) iQuery.findByString("OriginalFile", "name", localFile.getName());
+        Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), targetGroup);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -51,6 +51,7 @@ import omero.grid.ManagedRepositoryPrxHelper;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
 import omero.model.ChecksumAlgorithm;
+import omero.model.ExperimenterGroupI;
 import omero.model.OriginalFile;
 import omero.sys.EventContext;
 import omero.sys.Parameters;
@@ -577,7 +578,7 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
     public void testAdminImportIntoAnotherGroup() throws Exception {
         /* prepare as admin to import into another group */
         final long targetGroup = iAdmin.getEventContext().groupId;
-        newUserInGroup(iAdmin.lookupGroup(SYSTEM_GROUP), false);
+        newUserInGroup(new ExperimenterGroupI(roles.systemGroupId, false), false);
         client.getImplicitContext().put("omero.group", Long.toString(targetGroup));
 
         /* create and import a fake image */

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -59,6 +59,7 @@ import omero.util.TempFileManager;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -86,8 +87,9 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
     /* client file path transformer for comparing local and repo paths */
     private ClientFilePathTransformer cfpt = null;
 
-    @BeforeClass
+    @BeforeMethod
     public void setRepo() throws Exception {
+        newUserAndGroup("rw----");
         RepositoryMap rm = factory.sharedResources().repositories();
         for (int i = 0; i < rm.proxies.size(); i++) {
             final RepositoryPrx prx = rm.proxies.get(i);
@@ -574,7 +576,7 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
     @Test
     public void testAdminImportIntoAnotherGroup() throws Exception {
         /* prepare as admin to import into another group */
-        final long targetGroup = newUserAndGroup("rw----").groupId;
+        final long targetGroup = iAdmin.getEventContext().groupId;
         newUserInGroup(iAdmin.lookupGroup(SYSTEM_GROUP), false);
         client.getImplicitContext().put("omero.group", Long.toString(targetGroup));
 


### PR DESCRIPTION
# What this PR does

This PR allows full administrators, or sufficiently endowed light administrators, to import images into any group regardless of membership. More precisely, it stabilizes the test suite from the previous attempt which caused various intermittent errors like, `ome.conditions.SecurityViolation: User 318 is not a member of group 276 and cannot login`.

# Testing this PR

https://10.0.51.154:8443/job/OMERO-test-integration/ should be fairly blue. Note the included integration test and that, with the same server commit in #4957 and #5258, CI on either side has now not shown that error for some time.

# Related reading

https://trello.com/c/RQLsMkEV/14-fix-import-into-other-groups