### PR TITLE
Cli delete

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1568,8 +1568,10 @@ class GraphArg(object):
             for id in parts[1].split(","):
                 if "-" in id:
                     needsForce = True
-                    warnings.warn("This force flag to delete range is deprecated as\
-                                  of OMERO 5.3.2", DeprecationWarning)
+                    warnings.warn("Using '--dry-run'. \
+                                  Future versions will switch to '--force'. \
+                                  Explicitly set the parameter for \
+                                  portability", DeprecationWarning)
                     low, high = map(long, id.split("-"))
                     if high < low:
                         raise ValueError("Bad range: %s", arg)

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1567,9 +1567,9 @@ class GraphArg(object):
             needsForce = False
             for id in parts[1].split(","):
                 if "-" in id:
-                    warnings.warn("This flag is deprecated as of OMERO 5.3.2",
-                                  DeprecationWarning)
                     needsForce = True
+                    warnings.warn("This force flag to delete range is deprecated as\
+                                  of OMERO 5.3.2", DeprecationWarning)
                     low, high = map(long, id.split("-"))
                     if high < low:
                         raise ValueError("Bad range: %s", arg)

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1559,6 +1559,7 @@ class GraphArg(object):
         targetObjects = dict()
         try:
             parts = arg.split(":", 1)
+            print arg
             assert len(parts) == 2
             assert '+' not in parts[0]
             parts[0] = parts[0].lstrip("/")
@@ -1568,10 +1569,6 @@ class GraphArg(object):
             for id in parts[1].split(","):
                 if "-" in id:
                     needsForce = True
-                    warnings.warn("Using '--dry-run'. \
-                                  Future versions will switch to '--force'. \
-                                  Explicitly set the parameter for \
-                                  portability", DeprecationWarning)
                     low, high = map(long, id.split("-"))
                     if high < low:
                         raise ValueError("Bad range: %s", arg)
@@ -1814,6 +1811,11 @@ class GraphControl(CmdControl):
 
         commands, forces = zip(*args.obj)
         needsForce = any(forces)
+        if needsForce and not args.force:
+            warnings.warn("Using '--dry-run'. \
+                          Future versions will switch to '--force'. \
+                          Explicitly set the parameter for \
+                          portability", DeprecationWarning)
         for req in commands:
             req.dryRun = args.dry_run or needsForce
             if args.force:

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1559,7 +1559,6 @@ class GraphArg(object):
         targetObjects = dict()
         try:
             parts = arg.split(":", 1)
-            print arg
             assert len(parts) == 2
             assert '+' not in parts[0]
             parts[0] = parts[0].lstrip("/")

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -51,6 +51,7 @@ from omero_ext.argparse import SUPPRESS
 from omero.util.concurrency import get_event
 
 import omero
+import warnings
 
 #
 # Static setup
@@ -1566,6 +1567,8 @@ class GraphArg(object):
             needsForce = False
             for id in parts[1].split(","):
                 if "-" in id:
+                    warnings.warn("This flag is deprecated as of OMERO 5.3.2",
+                                  DeprecationWarning)
                     needsForce = True
                     low, high = map(long, id.split("-"))
                     if high < low:

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1653,7 +1653,7 @@ class CmdControl(BaseControl):
         if err:
             self.ctx.err(err)
         else:
-            if req.dryRun:
+            if hasattr(req, 'dryRun') and req.dryRun:
                 self.ctx.out("Dry run performed")
             self.ctx.out("ok")
 

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1809,12 +1809,13 @@ class GraphControl(CmdControl):
                 opt.excludeType = exc
 
         commands, forces = zip(*args.obj)
+        show = not (args.force or args.dry_run)
         needsForce = any(forces)
-        if needsForce and not args.force:
-            warnings.warn("Using '--dry-run'. \
-                          Future versions will switch to '--force'. \
-                          Explicitly set the parameter for \
-                          portability", DeprecationWarning)
+        if needsForce and show:
+            warnings.warn("\nUsing '--dry-run'.\
+                          Future versions will switch to '--force'.\
+                          Explicitly set the parameter for portability",
+                          DeprecationWarning)
         for req in commands:
             req.dryRun = args.dry_run or needsForce
             if args.force:

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1650,6 +1650,8 @@ class CmdControl(BaseControl):
         if err:
             self.ctx.err(err)
         else:
+            if req.dryRun:
+                self.ctx.out("Dry run performed")
             self.ctx.out("ok")
 
         if detailed:

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -32,7 +32,7 @@ Examples:
     omero delete Image:101,102,103 Dataset:201,202
     # Delete five images and four datasets including their contents
     # Note that --force flag is required when deleting a range, if not
-    # use a dry run is performed
+    # passed, a dry run is performed
     omero delete Image:106-110 Dataset:203-205,207 --force
     # Delete a project excluding contained datasets and linked annotations
     omero delete Project:101 --exclude Dataset,Annotation

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -31,7 +31,9 @@ Examples:
     # Delete three images and two datasets including their contents
     omero delete Image:101,102,103 Dataset:201,202
     # Delete five images and four datasets including their contents
-    omero delete Image:106-110 Dataset:203-205,207
+    # Note that --force flag is required when deleting a range, if not
+    # use a dry run is performed
+    omero delete Image:106-110 Dataset:203-205,207 --force
     # Delete a project excluding contained datasets and linked annotations
     omero delete Project:101 --exclude Dataset,Annotation
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_duplicate.py
@@ -144,7 +144,7 @@ class TestDuplicate(CLITest):
         # Check object has been duplicated
         assert len(objs) == 1
         assert objs[0].id.val == oid
-        assert len(lines_out) == 6
+        assert len(lines_out) == 7
         assert '%s:%s' % (object_type, objs[0].id.val) in out
         # Check object has been found in two different places of the output
         assert out.find(obj_arg) != out.rfind(obj_arg)


### PR DESCRIPTION
# What this PR does

Clarify the deletion of range
and deprecate the usage of  ``--force``

# Testing this PR
* Create for example 2 datasets
* Run ``bin/omero delete Dataset:151-152`` or ``bin/omero delete Dataset:151-152 --report``
* A message indicating that a dry run has performed should be displayed. This means that the deletion did not occur. Message should be displayed in both cases
* Run ``bin/omero delete Dataset:151-152 --force``, the message should not be displayed and the datasets should be deleted

# Related reading
https://trello.com/c/Y1oYE0dr/17-bug-omero-delete-range-fails