### PR TITLE
adjust Chgrp2, Chown2 for roles

### DIFF
--- a/components/blitz/resources/ome/services/blitz-graph-rules.xml
+++ b/components/blitz/resources/ome/services/blitz-graph-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -50,6 +50,8 @@
         After a forward slash for matches, the permissions required for the object by the user:
             u = may be updated
             d = may be deleted
+            m = may be moved
+            g = may be given
             o = owns
         In matches, starting these permissions letters with a ! negates the given set.
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -217,9 +217,13 @@
              they are owned by the object's owner.
           -->
 
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/m, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/d, X =/o A"
                                        p:changes="A:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/m, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/d, X =/o A"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[I]/m, L.child = A:FileAnnotation[E]{i}, X =/o A"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[I]/m, L.child = A:TagAnnotation[E]{i}, X =/o A"
                                        p:changes="A:{r}"/>
 
         <!-- If an annotated object is deleted or moved then consider its list, map, or XML annotations for deletion or moving. -->
@@ -254,9 +258,9 @@
 
         <!-- Move orphaned annotations with the data that are not owned by the moved object's owner if not to a private group. -->
 
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[E]{o}/m"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[E]{o}/d"
                                        p:changes="A:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[D]/m"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[D]/d"
                                        p:changes="A:[I]"/>
 
         <!-- Delete orphaned annotations, ignoring permissions for BasicAnnotation and CommentAnnotation. -->
@@ -307,15 +311,23 @@
                                        p:changes="ROI:{r}"/>
         <bean parent="graphPolicyRule" p:matches="P:Folder[I].childFolders = C:[E]{i}, P =/o C"
                                        p:changes="C:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ProjectDatasetLink.parent = P:[I], L.child = D:[E]{i}/m"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ProjectDatasetLink.parent = P:[I], L.child = D:[E]{i}/d"
                                        p:changes="D:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}/m"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}/d"
                                        p:changes="I:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderImageLink.parent = F:[I], L.child = I:[E]{i}/m"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderImageLink.parent = F:[I], L.child = I:[E]{i}/d"
                                        p:changes="I:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{i}/m"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{i}/d"
                                        p:changes="ROI:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, Folder[I].childFolders = C:[E]{i}/m"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ProjectDatasetLink.parent = P:[I]/m, L.child = D:[E]{i}"
+                                       p:changes="D:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink.parent = D:[I]/m, L.child = I:[E]{i}"
+                                       p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderImageLink.parent = F:[I]/m, L.child = I:[E]{i}"
+                                       p:changes="I:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink.parent = F:[I]/m, L.child = ROI:[E]{i}"
+                                       p:changes="ROI:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, Folder[I].childFolders = C:[E]{i}/d"
                                        p:changes="C:{r}"/>
 
         <!-- In considering moving a container's contents, do not move an object if it is in another container. -->
@@ -343,7 +355,9 @@
 
         <bean parent="graphPolicyRule" p:matches="D:Dataset[E]{o}/o" p:changes="D:[I]"/>
         <bean parent="graphPolicyRule" p:matches="F:Folder[E]{o}/o" p:changes="F:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, D:Dataset[E]{o}/d" p:changes="D:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, D:Dataset[E]{o}/m" p:changes="D:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, F:Folder[E]{o}/d" p:changes="F:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, F:Folder[E]{o}/m" p:changes="F:[I]/n"/>
 
         <!--
@@ -479,6 +493,7 @@
         <!-- Move orphaned images. -->
 
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{o}/o" p:changes="I:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, I:Image[E]{o}/d" p:changes="I:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, I:Image[E]{o}/m" p:changes="I:[I]/n"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
@@ -687,12 +702,15 @@
 
         <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{i}, S =/o P"
                                        p:changes="P:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{i}/d"
+                                       p:changes="P:{r}"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{i}/m"
                                        p:changes="P:{r}"/>
         <bean parent="graphPolicyRule" p:matches="$to_private, L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{r}, S =/!o P"
                                        p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="P:Plate[E]{o}/o" p:changes="P:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, P:Plate[E]{o}/d" p:changes="P:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, P:Plate[E]{o}/m" p:changes="P:[I]/n"/>
 
         <!--

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -217,9 +217,9 @@
              they are owned by the object's owner.
           -->
 
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/d, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/m, X =/o A"
                                        p:changes="A:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/d, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/m, X =/o A"
                                        p:changes="A:{r}"/>
 
         <!-- If an annotated object is deleted or moved then consider its list, map, or XML annotations for deletion or moving. -->
@@ -254,9 +254,9 @@
 
         <!-- Move orphaned annotations with the data that are not owned by the moved object's owner if not to a private group. -->
 
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[E]{o}/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[E]{o}/m"
                                        p:changes="A:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[D]/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:IAnnotationLink.parent = X:[I], L.child = A:Annotation[D]/m"
                                        p:changes="A:[I]"/>
 
         <!-- Delete orphaned annotations, ignoring permissions for BasicAnnotation and CommentAnnotation. -->
@@ -307,15 +307,15 @@
                                        p:changes="ROI:{r}"/>
         <bean parent="graphPolicyRule" p:matches="P:Folder[I].childFolders = C:[E]{i}, P =/o C"
                                        p:changes="C:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ProjectDatasetLink.parent = P:[I], L.child = D:[E]{i}/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ProjectDatasetLink.parent = P:[I], L.child = D:[E]{i}/m"
                                        p:changes="D:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:DatasetImageLink.parent = D:[I], L.child = I:[E]{i}/m"
                                        p:changes="I:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderImageLink.parent = F:[I], L.child = I:[E]{i}/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderImageLink.parent = F:[I], L.child = I:[E]{i}/m"
                                        p:changes="I:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{i}/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:FolderRoiLink.parent = F:[I], L.child = ROI:[E]{i}/m"
                                        p:changes="ROI:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, Folder[I].childFolders = C:[E]{i}/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, Folder[I].childFolders = C:[E]{i}/m"
                                        p:changes="C:{r}"/>
 
         <!-- In considering moving a container's contents, do not move an object if it is in another container. -->
@@ -343,8 +343,8 @@
 
         <bean parent="graphPolicyRule" p:matches="D:Dataset[E]{o}/o" p:changes="D:[I]"/>
         <bean parent="graphPolicyRule" p:matches="F:Folder[E]{o}/o" p:changes="F:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, D:Dataset[E]{o}/d" p:changes="D:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, F:Folder[E]{o}/d" p:changes="F:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, D:Dataset[E]{o}/m" p:changes="D:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, F:Folder[E]{o}/m" p:changes="F:[I]/n"/>
 
         <!--
              If a project, dataset, folder, image or ROI is moved for both sides of a link then, regardless of permissions, move the
@@ -479,7 +479,7 @@
         <!-- Move orphaned images. -->
 
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{o}/o" p:changes="I:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, I:Image[E]{o}/d" p:changes="I:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, I:Image[E]{o}/m" p:changes="I:[I]/n"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
 
@@ -687,13 +687,13 @@
 
         <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{i}, S =/o P"
                                        p:changes="P:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{i}/d"
+        <bean parent="graphPolicyRule" p:matches="!$to_private, L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{i}/m"
                                        p:changes="P:{r}"/>
         <bean parent="graphPolicyRule" p:matches="$to_private, L:ScreenPlateLink.parent = S:[I], L.child = P:[E]{r}, S =/!o P"
                                        p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="P:Plate[E]{o}/o" p:changes="P:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="!$to_private, P:Plate[E]{o}/d" p:changes="P:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="!$to_private, P:Plate[E]{o}/m" p:changes="P:[I]/n"/>
 
         <!--
              If a screen and plate are moved for both sides of a link then, regardless of permissions, move the link if same owners

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -237,9 +237,9 @@
              they are owned by the object's owner.
           -->
 
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/d, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/g, X =/o A"
                                        p:changes="A:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/d, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/g, X =/o A"
                                        p:changes="A:{r}"/>
 
         <!-- If an annotated object is deleted or given then consider its list, map, or XML annotations for deletion or giving. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -237,9 +237,13 @@
              they are owned by the object's owner.
           -->
 
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:FileAnnotation[E]{i}/g, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[I], L.child = A:FileAnnotation[E]{i}/g, X =/o A"
                                        p:changes="A:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[DI], L.child = A:TagAnnotation[E]{i}/g, X =/o A"
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[I], L.child = A:TagAnnotation[E]{i}/g, X =/o A"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[D], L.child = A:FileAnnotation[E]{i}/d, X =/o A"
+                                       p:changes="A:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink.parent = X:[D], L.child = A:TagAnnotation[E]{i}/d, X =/o A"
                                        p:changes="A:{r}"/>
 
         <!-- If an annotated object is deleted or given then consider its list, map, or XML annotations for deletion or giving. -->

--- a/components/server/src/ome/services/graphs/GraphPolicy.java
+++ b/components/server/src/ome/services/graphs/GraphPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -93,6 +93,18 @@ public abstract class GraphPolicy {
          * {@link ome.security.ACLVoter#allowChmod(IObject)}
          */
         CHMOD,
+
+        /**
+         * the user's ability to move the object, as judged by
+         * {@link ome.model.internal.Permissions#isDisallowChgrp()}
+         */
+        CHGRP,
+
+        /**
+         * the user's ability to give the object, as judged by
+         * {@link ome.model.internal.Permissions#isDisallowChown()}
+         */
+        CHOWN,
 
         /**
          * the user actually owns the object

--- a/components/server/src/ome/services/graphs/GraphPolicy.java
+++ b/components/server/src/ome/services/graphs/GraphPolicy.java
@@ -160,11 +160,14 @@ public abstract class GraphPolicy {
          * @param mayUpdate if the object may be updated
          * @param mayDelete if the object may be deleted
          * @param mayChmod if the object may have its permissions changed
+         * @param mayChgrp if the object may be moved
+         * @param mayChown if the object may be given
          * @param isOwner if the user owns the object
          * @param isCheckPermissions if the user is expected to have the permissions required to process the object
          */
         Details(IObject subject, Long ownerId, Long groupId, Action action, Orphan orphan,
-                boolean mayUpdate, boolean mayDelete, boolean mayChmod, boolean isOwner, boolean isCheckPermissions) {
+                boolean mayUpdate, boolean mayDelete, boolean mayChmod, boolean mayChgrp, boolean mayChown,
+                boolean isOwner, boolean isCheckPermissions) {
             this.subject = subject;
             this.ownerId = ownerId;
             this.groupId = groupId;
@@ -180,6 +183,12 @@ public abstract class GraphPolicy {
             }
             if (mayChmod) {
                 permissions.add(Ability.CHMOD);
+            }
+            if (mayChgrp) {
+                permissions.add(Ability.CHGRP);
+            }
+            if (mayChown) {
+                permissions.add(Ability.CHOWN);
             }
             if (isOwner) {
                 permissions.add(Ability.OWN);

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -427,7 +427,7 @@ public class GraphPolicyRule {
         final String errorMessage;
 
         /**
-         * Construct a policy rule.
+         * Construct a policy rule that affects the graph state.
          * @param asString a String representation of this rule,
          * recognizably corresponding to its original text-based configuration.
          * @param termMatchers the term matchers that must apply if the changes are to be applied
@@ -446,13 +446,13 @@ public class GraphPolicyRule {
         }
 
         /**
-         * Construct a policy rule.
+         * Construct a policy rule that detects an error condition.
          * @param asString a String representation of this rule,
          * recognizably corresponding to its original text-based configuration.
-         * @param termMatchers the term matchers that must apply if the changes are to be applied
-         * @param relationshipMatchers the relationship matchers that must apply if the changes are to be applied
-         * @param conditionMatchers the condition matchers that must apply if the changes are to be applied
-         * @param changes the effects of this rule, guarded by the matchers
+         * @param termMatchers the term matchers that must apply if the error is to be thrown
+         * @param relationshipMatchers the relationship matchers that must apply if the error is to be thrown
+         * @param conditionMatchers the condition matchers that must apply if the error is to be thrown
+         * @param errorMessage the message accompanying the error thrown by this rule in the event of a match
          */
         ParsedPolicyRule(String asString, List<TermMatch> termMatchers, List<RelationshipMatch> relationshipMatchers,
                 List<ConditionMatch> conditionMatchers, String errorMessage) {

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -57,7 +57,7 @@ public class GraphPolicyRule {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphPolicyRule.class);
 
     private static final Pattern NEW_TERM_PATTERN =
-            Pattern.compile("(\\w+\\:)?(\\!?[\\w]+)?(\\[\\!?[EDIO]+\\])?(\\{\\!?[iroa]+\\})?(\\/\\!?[udon]+)?(\\;\\S+)?");
+            Pattern.compile("(\\w+\\:)?(\\!?[\\w]+)?(\\[\\!?[EDIO]+\\])?(\\{\\!?[iroa]+\\})?(\\/\\!?[udomgn]+)?(\\;\\S+)?");
     private static final Pattern PREDICATE_PATTERN = Pattern.compile("\\;(\\w+)\\=([^\\;]+)(\\;\\S+)?");
     private static final Pattern EXISTING_TERM_PATTERN = Pattern.compile("(\\w+)");
     private static final Pattern CHANGE_PATTERN = Pattern.compile("(\\w+\\:)(\\[[EDIO\\-]\\])?(\\{[iroa]\\})?(\\/n)?");
@@ -591,6 +591,10 @@ public class GraphPolicyRule {
                     abilities.add(GraphPolicy.Ability.DELETE);
                 } else if (ability == 'o') {
                     abilities.add(GraphPolicy.Ability.OWN);
+                } else if (ability == 'm') {
+                    abilities.add(GraphPolicy.Ability.CHGRP);
+                } else if (ability == 'g') {
+                    abilities.add(GraphPolicy.Ability.CHOWN);
                 } else if (ability == 'n') {
                     isCheckPermissions = !required;
                 } else if (ability == '!') {

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -393,6 +393,8 @@ public class GraphTraversal {
         final Set<CI> mayUpdate = new HashSet<CI>();
         final Set<CI> mayDelete = new HashSet<CI>();
         final Set<CI> mayChmod = new HashSet<CI>();
+        final Set<CI> mayChgrp = new HashSet<CI>();
+        final Set<CI> mayChown = new HashSet<CI>();
         final Set<CI> owns = new HashSet<CI>();
         final Set<CI> overrides = new HashSet<CI>();
     }
@@ -734,6 +736,12 @@ public class GraphTraversal {
             }
             if (aclVoter.allowDelete(objectInstance, objectDetails)) {
                 planning.mayDelete.add(object);
+            }
+            if (!objectDetails.getPermissions().isDisallowChgrp()) {
+                planning.mayChgrp.add(object);
+            }
+            if (!objectDetails.getPermissions().isDisallowChown()) {
+                planning.mayChown.add(object);
             }
             if (objectInstance instanceof ExperimenterGroup) {
                 final ExperimenterGroup loadedGroup = (ExperimenterGroup) session.load(ExperimenterGroup.class, object.id);
@@ -1373,6 +1381,18 @@ public class GraphTraversal {
             final Set<CI> violations = Sets.difference(objects, planning.mayChmod);
             if (!violations.isEmpty()) {
                 throw new GraphException("not permitted to change permissions on " + Joiner.on(", ").join(violations));
+            }
+        }
+        if (abilities.contains(Ability.CHGRP)) {
+            final Set<CI> violations = Sets.difference(objects, planning.mayChgrp);
+            if (!violations.isEmpty()) {
+                throw new GraphException("not permitted to move " + Joiner.on(", ").join(violations));
+            }
+        }
+        if (abilities.contains(Ability.CHOWN)) {
+            final Set<CI> violations = Sets.difference(objects, planning.mayChown);
+            if (!violations.isEmpty()) {
+                throw new GraphException("not permitted to give " + Joiner.on(", ").join(violations));
             }
         }
         if (abilities.contains(Ability.OWN)) {

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -101,12 +101,16 @@ public class GraphTraversal {
          * @param mayUpdate if the object may be updated
          * @param mayDelete if the object may be deleted
          * @param mayChmod if the object may have its permissions changed
+         * @param mayChgrp if the object may be moved
+         * @param mayChown if the object may be given
          * @param isOwner if the user owns the object
          * @param isCheckPermissions if the user is expected to have the permissions required to process the object
          */
         DetailsWithCI(IObject subject, Long ownerId, Long groupId, Action action, Orphan orphan,
-                boolean mayUpdate, boolean mayDelete, boolean mayChmod, boolean isOwner, boolean isCheckPermissions) {
-            super(subject, ownerId, groupId, action, orphan, mayUpdate, mayDelete, mayChmod, isOwner, isCheckPermissions);
+                boolean mayUpdate, boolean mayDelete, boolean mayChmod, boolean mayChgrp, boolean mayChown,
+                boolean isOwner, boolean isCheckPermissions) {
+            super(subject, ownerId, groupId, action, orphan, mayUpdate, mayDelete, mayChmod, mayChgrp, mayChown,
+                    isOwner, isCheckPermissions);
             this.subjectAsCI = new CI(subject);
         }
 
@@ -1080,10 +1084,11 @@ public class GraphTraversal {
             if (isCheckUserPermissions) {
                 details = new DetailsWithCI(object.toIObject(), ownerId, groupId, action, orphan,
                         planning.mayUpdate.contains(object), planning.mayDelete.contains(object),
-                        planning.mayChmod.contains(object), planning.owns.contains(object),
-                        !planning.overrides.contains(object));
+                        planning.mayChmod.contains(object), planning.mayChgrp.contains(object), planning.mayChown.contains(object),
+                        planning.owns.contains(object), !planning.overrides.contains(object));
             } else {
-                details = new DetailsWithCI(object.toIObject(), ownerId, groupId, action, orphan, true, true, true, true, true);
+                details = new DetailsWithCI(object.toIObject(), ownerId, groupId, action, orphan,
+                        true, true, true, true, true, true, true);
             }
 
             cache.put(object, details);

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -300,8 +300,7 @@ public class GraphTraversal {
         /**
          * Construct a {@link CP} from this {@link CPI}.
          * Repeated calls to this method may return the same {@link CP} instance.
-         * @param id an instance ID
-         * @return a {@link CPI} with the corresponding values
+         * @return a {@link CP} with the corresponding values
          */
         CP toCP() {
             if (asCP == null) {


### PR DESCRIPTION
# What this PR does

Uses new `canChgrp`, `canChown` properties from #5204 to have `Chgrp2`, `Chown2` better handle when the light admin has `Chgrp` or `Chown` privilege without `Delete*`.

# Testing this PR

@pwalczysko's integration tests.

# Related reading

https://trello.com/c/F2dqugBK/