### PR TITLE
TablesFacility Query

### DIFF
--- a/components/blitz/src/omero/gateway/facility/Facility.java
+++ b/components/blitz/src/omero/gateway/facility/Facility.java
@@ -204,7 +204,10 @@ public abstract class Facility {
      *            The exception
      */
     public void logDebug(Object originator, String msg, Throwable t) {
-        gateway.getLogger().debug(originator, new LogMessage(msg, t));
+        if (t != null)
+            gateway.getLogger().debug(originator, new LogMessage(msg, t));
+        else
+            gateway.getLogger().debug(originator, msg);
     }
 
     /**
@@ -218,7 +221,10 @@ public abstract class Facility {
      *            The exception
      */
     public void logInfo(Object originator, String msg, Throwable t) {
-        gateway.getLogger().info(originator, new LogMessage(msg, t));
+        if (t != null)
+            gateway.getLogger().info(originator, new LogMessage(msg, t));
+        else
+            gateway.getLogger().info(originator, msg);
     }
 
     /**
@@ -232,7 +238,10 @@ public abstract class Facility {
      *            The exception
      */
     public void logWarn(Object originator, String msg, Throwable t) {
-        gateway.getLogger().warn(originator, new LogMessage(msg, t));
+        if (t != null)
+            gateway.getLogger().warn(originator, new LogMessage(msg, t));
+        else
+            gateway.getLogger().warn(originator, msg);
     }
 
     /**
@@ -246,7 +255,10 @@ public abstract class Facility {
      *            The exception
      */
     public void logError(Object originator, String msg, Throwable t) {
-        gateway.getLogger().error(originator, new LogMessage(msg, t));
+        if (t != null)
+            gateway.getLogger().error(originator, new LogMessage(msg, t));
+        else
+            gateway.getLogger().error(originator, msg);
     }
 
     /**

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -318,6 +318,30 @@ public class TablesFacility extends Facility {
      *             If an error occurred while trying to retrieve data from OMERO
      *             service.
      */
+    public TableData getTable(SecurityContext ctx, long fileId, List<Long> rows)
+            throws DSOutOfServiceException, DSAccessException {
+        long[] rowsArray = new long[rows.size()];
+        for (int i = 0; i < rows.size(); i++)
+            rowsArray[i] = rows.get(i);
+        return getTable(ctx, fileId, rowsArray);
+    }
+    
+    /**
+     * Load data from a table
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param fileId
+     *            The id of the {@link OriginalFile} which stores the table
+     * @param rows
+     *            The rows to get
+     * @return The specified data
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
     public TableData getTable(SecurityContext ctx, long fileId, long... rows)
             throws DSOutOfServiceException, DSAccessException {
         TablePrx table = null;

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -93,7 +93,7 @@ public class TablesFacility extends Facility {
             if (name == null)
                 name = UUID.randomUUID().toString();
 
-            TablesFacilityHelper helper = new TablesFacilityHelper();
+            TablesFacilityHelper helper = new TablesFacilityHelper(this);
             helper.parseTableData(data);
             
             SharedResourcesPrx sr = gateway.getSharedResources(ctx);
@@ -341,12 +341,12 @@ public class TablesFacility extends Facility {
                         Object.class);
             }
             
-            TablesFacilityHelper helper = new TablesFacilityHelper();
+            TablesFacilityHelper helper = new TablesFacilityHelper(this);
             helper.parseData(data, header);
             
             TableData result = new TableData(header, helper.getDataArray());
             result.setOriginalFileId(fileId);
-            result.setNumberOfRows(helper.getnRows());
+            result.setNumberOfRows(helper.getNRows());
             return result;
             
         } catch (Exception e) {
@@ -437,7 +437,7 @@ public class TablesFacility extends Facility {
             
             Data data = table.read(columns, rowFrom, rowTo + 1);
             
-            TablesFacilityHelper helper = new TablesFacilityHelper();
+            TablesFacilityHelper helper = new TablesFacilityHelper(this);
             helper.parseData(data, header);
             
             result = new TableData(header, helper.getDataArray());

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -31,42 +31,16 @@ import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.AnnotationData;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.FileAnnotationData;
-import omero.gateway.model.ImageData;
-import omero.gateway.model.MaskData;
-import omero.gateway.model.PlateData;
-import omero.gateway.model.ROIData;
 import omero.gateway.model.TableData;
 import omero.gateway.model.TableDataColumn;
-import omero.gateway.model.WellSampleData;
-import omero.grid.BoolColumn;
 import omero.grid.Column;
 import omero.grid.Data;
-import omero.grid.DoubleArrayColumn;
-import omero.grid.DoubleColumn;
-import omero.grid.FileColumn;
-import omero.grid.FloatArrayColumn;
-import omero.grid.ImageColumn;
-import omero.grid.LongArrayColumn;
-import omero.grid.LongColumn;
-import omero.grid.MaskColumn;
-import omero.grid.PlateColumn;
-import omero.grid.RoiColumn;
 import omero.grid.SharedResourcesPrx;
-import omero.grid.StringColumn;
 import omero.grid.TablePrx;
-import omero.grid.WellColumn;
 import omero.model.FileAnnotation;
 import omero.model.FileAnnotationI;
-import omero.model.Image;
-import omero.model.ImageI;
 import omero.model.OriginalFile;
 import omero.model.OriginalFileI;
-import omero.model.Plate;
-import omero.model.PlateI;
-import omero.model.Roi;
-import omero.model.RoiI;
-import omero.model.WellSample;
-import omero.model.WellSampleI;
 
 /**
  * {@link Facility} to interact with OMERO.tables
@@ -118,20 +92,9 @@ public class TablesFacility extends Facility {
             if (name == null)
                 name = UUID.randomUUID().toString();
 
-            TableDataColumn[] columns = data.getColumns() != null ? data
-                    .getColumns() : new TableDataColumn[0];
-
-            Column[] gridColumns = new Column[data.getColumns().length];
-            for (int i = 0; i < data.getColumns().length; i++) {
-                String cname = columns.length > i ? columns[i].getName() : "";
-                String desc = columns.length > i ? columns[i].getDescription()
-                        : "";
-                Object[] d = data.getData().length > i ? data.getData()[i]
-                        : new Object[0];
-                gridColumns[i] = createColumn(cname, desc,
-                        data.getColumns()[i].getType(), d);
-            }
-
+            TablesFacilityHelper helper = new TablesFacilityHelper();
+            helper.parseTableData(data);
+            
             SharedResourcesPrx sr = gateway.getSharedResources(ctx);
             if (!sr.areTablesEnabled()) {
                 throw new DSAccessException(
@@ -140,8 +103,8 @@ public class TablesFacility extends Facility {
             long repId = sr.repositories().descriptions.get(0).getId()
                     .getValue();
             table = sr.newTable(repId, name);
-            table.initialize(gridColumns);
-            table.addData(gridColumns);
+            table.initialize(helper.getGridColumns());
+            table.addData(helper.getGridColumns());
 
             DataManagerFacility dm = gateway
                     .getFacility(DataManagerFacility.class);
@@ -252,6 +215,144 @@ public class TablesFacility extends Facility {
     }
     
     /**
+     * Perform a query on the table
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param fileId
+     *            The id of the {@link OriginalFile} which stores the table
+     * @param condition
+     *            The query string
+     * @return A list of row indices matching the condition
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
+    public long[] query(SecurityContext ctx, long fileId,
+            String condition) throws DSOutOfServiceException, DSAccessException {
+        return query(ctx, fileId, condition, 0, 0, 0);
+    }
+
+    /**
+     * Perform a query on the table
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param fileId
+     *            The id of the {@link OriginalFile} which stores the table
+     * @param condition
+     *            The query string
+     * @param start
+     *            The index of the first row to consider (optional)
+     * @param stop
+     *            The index of the last+1 row to consider (optional)
+     * @param step
+     *            The stepping interval between the start and stop rows to
+     *            consider (Set to 0 to disable stepping)
+     * @return A list of row indices matching the condition
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
+    public long[] query(SecurityContext ctx, long fileId,
+            String condition, long start, long stop, long step)
+            throws DSOutOfServiceException, DSAccessException {
+        TablePrx table = null;
+        try {
+            OriginalFile file = new OriginalFileI(fileId, false);
+            SharedResourcesPrx sr = gateway.getSharedResources(ctx);
+            if (!sr.areTablesEnabled()) {
+                throw new DSAccessException(
+                        "Tables feature is not enabled on this server!");
+            }
+
+            table = sr.openTable(file);
+            if (start < 0)
+                start = 0;
+            if (stop <= 0)
+                stop = table.getNumberOfRows();
+            if (step < 0)
+                step = 0;
+            
+            return table.getWhereList(condition, null, start, stop, step);
+        } catch (Exception e) {
+            handleException(this, e, "Could not load table data");
+        } finally {
+            if (table != null)
+                try {
+                    table.close();
+                } catch (ServerError e) {
+                    logError(this, "Could not close table", e);
+                }
+        }
+        return new long[0];
+    }
+    
+    /**
+     * Load data from a table
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param fileId
+     *            The id of the {@link OriginalFile} which stores the table
+     * @param rows
+     *            The rows to get
+     * @return The specified data
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
+    public TableData getTable(SecurityContext ctx, long fileId, long... rows)
+            throws DSOutOfServiceException, DSAccessException {
+        TablePrx table = null;
+        try {
+            OriginalFile file = new OriginalFileI(fileId, false);
+            SharedResourcesPrx sr = gateway.getSharedResources(ctx);
+            if (!sr.areTablesEnabled()) {
+                throw new DSAccessException(
+                        "Tables feature is not enabled on this server!");
+            }
+            table = sr.openTable(file);
+            
+            Data data = table.readCoordinates(rows);
+            
+            Column[] cols = table.getHeaders();
+            
+            TableDataColumn[] header = new TableDataColumn[cols.length];
+            for (int i = 0; i < cols.length; i++) {
+                header[i] = new TableDataColumn(cols[i].name,
+                        cols[i].description, i,
+                        Object.class);
+            }
+            
+            TablesFacilityHelper helper = new TablesFacilityHelper();
+            helper.parseData(data, header);
+            
+            TableData result = new TableData(header, helper.getDataArray());
+            result.setOriginalFileId(fileId);
+            result.setNumberOfRows(helper.getnRows());
+            return result;
+            
+        } catch (Exception e) {
+            handleException(this, e, "Could not load table data");
+        } finally {
+            if (table != null)
+                try {
+                    table.close();
+                } catch (ServerError e) {
+                    logError(this, "Could not close table", e);
+                }
+        }
+        return null;
+    }
+            
+    /**
      * Load data from a table
      * 
      * @param ctx
@@ -304,10 +405,10 @@ public class TablesFacility extends Facility {
                         cols[columnIndex].description, columnIndex,
                         Object.class);
             }
-
-            if (table.getNumberOfRows() == 0)
+            
+            if (table.getNumberOfRows() == 0) 
                 return new TableData(header, new Object[columns.length][0]);
-
+            
             if (rowFrom < 0)
                 rowFrom = 0;
 
@@ -322,147 +423,14 @@ public class TablesFacility extends Facility {
                 throw new Exception("Can't fetch more than "
                         + (Integer.MAX_VALUE - 1) + " rows at once.");
 
-            int nRows = (int) (rowTo - rowFrom + 1);
-
-            Object[][] dataArray = null;
-            if (nRows > 0) {
-                dataArray = new Object[columns.length][nRows];
-                Data data = table.read(columns, rowFrom, rowTo + 1);
-                for (int i = 0; i < data.columns.length; i++) {
-                    Column col = data.columns[i];
-                    if (col instanceof BoolColumn) {
-                        Boolean[] rowData = new Boolean[nRows];
-                        boolean tableData[] = ((BoolColumn) col).values;
-                        for (int j = 0; j < nRows; j++)
-                            rowData[j] = tableData[j];
-                        dataArray[i] = rowData;
-                        header[i].setType(Boolean.class);
-                    }
-                    if (col instanceof DoubleArrayColumn) {
-                        Double[][] rowData = new Double[nRows][];
-                        double tableData[][] = ((DoubleArrayColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            Double[] tmp = new Double[tableData[j].length];
-                            for (int k = 0; k < tableData[j].length; k++) {
-                                tmp[k] = tableData[j][k];
-                            }
-                            rowData[j] = tmp;
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(Double[].class);
-                    }
-                    if (col instanceof DoubleColumn) {
-                        Double[] rowData = new Double[nRows];
-                        double tableData[] = ((DoubleColumn) col).values;
-                        for (int j = 0; j < nRows; j++)
-                            rowData[j] = tableData[j];
-                        dataArray[i] = rowData;
-                        header[i].setType(Double.class);
-                    }
-                    if (col instanceof FileColumn) {
-                        FileAnnotationData[] rowData = new FileAnnotationData[nRows];
-                        long tableData[] = ((FileColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            FileAnnotation f = new FileAnnotationI(
-                                    tableData[j], false);
-                            rowData[j] = new FileAnnotationData(f);
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(FileAnnotationData.class);
-                    }
-                    if (col instanceof FloatArrayColumn) {
-                        Float[][] rowData = new Float[nRows][];
-                        float tableData[][] = ((FloatArrayColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            Float[] tmp = new Float[tableData[j].length];
-                            for (int k = 0; k < tableData[j].length; k++) {
-                                tmp[k] = tableData[j][k];
-                            }
-                            rowData[j] = tmp;
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(Float[].class);
-                    }
-                    if (col instanceof ImageColumn) {
-                        ImageData[] rowData = new ImageData[nRows];
-                        long tableData[] = ((ImageColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            Image im = new ImageI(tableData[j], false);
-                            rowData[j] = new ImageData(im);
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(ImageData.class);
-                    }
-                    if (col instanceof LongArrayColumn) {
-                        Long[][] rowData = new Long[nRows][];
-                        long tableData[][] = ((LongArrayColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            Long[] tmp = new Long[tableData[j].length];
-                            for (int k = 0; k < tableData[j].length; k++) {
-                                tmp[k] = tableData[j][k];
-                            }
-                            rowData[j] = tmp;
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(Long[].class);
-                    }
-                    if (col instanceof LongColumn) {
-                        Long[] rowData = new Long[nRows];
-                        long tableData[] = ((LongColumn) col).values;
-                        for (int j = 0; j < nRows; j++)
-                            rowData[j] = tableData[j];
-                        dataArray[i] = rowData;
-                        header[i].setType(Long.class);
-                    }
-                    if (col instanceof MaskColumn) {
-                        MaskColumn mc = ((MaskColumn) col);
-                        MaskData[] rowData = new MaskData[nRows];
-                        for (int j = 0; j < nRows; j++) {
-                            MaskData md = new MaskData(mc.x[j], mc.y[j],
-                                    mc.w[j], mc.h[j], mc.bytes[j]);
-                            rowData[j] = md;
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(MaskData.class);
-                    }
-                    if (col instanceof PlateColumn) {
-                        PlateData[] rowData = new PlateData[nRows];
-                        long tableData[] = ((PlateColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            Plate p = new PlateI(tableData[j], false);
-                            rowData[j] = new PlateData(p);
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(PlateData.class);
-                    }
-                    if (col instanceof RoiColumn) {
-                        ROIData[] rowData = new ROIData[nRows];
-                        long tableData[] = ((RoiColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            Roi p = new RoiI(tableData[j], false);
-                            rowData[j] = new ROIData(p);
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(ROIData.class);
-                    }
-                    if (col instanceof StringColumn) {
-                        String[] rowData = ((StringColumn) col).values;
-                        dataArray[i] = rowData;
-                        header[i].setType(String.class);
-                    }
-                    if (col instanceof WellColumn) {
-                        WellSampleData[] rowData = new WellSampleData[nRows];
-                        long tableData[] = ((WellColumn) col).values;
-                        for (int j = 0; j < nRows; j++) {
-                            WellSample p = new WellSampleI(tableData[j], false);
-                            rowData[j] = new WellSampleData(p);
-                        }
-                        dataArray[i] = rowData;
-                        header[i].setType(ROIData.class);
-                    }
-                }
-            }
-            TableData result = new TableData(header, dataArray);
+            TableData result = null;
+            
+            Data data = table.read(columns, rowFrom, rowTo + 1);
+            
+            TablesFacilityHelper helper = new TablesFacilityHelper();
+            helper.parseData(data, header);
+            
+            result = new TableData(header, helper.getDataArray());
             result.setOffset(rowFrom);
             result.setOriginalFileId(fileId);
             result.setNumberOfRows(maxRow + 1);
@@ -519,155 +487,5 @@ public class TablesFacility extends Facility {
         }
         return result;
     }
-
-    /**
-     * Create a {@link Column} with the specified data
-     * 
-     * @param header
-     *            The header (column name)
-     * @param description
-     *            Description
-     * @param type
-     *            The type of data
-     * @param data
-     *            The data
-     * @return The {@link Column}
-     */
-    private Column createColumn(String header, String description,
-            Class<?> type, Object[] data) {
-        Column c = null;
-
-        if (type.equals(Boolean.class)) {
-            boolean[] d = new boolean[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = (Boolean) data[i];
-            c = new BoolColumn(header, description, d);
-        }
-
-        if (type.equals(Double[].class)) {
-            double[][] d = new double[data.length][];
-            int l = 0;
-            for (int i = 0; i < data.length; i++) {
-                Double[] src = (Double[]) data[i];
-                double[] dst = new double[src.length];
-                for (int j = 0; j < src.length; j++)
-                    dst[j] = src[j];
-                d[i] = dst;
-                l = dst.length;
-            }
-            c = new DoubleArrayColumn(header, description, l, d);
-        }
-
-        if (type.equals(Double.class)) {
-            double[] d = new double[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = (Double) data[i];
-            c = new DoubleColumn(header, description, d);
-        }
-
-        if (type.equals(FileAnnotationData.class)) {
-            long[] d = new long[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = ((FileAnnotationData) data[i]).getFileID();
-            c = new FileColumn(header, description, d);
-        }
-
-        if (type.equals(Float[].class)) {
-            float[][] d = new float[data.length][];
-            int l = 0;
-            for (int i = 0; i < data.length; i++) {
-                Float[] src = (Float[]) data[i];
-                float[] dst = new float[src.length];
-                for (int j = 0; j < src.length; j++)
-                    dst[j] = src[j];
-                d[i] = dst;
-                l = dst.length;
-            }
-            c = new FloatArrayColumn(header, description, l, d);
-        }
-
-        if (type.equals(ImageData.class)) {
-            long[] d = new long[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = ((ImageData) data[i]).getId();
-            c = new ImageColumn(header, description, d);
-        }
-
-        if (type.equals(Long[].class)) {
-            long[][] d = new long[data.length][];
-            int l = 0;
-            for (int i = 0; i < data.length; i++) {
-                Long[] src = (Long[]) data[i];
-                long[] dst = new long[src.length];
-                for (int j = 0; j < src.length; j++)
-                    dst[j] = src[j];
-                d[i] = dst;
-                l = dst.length;
-            }
-            c = new LongArrayColumn(header, description, l, d);
-        }
-
-        if (type.equals(Long.class)) {
-            long[] d = new long[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = (Long) data[i];
-            c = new LongColumn(header, description, d);
-        }
-
-        if (type.equals(MaskData.class)) {
-            long[] imageId = new long[data.length];
-            int[] theZ = new int[data.length];
-            int[] theT = new int[data.length];
-            double[] x = new double[data.length];
-            double[] y = new double[data.length];
-            double[] w = new double[data.length];
-            double[] h = new double[data.length];
-            byte[][] bytes = new byte[data.length][];
-
-            for (int i = 0; i < data.length; i++) {
-                MaskData md = (MaskData) data[i];
-                // TODO: Where get the imageId from!?
-                theZ[i] = md.getZ();
-                theT[i] = md.getT();
-                x[i] = md.getX();
-                y[i] = md.getY();
-                w[i] = md.getWidth();
-                h[i] = md.getHeight();
-                bytes[i] = md.getMask();
-            }
-
-            c = new MaskColumn(header, description, imageId, theZ, theT, x, y,
-                    w, h, bytes);
-        }
-
-        if (type.equals(PlateData.class)) {
-            long[] d = new long[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = ((PlateData) data[i]).getId();
-            c = new PlateColumn(header, description, d);
-        }
-
-        if (type.equals(ROIData.class)) {
-            long[] d = new long[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = ((ROIData) data[i]).getId();
-            c = new RoiColumn(header, description, d);
-        }
-
-        if (type.equals(String.class)) {
-            String[] d = new String[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = (String) data[i];
-            c = new StringColumn(header, description, Short.MAX_VALUE, d);
-        }
-
-        if (type.equals(WellSampleData.class)) {
-            long[] d = new long[data.length];
-            for (int i = 0; i < data.length; i++)
-                d[i] = ((WellSampleData) data[i]).getId();
-            c = new WellColumn(header, description, d);
-        }
-
-        return c;
-    }
+    
 }

--- a/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
@@ -18,6 +18,7 @@
  */
 package omero.gateway.facility;
 
+import omero.IllegalArgumentException;
 import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.MaskData;
@@ -62,16 +63,16 @@ import omero.model.WellSampleI;
 public class TablesFacilityHelper {
 
     /** The data array (after parsing omero.grid.Data) */
-    Object[][] dataArray;
+    private Object[][] dataArray;
 
     /** The number of columns */
-    int nCols;
+    private int nCols;
 
     /** The number of rows */
-    int nRows;
+    private int nRows;
 
     /** The omero.grid.Columns (after parsing TableData) */
-    Column[] gridColumns;
+    private Column[] gridColumns;
 
     /**
      * Create a new instance
@@ -87,6 +88,9 @@ public class TablesFacilityHelper {
      *            The TableData
      */
     void parseTableData(TableData data) {
+        if (data == null)
+            return;
+        
         TableDataColumn[] columns = data.getColumns() != null ? data
                 .getColumns() : new TableDataColumn[0];
 
@@ -110,12 +114,19 @@ public class TablesFacilityHelper {
      * @param data
      *            The omero.grid.Data object
      * @param header
-     *            The header (which will be updated with the correct column types)
+     *            The header (which will be updated with the correct column
+     *            types)
      */
     void parseData(Data data, TableDataColumn[] header) {
+        if (data == null || header == null)
+            return;
+        if (header.length != data.columns.length)
+            throw new IllegalArgumentException(
+                    "Number of column definitions must match the number of columns of the table");
+
         nCols = data.columns.length;
         nRows = data.rowNumbers.length;
-        
+
         dataArray = new Object[nCols][nRows];
 
         for (int i = 0; i < data.columns.length; i++) {
@@ -247,7 +258,7 @@ public class TablesFacilityHelper {
                     rowData[j] = new WellSampleData(p);
                 }
                 dataArray[i] = rowData;
-                header[i].setType(ROIData.class);
+                header[i].setType(WellSampleData.class);
             }
         }
     }
@@ -404,8 +415,8 @@ public class TablesFacilityHelper {
     }
 
     /**
-     * Get the number of rows ({@link #parseData(Data, TableDataColumn[])} needs to be called
-     * first)
+     * Get the number of columns ({@link #parseData(Data, TableDataColumn[])} needs
+     * to be called first)
      * 
      * @return See above
      */
@@ -414,8 +425,8 @@ public class TablesFacilityHelper {
     }
 
     /**
-     * Get the number of columns ({@link #parseData(Data, TableDataColumn[])} needs to be called
-     * first)
+     * Get the number of rows ({@link #parseData(Data, TableDataColumn[])}
+     * needs to be called first)
      * 
      * @return See above
      */
@@ -424,7 +435,8 @@ public class TablesFacilityHelper {
     }
 
     /**
-     * Get the data array ({@link #parseData(Data, TableDataColumn[])} needs to be called first)
+     * Get the data array ({@link #parseData(Data, TableDataColumn[])} needs to
+     * be called first)
      * 
      * @return See above
      */

--- a/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
@@ -74,10 +74,15 @@ public class TablesFacilityHelper {
     /** The omero.grid.Columns (after parsing TableData) */
     private Column[] gridColumns;
 
+    /** Reference to the TablesFacility */
+    private TablesFacility fac;
+    
     /**
      * Create a new instance
+     * @param fac Reference to the TablesFacility
      */
-    TablesFacilityHelper() {
+    TablesFacilityHelper(TablesFacility fac) {
+        this.fac = fac;
     }
 
     /**
@@ -246,8 +251,7 @@ public class TablesFacilityHelper {
                 header[i].setType(ROIData.class);
             }
             if (col instanceof StringColumn) {
-                String[] rowData = ((StringColumn) col).values;
-                dataArray[i] = rowData;
+                dataArray[i] = ((StringColumn) col).values;
                 header[i].setType(String.class);
             }
             if (col instanceof WellColumn) {
@@ -287,7 +291,7 @@ public class TablesFacilityHelper {
             c = new BoolColumn(header, description, d);
         }
 
-        if (type.equals(Double[].class)) {
+        else if (type.equals(Double[].class)) {
             double[][] d = new double[data.length][];
             int l = 0;
             for (int i = 0; i < data.length; i++) {
@@ -301,21 +305,21 @@ public class TablesFacilityHelper {
             c = new DoubleArrayColumn(header, description, l, d);
         }
 
-        if (type.equals(Double.class)) {
+        else if (type.equals(Double.class)) {
             double[] d = new double[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = (Double) data[i];
             c = new DoubleColumn(header, description, d);
         }
 
-        if (type.equals(FileAnnotationData.class)) {
+        else if (type.equals(FileAnnotationData.class)) {
             long[] d = new long[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = ((FileAnnotationData) data[i]).getFileID();
             c = new FileColumn(header, description, d);
         }
 
-        if (type.equals(Float[].class)) {
+        else if (type.equals(Float[].class)) {
             float[][] d = new float[data.length][];
             int l = 0;
             for (int i = 0; i < data.length; i++) {
@@ -329,14 +333,14 @@ public class TablesFacilityHelper {
             c = new FloatArrayColumn(header, description, l, d);
         }
 
-        if (type.equals(ImageData.class)) {
+        else if (type.equals(ImageData.class)) {
             long[] d = new long[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = ((ImageData) data[i]).getId();
             c = new ImageColumn(header, description, d);
         }
 
-        if (type.equals(Long[].class)) {
+        else if (type.equals(Long[].class)) {
             long[][] d = new long[data.length][];
             int l = 0;
             for (int i = 0; i < data.length; i++) {
@@ -350,14 +354,14 @@ public class TablesFacilityHelper {
             c = new LongArrayColumn(header, description, l, d);
         }
 
-        if (type.equals(Long.class)) {
+        else if (type.equals(Long.class)) {
             long[] d = new long[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = (Long) data[i];
             c = new LongColumn(header, description, d);
         }
 
-        if (type.equals(MaskData.class)) {
+        else if (type.equals(MaskData.class)) {
             long[] imageId = new long[data.length];
             int[] theZ = new int[data.length];
             int[] theT = new int[data.length];
@@ -383,34 +387,43 @@ public class TablesFacilityHelper {
                     w, h, bytes);
         }
 
-        if (type.equals(PlateData.class)) {
+        else if (type.equals(PlateData.class)) {
             long[] d = new long[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = ((PlateData) data[i]).getId();
             c = new PlateColumn(header, description, d);
         }
 
-        if (type.equals(ROIData.class)) {
+        else if (type.equals(ROIData.class)) {
             long[] d = new long[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = ((ROIData) data[i]).getId();
             c = new RoiColumn(header, description, d);
         }
 
-        if (type.equals(String.class)) {
+        else if (type.equals(String.class)) {
             String[] d = new String[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = (String) data[i];
             c = new StringColumn(header, description, Short.MAX_VALUE, d);
         }
 
-        if (type.equals(WellSampleData.class)) {
+        else if (type.equals(WellSampleData.class)) {
             long[] d = new long[data.length];
             for (int i = 0; i < data.length; i++)
                 d[i] = ((WellSampleData) data[i]).getId();
             c = new WellColumn(header, description, d);
         }
 
+        else if (type.equals(Object.class)) {
+            fac.logWarn(this, "No concrete type specified for column '"
+                    + header + "', using Object.toString()", null);
+            String[] d = new String[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = data[i].toString();
+            c = new StringColumn(header, description, Short.MAX_VALUE, d);
+        }
+        
         return c;
     }
 
@@ -420,7 +433,7 @@ public class TablesFacilityHelper {
      * 
      * @return See above
      */
-    int getnCols() {
+    int getNCols() {
         return nCols;
     }
 
@@ -430,7 +443,7 @@ public class TablesFacilityHelper {
      * 
      * @return See above
      */
-    int getnRows() {
+    int getNRows() {
         return nRows;
     }
 

--- a/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package omero.gateway.facility;
+
+import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.ImageData;
+import omero.gateway.model.MaskData;
+import omero.gateway.model.PlateData;
+import omero.gateway.model.ROIData;
+import omero.gateway.model.TableData;
+import omero.gateway.model.TableDataColumn;
+import omero.gateway.model.WellSampleData;
+import omero.grid.BoolColumn;
+import omero.grid.Column;
+import omero.grid.Data;
+import omero.grid.DoubleArrayColumn;
+import omero.grid.DoubleColumn;
+import omero.grid.FileColumn;
+import omero.grid.FloatArrayColumn;
+import omero.grid.ImageColumn;
+import omero.grid.LongArrayColumn;
+import omero.grid.LongColumn;
+import omero.grid.MaskColumn;
+import omero.grid.PlateColumn;
+import omero.grid.RoiColumn;
+import omero.grid.StringColumn;
+import omero.grid.WellColumn;
+import omero.model.FileAnnotation;
+import omero.model.FileAnnotationI;
+import omero.model.Image;
+import omero.model.ImageI;
+import omero.model.Plate;
+import omero.model.PlateI;
+import omero.model.Roi;
+import omero.model.RoiI;
+import omero.model.WellSample;
+import omero.model.WellSampleI;
+
+/**
+ * Helper class which deals with the various conversions from omero.grid objects
+ * into plain Java, respectively gateway.model objects
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class TablesFacilityHelper {
+
+    /** The data array (after parsing omero.grid.Data) */
+    Object[][] dataArray;
+
+    /** The number of columns */
+    int nCols;
+
+    /** The number of rows */
+    int nRows;
+
+    /** The omero.grid.Columns (after parsing TableData) */
+    Column[] gridColumns;
+
+    /**
+     * Create a new instance
+     */
+    TablesFacilityHelper() {
+    }
+
+    /**
+     * Turn a {@link TableData} into {@link Column}s; Get the result with
+     * {@link #getGridColumns()}
+     * 
+     * @param data
+     *            The TableData
+     */
+    void parseTableData(TableData data) {
+        TableDataColumn[] columns = data.getColumns() != null ? data
+                .getColumns() : new TableDataColumn[0];
+
+        gridColumns = new Column[data.getColumns().length];
+        for (int i = 0; i < data.getColumns().length; i++) {
+            String cname = columns.length > i ? columns[i].getName() : "";
+            String desc = columns.length > i ? columns[i].getDescription() : "";
+            Object[] d = data.getData().length > i ? data.getData()[i]
+                    : new Object[0];
+            gridColumns[i] = createColumn(cname, desc,
+                    data.getColumns()[i].getType(), d);
+        }
+    }
+
+    /**
+     * Turn an omero.grid.Data object into plain Java respectively gateway.model
+     * objects and {@link TableDataColumn}s;
+     * 
+     * Get the result with {@link #getDataArray()}
+     * 
+     * @param data
+     *            The omero.grid.Data object
+     * @param header
+     *            The header (which will be updated with the correct column types)
+     */
+    void parseData(Data data, TableDataColumn[] header) {
+        nCols = data.columns.length;
+        nRows = data.rowNumbers.length;
+        
+        dataArray = new Object[nCols][nRows];
+
+        for (int i = 0; i < data.columns.length; i++) {
+            Column col = data.columns[i];
+            if (col instanceof BoolColumn) {
+                Boolean[] rowData = new Boolean[nRows];
+                boolean tableData[] = ((BoolColumn) col).values;
+                for (int j = 0; j < nRows; j++)
+                    rowData[j] = tableData[j];
+                dataArray[i] = rowData;
+                header[i].setType(Boolean.class);
+            }
+            if (col instanceof DoubleArrayColumn) {
+                Double[][] rowData = new Double[nRows][];
+                double tableData[][] = ((DoubleArrayColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    Double[] tmp = new Double[tableData[j].length];
+                    for (int k = 0; k < tableData[j].length; k++) {
+                        tmp[k] = tableData[j][k];
+                    }
+                    rowData[j] = tmp;
+                }
+                dataArray[i] = rowData;
+                header[i].setType(Double[].class);
+            }
+            if (col instanceof DoubleColumn) {
+                Double[] rowData = new Double[nRows];
+                double tableData[] = ((DoubleColumn) col).values;
+                for (int j = 0; j < nRows; j++)
+                    rowData[j] = tableData[j];
+                dataArray[i] = rowData;
+                header[i].setType(Double.class);
+            }
+            if (col instanceof FileColumn) {
+                FileAnnotationData[] rowData = new FileAnnotationData[nRows];
+                long tableData[] = ((FileColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    FileAnnotation f = new FileAnnotationI(tableData[j], false);
+                    rowData[j] = new FileAnnotationData(f);
+                }
+                dataArray[i] = rowData;
+                header[i].setType(FileAnnotationData.class);
+            }
+            if (col instanceof FloatArrayColumn) {
+                Float[][] rowData = new Float[nRows][];
+                float tableData[][] = ((FloatArrayColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    Float[] tmp = new Float[tableData[j].length];
+                    for (int k = 0; k < tableData[j].length; k++) {
+                        tmp[k] = tableData[j][k];
+                    }
+                    rowData[j] = tmp;
+                }
+                dataArray[i] = rowData;
+                header[i].setType(Float[].class);
+            }
+            if (col instanceof ImageColumn) {
+                ImageData[] rowData = new ImageData[nRows];
+                long tableData[] = ((ImageColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    Image im = new ImageI(tableData[j], false);
+                    rowData[j] = new ImageData(im);
+                }
+                dataArray[i] = rowData;
+                header[i].setType(ImageData.class);
+            }
+            if (col instanceof LongArrayColumn) {
+                Long[][] rowData = new Long[nRows][];
+                long tableData[][] = ((LongArrayColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    Long[] tmp = new Long[tableData[j].length];
+                    for (int k = 0; k < tableData[j].length; k++) {
+                        tmp[k] = tableData[j][k];
+                    }
+                    rowData[j] = tmp;
+                }
+                dataArray[i] = rowData;
+                header[i].setType(Long[].class);
+            }
+            if (col instanceof LongColumn) {
+                Long[] rowData = new Long[nRows];
+                long tableData[] = ((LongColumn) col).values;
+                for (int j = 0; j < nRows; j++)
+                    rowData[j] = tableData[j];
+                dataArray[i] = rowData;
+                header[i].setType(Long.class);
+            }
+            if (col instanceof MaskColumn) {
+                MaskColumn mc = ((MaskColumn) col);
+                MaskData[] rowData = new MaskData[nRows];
+                for (int j = 0; j < nRows; j++) {
+                    MaskData md = new MaskData(mc.x[j], mc.y[j], mc.w[j],
+                            mc.h[j], mc.bytes[j]);
+                    rowData[j] = md;
+                }
+                dataArray[i] = rowData;
+                header[i].setType(MaskData.class);
+            }
+            if (col instanceof PlateColumn) {
+                PlateData[] rowData = new PlateData[nRows];
+                long tableData[] = ((PlateColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    Plate p = new PlateI(tableData[j], false);
+                    rowData[j] = new PlateData(p);
+                }
+                dataArray[i] = rowData;
+                header[i].setType(PlateData.class);
+            }
+            if (col instanceof RoiColumn) {
+                ROIData[] rowData = new ROIData[nRows];
+                long tableData[] = ((RoiColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    Roi p = new RoiI(tableData[j], false);
+                    rowData[j] = new ROIData(p);
+                }
+                dataArray[i] = rowData;
+                header[i].setType(ROIData.class);
+            }
+            if (col instanceof StringColumn) {
+                String[] rowData = ((StringColumn) col).values;
+                dataArray[i] = rowData;
+                header[i].setType(String.class);
+            }
+            if (col instanceof WellColumn) {
+                WellSampleData[] rowData = new WellSampleData[nRows];
+                long tableData[] = ((WellColumn) col).values;
+                for (int j = 0; j < nRows; j++) {
+                    WellSample p = new WellSampleI(tableData[j], false);
+                    rowData[j] = new WellSampleData(p);
+                }
+                dataArray[i] = rowData;
+                header[i].setType(ROIData.class);
+            }
+        }
+    }
+
+    /**
+     * Create a {@link Column} with the specified data
+     * 
+     * @param header
+     *            The header (column name)
+     * @param description
+     *            Description
+     * @param type
+     *            The type of data
+     * @param data
+     *            The data
+     * @return The {@link Column}
+     */
+    private Column createColumn(String header, String description,
+            Class<?> type, Object[] data) {
+        Column c = null;
+
+        if (type.equals(Boolean.class)) {
+            boolean[] d = new boolean[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (Boolean) data[i];
+            c = new BoolColumn(header, description, d);
+        }
+
+        if (type.equals(Double[].class)) {
+            double[][] d = new double[data.length][];
+            int l = 0;
+            for (int i = 0; i < data.length; i++) {
+                Double[] src = (Double[]) data[i];
+                double[] dst = new double[src.length];
+                for (int j = 0; j < src.length; j++)
+                    dst[j] = src[j];
+                d[i] = dst;
+                l = dst.length;
+            }
+            c = new DoubleArrayColumn(header, description, l, d);
+        }
+
+        if (type.equals(Double.class)) {
+            double[] d = new double[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (Double) data[i];
+            c = new DoubleColumn(header, description, d);
+        }
+
+        if (type.equals(FileAnnotationData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((FileAnnotationData) data[i]).getFileID();
+            c = new FileColumn(header, description, d);
+        }
+
+        if (type.equals(Float[].class)) {
+            float[][] d = new float[data.length][];
+            int l = 0;
+            for (int i = 0; i < data.length; i++) {
+                Float[] src = (Float[]) data[i];
+                float[] dst = new float[src.length];
+                for (int j = 0; j < src.length; j++)
+                    dst[j] = src[j];
+                d[i] = dst;
+                l = dst.length;
+            }
+            c = new FloatArrayColumn(header, description, l, d);
+        }
+
+        if (type.equals(ImageData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((ImageData) data[i]).getId();
+            c = new ImageColumn(header, description, d);
+        }
+
+        if (type.equals(Long[].class)) {
+            long[][] d = new long[data.length][];
+            int l = 0;
+            for (int i = 0; i < data.length; i++) {
+                Long[] src = (Long[]) data[i];
+                long[] dst = new long[src.length];
+                for (int j = 0; j < src.length; j++)
+                    dst[j] = src[j];
+                d[i] = dst;
+                l = dst.length;
+            }
+            c = new LongArrayColumn(header, description, l, d);
+        }
+
+        if (type.equals(Long.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (Long) data[i];
+            c = new LongColumn(header, description, d);
+        }
+
+        if (type.equals(MaskData.class)) {
+            long[] imageId = new long[data.length];
+            int[] theZ = new int[data.length];
+            int[] theT = new int[data.length];
+            double[] x = new double[data.length];
+            double[] y = new double[data.length];
+            double[] w = new double[data.length];
+            double[] h = new double[data.length];
+            byte[][] bytes = new byte[data.length][];
+
+            for (int i = 0; i < data.length; i++) {
+                MaskData md = (MaskData) data[i];
+                // TODO: Where get the imageId from!?
+                theZ[i] = md.getZ();
+                theT[i] = md.getT();
+                x[i] = md.getX();
+                y[i] = md.getY();
+                w[i] = md.getWidth();
+                h[i] = md.getHeight();
+                bytes[i] = md.getMask();
+            }
+
+            c = new MaskColumn(header, description, imageId, theZ, theT, x, y,
+                    w, h, bytes);
+        }
+
+        if (type.equals(PlateData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((PlateData) data[i]).getId();
+            c = new PlateColumn(header, description, d);
+        }
+
+        if (type.equals(ROIData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((ROIData) data[i]).getId();
+            c = new RoiColumn(header, description, d);
+        }
+
+        if (type.equals(String.class)) {
+            String[] d = new String[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = (String) data[i];
+            c = new StringColumn(header, description, Short.MAX_VALUE, d);
+        }
+
+        if (type.equals(WellSampleData.class)) {
+            long[] d = new long[data.length];
+            for (int i = 0; i < data.length; i++)
+                d[i] = ((WellSampleData) data[i]).getId();
+            c = new WellColumn(header, description, d);
+        }
+
+        return c;
+    }
+
+    /**
+     * Get the number of rows ({@link #parseData(Data, TableDataColumn[])} needs to be called
+     * first)
+     * 
+     * @return See above
+     */
+    int getnCols() {
+        return nCols;
+    }
+
+    /**
+     * Get the number of columns ({@link #parseData(Data, TableDataColumn[])} needs to be called
+     * first)
+     * 
+     * @return See above
+     */
+    int getnRows() {
+        return nRows;
+    }
+
+    /**
+     * Get the data array ({@link #parseData(Data, TableDataColumn[])} needs to be called first)
+     * 
+     * @return See above
+     */
+    Object[][] getDataArray() {
+        return dataArray;
+    }
+
+    /**
+     * Get the grid columns; ({@link #parseTableData(TableData)} needs to be
+     * called first)
+     * 
+     * @return See above
+     */
+    protected Column[] getGridColumns() {
+        return gridColumns;
+    }
+
+}

--- a/components/blitz/src/omero/gateway/model/TableData.java
+++ b/components/blitz/src/omero/gateway/model/TableData.java
@@ -104,7 +104,7 @@ public class TableData {
     }
 
     /**
-     * Get the data
+     * Get the data in form Object['column index']['row data']
      * 
      * @return See above
      */

--- a/components/blitz/src/omero/gateway/model/TableDataColumn.java
+++ b/components/blitz/src/omero/gateway/model/TableDataColumn.java
@@ -18,6 +18,8 @@
  */
 package omero.gateway.model;
 
+import omero.IllegalArgumentException;
+
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -72,6 +74,32 @@ public class TableDataColumn {
      */
     public TableDataColumn(String name, String description, int index,
             Class<?> type) {
+        if (type == null) {
+            throw new IllegalArgumentException("No type specified.");
+        }
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "Index must be a positive integer.");
+        }
+        if (type.equals(Integer.class)) {
+            throw new IllegalArgumentException(
+                    "Integer class is not supported, please use Long instead.");
+        }
+        if (type.equals(Float.class)) {
+            throw new IllegalArgumentException(
+                    "Float class is not supported, please use Double instead.");
+        }
+        if (!(type.equals(Object.class) || type.equals(Boolean.class)
+                || type.equals(Double.class) || type.equals(Double[].class)
+                || type.equals(FileAnnotationData.class)
+                || type.equals(Float[].class) || type.equals(ImageData.class)
+                || type.equals(Long.class) || type.equals(Long[].class)
+                || type.equals(MaskData.class) || type.equals(PlateData.class)
+                || type.equals(ROIData.class) || type.equals(String.class) || type
+                    .equals(WellSampleData.class))) {
+            throw new IllegalArgumentException(type.getSimpleName()
+                    + " class is not supported.");
+        }
         this.name = name != null ? name : "";
         this.description = description != null ? description : "";
         this.index = index;

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -43,10 +43,10 @@ public class TablesFacilityTest extends GatewayTest {
     private DatasetData ds;
 
     private TableData original;
-    
+
     private final String searchForThis = "searchForThis";
     private final long searchForThisResult = 123456789l;
-    
+
     @Override
     @BeforeClass(alwaysRun = true)
     protected void setUp() throws Exception {
@@ -75,12 +75,12 @@ public class TablesFacilityTest extends GatewayTest {
             Class<?> type = header[c].getType();
             for (int r = 0; r < nRows; r++) {
                 if (type.equals(String.class)) {
-                    if(r < 2)
+                    if (r < 2)
                         column[r] = searchForThis;
                     else
                         column[r] = "" + rand.nextInt();
                 } else if (type.equals(Long.class)) {
-                    if(r < 2)
+                    if (r < 2)
                         column[r] = searchForThisResult;
                     else
                         column[r] = rand.nextLong();
@@ -110,24 +110,46 @@ public class TablesFacilityTest extends GatewayTest {
         Assert.assertEquals(info.getNumberOfRows(), nRows);
         Assert.assertEquals(info.getColumns(), original.getColumns());
     }
-    
+
     @Test(dependsOnMethods = { "testAddTable" })
     public void testSearch() throws Exception {
-        long[] rows = tablesFacility.query(rootCtx, original.getOriginalFileId(), "(column0=='"+searchForThis+"')");
+        long[] rows = tablesFacility.query(rootCtx,
+                original.getOriginalFileId(), "(column0=='" + searchForThis
+                        + "')");
         Assert.assertEquals(rows.length, 2);
-        
-        TableData td = tablesFacility.getTable(rootCtx, original.getOriginalFileId(), rows);
+
+        TableData td = tablesFacility.getTable(rootCtx,
+                original.getOriginalFileId(), rows);
         Assert.assertEquals(td.getNumberOfRows(), 2);
-        
+
         TableDataColumn[] cols = td.getColumns();
         Object[][] data = td.getData();
-        for(int col=0; col<data.length; col++) 
-            for(int row=0; row<data[col].length; row++) {
-                if(col==0) 
+        for (int col = 0; col < data.length; col++)
+            for (int row = 0; row < data[col].length; row++) {
+                if (col == 0)
                     Assert.assertEquals(data[col][row], searchForThis);
-                if(cols[col].getType() == Long.class)
+                if (cols[col].getType() == Long.class)
                     Assert.assertEquals(data[col][row], searchForThisResult);
             }
+    }
+
+    @Test(dependsOnMethods = { "testAddTable" })
+    public void testInvalidParams() throws Exception {
+        try {
+            tablesFacility.query(rootCtx, original.getOriginalFileId(),
+                    "(column0=='" + searchForThis + "')", 10, 5, 0);
+            Assert.fail("Invalid parameters, an exception should have been thrown.");
+        } catch (Exception e) {
+            // expected
+        }
+
+        try {
+            tablesFacility.query(rootCtx, original.getOriginalFileId(),
+                    "(column0=='" + searchForThis + "')", 0, 5, 10);
+            Assert.fail("Invalid parameters, an exception should have been thrown.");
+        } catch (Exception e) {
+            // expected
+        }
     }
 
     @Test(dependsOnMethods = { "testAddTable" })

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -18,7 +18,6 @@
  */
 package integration.gateway;
 
-import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Random;
 import java.util.UUID;

--- a/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/TablesFacilityTest.java
@@ -18,6 +18,7 @@
  */
 package integration.gateway;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Random;
 import java.util.UUID;
@@ -25,6 +26,7 @@ import java.util.UUID;
 import omero.gateway.facility.TablesFacility;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.ProjectData;
 import omero.gateway.model.TableData;
 import omero.gateway.model.TableDataColumn;
 
@@ -150,6 +152,36 @@ public class TablesFacilityTest extends GatewayTest {
         } catch (Exception e) {
             // expected
         }
+        
+        try {
+            TableDataColumn[] columns = new TableDataColumn[1];
+            columns[0] = new TableDataColumn("column1", 0, ProjectData.class);
+            Object[][] data = new Object[1][1];
+            data[0][0] = new ProjectData();
+            TableData td = new TableData(columns, data);
+            tablesFacility.addTable(rootCtx, ds, "invalid", td);
+            Assert.fail("Invalid column type, an exception should have been thrown.");
+        } catch (Exception e) {
+            // expected
+        }
+    }
+
+    @Test(dependsOnMethods = { "testAddTable" })
+    public void testObjectColumnType() throws Exception {
+        ProjectData proj = new ProjectData();
+        proj.setName("test");
+        
+        TableDataColumn[] columns = new TableDataColumn[1];
+        columns[0] = new TableDataColumn("column1", 0, Object.class);
+        Object[][] data = new Object[1][1];
+        data[0][0] = proj;
+        
+        TableData td = new TableData(columns, data);
+        td = tablesFacility.addTable(rootCtx, ds, "Object column", td);
+        
+        TableData td2 = tablesFacility.getTable(rootCtx, td.getOriginalFileId());
+        Assert.assertEquals(td2.getColumns()[0].getType(), String.class);
+        Assert.assertEquals(td2.getNumberOfRows(), 1);
     }
 
     @Test(dependsOnMethods = { "testAddTable" })


### PR DESCRIPTION
# What this PR does

Add `query` method to `TablesFacility`.

Just noticed that a quite important functionality is missing in the TablesFacility, the possibility to perform queries on a table (see https://www.openmicroscopy.org/site/support/omero5.3/developers/Tables.html#query-language )

This might also be useful for IDR (and OMERO R gateway), when additional metadata is attached as potentially very large HDF5 objects.

It also externalizes various `omero.grid.` <-> `gateway.model.` conversion code into a separate `TablesFacilityHelper` class.

# Testing this PR

Check that the integration tests pass.
