### PR TITLE
remove admin privileges bean from classes that no longer use it

### DIFF
--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -141,7 +141,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
 
         this.helper = helper;
         helper.setSteps(dryRun ? 4 : 6);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         /* check that the user is a member of the destination group */
         final EventContext eventContext = helper.getEventContext();

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -83,7 +83,6 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
     private final Roles securityRoles;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
-    private final LightAdminPrivileges adminPrivileges;
     private final Deletion deletionInstance;
     private final Set<Class<? extends IObject>> targetClasses;
     private GraphPolicy graphPolicy;  /* not final because of adjustGraphPolicy */
@@ -124,7 +123,6 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
         this.securityRoles = securityRoles;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
-        this.adminPrivileges = adminPrivileges;
         this.deletionInstance = deletionInstance;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
@@ -150,7 +148,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
 
         this.helper = helper;
         helper.setSteps(dryRun ? 4 : 6);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         try {
             perm1 = (Long) Utils.internalForm(Permissions.parseString(permissions));

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -161,7 +161,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
 
         this.helper = helper;
         helper.setSteps(dryRun ? 5 : 7);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         /* if the current user is not an administrator then find of which groups the target user is a member */
         final EventContext eventContext = helper.getEventContext();

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -71,7 +71,6 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
     private final ACLVoter aclVoter;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
-    private final LightAdminPrivileges adminPrivileges;
     private final Set<Class<? extends IObject>> targetClasses;
     private final Deletion deletionInstance;
     private GraphPolicy graphPolicy;  /* not final because of adjustGraphPolicy */
@@ -108,7 +107,6 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
-        this.adminPrivileges = adminPrivileges;
         this.deletionInstance = deletionInstance;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
@@ -133,7 +131,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
 
         this.helper = helper;
         helper.setSteps(dryRun ? 4 : 6);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
                 aclVoter, systemTypes, graphPathBean, unnullable, new InternalProcessor(), dryRun);

--- a/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
@@ -79,7 +79,6 @@ public class DiskUsage2I extends DiskUsage2 implements IRequest {
     private final ACLVoter aclVoter;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
-    private final LightAdminPrivileges adminPrivileges;
     private final Set<Class<? extends IObject>> legalClasses;
     private final GraphPolicy graphPolicy;
     private PixelsService pixelsService;
@@ -114,7 +113,6 @@ public class DiskUsage2I extends DiskUsage2 implements IRequest {
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
-        this.adminPrivileges = adminPrivileges;
         this.legalClasses = targetClasses;
         this.graphPolicy = graphPolicy;
     }
@@ -153,7 +151,7 @@ public class DiskUsage2I extends DiskUsage2 implements IRequest {
 
         this.helper = helper;
         helper.setSteps(5);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         graphTraversal = new GraphTraversal(helper.getSession(), helper.getEventContext(), aclVoter, systemTypes, graphPathBean,
                 null, graphPolicy, new InternalProcessor());

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -97,7 +97,6 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
     private final ACLVoter aclVoter;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
-    private final LightAdminPrivileges adminPrivileges;
     private final Set<Class<? extends IObject>> targetClasses;
     private GraphPolicy graphPolicy;  /* not final because of adjustGraphPolicy */
     private final SetMultimap<String, String> unnullable;
@@ -139,7 +138,6 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
-        this.adminPrivileges = adminPrivileges;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
         this.unnullable = unnullable;
@@ -165,7 +163,7 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
 
         this.helper = helper;
         helper.setSteps(dryRun ? 3 : 8);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         classifier = new SpecificityClassifier<Class<? extends IObject>, Inclusion>(
                 new SpecificityClassifier.ContainmentTester<Class<? extends IObject>>() {

--- a/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
@@ -75,7 +75,6 @@ public class FindChildrenI extends FindChildren implements IRequest {
     private final ACLVoter aclVoter;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
-    private final LightAdminPrivileges adminPrivileges;
     private final Set<Class<? extends IObject>> targetClasses;
     private final GraphPolicy graphPolicy;
 
@@ -103,7 +102,6 @@ public class FindChildrenI extends FindChildren implements IRequest {
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
-        this.adminPrivileges = adminPrivileges;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
     }
@@ -125,7 +123,7 @@ public class FindChildrenI extends FindChildren implements IRequest {
 
         this.helper = helper;
         helper.setSteps(1);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         if (CollectionUtils.isEmpty(typesOfChildren)) {
             final Exception e = new IllegalArgumentException("no types of children specified to find");

--- a/components/blitz/src/omero/cmd/graphs/FindParentsI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindParentsI.java
@@ -75,7 +75,6 @@ public class FindParentsI extends FindParents implements IRequest {
     private final ACLVoter aclVoter;
     private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
-    private final LightAdminPrivileges adminPrivileges;
     private final Set<Class<? extends IObject>> targetClasses;
     private final GraphPolicy graphPolicy;
 
@@ -103,7 +102,6 @@ public class FindParentsI extends FindParents implements IRequest {
         this.aclVoter = aclVoter;
         this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
-        this.adminPrivileges = adminPrivileges;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
     }
@@ -125,7 +123,7 @@ public class FindParentsI extends FindParents implements IRequest {
 
         this.helper = helper;
         helper.setSteps(1);
-        this.graphHelper = new GraphHelper(helper, graphPathBean, adminPrivileges);
+        this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         if (CollectionUtils.isEmpty(typesOfParents)) {
             final Exception e = new IllegalArgumentException("no types of parents specified to find");

--- a/components/blitz/src/omero/cmd/graphs/GraphHelper.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphHelper.java
@@ -40,7 +40,6 @@ import ome.model.IObject;
 import ome.model.enums.AdminPrivilege;
 import ome.security.ACLVoter;
 import ome.security.SystemTypes;
-import ome.security.basic.LightAdminPrivileges;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
@@ -57,18 +56,15 @@ public class GraphHelper {
 
     private final Helper helper;
     private final GraphPathBean graphPathBean;
-    private final LightAdminPrivileges adminPrivileges;
 
     /**
      * Construct a helper for a graph request instance.
      * @param helper the general request helper for the graph request instance
      * @param graphPathBean the graph path bean
-     * @param adminPrivileges the light administrator privileges helper
      */
-    public GraphHelper(Helper helper, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges) {
+    public GraphHelper(Helper helper, GraphPathBean graphPathBean) {
         this.helper = helper;
         this.graphPathBean = graphPathBean;
-        this.adminPrivileges = adminPrivileges;
     }
 
     /**

--- a/components/server/resources/ome/services/indexer.xml
+++ b/components/server/resources/ome/services/indexer.xml
@@ -63,7 +63,6 @@
 
   <bean id="lightAdminPrivilegesSecurityFilter" class="ome.security.basic.LightAdminPrivilegesSecurityFilter">
     <constructor-arg ref="roles"/>
-    <constructor-arg ref="adminPrivileges"/>
     <property name="defaultFilterCondition" value="true"/>
   </bean>
 

--- a/components/server/resources/ome/services/pixeldata.xml
+++ b/components/server/resources/ome/services/pixeldata.xml
@@ -63,7 +63,6 @@
 
   <bean id="lightAdminPrivilegesSecurityFilter" class="ome.security.basic.LightAdminPrivilegesSecurityFilter">
     <constructor-arg ref="roles"/>
-    <constructor-arg ref="adminPrivileges"/>
     <property name="defaultFilterCondition" value="true"/>
   </bean>
 

--- a/components/server/resources/ome/services/sec-primitives.xml
+++ b/components/server/resources/ome/services/sec-primitives.xml
@@ -68,7 +68,6 @@
 
   <bean id="LightAdminPrivilegesSecurityFilter" class="ome.security.basic.LightAdminPrivilegesSecurityFilter">
     <constructor-arg ref="roles"/>
-    <constructor-arg ref="adminPrivileges"/>
   </bean>
 
   <alias name="${omero.security.chmod_strategy}" alias="chmodStrategy"/>

--- a/components/server/src/ome/security/basic/LightAdminPrivilegesSecurityFilter.java
+++ b/components/server/src/ome/security/basic/LightAdminPrivilegesSecurityFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2016-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify

--- a/components/server/src/ome/security/basic/LightAdminPrivilegesSecurityFilter.java
+++ b/components/server/src/ome/security/basic/LightAdminPrivilegesSecurityFilter.java
@@ -48,16 +48,12 @@ public class LightAdminPrivilegesSecurityFilter extends AbstractSecurityFilter {
             ImmutableMap.of("real_owner", "long",
                             "privileges", "string");
 
-    private final LightAdminPrivileges adminPrivileges;
-
     /**
      * Construct a new light administrator filter.
      * @param roles the users and groups that are special to OMERO
-     * @param adminPrivileges the light administrator privileges helper
      */
-    public LightAdminPrivilegesSecurityFilter(Roles roles, LightAdminPrivileges adminPrivileges) {
+    public LightAdminPrivilegesSecurityFilter(Roles roles) {
         super(roles);
-        this.adminPrivileges = adminPrivileges;
     }
 
     @Override


### PR DESCRIPTION
# What this PR does

Cleans up passing beans around: some classes no longer need the admin privileges bean so we can remove it from their code.

# Testing this PR

CI should remain unchanged.

# Related reading

https://trello.com/c/6TYMHVJj