### PR TITLE
histogram_json 404

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2431,6 +2431,8 @@ def histogram_json(request, iid, theC, conn=None, **kwargs):
     256 values as json
     """
     image = conn.getObject("Image", iid)
+    if image is None:
+        raise Http404
     maxW, maxH = conn.getMaxPlaneSize()
     sizeX = image.getSizeX()
     sizeY = image.getSizeY()


### PR DESCRIPTION
# What this PR does

Correctly returns 404 if image is not found for webgateway/histogram_json/ instead of an exception.
See https://trello.com/c/DCzm4guz/74-histogram-json-handle-image-404

# Testing this PR

1.Go to ```/webgateway/histogram_json/{image_id}/channel/0/``` for a valid and invalid ```image_id```.

2. Should get 404 for invalid image.
