### PR TITLE
Annotations checks

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -396,8 +396,7 @@ public class AbstractServerTest extends AbstractTest {
             final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
                     " WHERE id = :id";
             final Parameters params = new ParametersI().addId(object.getId());
-            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
-            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ALL_GROUPS_CONTEXT);
             final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -390,7 +390,7 @@ public class AbstractServerTest extends AbstractTest {
      * @param dataset an OMERO Dataset
      * @param image an OMERO Image
      * @return the created link
-     * @throws ServerError if the query caused a server error
+     * @throws ServerError an error possibly occurring during saving of the link
      */
     protected DatasetImageLink linkDatasetImage(Dataset dataset, Image image) throws ServerError {
         if (dataset.isLoaded() && dataset.getId() != null) {
@@ -411,7 +411,7 @@ public class AbstractServerTest extends AbstractTest {
      * @param project an OMERO Project
      * @param dataset an OMERO Dataset
      * @return the created link
-     * @throws ServerError if the query caused a server error
+     * @throws ServerError an error possibly occurring during saving of the link
      */
     protected ProjectDatasetLink linkProjectDataset(Project project, Dataset dataset) throws ServerError {
         if (project.isLoaded() && project.getId() != null) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -298,10 +298,10 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
-     * Cast the map of strings (e.g. the ALL_GROUPS_CONTEXT)
+     * Cast the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
      * into implicit context, which asks for <String, String>
      * @param implicitContext the implicit context to be changed
-     * @param newContext the map of strings (e.g. ALL_GROUPS_CONTEXT)
+     * @param newContext the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
      */
     protected void mergeIntoContext(ImplicitContext implicitContext, Map<String, String> newContext) {
         for (final Entry<String, String> entry : newContext.entrySet()) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -53,6 +53,7 @@ import omero.cmd.State;
 import omero.cmd.Status;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
+import omero.model.Annotation;
 import omero.model.BooleanAnnotation;
 import omero.model.BooleanAnnotationI;
 import omero.model.ChannelBinding;
@@ -287,6 +288,27 @@ public class AbstractServerTest extends AbstractTest {
                 c.__del__();
             }
         }
+    }
+
+    /**
+     * Add the given annotation to the given image.
+     * @param image an image
+     * @param annotation an annotation
+     * @return the new loaded link from the image to the annotation
+     * @throws ServerError unexpected
+     */
+    protected ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
+        if (image.isLoaded() && image.getId() != null) {
+            image = (Image) image.proxy();
+        }
+        if (annotation.isLoaded() && annotation.getId() != null) {
+            annotation = (Annotation) annotation.proxy();
+        }
+
+        final ImageAnnotationLink link = new ImageAnnotationLinkI();
+        link.setParent(image);
+        link.setChild(annotation);
+        return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -365,8 +365,7 @@ public class AbstractServerTest extends AbstractTest {
             final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
                     " WHERE id = :id";
             final Parameters params = new ParametersI().addId(object.getId());
-            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
-            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ALL_GROUPS_CONTEXT);
             final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -299,7 +299,7 @@ public class AbstractServerTest extends AbstractTest {
 
     /**
      * Cast the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
-     * into implicit context, which asks for <String, String>
+     * into implicit context, which asks for {@code <String, String>}.
      * @param implicitContext the implicit context to be changed
      * @param newContext the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
      */

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Map.Entry;
 
 import ome.formats.OMEROMetadataStoreClient;
 import ome.formats.importer.IObservable;
@@ -29,6 +30,7 @@ import ome.formats.importer.OMEROWrapper;
 import ome.formats.importer.util.ErrorHandler;
 import ome.io.nio.SimpleBackOff;
 import ome.services.blitz.repo.path.FsFile;
+import ome.system.Login;
 import omero.ApiUsageException;
 import omero.RLong;
 import omero.RType;
@@ -137,6 +139,8 @@ import org.testng.annotations.DataProvider;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import Ice.ImplicitContext;
+
 /**
  * Base test for integration tests.
  *
@@ -155,6 +159,9 @@ public class AbstractServerTest extends AbstractTest {
 
     /** Scaling factor used for CmdCallbackI loop timings. */
     protected long scalingFactor;
+
+    /** All groups context to use in cases where errors due to group restriction are to be avoided. */
+    protected static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
     /** The client object, this is the entry point to the Server. */
     protected omero.client client;
@@ -287,6 +294,18 @@ public class AbstractServerTest extends AbstractTest {
             if (c != null) {
                 c.__del__();
             }
+        }
+    }
+
+    /**
+     * Cast the map of strings (e.g. the ALL_GROUPS_CONTEXT)
+     * into implicit context, which asks for <String, String>
+     * @param implicitContext the implicit context to be changed
+     * @param newContext the map of strings (e.g. ALL_GROUPS_CONTEXT)
+     */
+    protected void mergeIntoContext(ImplicitContext implicitContext, Map<String, String> newContext) {
+        for (final Entry<String, String> entry : newContext.entrySet()) {
+            implicitContext.put(entry.getKey(), entry.getValue());
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -351,7 +351,7 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
-     * Assert that the given objects are in the giver group.
+     * Assert that the given objects are in the given group.
      * @param objects some model objects
      * @param expectedGroupId a group Id
      * @throws ServerError unexpected

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -297,7 +297,7 @@ public class AbstractServerTest extends AbstractTest {
      * @return the new loaded link from the image to the annotation
      * @throws ServerError unexpected
      */
-    protected ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
+    protected ImageAnnotationLink linkImageAnnotation(Image image, Annotation annotation) throws ServerError {
         if (image.isLoaded() && image.getId() != null) {
             image = (Image) image.proxy();
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -61,6 +61,8 @@ import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
 import omero.model.DatasetAnnotationLink;
 import omero.model.DatasetAnnotationLinkI;
+import omero.model.DatasetImageLink;
+import omero.model.DatasetImageLinkI;
 import omero.model.Detector;
 import omero.model.DetectorAnnotationLink;
 import omero.model.DetectorAnnotationLinkI;
@@ -357,6 +359,27 @@ public class AbstractServerTest extends AbstractTest {
             final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
         }
+    }
+
+    /**
+     * Create a link between a Dataset and an Image.
+     * @param dataset an OMERO Dataset
+     * @param image an OMERO Image
+     * @return the created link
+     * @throws ServerError if the query caused a server error
+     */
+    protected DatasetImageLink linkDatasetImage(Dataset dataset, Image image) throws ServerError {
+        if (dataset.isLoaded() && dataset.getId() != null) {
+            dataset = (Dataset) dataset.proxy();
+        }
+        if (image.isLoaded() && image.getId() != null) {
+            image = (Image) image.proxy();
+        }
+
+        final DatasetImageLink link = new DatasetImageLinkI();
+        link.setParent(dataset);
+        link.setChild(image);
+        return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -314,7 +314,7 @@ public class AbstractServerTest extends AbstractTest {
     /**
      * Assert that the given object is in the given group.
      * @param object a model object
-     * @param expectedGroupId a group Id
+     * @param group an ExperimenterGroup
      * @throws ServerError unexpected
      */
     protected void assertInGroup(IObject object, ExperimenterGroup group) throws ServerError {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -106,6 +106,8 @@ import omero.model.PlateAnnotationLinkI;
 import omero.model.Project;
 import omero.model.ProjectAnnotationLink;
 import omero.model.ProjectAnnotationLinkI;
+import omero.model.ProjectDatasetLink;
+import omero.model.ProjectDatasetLinkI;
 import omero.model.QuantumDef;
 import omero.model.RenderingDef;
 import omero.model.Screen;
@@ -380,6 +382,27 @@ public class AbstractServerTest extends AbstractTest {
         link.setParent(dataset);
         link.setChild(image);
         return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
+    }
+
+    /**
+     * Create a link between a Project and a Dataset.
+     * @param project an OMERO Project
+     * @param dataset an OMERO Dataset
+     * @return the created link
+     * @throws ServerError if the query caused a server error
+     */
+    protected ProjectDatasetLink linkProjectDataset(Project project, Dataset dataset) throws ServerError {
+        if (project.isLoaded() && project.getId() != null) {
+            project = (Project) project.proxy();
+        }
+        if (dataset.isLoaded() && dataset.getId() != null) {
+            dataset = (Dataset) dataset.proxy();
+        }
+
+        final ProjectDatasetLink link = new ProjectDatasetLinkI();
+        link.setParent(project);
+        link.setChild(dataset);
+        return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -295,7 +295,7 @@ public class AbstractServerTest extends AbstractTest {
      * @param image an image
      * @param annotation an annotation
      * @return the new loaded link from the image to the annotation
-     * @throws ServerError unexpected
+     * @throws ServerError an error possibly occurring during saving of the link
      */
     protected ImageAnnotationLink linkImageAnnotation(Image image, Annotation annotation) throws ServerError {
         if (image.isLoaded() && image.getId() != null) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -286,6 +286,48 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
+     * Assert that the given object is in the given group.
+     * @param object a model object
+     * @param expectedGroupId a group Id
+     * @throws ServerError unexpected
+     */
+    protected void assertInGroup(IObject object, ExperimenterGroup group) throws ServerError {
+        assertInGroup(Collections.singleton(object), group.getId().getValue());
+    }
+
+    /**
+     * Assert that the given object is in the given group.
+     * @param object a model object
+     * @param expectedGroupId a group Id
+     * @throws ServerError unexpected
+     */
+    protected void assertInGroup(IObject object, long expectedGroupId) throws ServerError {
+        assertInGroup(Collections.singleton(object), expectedGroupId);
+    }
+
+    /**
+     * Assert that the given objects are in the giver group.
+     * @param objects some model objects
+     * @param expectedGroupId a group Id
+     * @throws ServerError unexpected
+     */
+    protected void assertInGroup(Collection<? extends IObject> objects, long expectedGroupId) throws ServerError {
+        if (objects.isEmpty()) {
+            throw new IllegalArgumentException("must assert about some objects");
+        }
+        for (final IObject object : objects) {
+            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
+            final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
+                    " WHERE id = :id";
+            final Parameters params = new ParametersI().addId(object.getId());
+            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
+            final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
+            Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
+        }
+    }
+
+    /**
      * Assert that the given object is owned by the given owner.
      * @param object a model object
      * @param expectedOwner a user's event context

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -285,6 +285,36 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
+     * Assert that the given object is owned by the given owner.
+     * @param object a model object
+     * @param expectedOwner a user's event context
+     * @throws ServerError unexpected
+     */
+    protected void assertOwnedBy(IObject object, EventContext expectedOwner) throws ServerError {
+        assertOwnedBy(Collections.singleton(object), expectedOwner);
+    }
+
+    /**
+     * Assert that the given objects are owned by the given owner.
+     * @param objects some model objects
+     * @param expectedOwner a user's event context
+     * @throws ServerError unexpected
+     */
+    protected void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
+        if (objects.isEmpty()) {
+            throw new IllegalArgumentException("must assert about some objects");
+        }
+        for (final IObject object : objects) {
+            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
+            final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
+                    " WHERE id = " + object.getId().getValue();
+            final List<List<RType>> results = iQuery.projection(query, null);
+            final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
+            Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
+        }
+    }
+
+    /**
      * Creates a new group and experimenter and returns the event context.
      *
      * @param perms

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -129,6 +129,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 /**
@@ -307,8 +308,10 @@ public class AbstractServerTest extends AbstractTest {
         for (final IObject object : objects) {
             final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
             final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
+                    " WHERE id = :id";
+            final Parameters params = new ParametersI().addId(object.getId());
+            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
             final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -94,7 +94,6 @@ import omero.model.enums.ChecksumAlgorithmSHA1160;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 import omero.sys.Principal;
-import omero.util.TempFileManager;
 
 import org.testng.Assert;
 import org.testng.SkipException;

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -111,14 +111,9 @@ import com.google.common.collect.ImmutableSet;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.4.0
  */
-public class LightAdminPrivilegesTest extends AbstractServerImportTest {
-
-    private static final TempFileManager TEMPORARY_FILE_MANAGER = new TempFileManager(
-            "test-" + LightAdminPrivilegesTest.class.getSimpleName());
+public class LightAdminPrivilegesTest extends RolesTests {
 
     private ImmutableSet<AdminPrivilege> allPrivileges = null;
-
-    private File fakeImageFile = null;
 
     /**
      * Populate the set of available light administrator privileges.
@@ -131,17 +126,6 @@ public class LightAdminPrivilegesTest extends AbstractServerImportTest {
             privileges.add((AdminPrivilege) privilege);
         }
         allPrivileges = privileges.build();
-    }
-
-    /**
-     * Create a fake image file for use in import tests.
-     * @throws IOException unexpected
-     */
-    @BeforeClass
-    public void createFakeImageFile() throws IOException {
-        final File temporaryDirectory = TEMPORARY_FILE_MANAGER.createPath("images", null, true);
-        fakeImageFile = new File(temporaryDirectory, "image.fake");
-        fakeImageFile.createNewFile();
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -155,22 +155,6 @@ public class LightAdminPrivilegesTest extends RolesTests {
     }
 
     /**
-     * Sudo to the given user.
-     * @param targetName the name of a user
-     * @return context for a session owned by the given user
-     * @throws Exception if the sudo could not be performed
-     */
-    private EventContext sudo(String targetName) throws Exception {
-        final Principal principal = new Principal();
-        principal.name = targetName;
-        final Session session = factory.getSessionService().createSessionWithTimeout(principal, 100 * 1000);
-        final omero.client client = newOmeroClient();
-        final String sessionUUID = session.getUuid().getValue();
-        client.createSession(sessionUUID, sessionUUID);
-        return init(client);
-    }
-
-    /**
      * Create a light administrator, possibly without a specific privilege, and log in as them, possibly sudo'ing afterward.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group
      * @param sudoTo the name of the user to whom the new user should then sudo or {@code null} for no sudo

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -231,32 +231,6 @@ public class LightAdminPrivilegesTest extends RolesTests {
         return latestProxy;
     }
 
-    /* these permissions do not permit anything */
-    @SuppressWarnings("serial")
-    private static final Permissions NO_PERMISSIONS = new PermissionsI("------") {
-        @Override
-        public boolean isDisallow(int restriction, Ice.Current c) {
-            return true;
-        }
-    };
-
-    /**
-     * Get the current permissions for the given object.
-     * @param object a model object previously retrieved from the server
-     * @return the permissions for the object in the current context
-     * @throws ServerError if the query caused a server error
-     */
-    private Permissions getCurrentPermissions(IObject object) throws ServerError {
-        final Map<String, String> allGroupsContext = ImmutableMap.of(Login.OMERO_GROUP, "-1");
-        final String objectClass = object.getClass().getSuperclass().getSimpleName();
-        final long objectId = object.getId().getValue();
-        try {
-            return iQuery.get(objectClass, objectId, allGroupsContext).getDetails().getPermissions();
-        } catch (SecurityViolation sv) {
-            return NO_PERMISSIONS;
-        }
-    }
-
     /* -=-=- TEST NECESSITY OF LIGHT ADMINISTRATOR PRIVILEGES -=-=- */
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -566,42 +566,23 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        /* Check one of the objects for non-existence after deletion. First, logging
         * in as root, retrieve all the objects to check them later*/
        logRootIntoGroup(normalUser.groupId);
-       OriginalFile retrievedRemoteFile = (OriginalFile) iQuery.findByQuery(
-               "FROM OriginalFile WHERE id = :id",
-               new ParametersI().addId(remoteFileId));
-       Image retrievedImage = (Image) iQuery.findByQuery(
-               "FROM Image WHERE fileset IN "
-               + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
-               new ParametersI().addId(remoteFileId));
-       Dataset retrievedDat = (Dataset) iQuery.findByQuery(
-               "FROM Dataset WHERE id = :id",
-               new ParametersI().addId(sentDat.getId()));
-       Project retrievedProj = (Project) iQuery.findByQuery(
-               "FROM Project WHERE id = :id",
-               new ParametersI().addId(sentProj.getId()));
-       DatasetImageLink retrievedDatasetImageLink = (DatasetImageLink) iQuery.findByQuery(
-               "FROM DatasetImageLink WHERE child.id = :id",
-               new ParametersI().addId(image.getId()));
-       ProjectDatasetLink retrievedProjectDatasetLink = (ProjectDatasetLink) iQuery.findByQuery(
-               "FROM ProjectDatasetLink WHERE child.id = :id",
-               new ParametersI().addId(sentDat.getId()));
        /* now check the existence/non-existence of the objects as appropriate */
        if (deletePassing) {
            /* successful delete expected */
-           Assert.assertNull(retrievedRemoteFile, "original file should be deleted");
-           Assert.assertNull(retrievedImage, "image should be deleted");
-           Assert.assertNull(retrievedDat, "dataset should be deleted");
-           Assert.assertNull(retrievedProj, "project should be deleted");
-           Assert.assertNull(retrievedDatasetImageLink, "Dat-Image link should be deleted");
-           Assert.assertNull(retrievedProjectDatasetLink, "Proj-Dat link should be deleted");
+           assertDoesNotExist((new OriginalFileI(remoteFileId, false)));
+           assertDoesNotExist(image);
+           assertDoesNotExist(sentDat);
+           assertDoesNotExist(sentProj);
+           assertDoesNotExist(datasetImageLink);
+           assertDoesNotExist(projectDatasetLink);
        } else {
            /* no deletion should have been successful without permDeleteOwned */
-           Assert.assertNotNull(retrievedRemoteFile, "original file not deleted");
-           Assert.assertNotNull(retrievedImage, "image not deleted");
-           Assert.assertNotNull(retrievedDat, "dataset not deleted");
-           Assert.assertNotNull(retrievedProj, "project not deleted");
-           Assert.assertNotNull(retrievedDatasetImageLink, "Dat-Image link not deleted");
-           Assert.assertNotNull(retrievedProjectDatasetLink, "Proj-Dat link not deleted");
+           assertExists((new OriginalFileI(remoteFileId, false)));
+           assertExists(image);
+           assertExists(sentDat);
+           assertExists(sentProj);
+           assertExists(datasetImageLink);
+           assertExists(projectDatasetLink);
        }
    }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -450,7 +450,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                 new ParametersI().addId(previousId).add("name", imageName));
         assertOwnedBy(remoteFile, normalUser);
-        Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), normalUser.groupId);
+        assertInGroup(remoteFile, normalUser.groupId);
 
         /* check that the light admin when sudoed, can link the created Dataset
          * to the created Project, check the ownership of the links
@@ -525,9 +525,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                "SELECT id, details.group.id FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                new ParametersI().addId(previousId).add("name", imageName)).get(0);
        final long remoteFileId = ((RLong) resultAfterImport.get(0)).getValue();
-       final long remoteFileGroupId = ((RLong) resultAfterImport.get(1)).getValue();
        assertOwnedBy((new OriginalFileI(remoteFileId, false)), normalUser);
-       Assert.assertEquals(remoteFileGroupId, normalUser.groupId);
+       assertInGroup((new OriginalFileI(remoteFileId, false)), normalUser.groupId);
        /* link the Project and the Dataset */
        ProjectDatasetLink link = linkProjectDataset(sentProj, sentDat);
        Image image = (Image) iQuery.findByQuery(

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -366,8 +366,7 @@ public class LightAdminRolesTest extends RolesTests {
    }
 
     /**
-     * Test that a light admin can
-     * edit the name of a project
+     * Test that a light admin can edit the name of a project
      * on behalf of another user solely with <tt>Sudo</tt> privilege
      * or without it, using permWriteOwned privilege
      * @param isSudoing if to test a success of workflows where Sudoed in

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -19,8 +19,6 @@
 
 package integration;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +44,6 @@ import omero.model.AdminPrivilege;
 import omero.model.AdminPrivilegeI;
 import omero.model.Annotation;
 import omero.model.Dataset;
-import omero.model.DatasetI;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
 import omero.model.Experimenter;
@@ -69,7 +66,6 @@ import omero.model.Pixels;
 import omero.model.Project;
 import omero.model.ProjectDatasetLink;
 import omero.model.ProjectDatasetLinkI;
-import omero.model.ProjectI;
 import omero.model.RectangleI;
 import omero.model.RenderingDef;
 import omero.model.Roi;
@@ -92,17 +88,13 @@ import omero.model.enums.AdminPrivilegeWriteScriptRepo;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 import omero.sys.Principal;
-import omero.util.TempFileManager;
 
 import org.testng.Assert;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Tests the concrete workflows of the light admins
@@ -110,22 +102,6 @@ import com.google.common.collect.ImmutableSet;
  * @since 5.4.0
  */
 public class LightAdminRolesTest extends RolesTests {
-
-    private ImmutableSet<AdminPrivilege> allPrivileges = null;
-
-    /**
-     * Populate the set of available light administrator privileges.
-     * @throws ServerError unexpected
-     */
-    @BeforeClass
-    public void populateAllPrivileges() throws ServerError {
-        final ImmutableSet.Builder<AdminPrivilege> privileges = ImmutableSet.builder();
-        for (final IObject privilege : factory.getTypesService().allEnumerations("AdminPrivilege")) {
-            privileges.add((AdminPrivilege) privilege);
-        }
-        allPrivileges = privileges.build();
-    }
-
 
     /**
      * Assert that the given object is owned by the given owner.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1787,9 +1787,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testOfficialScriptDeleteNoSudo(boolean isPrivileged, String groupPermissions) throws Exception {
-        if (groupPermissions.equals("rwrw--")) {
-            throw new SkipException("does not work in read-write group");
-        }
         boolean isExpectSuccessDeleteOfficialScript = isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -985,7 +985,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(originalFile, normalUser.groupId);
             assertInGroup(image, normalUser.groupId);
             assertInGroup(sentDat, normalUser.groupId);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
         /* check that the image, dataset and their link were not moved if
          * the permissions were not sufficient
          */
@@ -1013,8 +1013,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
             /* the image, dataset and link belong to the normalUser, but is in the light admin's group */
@@ -1024,8 +1024,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
@@ -1036,8 +1036,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
             /* the image, dataset and link are in light admin's group and belong to light admin */
@@ -1047,8 +1047,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -582,7 +582,7 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertEquals(getCurrentPermissions(image).canChgrp(), canChgrpExpectedTrue);
         doChange(client, factory, Requests.chgrp().target(image).toGroup(anotherGroupId).build(),
                 chgrpNonMemberExpectSuccess);
-        if(chgrpNonMemberExpectSuccess) {
+        if (chgrpNonMemberExpectSuccess) {
             /* check that the image and its original file moved to another group */
             assertInGroup(image, anotherGroupId);
             assertInGroup(originalFile, anotherGroupId);
@@ -993,7 +993,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(originalFile, lightAdmin.groupId);
             assertInGroup(image, lightAdmin.groupId);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
          * try to change the ownership of the dataset to the normalUser.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1330,7 +1330,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* link the file attachment to the image of the user as light admin
          * This will not work in private group. See definition of the boolean
          * isExpectSuccessLinkFileAttachemnt */
-        ImageAnnotationLink link = new ImageAnnotationLinkI();
+        ImageAnnotationLink link = null;
         try {
             link = (ImageAnnotationLink) linkImageAnnotation(sentImage, fileAnnotation);
             /* Check the value of canAnnotate on the image is true in this case.*/

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -560,11 +560,8 @@ public class LightAdminRolesTest extends RolesTests {
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
+        sudo(new ExperimenterI(normalUser.userId, false));
 
-        try {
-            sudo(new ExperimenterI(normalUser.userId, false));
-            }catch (SecurityViolation sv) {
-            }
         /* take care of workflows which do not use sudo */
         if (!isSudoing) {
             loginUser(lightAdmin);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -86,6 +86,7 @@ import omero.model.enums.AdminPrivilegeWriteManagedRepo;
 import omero.model.enums.AdminPrivilegeWriteOwned;
 import omero.model.enums.AdminPrivilegeWriteScriptRepo;
 import omero.sys.EventContext;
+import omero.sys.Parameters;
 import omero.sys.ParametersI;
 import omero.sys.Principal;
 
@@ -126,8 +127,10 @@ public class LightAdminRolesTest extends RolesTests {
         for (final IObject object : objects) {
             final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
             final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
+                    " WHERE id = :id";
+            final Parameters params = new ParametersI().addId(object.getId());
+            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
             final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -105,40 +105,6 @@ import com.google.common.collect.ImmutableMap;
 public class LightAdminRolesTest extends RolesTests {
 
     /**
-     * Assert that the given object is in the given group.
-     * @param object a model object
-     * @param expectedGroupId a group Id
-     * @throws ServerError unexpected
-     */
-    private void assertInGroup(IObject object, long expectedGroupId) throws ServerError {
-        assertInGroup(Collections.singleton(object), expectedGroupId);
-    }
-
-    /**
-     * Assert that the given objects are in the giver group.
-     * @param objects some model objects
-     * @param expectedGroupId a group Id
-     * @throws ServerError unexpected
-     */
-    private void assertInGroup(Collection<? extends IObject> objects, long expectedGroupId) throws ServerError {
-        if (objects.isEmpty()) {
-            throw new IllegalArgumentException("must assert about some objects");
-        }
-        for (final IObject object : objects) {
-            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
-            final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = :id";
-            final Parameters params = new ParametersI().addId(object.getId());
-            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
-            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
-            final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
-            Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
-        }
-    }
-
-
-
-    /**
      * Add a FileAnnotation with Original File to the given image.
      * @param image an image
      * @return the new model objects

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -977,14 +977,14 @@ public class LightAdminRolesTest extends RolesTests {
 
         /* check that the image, dataset, and their link was moved too if the permissions
          * were sufficient */
-        long datasetImageLinkId = ((RLong) iQuery.projection(
-                "SELECT id FROM DatasetImageLink WHERE parent.id = :id",
-                new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
+        final DatasetImageLink datasetImageLink = (DatasetImageLink) iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE parent.id = :id",
+                new ParametersI().addId(sentDat.getId()));
         if (permChgrp) {
             assertInGroup(originalFile, normalUser.groupId);
             assertInGroup(image, normalUser.groupId);
             assertInGroup(sentDat, normalUser.groupId);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
+            assertInGroup(datasetImageLink, normalUser.groupId);
         /* check that the image, dataset and their link were not moved if
          * the permissions were not sufficient
          */
@@ -992,7 +992,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(originalFile, lightAdmin.groupId);
             assertInGroup(image, lightAdmin.groupId);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
+            assertInGroup(datasetImageLink, lightAdmin.groupId);
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
          * try to change the ownership of the dataset to the normalUser.
@@ -1012,8 +1012,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy(datasetImageLink, normalUser);
+            assertInGroup(datasetImageLink, normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
             /* the image, dataset and link belong to the normalUser, but is in the light admin's group */
@@ -1023,8 +1023,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy(datasetImageLink, normalUser);
+            assertInGroup(datasetImageLink, lightAdmin.groupId);
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
@@ -1035,8 +1035,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy(datasetImageLink, lightAdmin);
+            assertInGroup(datasetImageLink, normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
             /* the image, dataset and link are in light admin's group and belong to light admin */
@@ -1046,8 +1046,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy(datasetImageLink, lightAdmin);
+            assertInGroup(datasetImageLink, lightAdmin.groupId);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1303,6 +1303,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         image = (Image) iQuery.findByQuery("FROM Image WHERE fileset IN "
                 + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
                 new ParametersI().addId(remoteFile.getId()));
+        long datasetImageLinkId = ((RLong) iQuery.projection(
+                "SELECT id FROM DatasetImageLink WHERE parent.id = :id",
+                new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
         assertOwnedBy(image, lightAdmin);
         assertInGroup(image, lightAdmin.groupId);
 
@@ -1323,10 +1326,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * and thus the canChgrp must be "true".*/
         Assert.assertTrue(getCurrentPermissions(sentDat).canChgrp());
 
-        /* retrieve again the image, dataset and link */
-        long datasetImageLinkId = ((RLong) iQuery.projection(
-                "SELECT id FROM DatasetImageLink WHERE parent.id = :id",
-                new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
         /* check that the image, dataset, and their link was moved too if the permissions
          * were sufficient */
         if (permChgrp) {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -163,30 +163,6 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-    /**
-     * Get the current permissions for the given object.
-     * @param object a model object previously retrieved from the server
-     * @return the permissions for the object in the current context
-     * @throws Exception 
-     */
-    private Permissions getCurrentPermissions(IObject object) throws Exception {
-        assertExists(object);
-        final String objectClass = object.getClass().getSuperclass().getSimpleName();
-        final long objectId = object.getId().getValue();
-        try {
-            final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
-            final IObject objectRetrieved;
-            if (objectClass.endsWith("Link")) {
-                objectRetrieved = iQuery.findByQuery("FROM " + objectClass + " link JOIN FETCH link.child WHERE link.id = :id",
-                        new ParametersI().addId(objectId), allGroupsContext);
-            } else {
-                objectRetrieved = iQuery.get(objectClass, objectId, allGroupsContext);
-            }
-            return objectRetrieved.getDetails().getPermissions();
-        } catch (SecurityViolation sv) {
-            return new PermissionsI("------");
-        }
-    }
 
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -293,20 +293,13 @@ public class LightAdminRolesTest extends RolesTests {
     /**
      * Sudo to the given user.
      * @param target a user
-     * @return context for a session owned by the given user
      * @throws Exception if the sudo could not be performed
      */
-    private EventContext sudo(Experimenter target) throws Exception {
+    private void sudo(Experimenter target) throws Exception {
         if (!target.isLoaded()) {
             target = iAdmin.getExperimenter(target.getId().getValue());
         }
-        final Principal principal = new Principal();
-        principal.name = target.getOmeName().getValue();
-        final Session session = factory.getSessionService().createSessionWithTimeout(principal, 100 * 1000);
-        final omero.client client = newOmeroClient();
-        final String sessionUUID = session.getUuid().getValue();
-        client.createSession(sessionUUID, sessionUUID);
-        return init(client);
+        sudo(target.getOmeName().getValue());
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -122,7 +122,7 @@ public class LightAdminRolesTest extends RolesTests {
         fileAnnotation = (FileAnnotation) iUpdate.saveAndReturnObject(fileAnnotation);
         originalFileAnnotationAndLink.add(originalFile.proxy());
         originalFileAnnotationAndLink.add(fileAnnotation.proxy());
-        final ImageAnnotationLink link = annotateImage(image, fileAnnotation);
+        final ImageAnnotationLink link = linkImageAnnotation(image, fileAnnotation);
         originalFileAnnotationAndLink.add(link.proxy());
         return originalFileAnnotationAndLink;
     }
@@ -467,7 +467,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Tag the imported image */
         TagAnnotation tagAnnotation = new TagAnnotationI();
         tagAnnotation = (TagAnnotation) iUpdate.saveAndReturnObject(tagAnnotation);
-        final ImageAnnotationLink tagAnnotationLink = annotateImage(image, tagAnnotation);
+        final ImageAnnotationLink tagAnnotationLink = linkImageAnnotation(image, tagAnnotation);
         /* add a file attachment with original file to the imported image.*/
         List<IObject> originalFileAnnotationAndLink = createFileAnnotationWithOriginalFileAndLink(image);
         final OriginalFile annotOriginalFile = (OriginalFile) originalFileAnnotationAndLink.get(0);
@@ -564,7 +564,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Tag the imported image */
         TagAnnotation tagAnnotation = new TagAnnotationI();
         tagAnnotation = (TagAnnotation) iUpdate.saveAndReturnObject(tagAnnotation);
-        final ImageAnnotationLink tagAnnotationLink = annotateImage(image, tagAnnotation);
+        final ImageAnnotationLink tagAnnotationLink = linkImageAnnotation(image, tagAnnotation);
         /* add a file attachment with original file to the imported image.*/
         List<IObject> originalFileAnnotationAndLink = createFileAnnotationWithOriginalFileAndLink(image);
         final OriginalFile annotOriginalFile = (OriginalFile) originalFileAnnotationAndLink.get(0);
@@ -664,7 +664,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Tag the imported image */
         TagAnnotation tagAnnotation = new TagAnnotationI();
         tagAnnotation = (TagAnnotation) iUpdate.saveAndReturnObject(tagAnnotation);
-        final ImageAnnotationLink tagAnnotationLink = annotateImage(image, tagAnnotation);
+        final ImageAnnotationLink tagAnnotationLink = linkImageAnnotation(image, tagAnnotation);
 
         /* add a file attachment with original file to the imported image.*/
         List<IObject> originalFileAnnotationAndLink = createFileAnnotationWithOriginalFileAndLink(image);
@@ -1370,7 +1370,7 @@ public class LightAdminRolesTest extends RolesTests {
          * isExpectSuccessLinkFileAttachemnt */
         ImageAnnotationLink link = new ImageAnnotationLinkI();
         try {
-            link = (ImageAnnotationLink) annotateImage(sentImage, fileAnnotation);
+            link = (ImageAnnotationLink) linkImageAnnotation(sentImage, fileAnnotation);
             /* Check the value of canAnnotate on the image is true in this case.*/
             Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertTrue(isExpectSuccessLinkFileAttachemnt);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1008,9 +1008,14 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Dataset dat = mmFactory.simpleDataset();
         Dataset sentDat = null;
-        if (createDatasetExpectSuccess) {/* you are allowed to create the dataset only
-        with sufficient permissions, which are captured in createDatasetExpectSuccess.*/
+        /* lightAdmin is allowed to create the dataset only
+         * with sufficient permissions, which are captured
+         * in createDatasetExpectSuccess boolean.*/
+        try {
             sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+            Assert.assertTrue(createDatasetExpectSuccess);
+        } catch (ServerError se) {
+            Assert.assertFalse(createDatasetExpectSuccess);
         }
         /* import an image into the created Dataset */
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -104,36 +104,6 @@ import com.google.common.collect.ImmutableMap;
 public class LightAdminRolesTest extends RolesTests {
 
     /**
-     * Assert that the given object is owned by the given owner.
-     * @param object a model object
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(IObject object, EventContext expectedOwner) throws ServerError {
-        assertOwnedBy(Collections.singleton(object), expectedOwner);
-    }
-
-    /**
-     * Assert that the given objects are owned by the given owner.
-     * @param objects some model objects
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
-        if (objects.isEmpty()) {
-            throw new IllegalArgumentException("must assert about some objects");
-        }
-        for (final IObject object : objects) {
-            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
-            final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
-            final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
-            Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
-        }
-    }
-
-    /**
      * Assert that the given object is in the given group.
      * @param object a model object
      * @param expectedGroupId a group Id

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -149,29 +149,6 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Create a link between a Project and a Dataset.
-     * @param project an OMERO Project
-     * @param dataset an OMERO Dataset
-     * @return the created link
-     * @throws ServerError if the query caused a server error
-     */
-    private ProjectDatasetLink linkProjectDataset(Project project, Dataset dataset) throws ServerError {
-        if (project.isLoaded() && project.getId() != null) {
-            project = (Project) project.proxy();
-        }
-        if (dataset.isLoaded() && dataset.getId() != null) {
-            dataset = (Dataset) dataset.proxy();
-        }
-
-        final ProjectDatasetLink link = new ProjectDatasetLinkI();
-        link.setParent(project);
-        link.setChild(dataset);
-        return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
-    }
-
-
-
-    /**
      * Create a light administrator, with a specific privilege, and log in as them.
      * All the other privileges will be set to False.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1289,10 +1289,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 "SELECT id FROM OriginalFile WHERE name = :name ORDER BY id DESC LIMIT 1",
                 new ParametersI().add("name", imageName));
         final long previousId = result.isEmpty() ? -1 : ((RLong) result.get(0).get(0)).getValue();
-        try { /* expected */
-            List<String> path = Collections.singletonList(fakeImageFile.getPath());
-            importFileset(path, path.size(), sentDat);
-        } catch (ServerError se) { /* not expected */}
+        List<String> path = Collections.singletonList(fakeImageFile.getPath());
+        importFileset(path, path.size(), sentDat);
         OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
                 "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                 new ParametersI().addId(previousId).add("name", imageName));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -128,27 +128,6 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Add the given annotation to the given image.
-     * @param image an image
-     * @param annotation an annotation
-     * @return the new loaded link from the image to the annotation
-     * @throws ServerError unexpected
-     */
-    private ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
-        if (image.isLoaded() && image.getId() != null) {
-            image = (Image) image.proxy();
-        }
-        if (annotation.isLoaded() && annotation.getId() != null) {
-            annotation = (Annotation) annotation.proxy();
-        }
-
-        final ImageAnnotationLink link = new ImageAnnotationLinkI();
-        link.setParent(image);
-        link.setChild(annotation);
-        return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
-    }
-
-    /**
      * Create a light administrator, with a specific privilege, and log in as them.
      * All the other privileges will be set to False.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -482,7 +482,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /*in order to find the image in whatever group, get context with group
          * set to -1 (=all groups) */
-        client.getImplicitContext().put("omero.group", "-1");
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
         /* try to move the image into another group of the normalUser
          * which should succeed if sudoing and also in case
          * the light admin has Chgrp permissions
@@ -568,7 +568,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /*in order to find the image in whatever group, get context with group
          * set to -1 (=all groups) */
-        client.getImplicitContext().put("omero.group", Long.toString(-1));
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
 
         /* try to move into another group the normalUser
          * is not a member of, which should fail in all cases
@@ -963,7 +963,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* in order to find the image in whatever group, get context with group
          * set to -1 (=all groups)
          */
-        client.getImplicitContext().put("omero.group", "-1");
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
         /* try to move the dataset (and with it the linked image)
          * from light admin's default group
          * into the default group of the normalUser
@@ -1127,7 +1127,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /* check the transfer of all the data in the first group was successful */
         /* check ownership of the first hierarchy set*/
-        client.getImplicitContext().put("omero.group", "-1");
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
         assertOwnedBy(sentProj1, recipient);
         assertOwnedBy(sentDat1, recipient);
         assertOwnedBy(sentImage1, recipient);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1343,9 +1343,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
-         * try to change the ownership of the dataset to the normalUser */
-        /* Chowning the dataset should fail in case you have not both of
-         * isAdmin & Chown permissions which are
+         * try to change the ownership of the dataset to the normalUser.
+         * Chowning the dataset should fail in case you have not Chown permissions which are
          * captured in the boolean importYourGroupAndChgrpAndChownExpectSuccess.
          * Additionally, in this boolean is permChgrp, which was necessary for the
          * previous step of moving the data into normalUser's group.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1344,16 +1344,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
          * try to change the ownership of the dataset to the normalUser.
-         * Chowning the dataset should fail in case you have not Chown permissions which are
-         * captured in the boolean importYourGroupAndChgrpAndChownExpectSuccess.
-         * Additionally, in this boolean is permChgrp, which was necessary for the
-         * previous step of moving the data into normalUser's group.
+         * Chowning the dataset should fail in case you have not Chown permissions.
          * A successful chowning of the dataset will chown the linked image
-         * and the link too.*/
+         * and the link too. Also check that the canChown boolean on the Dataset must be in
+         * sync with the permChown.*/
+        Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), permChown);
+        doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), permChown);
+        /* boolean importYourGroupAndChgrpAndChownExpectSuccess
+         * captures permChown and permChgrp. Check the objects ownership and groups.*/
         if (importYourGroupAndChgrpAndChownExpectSuccess) {/* whole workflow2 succeeded */
-            /* Check the value of canChown on the dataset is true in this case.*/
-            Assert.assertTrue(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             /* image, dataset and link are in the normalUser's group and belong to normalUser */
             assertOwnedBy(remoteFile, normalUser);
             assertInGroup(remoteFile, normalUser.groupId);
@@ -1365,9 +1364,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
-            /* Check the value of canChown on the dataset is true in this case.*/
-            Assert.assertTrue(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             /* the image, dataset and link belong to the normalUser, but is in the light admin's group */
             assertOwnedBy(remoteFile, normalUser);
             assertInGroup(remoteFile, lightAdmin.groupId);
@@ -1380,9 +1376,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
-            /* Check the value of canChown on the dataset is false in this case.*/
-            Assert.assertFalse(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             /* the image, dataset and link are in normalUser's group but still belong to light admin */
             assertOwnedBy(remoteFile, lightAdmin);
             assertInGroup(remoteFile, normalUser.groupId);
@@ -1394,9 +1387,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
-            /* Check the value of canChown on the dataset is false in this case.*/
-            Assert.assertFalse(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             /* the image, dataset and link are in light admin's group and belong to light admin */
             assertOwnedBy(remoteFile, lightAdmin);
             assertInGroup(remoteFile, lightAdmin.groupId);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -169,26 +169,7 @@ public class LightAdminRolesTest extends RolesTests {
         return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
     }
 
-    /**
-     * Create a link between a Dataset and an Image.
-     * @param dataset an OMERO Dataset
-     * @param image an OMERO Image
-     * @return the created link
-     * @throws ServerError if the query caused a server error
-     */
-    private DatasetImageLink linkDatasetImage(Dataset dataset, Image image) throws ServerError {
-        if (dataset.isLoaded() && dataset.getId() != null) {
-            dataset = (Dataset) dataset.proxy();
-        }
-        if (image.isLoaded() && image.getId() != null) {
-            image = (Image) image.proxy();
-        }
 
-        final DatasetImageLink link = new DatasetImageLinkI();
-        link.setParent(dataset);
-        link.setChild(image);
-        return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
-    }
 
     /**
      * Create a light administrator, with a specific privilege, and log in as them.

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -311,6 +311,18 @@ public class ModelMockFactory {
     }
 
     /**
+     * Create a FileAnnotation with Original File.
+     * @return the FileAnnotation
+     * @throws Exception unexpected
+     */
+    protected FileAnnotation createFileAnnotation() throws Exception {
+        FileAnnotation fileAnnotation = new FileAnnotationI();
+        OriginalFile originalFile = createOriginalFile();
+        fileAnnotation.setFile(originalFile);
+        return fileAnnotation;
+    }
+
+    /**
      * Creates and returns an original file object.
      *
      * @return See above.

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -313,9 +313,8 @@ public class ModelMockFactory {
     /**
      * Create a FileAnnotation with Original File.
      * @return the FileAnnotation
-     * @throws Exception unexpected
      */
-    protected FileAnnotation createFileAnnotation() throws Exception {
+    protected FileAnnotation createFileAnnotation() {
         FileAnnotation fileAnnotation = new FileAnnotationI();
         OriginalFile originalFile = createOriginalFile();
         fileAnnotation.setFile(originalFile);
@@ -324,12 +323,9 @@ public class ModelMockFactory {
 
     /**
      * Creates and returns an original file object.
-     *
      * @return See above.
-     * @throws Exception
-     *             Thrown if an error occurred.
      */
-    public OriginalFile createOriginalFile() throws Exception {
+    public OriginalFile createOriginalFile() {
         OriginalFileI oFile = new OriginalFileI();
         oFile.setName(omero.rtypes.rstring("Test_" + UUID.randomUUID().toString()));
         oFile.setPath(omero.rtypes.rstring("/omero/"));

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -42,7 +42,10 @@ import omero.model.Image;
 import omero.model.OriginalFile;
 import omero.model.Permissions;
 import omero.model.PermissionsI;
+import omero.model.Session;
+import omero.sys.EventContext;
 import omero.sys.ParametersI;
+import omero.sys.Principal;
 import omero.util.TempFileManager;
 
 /**
@@ -130,4 +133,19 @@ public class RolesTests extends AbstractServerImportTest {
         return originalFileAndImage;
     }
 
+    /**
+     * Sudo to the given user.
+     * @param targetName the name of a user
+     * @return context for a session owned by the given user
+     * @throws Exception if the sudo could not be performed
+     */
+    protected EventContext sudo(String targetName) throws Exception {
+        final Principal principal = new Principal();
+        principal.name = targetName;
+        final Session session = factory.getSessionService().createSessionWithTimeout(principal, 100 * 1000);
+        final omero.client client = newOmeroClient();
+        final String sessionUUID = session.getUuid().getValue();
+        client.createSession(sessionUUID, sessionUUID);
+        return init(client);
+    }
 }

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -109,7 +109,7 @@ public class RolesTests extends AbstractServerImportTest {
      * Import an image with original file into a given dataset.
      * @param dat dataset to which to import the image if not null
      * @return the original file and the imported image
-     * @throws Exception unexpected
+     * @throws Exception if the import fails
      */
     protected List<IObject> importImageWithOriginalFile(Dataset dat) throws Exception {
         final List<IObject> originalFileAndImage = new ArrayList<IObject>();

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -91,13 +91,12 @@ public class RolesTests extends AbstractServerImportTest {
         final String objectClass = object.getClass().getSuperclass().getSimpleName();
         final long objectId = object.getId().getValue();
         try {
-            final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
             final IObject objectRetrieved;
             if (objectClass.endsWith("Link")) {
                 objectRetrieved = iQuery.findByQuery("FROM " + objectClass + " link JOIN FETCH link.child WHERE link.id = :id",
-                        new ParametersI().addId(objectId), allGroupsContext);
+                        new ParametersI().addId(objectId), ALL_GROUPS_CONTEXT);
             } else {
-                objectRetrieved = iQuery.get(objectClass, objectId, allGroupsContext);
+                objectRetrieved = iQuery.get(objectClass, objectId, ALL_GROUPS_CONTEXT);
             }
 
             return objectRetrieved.getDetails().getPermissions();

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.annotations.BeforeClass;
+
+import omero.RLong;
+import omero.RString;
+import omero.RType;
+import omero.model.Dataset;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.OriginalFile;
+import omero.sys.ParametersI;
+import omero.util.TempFileManager;
+
+/**
+ * Helper methods class for supporting of "new role" workflow
+ * and security tests.
+ * @author p.walczysko@dundee.ac.uk
+ * @since 5.4.0
+ */
+public class RolesTests extends AbstractServerImportTest {
+
+    private static final TempFileManager TEMPORARY_FILE_MANAGER = new TempFileManager(
+            "test-" + LightAdminRolesTest.class.getSimpleName());
+
+    protected File fakeImageFile = null;
+
+    /**
+     * Create a fake image file for use in import tests.
+     * @throws IOException unexpected
+     */
+    @BeforeClass
+    public void createFakeImageFile() throws IOException {
+        final File temporaryDirectory = TEMPORARY_FILE_MANAGER.createPath("images", null, true);
+        fakeImageFile = new File(temporaryDirectory, "image.fake");
+        fakeImageFile.createNewFile();
+    }
+
+    /**
+     * Import an image with original file into a given dataset.
+     * @param dat dataset to which to import the image if not null
+     * @return the original file and the imported image
+     * @throws Exception unexpected
+     */
+    protected List<IObject> importImageWithOriginalFile(Dataset dat) throws Exception {
+        final List<IObject> originalFileAndImage = new ArrayList<IObject>();
+        final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
+        final List<List<RType>> result = iQuery.projection(
+                "SELECT id FROM OriginalFile WHERE name = :name ORDER BY id DESC LIMIT 1",
+                new ParametersI().add("name", imageName));
+        final long previousId = result.isEmpty() ? -1 : ((RLong) result.get(0).get(0)).getValue();
+        List<String> path = Collections.singletonList(fakeImageFile.getPath());
+        importFileset(path, path.size(), dat);
+        final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
+                "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
+                new ParametersI().addId(previousId).add("name", imageName));
+        originalFileAndImage.add(remoteFile);
+        final Image image = (Image) iQuery.findByQuery(
+                "FROM Image WHERE fileset IN "
+                + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
+                new ParametersI().addId(remoteFile.getId()));
+        originalFileAndImage.add(image);
+        return originalFileAndImage;
+    }
+
+}

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -269,9 +269,8 @@ public class ThumbnailStoreTest extends AbstractServerTest {
         try {
             /* use all-groups context to fetch both thumbnails at once */
             final List<Long> pixelsIdsαβ = ImmutableList.of(pixelsIdα, pixelsIdβ);
-            final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
             svc = factory.createThumbnailStore();
-            thumbnails = svc.getThumbnailByLongestSideSet(null, pixelsIdsαβ, allGroupsContext);
+            thumbnails = svc.getThumbnailByLongestSideSet(null, pixelsIdsαβ, ALL_GROUPS_CONTEXT);
         } finally {
             if (svc != null) {
                 {

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -489,10 +489,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
         disconnect();
         ctx = init(ctx);
 
@@ -556,10 +553,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
         disconnect();
         ctx = init(ctx);
 
@@ -623,10 +617,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
 
         disconnect();
         ctx = init(ctx);
@@ -699,10 +690,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
 
         disconnect();
         ctx = init(ctx);

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -875,24 +875,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Assert that the given object is in the given group.
-     * @param object a model object
-     * @param group an experimenter group
-     * @throws Exception unexpected
-     */
-    private void assertObjectInGroup(IObject object, ExperimenterGroup group) throws Exception {
-        if (iAdmin.getEventContext().groupId != group.getId().getValue()) {
-            loginUser(group);
-        }
-        Class <? extends IObject> objectClass = object.getClass();
-        while (objectClass.getSuperclass() != IObject.class) {
-            objectClass = objectClass.getSuperclass().asSubclass(IObject.class);
-        }
-        object = iQuery.get(objectClass.getSimpleName(), object.getId().getValue());
-        Assert.assertEquals(object.getDetails().getGroup().getId().getValue(), group.getId().getValue());
-    }
-
-    /**
      * Test moving folder hierarchies.
      * @param folderOption if the child option should target folders
      * @param includeOrphans how to set child options
@@ -974,9 +956,9 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         /* check which objects are now in which groups */
 
-        assertObjectInGroup(parentFolder, toGroup);
-        assertObjectInGroup(childFolder, childFolderMoves ? toGroup : fromGroup);
-        assertObjectInGroup(roi, roiMoves ? toGroup : fromGroup);
+        assertInGroup(parentFolder, toGroup);
+        assertInGroup(childFolder, childFolderMoves ? toGroup : fromGroup);
+        assertInGroup(roi, roiMoves ? toGroup : fromGroup);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -473,6 +473,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
      * @throws Exception
      *             Thrown if an error occurred.
      */
+    @Test
     public void testMoveDatasetImageGraphLinkDoneByImageOwnerRWRWtoRW()
             throws Exception {
         String perms = "rw----"; // destination

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -866,23 +866,16 @@ public class HierarchyMoveTest extends AbstractServerTest {
         iAdmin.getEventContext(); // Refresh
 
         Project p = (Project) iUpdate.saveAndReturnObject(mmFactory
-                .simpleProjectData().asIObject());
+                .simpleProjectData().asIObject()).proxy();
         Dataset d = (Dataset) iUpdate.saveAndReturnObject(mmFactory
-                .simpleDatasetData().asIObject());
+                .simpleDatasetData().asIObject()).proxy();
         Image image1 = (Image) iUpdate.saveAndReturnObject(mmFactory
-                .simpleImage());
+                .simpleImage()).proxy();
         Image image2 = (Image) iUpdate.saveAndReturnObject(mmFactory
-                .simpleImage());
+                .simpleImage()).proxy();
         List<IObject> links = new ArrayList<IObject>();
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild(image1);
-        link.setParent(d);
-        links.add(link);
-
-        link = new DatasetImageLinkI();
-        link.setChild(image2);
-        link.setParent(d);
-        links.add(link);
+        links.add(linkDatasetImage(d, image1));
+        links.add(linkDatasetImage(d, image2));
 
         ProjectDatasetLink l = new ProjectDatasetLinkI();
         l.setChild(d);
@@ -1049,10 +1042,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
 
         /* only the original and the other are in the dataset; the projection is not */
         for (final Image image : new Image[] {original, other}) {
-            final DatasetImageLink link = new DatasetImageLinkI();
-            link.setParent(dataset);
-            link.setChild(image);
-            iUpdate.saveAndReturnObject(link);
+            linkDatasetImage(dataset, image);
         }
 
         /* move the dataset */

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -877,10 +877,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(linkDatasetImage(d, image1));
         links.add(linkDatasetImage(d, image2));
 
-        ProjectDatasetLink l = new ProjectDatasetLinkI();
-        l.setChild(d);
-        l.setParent(p);
-        links.add(l);
+        links.add(linkProjectDataset(p, d));
         iUpdate.saveAndReturnArray(links);
 
         List<Long> ids = new ArrayList<Long>();

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -142,7 +142,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(),
              new TagAnnotationI(), new FileAnnotationI(), new MapAnnotationI()}) {
-            final ImageAnnotationLink link = annotateImage(image, annotation);
+            final ImageAnnotationLink link = linkImageAnnotation(image, annotation);
             annotationObjects.add(link.proxy());
             annotationObjects.add(link.getChild().proxy());
         }
@@ -291,13 +291,13 @@ public class PermissionsTest extends AbstractServerTest {
         testImages.add(otherImage.getId().getValue());
         for (final IObject annotation : annotationsDoublyLinked) {
             if (annotation instanceof TagAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (TagAnnotation) annotation);
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             } else if (annotation instanceof FileAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (FileAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (FileAnnotation) annotation);
                 fileAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             } else if (annotation instanceof MapAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (MapAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (MapAnnotation) annotation);
                 mapAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             }
         }
@@ -641,9 +641,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users1CanAnnotateOthers) {
             for (final IObject annotation : annotationsOthersForTripleLinking1) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image1, (Annotation) annotation);
                     linksOwnToOthersAnnOwnImage1.add((ImageAnnotationLink) linkOwnImage.proxy());
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage1, (Annotation) annotation);
                     linksOwnToOthersAnnOthersImage1.add((ImageAnnotationLink) linkOtherImage.proxy());
                 }
             }
@@ -653,9 +653,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users2CanAnnotateOthers) {
             for (final IObject annotation : annotationsOthersForTripleLinking2) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image2, (Annotation) annotation);
                     linksOwnToOthersAnnOwnImage2.add((ImageAnnotationLink) linkOwnImage.proxy());
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage2, (Annotation) annotation);
                     linksOwnToOthersAnnOthersImage2.add((ImageAnnotationLink) linkOtherImage.proxy());
                 }
             }
@@ -673,9 +673,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users1CanAnnotateOthers) {
             for (final IObject annotation : annotationsOwnForTripleLinking1) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage1, (Annotation) annotation);
                     linksOthersToOwnAnnOthersImage1.add((ImageAnnotationLink) linkOtherImage.proxy());
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image1, (Annotation) annotation);
                     linksOthersToOwnAnnOwnImage1.add((ImageAnnotationLink) linkOwnImage.proxy());
                 }
             }
@@ -684,9 +684,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users2CanAnnotateOthers) {
             for (final IObject annotation : annotationsOwnForTripleLinking2) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage2, (Annotation) annotation);
                     linksOthersToOwnAnnOthersImage2.add((ImageAnnotationLink) linkOtherImage.proxy());
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image2, (Annotation) annotation);
                     linksOthersToOwnAnnOwnImage2.add((ImageAnnotationLink) linkOwnImage.proxy());
                 }
             }

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -44,7 +44,6 @@ import omero.model.AnnotationAnnotationLinkI;
 import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
-import omero.model.DatasetImageLinkI;
 import omero.model.Experiment;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
@@ -1235,10 +1234,7 @@ public class PermissionsTest extends AbstractServerTest {
         init(linkOwner);
         final IObject link;
         if (isInDataset) {
-            final DatasetImageLink linkDI = new DatasetImageLinkI();
-            linkDI.setParent((Dataset) container);
-            linkDI.setChild(image);
-            link = iUpdate.saveAndReturnObject(linkDI);
+            link = linkDatasetImage((Dataset) container, image);
         } else {
             final FolderImageLink linkFI = new FolderImageLinkI();
             linkFI.setParent((Folder) container);
@@ -1316,10 +1312,7 @@ public class PermissionsTest extends AbstractServerTest {
         init(linkOwner);
         final IObject link;
         if (isInDataset) {
-            final DatasetImageLink linkDI = new DatasetImageLinkI();
-            linkDI.setParent((Dataset) container);
-            linkDI.setChild(image);
-            link = iUpdate.saveAndReturnObject(linkDI);
+            link = linkDatasetImage((Dataset) container, image);
         } else {
             final FolderImageLink linkFI = new FolderImageLinkI();
             linkFI.setParent((Folder) container);
@@ -1588,10 +1581,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         final List<DatasetImageLink> links = new ArrayList<DatasetImageLink>(images.size());
         for (final IObject image : images) {
-            DatasetImageLink link = new DatasetImageLinkI();
-            link.setParent(dataset);
-            link.setChild((Image) image.proxy());
-            links.add((DatasetImageLink) iUpdate.saveAndReturnObject(link).proxy());
+            links.add(linkDatasetImage(dataset, (Image) image));
         }
 
         /* check that the objects' ownership is all as expected */

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -127,27 +127,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Add the given annotation to the given image.
-     * @param image an image
-     * @param annotation an annotation
-     * @return the new loaded link from the image to the annotation
-     * @throws ServerError unexpected
-     */
-    private ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
-        if (image.isLoaded() && image.getId() != null) {
-            image = (Image) image.proxy();
-        }
-        if (annotation.isLoaded() && annotation.getId() != null) {
-            annotation = (Annotation) annotation.proxy();
-        }
-
-        final ImageAnnotationLink link = new ImageAnnotationLinkI();
-        link.setParent(image);
-        link.setChild(annotation);
-        return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
-    }
-
-    /**
      * Add a comment, tag, MapAnnotation, FileAnnotation,
      * Thumbnail and a ROI to the given image.
      * @param image an image

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -252,36 +252,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Assert that the given object is owned by the given owner.
-     * @param object a model object
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(IObject object, EventContext expectedOwner) throws ServerError {
-        assertOwnedBy(Collections.singleton(object), expectedOwner);
-    }
-
-    /**
-     * Assert that the given objects are owned by the given owner.
-     * @param objects some model objects
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
-        if (objects.isEmpty()) {
-            throw new IllegalArgumentException("must assert about some objects");
-        }
-        for (final IObject object : objects) {
-            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
-            final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
-            final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
-            Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
-        }
-    }
-
-    /**
      * Test a specific case of using {@link Chown2} with owner's shared annotations in a private group.
      * @param isDataOwner if the user submitting the {@link Chown2} request owns the data in the group
      * @param isAdmin if the user submitting the {@link Chown2} request is a member of the system group


### PR DESCRIPTION
# What this PR does

Adds checks for image annotations/attachments behaviour in cases of chown and chgrp of the image. This PR is on top of tests in https://github.com/openmicroscopy/openmicroscopy/pull/5248.  It contains all the commits of https://github.com/openmicroscopy/openmicroscopy/pull/5248 up to https://github.com/openmicroscopy/openmicroscopy/pull/5248/commits/9622b4f2391c462639dbfcba9fb781f17c32f573


# Testing this PR

Check the new annotation testing logic in 3 integration tests
 ``integration.LightAdminRolesTest.testChown ``,
 ``integration.LightAdminRolesTest.testChgrp`` ``integration.LightAdminRolesTest.testChgrpNonMember``


Also, check the cleaning and neatification of the whole code in ``LightAdminRoles.java``.

See points on https://trello.com/c/ygDN23CC/41-new-role-integration-tests-petr#comment-591dd5838105efbbf2de4c08


