### PR TITLE
canAnnotate comment fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_comment.html
@@ -26,7 +26,8 @@
     </h1>
     <div class="annotations_section" style="display: none" data-name='comments'>
 
-            {% if manager.canAnnotate or not annotationBlocked %}
+            <!-- if canAnnotate single object OR batch (obj_string) isn't blocked... -->
+            {% if manager.canAnnotate or obj_string and not annotationBlocked %}
             <form id="add_comment_form" action="{% url 'annotate_comment' %}" method="post">{% csrf_token %}
             <table>
                 <tr>


### PR DESCRIPTION
# What this PR does

Fixes use of 'canAnnotate()' for Comments in right panel.
Should not allow group owner to annotate others' data in a private group.

# Testing this PR
Test that: 
 - Group owner can't add Comments to others' data in private group
 - This should be true when single object selected OR multiple (batch annotate).