### PR TITLE
Update Slack section to notify only when the success status is changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,4 @@ script:
 notifications:
   slack:
     secure: YoCiRg7KuG+jQdW2wD5aBVurfJoKTT+/bKexZD/t5w+WjR4oKi0eoj+La4niUHxmUGHmJAuRYq/7wpP7nq1RBOcXQYpq9S842tmhhQZeC2EGFGw3YlBBEQj9oqMl9JlcI4lTkSo4V/uCnwdrFAGfGaAjICuCnEb9rvBhsXeqYtU=
+    on_success: change


### PR DESCRIPTION
See https://docs.travis-ci.com/user/notifications/#Configuring-slack-notifications
this should reduce the level of notifications (currently set to always)
/cc @joshmoore @jburel 