### PR TITLE
Import annotation cli

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -492,9 +492,16 @@ public class CommandLineImporter {
         CommentAnnotationI annotation;
         if (namespaces.size() != strings.size())
         {
+            String ns = null;
+            if (namespaces.size() == 1) {
+                ns = namespaces.get(0);
+            }
             for(int i = 0; i < strings.size(); i++)
             {
                 annotation = new CommentAnnotationI();
+                if (ns != null) {
+                    annotation.setTextValue(omero.rtypes.rstring(ns));
+                }
                 annotation.setTextValue(omero.rtypes.rstring(strings.get(i)));
                 annotations.add(annotation);
             }

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -34,12 +34,8 @@ import ome.formats.importer.transfers.AbstractFileTransfer;
 import ome.formats.importer.transfers.CleanupFailure;
 import ome.formats.importer.transfers.FileTransfer;
 import ome.formats.importer.transfers.UploadFileTransfer;
-import omero.api.ServiceFactoryPrx;
-import omero.api.ServiceInterfacePrx;
-import omero.cmd.HandlePrx;
 import omero.cmd.Response;
 import omero.grid.ImportProcessPrx;
-import omero.grid.ImportProcessPrxHelper;
 import omero.model.Annotation;
 import omero.model.CommentAnnotationI;
 

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -492,19 +492,24 @@ public class CommandLineImporter {
     private static List<Annotation> toTextAnnotations(
                    List<String> namespaces, List<String> strings)
     {
+        List<Annotation> annotations = new ArrayList<Annotation>();
+        CommentAnnotationI annotation;
         if (namespaces.size() != strings.size())
         {
-            throw new IllegalArgumentException(String.format(
-                            "#Namespaces:%d != #Text:%d", namespaces.size(),
-                            strings.size()));
-        }
-        List<Annotation> annotations = new ArrayList<Annotation>();
-        for(int i = 0; i < namespaces.size(); i++)
-        {
-            CommentAnnotationI annotation = new CommentAnnotationI();
-            annotation.setNs(omero.rtypes.rstring(namespaces.get(i)));
-            annotation.setTextValue(omero.rtypes.rstring(strings.get(i)));
-            annotations.add(annotation);
+            for(int i = 0; i < strings.size(); i++)
+            {
+                annotation = new CommentAnnotationI();
+                annotation.setTextValue(omero.rtypes.rstring(strings.get(i)));
+                annotations.add(annotation);
+            }
+        } else {
+            for(int i = 0; i < namespaces.size(); i++)
+            {
+                annotation = new CommentAnnotationI();
+                annotation.setNs(omero.rtypes.rstring(namespaces.get(i)));
+                annotation.setTextValue(omero.rtypes.rstring(strings.get(i)));
+                annotations.add(annotation);
+            }
         }
         return annotations;
     }

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -380,7 +380,7 @@ public class CommandLineImporter {
             + "  --email EMAIL\t\t\t\tEmail for reported errors. Required --report\n"
             + "  --debug LEVEL\t\t\t\tTurn debug logging on (optional level)\n"
             + "  --annotation-ns ANNOTATION_NS\t\tNamespace to use for subsequent annotation\n"
-            + "  --annotation-text ANNOTATION_TEXT\tContent for a text annotation (requires namespace)\n"
+            + "  --annotation-text ANNOTATION_TEXT\tContent for a text annotation\n"
             + "  --annotation-link ANNOTATION_LINK\tComment annotation ID to link all images to\n"
             + "\n"
             + "Examples:\n"

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -369,7 +369,7 @@ class ImportControl(BaseControl):
             help="Namespace to use for subsequent annotation (**)")
         add_annotation_argument(
             "--annotation-text", metavar="ANNOTATION_TEXT",
-            help="Content for a text annotation (requires namespace) (**)")
+            help="Content for a text annotation (**)")
         add_annotation_argument(
             "--annotation-link",
             metavar="ANNOTATION_LINK",


### PR DESCRIPTION
# What this PR does

This PR allows to add textual annotation without having to specify a namespace
If one namespace is passed, it is set for all annotations
if more than one is passed, it is applied only if the number of annotations equals the number of namespaces

# Testing this PR

Check that the integration tests are green

# Related reading

https://trello.com/c/6Sm4nnHZ/533-import-videos


cc @bramalingam 