### PR TITLE
Add help target for sudo

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -410,7 +410,7 @@ SUDO_HELP = """
 The --sudo option is available to all
 commands accepting connection arguments.
 
-Below few examples on how to use the sudo option
+Below are a few examples showing on how to use the sudo option
 
 Examples:
 
@@ -422,6 +422,7 @@ Examples:
     bin/omero login --sudo owner -s servername -u username -g groupname
     Password for owner:
 """
+
 
 class Context:
     """Simple context used for default logic. The CLI registry which registers

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -410,7 +410,7 @@ SUDO_HELP = """
 The --sudo option is available to all
 commands accepting connection arguments.
 
-Below are a few examples showing on how to use the sudo option
+Below are a few examples showing how to use the sudo option
 
 Examples:
 

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -406,6 +406,22 @@ ENV_HELP = """Environment variables:
                     Default: $OMERO_USERDIR/tmp
 """
 
+SUDO_HELP = """
+The --sudo option is available to all
+commands accepting connection arguments.
+
+Below few examples on how to use the sudo option
+
+Examples:
+
+    # Import data for user *username*
+    bin/omero import --sudo root -s servername -u username image.tiff
+    # Create a connection as another user
+    bin/omero login --sudo root -s servername -u username -g groupname
+    Password for root:
+    bin/omero login --sudo owner -s servername -u username -g groupname
+    Password for owner:
+"""
 
 class Context:
     """Simple context used for default logic. The CLI registry which registers
@@ -431,7 +447,7 @@ class Context:
         self.isquiet = False
         # This usage will go away and default will be False
         self.isdebug = DEBUG
-        self.topics = {"debug": DEBUG_HELP, "env": ENV_HELP}
+        self.topics = {"debug": DEBUG_HELP, "env": ENV_HELP, "sudo": SUDO_HELP}
         self.parser = Parser(prog=prog, description=OMERODOC)
         self.subparsers = self.parser_init(self.parser)
 

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -412,7 +412,7 @@ commands accepting connection arguments.
 
 Below are a few examples showing how to use the sudo option
 
-Examples:
+Examples (admin or group owner only):
 
     # Import data for user *username*
     bin/omero import --sudo root -s servername -u username image.tiff


### PR DESCRIPTION
# What this PR does
Add examples on how to use ``--sudo``
The examples printed out are coming from the documentation

# Testing this PR

Run ``bin/omero help sudo`` and check the output

# Related reading
https://trello.com/c/F82A06Ab/735-cli-no-help-on-sudo

cc @pwalczysko 