### PR TITLE
cache OMERO sessions in level 2 Hibernate cache

### DIFF
--- a/components/server/src/ome/api/local/LocalQuery.java
+++ b/components/server/src/ome/api/local/LocalQuery.java
@@ -1,7 +1,5 @@
 /*
- * ome.api.local.LocalQuery
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -9,6 +7,11 @@ package ome.api.local;
 
 import org.springframework.orm.hibernate3.HibernateCallback;
 
+import ome.annotations.NotNull;
+import ome.conditions.ValidationException;
+import ome.model.IObject;
+import ome.parameters.Parameters;
+import ome.parameters.QueryParameter;
 import ome.services.query.Query;
 
 /**
@@ -101,4 +104,25 @@ public interface LocalQuery extends ome.api.IQuery {
      */
     boolean checkProperty(String type, String property);
 
+    /**
+     * Executes the stored query with the given name. If a query with the name
+     * cannot be found, an exception will be thrown.
+     * Differs from {@link #findByQuery(String, Parameters)} in that it enables
+     * Hibernate's level two cache for the query.
+     *
+     * The queryName parameter can be an actual query String if the
+     * StringQuerySource is configured on the server and the user running the
+     * query has proper permissions.
+     *
+     * @param queryName
+     *            String identifier of the query to execute
+     * @param parameters
+     *            array of {@link QueryParameter}. Not null. The
+     *            {@link QueryParameter#name} field maps to a field-name which
+     *            is then matched against the {@link QueryParameter#value}
+     * @return Possibly null IObject result.
+     * @throws ValidationException
+     */
+    <T extends IObject> T findByQueryCached(@NotNull
+    String queryName, Parameters parameters) throws ValidationException;
 }

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import ome.api.IQuery;
 import ome.api.local.LocalAdmin;
 import ome.api.local.LocalQuery;
 import ome.api.local.LocalUpdate;
@@ -450,11 +449,11 @@ public class BasicSecuritySystem implements SecuritySystem,
         if (isReadOnly) {
             sess = new ome.model.meta.Session(sessionId, false);
         } else {
-            final IQuery iQuery = sf.getQueryService();
+            final LocalQuery iQuery = (LocalQuery) sf.getQueryService();
             final String sessionClass = iQuery.find(Share.class, sessionId) == null ? "Session" : "Share";
             final String hql = "FROM " + sessionClass + " s LEFT OUTER JOIN FETCH s.sudoer WHERE s.id = :id";
             final Parameters params = new Parameters().addId(sessionId);
-            sess = iQuery.findByQuery(hql, params);
+            sess = iQuery.findByQueryCached(hql, params);
         }
 
         tokenHolder.setToken(callGroup.getGraphHolder());

--- a/components/server/src/ome/services/query/Query.java
+++ b/components/server/src/ome/services/query/Query.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -97,6 +97,9 @@ public abstract class Query<T> implements HibernateCallback {
      * @see #_criteria
      */
     private org.hibernate.Query _query;
+
+    /* if the Hibernate level 2 cache should be used */
+    private Boolean isCacheable = null;
 
     /**
      * one of two possible outcomes of the {@link #buildQuery(Session)} method.
@@ -238,10 +241,18 @@ public abstract class Query<T> implements HibernateCallback {
             if (_query != null) {
                 _query.setFirstResult(offset);
                 _query.setMaxResults(limit);
+                if (isCacheable != null) {
+                    /* override default */
+                    _query.setCacheable(isCacheable);
+                }
                 return unique ? _query.uniqueResult() : _query.list();
             } else {
                 _criteria.setFirstResult(offset);
                 _criteria.setMaxResults(limit);
+                if (isCacheable != null) {
+                    /* override default */
+                    _criteria.setCacheable(isCacheable);
+                }
                 return unique ? _criteria.uniqueResult() : _criteria.list();
             }
 
@@ -337,6 +348,23 @@ public abstract class Query<T> implements HibernateCallback {
         for (String enabledFilter : newlyEnabledFilters) {
             session.disableFilter(enabledFilter);
         }
+    }
 
+    /**
+     * Enable the Hibernate level 2 cache for this query.
+     * @return this instance, for method chaining
+     */
+    public Query<T> enableQueryCache() {
+        isCacheable = true;
+        return this;
+    }
+
+    /**
+     * Disable the Hibernate level 2 cache for this query.
+     * @return this instance, for method chaining
+     */
+    public Query<T> disableQueryCache() {
+        isCacheable = false;
+        return this;
     }
 }

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -21,8 +21,8 @@ import java.util.concurrent.Future;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
 
-import ome.api.IQuery;
 import ome.api.local.LocalAdmin;
+import ome.api.local.LocalQuery;
 import ome.conditions.ApiUsageException;
 import ome.conditions.AuthenticationException;
 import ome.conditions.InternalException;
@@ -1464,9 +1464,9 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             final List<Long> memberOfGroupsIds = admin.getMemberOfGroupIds(exp);
             final List<Long> leaderOfGroupsIds = admin.getLeaderOfGroupIds(exp);
             final List<String> userRoles = admin.getUserRoles(exp);
-            final IQuery iQuery = sf.getQueryService();
+            final LocalQuery iQuery = (LocalQuery) sf.getQueryService();
             final String sessionClass = iQuery.find(Share.class, session.getId()) == null ? "Session" : "Share";
-            final Session reloaded = (Session) iQuery.findByQuery(
+            final Session reloaded = (Session) iQuery.findByQueryCached(
                             "select s from " + sessionClass + " s "
                             + "left outer join fetch s.sudoer "
                             + "left outer join fetch s.annotationLinks l "

--- a/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -247,7 +247,7 @@ public abstract class AbstractBasicSecuritySystemTest extends
                 returnValue(group));
         if (!readOnly) {
             sf.mockQuery.expects(once()).method("find").will(returnValue(event.getSession()));
-            sf.mockQuery.expects(once()).method("findByQuery").will(returnValue(event.getSession()));
+            sf.mockQuery.expects(once()).method("findByQueryCached").will(returnValue(event.getSession()));
             sf.mockAdmin.expects(once()).method("userProxy").will(
                     returnValue(user));
             sf.mockUpdate.expects(once()).method("saveAndReturnObject").will(

--- a/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
+++ b/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
@@ -356,7 +356,7 @@ public class SessMgrUnitTest extends MockObjectTestCase {
         sf.mockQuery.expects(atLeastOnce()).method("find")
             .with(new IsEqual(Share.class), new IsEqual(session.getId()))
             .will(returnValue(null));
-        sf.mockQuery.expects(atLeastOnce()).method("findByQuery")
+        sf.mockQuery.expects(atLeastOnce()).method("findByQueryCached")
             .with(new StringContains("Session"), ANYTHING)
             .will(returnValue(session));
         sf.mockQuery.expects(once()).method("projection").will(


### PR DESCRIPTION
# What this PR does

Adjusts HQL queries of sessions in performance bottlenecks to enable caching.

# Testing this PR

The server, especially integration tests, should in general run a little faster.

# Related reading

https://trello.com/c/tYg2svfX/