### PR TITLE
more carefully prevent update/delete for user group

### DIFF
--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -464,7 +464,11 @@ public class BasicACLVoter implements ACLVoter {
             final Long gid = d.getGroup().getId();
             if (roles.getUserGroupId() == gid) {
                 /* special handling for user group permissions */
-                grpPermissions = new Permissions(Permissions.EMPTY);
+                if (iObject instanceof OriginalFile && "Directory".equals(((OriginalFile) iObject).getMimetype())) {
+                    grpPermissions = c.getPermissionsForGroup(gid);
+                } else {
+                    grpPermissions = new Permissions(Permissions.EMPTY);
+                }
             } else {
                 /* not user group so use group's permissions */
                 grpPermissions = c.getPermissionsForGroup(gid);

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -467,7 +467,7 @@ public class BasicACLVoter implements ACLVoter {
                 if (iObject instanceof OriginalFile && "Directory".equals(((OriginalFile) iObject).getMimetype())) {
                     grpPermissions = c.getPermissionsForGroup(gid);
                 } else {
-                    grpPermissions = new Permissions(Permissions.EMPTY);
+                    grpPermissions = new Permissions(Permissions.PRIVATE);
                 }
             } else {
                 /* not user group so use group's permissions */

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -702,10 +702,12 @@ public class GraphTraversal {
         if (isCheckUserPermissions) {
             /* BasicACLVoter needs to check fuller instances of some objects */
             if (objectInstance instanceof OriginalFile) {
-                objectInstance = new OriginalFile(object.id, true);
-                final String query = "SELECT repo FROM OriginalFile WHERE id = :id";
-                final String repo = (String) session.createQuery(query).setLong("id", object.id).uniqueResult();
-                ((OriginalFile) objectInstance).setRepo(repo);
+                final String query = "SELECT mimetype, repo FROM OriginalFile WHERE id = :id";
+                final Object[] result = (Object[]) session.createQuery(query).setLong("id", object.id).uniqueResult();
+                final OriginalFile file = new OriginalFile(object.id, true);
+                file.setMimetype((String) result[0]);
+                file.setRepo((String) result[1]);
+                objectInstance = file;
             }
 
             /* allowLoad ensures that BasicEventContext.groupPermissionsMap is populated */


### PR DESCRIPTION
# What this PR does

Makes the ACL checks for update/delete wrt the `user` group clearer and safer.

# Testing this PR

https://10.0.51.154:8443/job/OMERO-test-integration/testngreports/ should have no skips or failures: @pwalczysko, this PR should fix *all* cases of `testOfficialScriptDeleteNoSudo` if you want to try again removing the skip. (Can be tested locally if need be.)

The test in the description of https://github.com/openmicroscopy/omero_private/issues/13 should fail. (Source may need a bit of tweaking for current branch, but not much: `PYTHON_MIMETYPE == "text/x-python"` and `roles` is now already a field in the superclass.)