### PR TITLE
Remove scc travis-merge step from the Travis build (rebased onto roles)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,7 @@ env:
     - BUILD="build-java"
 
 before_install:
-    - git config github.token 3bc7fc530b01081559eb911f59ccfec7f4fb2592
-    - git config --global user.email snoopycrimecop@gmail.com
-    - git config --global user.name 'Snoopy Crime Cop'
-    - pip install --user scc pytest
-    - scc travis-merge
+    - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all.txt; fi
     - export PATH=$PATH:$HOME/.local/bin
     - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest==2.7.3; fi


### PR DESCRIPTION

This is the same as gh-5285 but rebased onto roles.

----

Following https://blog.travis-ci.com/2017-05-08-security-advisory, the public token used to merge dependent PRs has been revoked. To fix builds in the meantime, this commit removes the set up and usage of scc travis-merge which implies every PR will now be tested in isolation via Travis CI.
/cc @mtbc 

                