### PR TITLE
Disable histogram in share

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -434,13 +434,13 @@
         <input id="rd-wblitz-rmodel" type="checkbox" />
         <label for="rd-wblitz-rmodel">Grayscale</label>
         <div style="float:right {% if tiledImage %}; color:#bbb{%endif%}"
-          {% if tiledImage %}
-            title="Histogram not supported for tiled images"
+          {% if tiledImage or share %}
+            title="Histogram not supported for tiled images or in share"
           {%else%}
             title="Show histogram of pixel intensities for selected channel"
           {% endif %} >
           <!-- histogram (not supported for Big images) -->
-          <input id="showhistogram" type="checkbox" {% if tiledImage %}disabled{% endif %}/>
+          <input id="showhistogram" type="checkbox" {% if tiledImage or share %}disabled{% endif %}/>
           <label for="showhistogram">Show Histogram</label>
         </div>
         <div id="histogram" style="display:none; width: 100%; height: 125px; background:white; border: solid #ccc 1px; margin-bottom: 6px"></div>


### PR DESCRIPTION
# What this PR does

Disable histogram in share since the loading does not work


# Testing this PR

 * Open an image in a share
 * Check that you cannot tick ``show histogram`` in preview panel



# Related reading

https://trello.com/c/1TZllGio/92-bug-histogram-and-share
