### PR TITLE
Make Job no longer a system type for OMERO

### DIFF
--- a/components/server/src/ome/security/SystemTypes.java
+++ b/components/server/src/ome/security/SystemTypes.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -11,7 +9,6 @@ import ome.model.IEnum;
 import ome.model.IGlobal;
 import ome.model.IObject;
 import ome.model.internal.Details;
-import ome.model.jobs.Job;
 import ome.model.meta.DBPatch;
 import ome.model.meta.Event;
 import ome.model.meta.EventLog;
@@ -71,8 +68,6 @@ public class SystemTypes {
         } else if (EventLog.class.isAssignableFrom(klass)) {
             return true;
         } else if (IEnum.class.isAssignableFrom(klass)) {
-            return true;
-        } else if (Job.class.isAssignableFrom(klass)) {
             return true;
         } else if (DBPatch.class.isAssignableFrom(klass)) {
             return true;

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -53,7 +53,6 @@ import com.google.common.collect.Sets;
 import ome.model.IObject;
 import ome.model.core.OriginalFile;
 import ome.model.internal.Permissions;
-import ome.model.jobs.Job;
 import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
 import ome.security.ACLVoter;
@@ -1280,22 +1279,6 @@ public class GraphTraversal {
     }
 
     /**
-     * Determine if the given {@link IObject} class is the type of a job.
-     * The basic ACL voter wrongly asserts that normal users may not delete their own jobs.
-     * @param className a class name
-     * @return if the class is a job type
-     * @throws GraphException if {@code className} does not name an accessible class
-     */
-    private boolean isJobType(String className) throws GraphException {
-        try {
-            final Class<? extends IObject> actualClass = (Class<? extends IObject>) Class.forName(className);
-            return Job.class.isAssignableFrom(actualClass);
-        } catch (ClassNotFoundException e) {
-            throw new GraphException("no model object class named " + className);
-        }
-    }
-
-    /**
      * Assert that the processor may operate upon the given objects with {@link Processor#processInstances(String, Collection)}.
      * Never fails for system types.
      * @param className a class name
@@ -1304,9 +1287,7 @@ public class GraphTraversal {
      */
     private void assertMayBeProcessed(String className, Collection<Long> ids) throws GraphException {
         final Set<CI> objects = idsToCIs(className, ids);
-        if (!isJobType(className)) {
-            assertPermissions(objects, processor.getRequiredPermissions());
-        }
+        assertPermissions(objects, processor.getRequiredPermissions());
         if (isCheckUserPermissions) {
             for (final CI object : Sets.difference(objects, planning.overrides)) {
                 try {
@@ -1325,9 +1306,7 @@ public class GraphTraversal {
      * @throws GraphException if the user may not delete all of the objects
      */
     private void assertMayBeDeleted(String className, Collection<Long> ids) throws GraphException {
-        if (!isJobType(className)) {
-            assertPermissions(idsToCIs(className, ids), Collections.singleton(Ability.DELETE));
-        }
+        assertPermissions(idsToCIs(className, ids), Collections.singleton(Ability.DELETE));
     }
 
     /**
@@ -1337,9 +1316,7 @@ public class GraphTraversal {
      * @throws GraphException if the user may not update all of the objects
      */
     private void assertMayBeUpdated(String className, Collection<Long> ids) throws GraphException {
-        if (!isJobType(className)) {
-            assertPermissions(idsToCIs(className, ids), Collections.singleton(Ability.UPDATE));
-        }
+        assertPermissions(idsToCIs(className, ids), Collections.singleton(Ability.UPDATE));
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/MetadataServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/MetadataServiceTest.java
@@ -1,9 +1,8 @@
 /*
- * $Id$
- *
  *   Copyright 2006-2014 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import java.util.ArrayList;
@@ -21,7 +20,6 @@ import omero.ApiUsageException;
 import omero.ServerError;
 import omero.api.IAdminPrx;
 import omero.api.IMetadataPrx;
-import omero.api.IUpdatePrx;
 import omero.api.ServiceFactoryPrx;
 import omero.model.AcquisitionMode;
 import omero.model.Annotation;
@@ -1975,16 +1973,14 @@ public class MetadataServiceTest extends AbstractServerTest {
 
         final long currentGroupId = iAdmin.getEventContext().groupId;
         final Map<String, String> groupContext = ImmutableMap.of(Login.OMERO_GROUP, Long.toString(currentGroupId));
-        final IUpdatePrx iUpdateRoot = (IUpdatePrx) root.getSession().getUpdateService().ice_context(groupContext);
-
         final IMetadataPrx iMetadata = (IMetadataPrx) root.getSession().getMetadataService().ice_context(groupContext);
 
         Job uploadJob1 = getNewUploadJob();
-        uploadJob1 = (Job) iUpdateRoot.saveAndReturnObject(uploadJob1);
+        uploadJob1 = (Job) iUpdate.saveAndReturnObject(uploadJob1);
         final long uploadJob1Id = uploadJob1.getId().getValue();
 
         Job uploadJob2 = getNewUploadJob();
-        uploadJob2 = (Job) iUpdateRoot.saveAndReturnObject(uploadJob2);
+        uploadJob2 = (Job) iUpdate.saveAndReturnObject(uploadJob2);
         final long uploadJob2Id = uploadJob2.getId().getValue();
 
         OriginalFile importLog1 = new OriginalFileI();


### PR DESCRIPTION
# What this PR does

Has the security system no longer regard `Job` as being a system type.

# Testing this PR

CI should pass.

# Related reading

https://trello.com/c/aC6uk5Vy/489-job-as-system-type