### PR TITLE
OMERO.tables Image and Well metadata support

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2749,10 +2749,13 @@ def object_table_query(request, objtype, objid, conn=None, **kwargs):
     # one (= the one with the highest identifier)
     fileId = 0
     ann = None
+    tableData = None
     for annotation in a['data']:
-        if annotation['file'] > fileId:
-            fileId = annotation['file']
+        tableData = _table_query(request, annotation['file'], conn, **kwargs)
+        if 'error' not in tableData:
             ann = annotation
+            fileId = annotation['file']
+            break
     tableData = _table_query(request, fileId, conn, **kwargs)
     tableData['id'] = fileId
     tableData['annId'] = ann['id']

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2749,8 +2749,9 @@ def object_table_query(request, objtype, objid, conn=None, **kwargs):
     # one (= the one with the highest identifier)
     fileId = 0
     ann = None
+    annList = sorted(a['data'], key=lambda x: x['file'], reverse=True)
     tableData = None
-    for annotation in a['data']:
+    for annotation in annList:
         tableData = _table_query(request, annotation['file'], conn, **kwargs)
         if 'error' not in tableData:
             ann = annotation

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2757,6 +2757,8 @@ def object_table_query(request, objtype, objid, conn=None, **kwargs):
             ann = annotation
             fileId = annotation['file']
             break
+    if ann is None:
+        return dict(error='Could not retrieve matching bulk annotation table')
     tableData = _table_query(request, fileId, conn, **kwargs)
     tableData['id'] = fileId
     tableData['annId'] = ann['id']


### PR DESCRIPTION
This PR adds the ability to display Image and Well metadata in the `Tables` section for the same Plate.


# Testing this PR

1. required setup
  - OMERO 5.3 with changes from this PR.
  - two bulk_annotations attached to the same Plate, created with 'Populate_metadata' script as described here: http://help.openmicroscopy.org/scripts.html#metadata. One bulk_annotation should contain `Well` column, the other `Image` column.

2. actions to perform
- After creating bulk annotations, check if metadata is visible for both Well and Image (that were annotated with the csv files).

3. expected observations
Metadata should be visible in `Tables` tab.

# Related reading

Link to cards, tickets, other PRs:

1. background for understanding this PR
Currently only the latest OMERO.table is searched for Image or Well metadata which means that only Well or Image metadata will be shown in `Tables` section. With this PR a query is ran against attached OMERO.tables, from the latest, until match is found. This adds the ability to show metadata for Images and Wells from the same Plate.

2. what this PR assists, fixes, or otherwise affects
