### PR TITLE
remove pytest markers

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -385,8 +385,7 @@ client.closeSession()
         finally:
             impl.cleanup()
 
-    @pytest.mark.intermittent(reason="Minor performance failure",
-                              ticket="11539")
+    @pytest.mark.broken(reason="Minor performance failure", ticket="11539")
     def testParamLoadingPerformanceTicket2285(self):
         root_client = self.new_client(system=True)
         svc = root_client.sf.getScriptService()

--- a/components/tools/pytest.ini
+++ b/components/tools/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 markers =
-    long_running: mark the test as long-running, i.e. typically requiring more than 10 minutes to complete
     broken: mark the test as broken, i.e. it may be intermittent or failing without a fully understood cause
-    intermittent: mark the test as intermittent, this marker is mainly for documentation and is preferred over broken for genuinely intermittent tests

--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -5,7 +5,7 @@
 
     <property name="env.DESTDIR"    value="${up-two}/target/"/>
     <property name="env.ICE_CONFIG" value="${basedir}/../../../etc/ice.config"/>
-    <property name="MARK" value="not (long_running or broken)"/>
+    <property name="MARK" value="not broken"/>
 
     <defineVariables/>
 


### PR DESCRIPTION
# What this PR does

This removes the `intermittent` and `long_running` custom pytest markers: they are now hardly used.

If merged then a docs PR will follow.

# Testing this PR

CI should remain green.