### PR TITLE
allow thread to access context's stderr

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -813,6 +813,7 @@ class SessionsControl(BaseControl):
                         return
         t = T()
         t.client = self.ctx.conn(args)
+        t.err = self.ctx.err
         t.event = get_event(name="keepalive")
         t.start()
         try:


### PR DESCRIPTION
# What this PR does

Fixes an error reporting bug with CLI keepalive.

# Testing this PR

1. Run `bin/omero sessions keepalive`.
2. Cause an error somehow, e.g., stop the server.
3. Observe that an error message is printed but not a stack trace.

# Related reading

https://trello.com/c/nH6UzZgN/668-cli-bug-on-server-restart