### PR TITLE
Clarify 5.3.2 re: group owner annotation in web

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -13,7 +13,9 @@ Improvements include:
 - textual annotations without a namespace can now be added at import using the CLI
 - improved thumbnails retrieval in OMERO.web
 - added "Open With" option to the right-hand panel in OMERO.web
-- group owners are now prevented from annotating other people's data in OMERO.web
+- private group owners are now not offered the ability to annotate other
+  people's data in OMERO.web UI, an action which was not permitted by the
+  server anyway
 - preview of wells now available in the right-hand panel
 
 Sysadmin changes include:


### PR DESCRIPTION
# What this PR does

Corrects a misleading point in the 5.3.2 announcement which suggested no group owners can annotate other people's data in web, whereas actually private group owner who can't anyway are now not offered the action in the UI - as per https://trello.com/c/rr3RX2Pp/76-bug-webclient-offers-annotation-to-private-group-owners-server-does-not

# Testing this PR

Check wording, won't be built on staging until merged and an autogen PR opened against the docs


# Related reading

See card above