### PR TITLE
have managed repo integration test use more from superclass

### DIFF
--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -66,7 +66,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -957,7 +956,7 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
      * @param parentsSecond if to set {@code parents == true} in <em>re</em>creating the directory
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "every pair of Booleans")
+    @Test(dataProvider = "test cases using two Boolean arguments")
     public void testRecreateDirectory(boolean parentsFirst, boolean parentsSecond) throws Exception {
         logRootIntoGroup();
         setRepo();
@@ -969,18 +968,5 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
         } catch (ResourceError e) {
             Assert.assertFalse(parentsSecond);
         }
-    }
-
-    /**
-     * @return every combination of Boolean pairs
-     */
-    @DataProvider(name = "every pair of Booleans")
-    public Object[][] provideEveryPairOfBooleans() {
-        return new Object[][] {
-                new Boolean[] {false, false},
-                new Boolean[] {false, true},
-                new Boolean[] {true,  false},
-                new Boolean[] {true,  true}
-        };
     }
 }

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -60,7 +60,6 @@ import omero.model.ExperimenterI;
 import omero.model.OriginalFile;
 import omero.sys.EventContext;
 import omero.sys.Parameters;
-import omero.sys.Roles;
 import omero.util.TempFileManager;
 
 import org.testng.Assert;
@@ -889,7 +888,6 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
     @Test
     public void testMakeFilesetDirectoryNormalUser() throws Exception {
         /* import an image */
-        final Roles roles = iAdmin.getSecurityRoles();  // TODO will be a field provided by superclass
         final File uniquePath = tempFileManager.createPath(UUID.randomUUID().toString(), null, true);
         final File file = ensureFileExists(uniquePath, UUID.randomUUID().toString() + ".fake");
         final ImportLocation importLocation = importFileset(Collections.singletonList(file.getAbsolutePath()));
@@ -930,7 +928,6 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
     @Test
     public void testMakeArbitraryDirectoryAdminUser() throws Exception {
         /* set up the new user as an administrator */
-        final Roles roles = iAdmin.getSecurityRoles();  // TODO will be a field provided by superclass
         final EventContext ec = iAdmin.getEventContext();
         root.getSession().getAdminService().addGroups(new ExperimenterI(ec.userId, false),
                 Collections.<ExperimenterGroup>singletonList(new ExperimenterGroupI(roles.systemGroupId, false)));


### PR DESCRIPTION
# What this PR does

Cleans up `ManagedRepositoryTest` by reusing field and data provider now provided by superclass.

# Testing this PR

CI should remain unchanged.

# Related reading

https://trello.com/c/Suw5gv8E/44-managedrepositorytest-cleanup