### PR TITLE
tables: if lock fails, fall back to read-only

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -8,6 +8,7 @@
 
 import Ice
 import time
+import errno
 import numpy
 import logging
 import threading
@@ -137,7 +138,7 @@ class HdfList(object):
                 None, None,
                 "Cannot acquire exclusive lock on: %s" % hdfpath, 0)
         except IOError, ie:
-            if ie.errno == 9:  # Bad File Descriptor (NFS)
+            if ie.errno == errno.EBADF:  # Bad File Descriptor (NFS)
                 hdffile.close()
                 hdffile = hdfstorage.openfile("r")
                 fileno = hdffile.fileno()

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -136,6 +136,14 @@ class HdfList(object):
             raise omero.LockTimeout(
                 None, None,
                 "Cannot acquire exclusive lock on: %s" % hdfpath, 0)
+        except IOError, ie:
+            if ie.errno == 9:  # Bad File Descriptor (NFS)
+                hdffile.close()
+                hdffile = hdfstorage.openfile("r")
+                fileno = hdffile.fileno()
+            else:
+                hdffile.close()
+                raise
         except:
             hdffile.close()
             raise


### PR DESCRIPTION
# What this PR does

Workaround portalocker.py being broken on NFS.

# Testing this PR

1. Mount /OMERO read-only from NFS (like on the orcas)
2. Try to open an HDF5 file. `Bad file descriptor` will be printed in Tables-0.log
3. With this patch, the file should be opened read-only

# Related reading

1. See gh-4916
