### PR TITLE
Gateway login improvements

### DIFF
--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -263,7 +263,7 @@ public class Gateway {
         } catch (PermissionDeniedException e) {
             throw new DSOutOfServiceException("Login credentials not valid", e);
         } catch (ServerError e) {
-            throw new DSOutOfServiceException("Server error", e);
+            throw new DSOutOfServiceException(e.getMessage(), e);
         } catch (SocketException e) {
             throw new DSOutOfServiceException(e.getMessage(), e);
         } catch (DNSException e) {

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -85,6 +85,7 @@ import omero.gateway.model.GroupData;
 import omero.gateway.util.PojoMapper;
 import Glacier2.CannotCreateSessionException;
 import Glacier2.PermissionDeniedException;
+import Ice.ConnectionRefusedException;
 import Ice.DNSException;
 import Ice.SocketException;
 
@@ -264,6 +265,8 @@ public class Gateway {
         } catch (ServerError e) {
             throw new DSOutOfServiceException("Server error", e);
         } catch (SocketException e) {
+            if (e instanceof ConnectionRefusedException)
+                throw new DSOutOfServiceException("Connection refused", e);
             throw new DSOutOfServiceException("Host unreachable", e);
         } catch (DNSException e) {
             throw new DSOutOfServiceException("Can't resolve hostname "
@@ -1055,7 +1058,8 @@ public class Gateway {
                             .getUsername(), c.getUser().getPassword());
                 }
             }
-        } catch (Exception e1) {
+        } 
+        catch (Exception e1) {
             // close the session again before passing on the exception
             secureClient.closeSession();
             throw e1;

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -265,9 +265,7 @@ public class Gateway {
         } catch (ServerError e) {
             throw new DSOutOfServiceException("Server error", e);
         } catch (SocketException e) {
-            if (e instanceof ConnectionRefusedException)
-                throw new DSOutOfServiceException("Connection refused", e);
-            throw new DSOutOfServiceException("Host unreachable", e);
+            throw new DSOutOfServiceException(e.getMessage(), e);
         } catch (DNSException e) {
             throw new DSOutOfServiceException("Can't resolve hostname "
                     + c.getServer().getHostname(), e);

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -1013,8 +1013,9 @@ public class Gateway {
                         "guest", "guest");
                 this.pcs.firePropertyChange(PROP_SESSION_CREATED, null, secureClient.getSessionId());
                 guestSession.getSessionService().getSession(username);
-            } catch (Exception e) {
-                // thrown if it is not a session or session has expired.
+            } catch (Throwable e) {
+                // thrown if it is not a session, session has expired, or 
+                // the guest login doesn't exist on the server
                 session = false;
             } finally {
                 String id = secureClient.getSessionId();

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -71,4 +71,45 @@ public class GatewayUsageTest extends AbstractServerTest
         Assert.assertNotNull(root);
         gw.disconnect();
     }
+    
+    @Test
+    public void testFailedLogin() throws DSOutOfServiceException {
+        omero.client client = new omero.client();
+        String port = client.getProperty("omero.port");
+
+        LoginCredentials c = new LoginCredentials();
+        c.getServer().setHostname(client.getProperty("omero.host"));
+        c.getServer().setPort(Integer.parseInt(port));
+        c.getUser().setUsername("root");
+        c.getUser().setPassword("wrongPassword");
+
+        Gateway gw = new Gateway(new SimpleLogger());
+
+        try {
+            gw.connect(c);
+            Assert.fail("Connection should have failed");
+        } catch (Exception e) {
+            // Something about false "credentials"
+            Assert.assertTrue(e.getMessage().contains("credentials"));
+        }
+
+        c.getServer().setHostname("UnknownHost");
+        try {
+            gw.connect(c);
+            Assert.fail("Connection should have failed");
+        } catch (Exception e) {
+            // Something about "resolve" hostname failed
+            Assert.assertTrue(e.getMessage().contains("resolve"));
+        }
+
+        c.getServer().setHostname("192.168.213.213");
+        try {
+            gw.connect(c);
+            Assert.fail("Connection should have failed");
+        } catch (Exception e) {
+            // Something about host "unreachable"
+            Assert.assertTrue(e.getMessage().contains("unreachable"));
+        }
+    }
+
 }

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -101,15 +101,6 @@ public class GatewayUsageTest extends AbstractServerTest
             // Something about "resolve" hostname failed
             Assert.assertTrue(e.getMessage().contains("resolve"));
         }
-
-        c.getServer().setHostname("192.168.213.213");
-        try {
-            gw.connect(c);
-            Assert.fail("Connection should have failed");
-        } catch (Exception e) {
-            // Something about host "unreachable"
-            Assert.assertTrue(e.getMessage().contains("unreachable"));
-        }
     }
 
 }


### PR DESCRIPTION
# What this PR does

Fixes two issues:
- If a server doesn't have a `guest` account, the connection failed because `ServerError` was thrown (and not handled) on the session id check. Noticed during workshop prep for the romero.gateway notebook.
- Generally if something failed on the session creation and/or login level the client got a very generic `DSOutOfServiceException`. With this PR the client at least will get some more information about the reason. 'Host not reachable', 'Login credentials invalid', 'Version mismatch', etc. When extracting the Gateway code from Insight somewhere on the way the version check got lost. Can't imagine that was intentional, therefore added version check again (otherwise the client get rather cryptic marshal exceptions).

# Testing this PR

- Try to connect to a server which doesn't have the `guest` account. Is there still a server like this running somewhere @joshmoore ?
- Try various error conditions, wrong credentials, incompatible server version, etc. Check that the message of the `DSOutOfServiceException` makes sense.
- Try a valid condition, and make sure you can still connect to the server with correct version and login credentials.
- Check integration test

Here's a simple example test 'client' code: https://gist.github.com/dominikl/b48a029cb4977bfafa7ddb3f027d6d85 or test with Insight and check its log file.


