### PR TITLE
remove unused arguments and fields from graphs code

### DIFF
--- a/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
+++ b/components/blitz/resources/ome/services/blitz-servantDefinitions.xml
@@ -335,7 +335,6 @@
   <bean id="graphRequestFactory" class="omero.cmd.graphs.GraphRequestFactory">
       <constructor-arg ref="aclVoter"/>
       <constructor-arg ref="roles"/>
-      <constructor-arg ref="systemTypes"/>
       <constructor-arg ref="graphPathBean"/>
       <constructor-arg ref="adminPrivileges"/>
       <constructor-arg ref="ome.services.delete.Deletion"/>

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -185,7 +185,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                        graphTraversal.planOperation(targetMultimap, true, true);
                 return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
                 graphTraversal.assertNoPolicyViolations();

--- a/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chgrp2I.java
@@ -43,7 +43,6 @@ import ome.model.enums.AdminPrivilege;
 import ome.model.internal.Permissions;
 import ome.model.meta.ExperimenterGroup;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.delete.Deletion;
 import ome.services.graphs.GraphException;
@@ -75,7 +74,6 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.OWN);
 
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final LightAdminPrivileges adminPrivileges;
     private final Deletion deletionInstance;
@@ -100,7 +98,6 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
      * Construct a new <q>chgrp</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param deletionInstance a deletion instance for deleting files
@@ -109,11 +106,10 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      * @param applicationContext the OMERO application context from Spring
      */
-    public Chgrp2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses,
-            GraphPolicy graphPolicy, SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
+    public Chgrp2I(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.adminPrivileges = adminPrivileges;
         this.deletionInstance = deletionInstance;
@@ -167,7 +163,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, WrappableRequest<Chgrp2
         }
 
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, requiredAbilities, graphPolicy, graphPolicyAdjusters,
-                aclVoter, systemTypes, graphPathBean, unnullable, new InternalProcessor(requiredAbilities), dryRun);
+                aclVoter, graphPathBean, unnullable, new InternalProcessor(requiredAbilities), dryRun);
 
         if (isChgrpPrivilege) {
             graphTraversal.setOwnsAll();

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -46,7 +46,6 @@ import ome.model.internal.Permissions;
 import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.delete.Deletion;
 import ome.services.graphs.GraphException;
@@ -81,7 +80,6 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
 
     private final ACLVoter aclVoter;
     private final Roles securityRoles;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Deletion deletionInstance;
     private final Set<Class<? extends IObject>> targetClasses;
@@ -107,7 +105,6 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
      * Construct a new <q>chmod</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param deletionInstance a deletion instance for deleting files
@@ -116,12 +113,11 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      * @param applicationContext the OMERO application context from Spring
      */
-    public Chmod2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses,
-            GraphPolicy graphPolicy, SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
+    public Chmod2I(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
         this.aclVoter = aclVoter;
         this.securityRoles = securityRoles;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.deletionInstance = deletionInstance;
         this.targetClasses = targetClasses;
@@ -170,7 +166,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
         graphPolicy.registerPredicate(new GroupPredicate(securityRoles));
 
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, systemTypes, graphPathBean, unnullable, new InternalProcessor(), dryRun);
+                aclVoter, graphPathBean, unnullable, new InternalProcessor(), dryRun);
 
         graphPolicyAdjusters = null;
     }

--- a/components/blitz/src/omero/cmd/graphs/Chmod2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chmod2I.java
@@ -190,7 +190,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
                 final boolean isToGroupReadable = newPermissions.isGranted(Permissions.Role.GROUP, Permissions.Right.READ);
                 if (isToGroupReadable) {
                     /* can always skip graph policy rules as is not downgrade to private */
-                    plan = graphTraversal.planOperation(helper.getSession(), targetMultimap, true, false);
+                    plan = graphTraversal.planOperation(targetMultimap, true, false);
                 } else {
                     /* determine which target groups are not already private ... */
                     final String groupClass = ExperimenterGroup.class.getName();
@@ -214,7 +214,7 @@ public class Chmod2I extends Chmod2 implements IRequest, WrappableRequest<Chmod2
                         }
                     }
                     /* ... and apply the graph policy rules to those */
-                    plan = graphTraversal.planOperation(helper.getSession(), targetsNotPrivate, true, true);
+                    plan = graphTraversal.planOperation(targetsNotPrivate, true, true);
                 }
                 return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -310,7 +310,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                        graphTraversal.planOperation(targetMultimap, true, true);
                 return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 2:
                 graphTraversal.assertNoPolicyViolations();

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -58,7 +58,6 @@ import ome.model.meta.Experimenter;
 import ome.model.screen.ScreenPlateLink;
 import ome.parameters.Parameters;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.delete.Deletion;
 import ome.services.graphs.GraphException;
@@ -92,7 +91,6 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.DELETE);
 
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final LightAdminPrivileges adminPrivileges;
     private final Deletion deletionInstance;
@@ -119,7 +117,6 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
      * Construct a new <q>chown</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param deletionInstance a deletion instance for deleting files
@@ -128,11 +125,10 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      * @param applicationContext the OMERO application context from Spring
      */
-    public Chown2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses,
-            GraphPolicy graphPolicy, SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
+    public Chown2I(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.adminPrivileges = adminPrivileges;
         this.deletionInstance = deletionInstance;
@@ -200,7 +196,7 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
         }
 
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, systemTypes, graphPathBean, unnullable, new InternalProcessor(requiredAbilities), dryRun);
+                aclVoter, graphPathBean, unnullable, new InternalProcessor(requiredAbilities), dryRun);
 
         if (isChownPrivilege) {
             graphTraversal.setOwnsAll();

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -38,7 +38,6 @@ import com.google.common.collect.SetMultimap;
 
 import ome.model.IObject;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.delete.Deletion;
 import ome.services.graphs.GraphException;
@@ -69,7 +68,6 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of(GraphPolicy.Ability.DELETE);
 
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Set<Class<? extends IObject>> targetClasses;
     private final Deletion deletionInstance;
@@ -92,7 +90,6 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
      * Construct a new <q>delete</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param deletionInstance a deletion instance for deleting files
@@ -101,11 +98,10 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      * @param applicationContext the OMERO application context from Spring
      */
-    public Delete2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses,
-            GraphPolicy graphPolicy, SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
+    public Delete2I(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.deletionInstance = deletionInstance;
         this.targetClasses = targetClasses;
@@ -134,7 +130,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
         this.graphHelper = new GraphHelper(helper, graphPathBean);
 
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, systemTypes, graphPathBean, unnullable, new InternalProcessor(), dryRun);
+                aclVoter, graphPathBean, unnullable, new InternalProcessor(), dryRun);
 
         graphPolicyAdjusters = null;
     }

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -148,7 +148,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(helper.getSession(), targetMultimap, false, true);
+                        graphTraversal.planOperation(targetMultimap, false, true);
                 if (!plan.getKey().isEmpty()) {
                     final Exception e = new IllegalStateException("deletion does not do anything other than delete");
                     helper.cancel(new ERR(), e, "graph-fail");

--- a/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
@@ -43,7 +43,6 @@ import ome.io.nio.ThumbnailService;
 import ome.model.IObject;
 import ome.parameters.Parameters;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
@@ -77,7 +76,6 @@ public class DiskUsage2I extends DiskUsage2 implements IRequest {
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of();
 
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Set<Class<? extends IObject>> legalClasses;
     private final GraphPolicy graphPolicy;
@@ -102,16 +100,14 @@ public class DiskUsage2I extends DiskUsage2 implements IRequest {
      * Construct a new disk usage request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param targetClasses legal target object classes for the search
      * @param graphPolicy the graph policy to apply for the search
      */
-    public DiskUsage2I(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
+    public DiskUsage2I(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.legalClasses = targetClasses;
         this.graphPolicy = graphPolicy;
@@ -153,8 +149,8 @@ public class DiskUsage2I extends DiskUsage2 implements IRequest {
         helper.setSteps(5);
         this.graphHelper = new GraphHelper(helper, graphPathBean);
 
-        graphTraversal = new GraphTraversal(helper.getSession(), helper.getEventContext(), aclVoter, systemTypes, graphPathBean,
-                null, graphPolicy, new InternalProcessor());
+        graphTraversal = new GraphTraversal(helper.getSession(), helper.getEventContext(), aclVoter, graphPathBean, null,
+                graphPolicy, new InternalProcessor());
     }
 
     @Override

--- a/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
+++ b/components/blitz/src/omero/cmd/graphs/DiskUsage2I.java
@@ -186,7 +186,7 @@ public class DiskUsage2I extends DiskUsage2 implements IRequest {
                 return null;
             case 1:
                 final Map.Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                        graphTraversal.planOperation(targetMultimap, true, true);
                 targetMultimap.clear();
                 if (plan.getValue().isEmpty()) {
                     graphTraversal.assertNoUnlinking();

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -673,7 +673,7 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                        graphTraversal.planOperation(targetMultimap, true, true);
                 if (plan.getValue().isEmpty()) {
                     graphTraversal.assertNoUnlinking();
                 } else {

--- a/components/blitz/src/omero/cmd/graphs/DuplicateI.java
+++ b/components/blitz/src/omero/cmd/graphs/DuplicateI.java
@@ -54,7 +54,6 @@ import com.google.common.collect.SetMultimap;
 
 import ome.model.IObject;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.delete.Deletion;
 import ome.services.graphs.GraphException;
@@ -95,7 +94,6 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
     };
 
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Set<Class<? extends IObject>> targetClasses;
     private GraphPolicy graphPolicy;  /* not final because of adjustGraphPolicy */
@@ -123,7 +121,6 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
      * Construct a new <q>duplicate</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param deletionInstance a deletion instance for deleting files
@@ -132,11 +129,10 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      * @param applicationContext the OMERO application context from Spring
      */
-    public DuplicateI(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses,
-            GraphPolicy graphPolicy, SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
+    public DuplicateI(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Deletion deletionInstance, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy,
+            SetMultimap<String, String> unnullable, ApplicationContext applicationContext) {
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
@@ -195,7 +191,7 @@ public class DuplicateI extends Duplicate implements IRequest, WrappableRequest<
         graphPolicy.registerPredicate(new PermissionsPredicate());
 
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, systemTypes, graphPathBean, unnullable, new InternalProcessor(), dryRun);
+                aclVoter, graphPathBean, unnullable, new InternalProcessor(), dryRun);
 
         graphPolicyAdjusters = null;
     }

--- a/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
@@ -174,7 +174,7 @@ public class FindChildrenI extends FindChildren implements IRequest {
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                        graphTraversal.planOperation(targetMultimap, true, true);
                 if (!plan.getValue().isEmpty()) {
                     final Exception e = new IllegalStateException("querying the model graph does not delete any objects");
                     helper.cancel(new ERR(), e, "graph-fail");

--- a/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindChildrenI.java
@@ -43,7 +43,6 @@ import com.google.common.collect.Sets;
 
 import ome.model.IObject;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
@@ -73,7 +72,6 @@ public class FindChildrenI extends FindChildren implements IRequest {
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of();
 
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Set<Class<? extends IObject>> targetClasses;
     private final GraphPolicy graphPolicy;
@@ -91,16 +89,14 @@ public class FindChildrenI extends FindChildren implements IRequest {
      * Construct a new <q>find-children</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param targetClasses legal target object classes for the search
      * @param graphPolicy the graph policy to apply for the search
      */
-    public FindChildrenI(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
+    public FindChildrenI(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
@@ -162,7 +158,7 @@ public class FindChildrenI extends FindChildren implements IRequest {
         }
 
         graphTraversal = graphHelper.prepareGraphTraversal(null, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, systemTypes, graphPathBean, null, new NullGraphTraversalProcessor(REQUIRED_ABILITIES), false);
+                aclVoter, graphPathBean, null, new NullGraphTraversalProcessor(REQUIRED_ABILITIES), false);
     }
 
     @Override

--- a/components/blitz/src/omero/cmd/graphs/FindParentsI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindParentsI.java
@@ -43,7 +43,6 @@ import com.google.common.collect.Sets;
 
 import ome.model.IObject;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphPathBean;
@@ -73,7 +72,6 @@ public class FindParentsI extends FindParents implements IRequest {
     private static final Set<GraphPolicy.Ability> REQUIRED_ABILITIES = ImmutableSet.of();
 
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final Set<Class<? extends IObject>> targetClasses;
     private final GraphPolicy graphPolicy;
@@ -91,16 +89,14 @@ public class FindParentsI extends FindParents implements IRequest {
      * Construct a new <q>find-parents</q> request; called from {@link GraphRequestFactory#getRequest(Class)}.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean to use
      * @param adminPrivileges the light administrator privileges helper
      * @param targetClasses legal target object classes for the search
      * @param graphPolicy the graph policy to apply for the search
      */
-    public FindParentsI(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            LightAdminPrivileges adminPrivileges, Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
+    public FindParentsI(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean, LightAdminPrivileges adminPrivileges,
+            Set<Class<? extends IObject>> targetClasses, GraphPolicy graphPolicy) {
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.targetClasses = targetClasses;
         this.graphPolicy = graphPolicy;
@@ -162,7 +158,7 @@ public class FindParentsI extends FindParents implements IRequest {
         }
 
         graphTraversal = graphHelper.prepareGraphTraversal(null, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, systemTypes, graphPathBean, null, new NullGraphTraversalProcessor(REQUIRED_ABILITIES), false);
+                aclVoter, graphPathBean, null, new NullGraphTraversalProcessor(REQUIRED_ABILITIES), false);
     }
 
     @Override

--- a/components/blitz/src/omero/cmd/graphs/FindParentsI.java
+++ b/components/blitz/src/omero/cmd/graphs/FindParentsI.java
@@ -174,7 +174,7 @@ public class FindParentsI extends FindParents implements IRequest {
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(helper.getSession(), targetMultimap, true, true);
+                        graphTraversal.planOperation(targetMultimap, true, true);
                 if (!plan.getValue().isEmpty()) {
                     final Exception e = new IllegalStateException("querying the model graph does not delete any objects");
                     helper.cancel(new ERR(), e, "graph-fail");

--- a/components/blitz/src/omero/cmd/graphs/GraphHelper.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphHelper.java
@@ -39,7 +39,6 @@ import ome.conditions.InternalException;
 import ome.model.IObject;
 import ome.model.enums.AdminPrivilege;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.services.graphs.GraphPathBean;
 import ome.services.graphs.GraphPolicy;
 import ome.services.graphs.GraphTraversal;
@@ -107,7 +106,6 @@ public class GraphHelper {
      * @param graphPolicy the graph policy for the request
      * @param graphPolicyAdjusters the adjusters to be applied to the graph policy
      * @param aclVoter ACL voter for permissions checking
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      * @param processor how to operate on the resulting target object graph
@@ -116,8 +114,8 @@ public class GraphHelper {
      */
     public GraphTraversal prepareGraphTraversal(List<ChildOption> childOptions, Set<GraphPolicy.Ability> requiredPermissions,
             GraphPolicy graphPolicy, Iterable<Function<GraphPolicy, GraphPolicy>> graphPolicyAdjusters,
-            ACLVoter aclVoter, SystemTypes systemTypes, GraphPathBean graphPathBean,
-            SetMultimap<String, String> unnullable, GraphTraversal.Processor processor, boolean dryRun) {
+            ACLVoter aclVoter, GraphPathBean graphPathBean, SetMultimap<String, String> unnullable,
+            GraphTraversal.Processor processor, boolean dryRun) {
 
         if (childOptions != null) {
             final List<ChildOptionI> childOptionsI = ChildOptionI.castChildOptions(childOptions);
@@ -135,8 +133,8 @@ public class GraphHelper {
             processor = GraphUtil.disableProcessor(processor);
         }
 
-        return new GraphTraversal(helper.getSession(), helper.getEventContext(), aclVoter, systemTypes, graphPathBean, unnullable,
-                graphPolicy, processor);
+        return new GraphTraversal(helper.getSession(), helper.getEventContext(), aclVoter, graphPathBean, unnullable, graphPolicy,
+                processor);
     }
 
     /**

--- a/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
+++ b/components/blitz/src/omero/cmd/graphs/GraphRequestFactory.java
@@ -37,7 +37,6 @@ import com.google.common.collect.SetMultimap;
 import ome.model.IObject;
 import ome.model.internal.Permissions;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.delete.Deletion;
 import ome.services.graphs.GraphException;
@@ -60,7 +59,6 @@ public class GraphRequestFactory implements ApplicationContextAware {
 
     private final ACLVoter aclVoter;
     private final Roles securityRoles;
-    private final SystemTypes systemTypes;
     private final GraphPathBean graphPathBean;
     private final LightAdminPrivileges adminPrivileges;
     private final Deletion deletionInstance;
@@ -75,7 +73,6 @@ public class GraphRequestFactory implements ApplicationContextAware {
      * Construct a new graph request factory.
      * @param aclVoter ACL voter for permissions checking
      * @param securityRoles the security roles
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean
      * @param adminPrivileges the light administrator privileges helper
      * @param deletionInstance a deletion instance for deleting files
@@ -85,13 +82,12 @@ public class GraphRequestFactory implements ApplicationContextAware {
      * @param defaultExcludeNs the default value for an unset excludeNs field
      * @throws GraphException if the graph path rules could not be parsed
      */
-    public GraphRequestFactory(ACLVoter aclVoter, Roles securityRoles, SystemTypes systemTypes, GraphPathBean graphPathBean,
+    public GraphRequestFactory(ACLVoter aclVoter, Roles securityRoles, GraphPathBean graphPathBean,
             LightAdminPrivileges adminPrivileges, Deletion deletionInstance, Map<Class<? extends Request>, List<String>> allTargets,
             Map<Class<? extends Request>, List<GraphPolicyRule>> allRules, List<String> unnullable, Set<String> defaultExcludeNs)
                     throws GraphException {
         this.aclVoter = aclVoter;
         this.securityRoles = securityRoles;
-        this.systemTypes = systemTypes;
         this.graphPathBean = graphPathBean;
         this.adminPrivileges = adminPrivileges;
         this.deletionInstance = deletionInstance;
@@ -176,15 +172,15 @@ public class GraphRequestFactory implements ApplicationContextAware {
                     graphPolicy = graphPolicy.getCleanInstance();
                 }
                 if (GraphModify2.class.isAssignableFrom(requestClass)) {
-                    final Constructor<R> constructor = requestClass.getConstructor(ACLVoter.class, Roles.class, SystemTypes.class,
+                    final Constructor<R> constructor = requestClass.getConstructor(ACLVoter.class, Roles.class,
                             GraphPathBean.class, LightAdminPrivileges.class, Deletion.class, Set.class, GraphPolicy.class,
                             SetMultimap.class, ApplicationContext.class);
-                    request = constructor.newInstance(aclVoter, securityRoles, systemTypes, graphPathBean, adminPrivileges,
-                            deletionInstance, targetClasses, graphPolicy, unnullable, applicationContext);
+                    request = constructor.newInstance(aclVoter, securityRoles, graphPathBean, adminPrivileges, deletionInstance,
+                            targetClasses, graphPolicy, unnullable, applicationContext);
                 } else {
-                    final Constructor<R> constructor = requestClass.getConstructor(ACLVoter.class, Roles.class, SystemTypes.class,
+                    final Constructor<R> constructor = requestClass.getConstructor(ACLVoter.class, Roles.class,
                             GraphPathBean.class, LightAdminPrivileges.class, Set.class, GraphPolicy.class);
-                    request = constructor.newInstance(aclVoter, securityRoles, systemTypes, graphPathBean, adminPrivileges,
+                    request = constructor.newInstance(aclVoter, securityRoles, graphPathBean, adminPrivileges,
                             targetClasses, graphPolicy);
                 }
             }

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -181,7 +181,7 @@ public class GraphTraversal {
         }
 
         /**
-         * Construct a new {@link IObject}
+         * Construct a new {@link IObject}.
          * @return an unloaded {@link IObject} corresponding to this {@link CI}
          * @throws GraphException if the {@link IObject} could not be constructed
          */

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -56,7 +56,6 @@ import ome.model.internal.Permissions;
 import ome.model.meta.Experimenter;
 import ome.model.meta.ExperimenterGroup;
 import ome.security.ACLVoter;
-import ome.security.SystemTypes;
 import ome.security.basic.LightAdminPrivileges;
 import ome.services.graphs.GraphPathBean.PropertyKind;
 import ome.services.graphs.GraphPolicy.Ability;
@@ -465,7 +464,6 @@ public class GraphTraversal {
     private final EventContext eventContext;
     private final boolean isCheckUserPermissions;
     private final ACLVoter aclVoter;
-    private final SystemTypes systemTypes;
     private final GraphPathBean model;
     private final SetMultimap<String, String> unnullable;
     private final Set<Milestone> progress = EnumSet.noneOf(Milestone.class);
@@ -478,18 +476,16 @@ public class GraphTraversal {
      * @param session the Hibernate session
      * @param eventContext the current event context
      * @param aclVoter ACL voter for permissions checking
-     * @param systemTypes for identifying the system types
      * @param graphPathBean the graph path bean
      * @param unnullable properties that, while nullable, may not be nulled by a graph traversal operation
      * @param policy how to determine which related objects to include in the operation
      * @param processor how to operate on the resulting target object graph
      */
-    public GraphTraversal(Session session, EventContext eventContext, ACLVoter aclVoter, SystemTypes systemTypes,
-            GraphPathBean graphPathBean, SetMultimap<String, String> unnullable, GraphPolicy policy, Processor processor) {
+    public GraphTraversal(Session session, EventContext eventContext, ACLVoter aclVoter, GraphPathBean graphPathBean,
+            SetMultimap<String, String> unnullable, GraphPolicy policy, Processor processor) {
         this.session = session;
         this.eventContext = eventContext;
         this.aclVoter = aclVoter;
-        this.systemTypes = systemTypes;
         this.model = graphPathBean;
         this.unnullable = unnullable;
         this.planning = new Planning();

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -500,25 +500,24 @@ public class GraphTraversal {
 
     /**
      * Traverse model object graph to determine steps for the proposed operation.
-     * @param session the Hibernate session to use for HQL queries
      * @param objects the model objects to process
      * @param include if the given model objects are to be included (instead of just deleted)
      * @param applyRules if the given model objects should have the policy rules applied to them
      * @return the model objects included in the operation, and the deleted objects
      * @throws GraphException if the model objects were not as expected
      */
-    public Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> planOperation(Session session,
-            SetMultimap<String, Long> objects, boolean include, boolean applyRules) throws GraphException {
+    public Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> planOperation(SetMultimap<String, Long> objects,
+            boolean include, boolean applyRules) throws GraphException {
         if (progress.contains(Milestone.PLANNED)) {
             throw new IllegalStateException("operation already planned");
         }
         final Set<CI> targetSet = include ? planning.included : planning.deleted;
         /* note the object instances for processing */
-        targetSet.addAll(objectsToCIs(session, objects));
+        targetSet.addAll(objectsToCIs(objects));
         if (applyRules) {
             /* actually do the planning of the operation */
             planning.toProcess.addAll(targetSet);
-            planOperation(session);
+            planOperation();
         } else {
             /* act as if the target objects have no links and no rules match them */
             for (final CI targetObject : targetSet) {
@@ -540,15 +539,14 @@ public class GraphTraversal {
 
     /**
      * Traverse model object graph to determine steps for the proposed operation.
-     * @param session the Hibernate session to use for HQL queries
      * @param objectInstances the model objects to process, may be unloaded with ID only
      * @param include if the given model objects are to be included (instead of just deleted)
      * @param applyRules if the given model objects should have the policy rules applied to them
      * @return the model objects included in the operation, and the deleted objects, may be unloaded with ID only
      * @throws GraphException if the model objects were not as expected
      */
-    public Entry<Collection<IObject>, Collection<IObject>> planOperation(Session session,
-            Collection<? extends IObject> objectInstances, boolean include, boolean applyRules) throws GraphException {
+    public Entry<Collection<IObject>, Collection<IObject>> planOperation(Collection<? extends IObject> objectInstances,
+            boolean include, boolean applyRules) throws GraphException {
         if (progress.contains(Milestone.PLANNED)) {
             throw new IllegalStateException("operation already planned");
         }
@@ -564,11 +562,11 @@ public class GraphTraversal {
                 objectsToQuery.put(instance.getClass().getName(), instance.getId());
             }
         }
-        targetSet.addAll(objectsToCIs(session, objectsToQuery));
+        targetSet.addAll(objectsToCIs(objectsToQuery));
         if (applyRules) {
             /* actually do the planning of the operation */
             planning.toProcess.addAll(targetSet);
-            planOperation(session);
+            planOperation();
         } else {
             /* act as if the target objects have no links and no rules match them */
             for (final CI targetObject : targetSet) {
@@ -591,10 +589,9 @@ public class GraphTraversal {
     /**
      * Traverse model object graph to determine steps for the proposed operation.
      * Assumes that the internal {@code planning} field is set up and mutates it accordingly.
-     * @param session the Hibernate session to use for HQL queries
      * @throws GraphException if the model objects were not as expected
      */
-    private void planOperation(Session session) throws GraphException {
+    private void planOperation() throws GraphException {
         /* track state to guarantee progress in reprocessing objects whose orphan status is relevant */
         Set<CI> optimisticReprocess = null;
         /* set of not-last objects after latest review */
@@ -621,7 +618,7 @@ public class GraphTraversal {
                 toCache.removeAll(planning.cached);
                 if (!toCache.isEmpty()) {
                     optimisticReprocess = null;
-                    cache(session, toCache);
+                    cache(toCache);
                     continue;
                 }
                 /* try processing the findIfLast in case of any changes */
@@ -838,12 +835,11 @@ public class GraphTraversal {
 
     /**
      * Convert the indicated objects to {@link CI}s with their actual class identified.
-     * @param session a Hibernate session
      * @param objects the objects to query
      * @return {@link CI}s corresponding to the objects
      * @throws GraphException if any of the specified objects could not be queried
      */
-    private Collection<CI> objectsToCIs(Session session, SetMultimap<String, Long> objects) throws GraphException {
+    private Collection<CI> objectsToCIs(SetMultimap<String, Long> objects) throws GraphException {
         final List<CI> returnValue = new ArrayList<CI>(objects.size());
         for (final Entry<String, Collection<Long>> oneQueryClass : objects.asMap().entrySet()) {
             final String className = oneQueryClass.getKey();
@@ -929,11 +925,10 @@ public class GraphTraversal {
 
     /**
      * Load object instances and their links into the various cache fields of {@link Planning}.
-     * @param session a Hibernate session
      * @param toCache the objects to cache
      * @throws GraphException if the objects could not be converted to unloaded instances
      */
-    private void cache(Session session, Collection<CI> toCache) throws GraphException {
+    private void cache(Collection<CI> toCache) throws GraphException {
         /* note which links to query, organized for batch querying */
         final SetMultimap<CP, Long> forwardLinksWanted = HashMultimap.create();
         final SetMultimap<CP, Long> backwardLinksWanted = HashMultimap.create();

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -1206,8 +1206,8 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
     /**
      * Test that {@link omero.model.Permissions#canChgrp()} respects {@code allTargets} as passed to
      * {@link omero.cmd.graphs.GraphRequestFactory#GraphRequestFactory(ome.security.ACLVoter, ome.system.Roles,
-     *  ome.security.SystemTypes, ome.services.graphs.GraphPathBean, ome.security.basic.LightAdminPrivileges,
-     *  ome.services.delete.Deletion, Map, Map, List, Set)}.
+     *  ome.services.graphs.GraphPathBean, ome.security.basic.LightAdminPrivileges, ome.services.delete.Deletion,
+     *  Map, Map, List, Set)}.
      * @throws Exception unexpected
      */
     @Test

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -1717,8 +1717,8 @@ public class PermissionsTest extends AbstractServerTest {
     /**
      * Test that {@link omero.model.Permissions#canChown()} respects {@code allTargets} as passed to
      * {@link omero.cmd.graphs.GraphRequestFactory#GraphRequestFactory(ome.security.ACLVoter, ome.system.Roles,
-     *  ome.security.SystemTypes, ome.services.graphs.GraphPathBean, ome.security.basic.LightAdminPrivileges,
-     *  ome.services.delete.Deletion, Map, Map, List, Set)}.
+     *  ome.services.graphs.GraphPathBean, ome.security.basic.LightAdminPrivileges, ome.services.delete.Deletion,
+     *  Map, Map, List, Set)}.
      * @throws Exception unexpected
      */
     @Test


### PR DESCRIPTION
# What this PR does

Changes in the graph traversal code means that some arguments and fields (session, system types) are no longer required. This PR reduces the clutter in the code without changing behavior.

# Testing this PR

CI should show no regressions.