### PR TITLE
have "git describe" set omero.version using --first-parent

### DIFF
--- a/components/antlib/resources/version.xml
+++ b/components/antlib/resources/version.xml
@@ -70,6 +70,7 @@
                     <arg value="--match"/>
                     <arg value="${gitmatch}"/>
                     <arg line="--dirty"/>
+                    <arg line="--first-parent"/>
                 </args>
             </git>
 

--- a/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,6 +20,8 @@
  */
 package integration.gateway;
 
+import integration.ModelMockFactory;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -29,11 +31,14 @@ import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.model.IObject;
+import omero.model.Plate;
+import omero.model.Well;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import edu.emory.mathcs.backport.java.util.Collections;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FolderData;
@@ -42,6 +47,7 @@ import omero.gateway.model.ImageData;
 import omero.gateway.model.PlateData;
 import omero.gateway.model.ProjectData;
 import omero.gateway.model.ScreenData;
+import omero.gateway.model.WellData;
 import omero.gateway.util.PojoMapper;
 
 /**
@@ -76,6 +82,9 @@ public class BrowseFacilityTest extends GatewayTest {
     private FolderData userFolder2;
     private FolderData userFolder3;
     private FolderData user2Folder;
+    
+    private PlateData wellsPlate;
+    private ArrayList<Long> wellIds;
     
     @Override
     @BeforeClass(alwaysRun = true)
@@ -363,6 +372,19 @@ public class BrowseFacilityTest extends GatewayTest {
         Assert.assertFalse(luts.isEmpty());
      }
     
+    @Test
+    public void testGeWells() throws DSOutOfServiceException, DSAccessException {
+        Collection<WellData> wells = browseFacility.getWells(rootCtx, wellIds);
+        Assert.assertEquals(wells.size(), wellIds.size());
+        ArrayList<Long> loadedIds = new ArrayList<Long>();
+        for(WellData w : wells) {
+            Assert.assertEquals(w.getWellSamples().size(), 2);
+            loadedIds.add(w.getId());
+        }
+        Collections.sort(loadedIds);
+        Assert.assertEquals(loadedIds, wellIds);
+     }
+    
     private void initData() throws Exception {
         this.group = createGroup();
         this.user = createExperimenter(group);
@@ -396,6 +418,17 @@ public class BrowseFacilityTest extends GatewayTest {
         this.img2 = createImage(ctx, ds2);
         
         this.user2Folder = createFolder(ctx);
+        
+        ModelMockFactory mf = new ModelMockFactory(gw.getTypesService(rootCtx));
+        this.wellsPlate = new PlateData(mf.createPlate(3, 3, 2, 1, false));
+        this.wellsPlate = (PlateData) datamanagerFacility.saveAndReturnObject(rootCtx, wellsPlate);
+        
+        this.wellIds = new ArrayList<Long>();
+        Plate p = this.wellsPlate.asPlate();
+        for (Well w : p.copyWells()) {
+            this.wellIds.add(w.getId().getValue());
+        }
+        Collections.sort(this.wellIds);
     }
 
 }

--- a/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
@@ -24,6 +24,7 @@ import integration.ModelMockFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -38,7 +39,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FolderData;

--- a/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/BrowseFacilityTest.java
@@ -373,7 +373,7 @@ public class BrowseFacilityTest extends GatewayTest {
      }
     
     @Test
-    public void testGeWells() throws DSOutOfServiceException, DSAccessException {
+    public void testGetWells() throws DSOutOfServiceException, DSAccessException {
         Collection<WellData> wells = browseFacility.getWells(rootCtx, wellIds);
         Assert.assertEquals(wells.size(), wellIds.size());
         ArrayList<Long> loadedIds = new ArrayList<Long>();

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -813,6 +813,7 @@ class SessionsControl(BaseControl):
                         return
         t = T()
         t.client = self.ctx.conn(args)
+        t.err = self.ctx.err
         t.event = get_event(name="keepalive")
         t.start()
         try:

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -385,8 +385,7 @@ client.closeSession()
         finally:
             impl.cleanup()
 
-    @pytest.mark.intermittent(reason="Minor performance failure",
-                              ticket="11539")
+    @pytest.mark.broken(reason="Minor performance failure", ticket="11539")
     def testParamLoadingPerformanceTicket2285(self):
         root_client = self.new_client(system=True)
         svc = root_client.sf.getScriptService()

--- a/components/tools/pytest.ini
+++ b/components/tools/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 markers =
-    long_running: mark the test as long-running, i.e. typically requiring more than 10 minutes to complete
     broken: mark the test as broken, i.e. it may be intermittent or failing without a fully understood cause
-    intermittent: mark the test as intermittent, this marker is mainly for documentation and is preferred over broken for genuinely intermittent tests

--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -5,7 +5,7 @@
 
     <property name="env.DESTDIR"    value="${up-two}/target/"/>
     <property name="env.ICE_CONFIG" value="${basedir}/../../../etc/ice.config"/>
-    <property name="MARK" value="not (long_running or broken)"/>
+    <property name="MARK" value="not broken"/>
 
     <defineVariables/>
 


### PR DESCRIPTION
# What this PR does

Ignores merged-in branches when deciding which git tag to use in naming the build. This means that we don't have to make a 5.4 tag for a new-version devspace every time we merge in mainline. However, it does mean that once the devspace *becomes* mainline, *if* that is effected by merging the devspace into mainline then 5.4 would need to be tagged there.

# Testing this PR

Check out `roles`, try merging `scc/develop/merge/daily` into it, don't worry about merge conflicts, just try building and when it finishes or errors out see that `target/omero.version` mentions 5.4, not 5.3.

--exclude for now

# Related reading

Discussion on #5308.