### PR TITLE
Don't recursively load feedback on ajaxError

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
@@ -514,6 +514,10 @@ OME.setupAjaxError = function(feedbackUrl){
         } else if (req.status == 500) {
             // Our 500 handler returns only the stack-trace if request.is_json()
             error = req.responseText;
+            // If the failed request was loading feedback, prevent recursive loading of feedback!
+            if (settings.url.startsWith(feedbackUrl)) {
+                return;
+            }
             OME.feedback_dialog(error, feedbackUrl);
         } else if (req.status == 400) {
             if (req.responseText.indexOf('Request Line is too large') > -1) {


### PR DESCRIPTION
# What this PR does

This fixes the recursive loading of ```/feedback/feedback``` when loading this generates 500 errors.
Several times recently, qa has received thousands of e-mails starting:
```
Internal Server Error: /feedback/feedback/
Traceback (most recent call last):
```
which are caused by:
 - webclient page loads OK
 - subsequent ajax call fails (```500``` error)
 - this is handled by ajaxError trying to load ```/feedback/feedback/``` which also fails
 - then we enter a recursive loop, generating an e-mail to qa each time!

# Testing this PR

Can be tested locally:
- load webclient page - open devtools to monitor Network requests
- edit an OMERO.web python file to create an error e.g. bogus import statement
- trigger ajax call from webclient (e.g. click on Project)
- you should get a 500 response for the original ajax call and a subsequent call to ```feedback``` which also fails with 500 error.
- shouldn't see any more recursive calls to ```feedback```. 

cc @kennethgillen @manics 