### PR TITLE
improve file deleter logging

### DIFF
--- a/components/server/src/ome/services/delete/files/FileDeleter.java
+++ b/components/server/src/ome/services/delete/files/FileDeleter.java
@@ -20,6 +20,7 @@ package ome.services.delete.files;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import ome.io.nio.AbstractFileSystemService;
@@ -90,9 +91,12 @@ public class FileDeleter {
         undeletedFiles.put(Type.Pixels.toString(), pixelsFD.getUndeletedFiles());
 
         if (log.isDebugEnabled()) {
-            for (String table : undeletedFiles.keySet()) {
-                log.debug("Failed to delete files : " + table + ":"
-                        + Arrays.toString(undeletedFiles.get(table)));
+            for (final Map.Entry<String, long[]> undeletedFilesOneClass : undeletedFiles.entrySet()) {
+                final String className = undeletedFilesOneClass.getKey();
+                final long[] ids = undeletedFilesOneClass.getValue();
+                if (ids.length > 0) {
+                    log.debug("Failed to delete files : " + className + ":" + Arrays.toString(ids));
+                }
             }
         }
     }


### PR DESCRIPTION
# What this PR does

Does not log "failed to delete files" for an empty list of files.

# Testing this PR

Easiest might be to turn on debug logging (in `etc/logback.xml` tweak the line for `ome.services.delete`), run a bunch of integration tests with and without this PR, then compare the DEBUG lines from each. Alternatively, try to manually cause such failures and check for no regression in the logging.