### PR TITLE
open_with_webgateway_viewer

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -558,7 +558,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     # OPEN WITH
     "omero.web.open_with":
         ["OPEN_WITH",
-         ('[["Image viewer", "webindex", {"supported_objects": ["image"],'
+         ('[["Image viewer", "webgateway", {"supported_objects": ["image"],'
           '"script_url": "webclient/javascript/ome.openwith_viewer.js"}]]'),
          json.loads,
          ("A list of viewers that can be used to display selected Images "


### PR DESCRIPTION
# What this PR does

This allows the old webgateway image viewer to be used via Open with "Image Viewer" even if the default image viewer has been configured to use some other viewer, such as iviewer.
See https://trello.com/c/RDhnan5w/39-default-viewer-replacement

# Updating 'Open with' Config

If you have previously configured any ```open_with``` options, then the ```etc/grid/config.xml``` will contain the original ```open_with > 'Image Viewer' ``` setting, so that the code change in this PR will have no effect, e.g. when upgrading server.
To fix it, you'd have to manually update the open_with configuration, but this is a little painful. If you want to preserve the order of open_with options then what I did was:
```
$ bin/omero config get omero.web.open_with
[["Image viewer", "webindex", {"supported_objects": ["image"], "script_url": "we....
```
Then edit ```webindex -> webgateway``` and paste the whole config back into
```
$ bin/omero config set omero.web.open_with '[["Image viewer", "webgateway", {"supported_objects": ["image"], "scr....'
```

# Testing this PR

The config below has been set up on devspace machine and can be tested directly at
http://10.0.51.146/web/webclient/ (root/omero).
Double-click thumbnail should open iviewer. Open with -> Image viewer should open webgateway viewer.

1. Configure a different default viewer. E.g. with iviewer installed
``` $ bin/omero config set omero.web.viewer.view omero_iviewer.views.index ```

2. Using Open with -> Image viewer should still open the image viewer at ```/webgateway/img_detail/:id/```

# Related reading

Link to cards, tickets, other PRs:

https://trello.com/c/RDhnan5w/39-default-viewer-replacement
