### PR TITLE
add a training example for bulk shape access

### DIFF
--- a/examples/Training/python/Bulk_Shapes.py
+++ b/examples/Training/python/Bulk_Shapes.py
@@ -45,7 +45,7 @@ for shape in range(total_shape_count):
     roi.addShape(point)
 
 roi = updateService.saveAndReturnObject(roi)
-print "created {} shapes".format(total_shape_count)
+print "created {0} shapes".format(total_shape_count)
 
 
 # Query Shapes in batches
@@ -68,8 +68,8 @@ while True:
         shapes_queried += len(shapes)
         shape_batch_count += 1
 
-print "retrieved {} shapes in {} batches".format(shapes_queried,
-                                                 shape_batch_count)
+print "retrieved {0} shapes in {1} batches".format(shapes_queried,
+                                                   shape_batch_count)
 
 
 # Delete ROI with Shapes

--- a/examples/Training/python/Bulk_Shapes.py
+++ b/examples/Training/python/Bulk_Shapes.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+#                    All Rights Reserved.
+# Use is subject to license terms supplied in LICENSE.txt
+#
+
+"""
+FOR TRAINING PURPOSES ONLY!
+"""
+
+import omero
+from omero.gateway import BlitzGateway
+from omero.rtypes import rdouble
+from Parse_OMERO_Properties import USERNAME, PASSWORD, HOST, PORT
+
+"""
+start-code
+"""
+
+# Create a connection
+# ===================
+conn = BlitzGateway(USERNAME, PASSWORD, host=HOST, port=PORT)
+conn.connect()
+queryService = conn.getQueryService()
+updateService = conn.getUpdateService()
+
+
+# Decide how many Shapes
+# ======================
+total_shape_count = 20
+
+
+# Create ROI with Shapes
+# ======================
+
+roi = omero.model.RoiI()
+
+for shape in range(total_shape_count):
+    point = omero.model.PointI()
+    point.setX(rdouble(2))
+    point.setY(rdouble(3))
+    roi.addShape(point)
+
+roi = updateService.saveAndReturnObject(roi)
+print "created {} shapes".format(total_shape_count)
+
+
+# Query Shapes in batches
+# =======================
+shapes_per_batch = 5
+shapes_queried = 0
+shape_batch_count = 0
+
+hql = 'FROM Shape WHERE roi.id = :id ORDER BY id'
+
+while True:
+    params = omero.sys.ParametersI()
+    params.addId(roi.id)
+    params.page(shapes_queried, shapes_per_batch)
+    shapes = queryService.findAllByQuery(hql, params)
+
+    if not shapes:
+        break
+    else:
+        shapes_queried += len(shapes)
+        shape_batch_count += 1
+
+print "retrieved {} shapes in {} batches".format(shapes_queried,
+                                                 shape_batch_count)
+
+
+# Delete ROI with Shapes
+# ======================
+conn.deleteObject(roi)
+
+
+# Close connection
+# ================
+# When you are done, close the session to free up server resources.
+conn.close()

--- a/examples/Training/python/__main__.py
+++ b/examples/Training/python/__main__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
 #                    All Rights Reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
@@ -12,6 +12,7 @@ training_dir = os.path.dirname(os.path.abspath(__file__))
 
 if __name__ == "__main__":
         print "Running training suite"
+        execfile(os.path.join(training_dir, 'Bulk_Shapes.py'))
         execfile(os.path.join(training_dir, 'Connect_To_OMERO.py'))
         execfile(os.path.join(training_dir, 'Create_Image.py'))
         execfile(os.path.join(training_dir, 'Delete.py'))


### PR DESCRIPTION
# What this PR does

Adds a Python training example showing that shapes can be retrieved from a ROI using batch querying for scalability. Batched writing can follow once https://trello.com/c/Q499M0qm/758-cannot-write-rois-at-scale is solved. Cc: @polarise.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-training/ should remain green. Also, give it a try locally:

```shell
$ python python/Bulk_Shapes.py 
created 20 shapes
retrieved 20 shapes in 4 batches
```