### PR TITLE
render.py active channels

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/render.py
+++ b/components/tools/OmeroPy/src/omero/plugins/render.py
@@ -457,8 +457,6 @@ class RenderControl(BaseControl):
         for (i, c) in newchannels.iteritems():
             if c.label:
                 namedict[i] = c.label
-            if not c.active:
-                continue
             cindices.append(i)
             rangelist.append([c.min, c.max])
             colourlist.append(c.color)


### PR DESCRIPTION
# What this PR does

Copy settings even if the channel is off


# Testing this PR

Copy settings across images with some channels off


# Related reading
https://trello.com/c/6GvOjNN0/26-bug-rendering-settings-not-applied-to-channels-that-also-have-the-tag-active-false

cc @joshmoore 