### PR TITLE
zeroc-ice for ice 3.5

### DIFF
--- a/components/tools/OmeroWeb/requirements-py27-all-ice35.txt
+++ b/components/tools/OmeroWeb/requirements-py27-all-ice35.txt
@@ -1,0 +1,9 @@
+# Python installation requirements for OMERO.web
+# ==============================================
+#
+#     pip install -r requirements-py27-all-ice35.txt
+#
+
+numpy>=1.9
+Pillow<3.4
+-r requirements-py27-ice35.txt

--- a/components/tools/OmeroWeb/requirements-py27-ice35.txt
+++ b/components/tools/OmeroWeb/requirements-py27-ice35.txt
@@ -1,0 +1,11 @@
+# Python installation requirements for OMERO.web
+# ==============================================
+#
+#     pip install -r requirements-py27-ice35.txt
+#
+
+Django>=1.8,<1.9
+django-pipeline==1.3.20
+gunicorn>=19.3
+
+omero-marshal==0.5.1


### PR DESCRIPTION
# What this PR does

Do not install zeroc-ice for ice 3.5


# Testing this PR

Use omero-install with OMEROVER=OMERO-DEV-merge-build ICEVER=ice35


# Related reading

Error showed up when investigating https://github.com/ome/omero-install/pull/154

see https://github.com/ome/omero-install/pull/156