### PR TITLE
well index undefined

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.general.js.html
@@ -114,7 +114,7 @@ $(function () {
                             url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/';
                         }
                     } else if(orel=="well"){
-                        var well_index = selected[0]["index"];
+                        var well_index = selected[0]["index"] || 0;
                         url = '{% url 'load_metadata_details' %}well/'+oid.split('-')[1]+'/?index='+ well_index;
                     } else {
                         url = prefix+'metadata_details/'+orel+'/'+oid.split("-")[1]+'/';


### PR DESCRIPTION
# What this PR does

Fixes loading of Well in right panel when browsing Well under Tag tree, or when clicking on Well in search results, see https://trello.com/c/SxHW81MY/38-bug-well-indexundefined

# Testing this PR

1.Tag a Well then browse to that Well under Tag tree and select the Well to load in right panel.
2. Search for the Tag and click on the Well in search results.
3. Should see no error and 'Full viewer' button should open image.
