### PR TITLE
canLink fix jsTree

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1092,8 +1092,13 @@ $(function() {
                     parentAllowsCreate = (node.type === "orphaned" || node.type === "experimenter");
 
 
-                // Although not everything created here will go under selected node,
-                // we still don't allow creation if linking not allowed
+                // We don't allow creating if new node will not be displayed in tree.
+                // If you canLink under selected Project, Dataset will be in tree
+                if(canLink && node.type === "project" && !tagTree) {
+                    config["create"]["_disabled"] = false;
+                    config["create"]["submenu"]["dataset"]["_disabled"] = false;
+                }
+                // Otherwise can only create if we're filtering for your data
                 if(canCreate && (canLink || parentAllowsCreate)) {
                     // Enable tag or P/D/I submenus created above
                     config["create"]["_disabled"] = false;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -537,7 +537,7 @@
                     // If a project is selected (or selected is a child of project) create dataset under it
                     var url, position = 0;
                     var parent = false;
-                    if(selected.length > 0 && cont_type == 'dataset') {
+                    if (selected.length > 0 && cont_type == 'dataset') {
                         if (selected[0].type === 'project') {
                             parent = selected[0];
                         } else if (inst.get_node(selected[0].parent).type === 'project') {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -537,14 +537,14 @@
                     // If a project is selected (or selected is a child of project) create dataset under it
                     var url, position = 0;
                     var parent = false;
-                    if(selected.length == 1 && cont_type == 'dataset') {
+                    if(selected.length > 0 && cont_type == 'dataset') {
                         if (selected[0].type === 'project') {
                             parent = selected[0];
                         } else if (inst.get_node(selected[0].parent).type === 'project') {
                             parent = inst.get_node(selected[0].parent);
                         }
                     // If a tagset is selected (or selected is a child of tagset), create tag under it
-                    } else if(selected.length == 1 && cont_type == 'tag') {
+                    } else if(selected.length > 0 && cont_type == 'tag') {
                         if (selected[0].type === 'tagset') {
                             parent = selected[0];
                         } else if (inst.get_node(selected[0].parent).type === 'tagset') {


### PR DESCRIPTION
# What this PR does

Fixes bug when root is trying to create a new Dataset under a Project in a ReadOnly group.
See https://trello.com/c/cejkZq7B/16-bug-create-controls-not-displayed-in-read-only

# Testing this PR

1. Log in as root. View another user's Project in a Readonly group (filter data by user not by All Members)
2. Using right-click menu on Project, should be able to create a Dataset.
3. NB: The Project-Dataset Link will be owned by 'root' so the owner of the Project won't be able to delete it (remove Dataset from Project) unless they move the Project to a read-edit group.

cc @pwalczysko 