### PR TITLE
have graph traversal automatically review "linking" model objects

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -682,15 +682,15 @@
         <!-- Move a reagent only if also moving screens and wells that use it. -->
 
         <bean parent="graphPolicyRule" p:matches="Screen[I].reagents = R:[E]{i}" p:changes="R:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!D].parent = [I], L.child = R:[E]{i}" p:changes="R:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[EI].parent = [I], L.child = R:[E]{i}" p:changes="R:{r}"/>
         <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].child = R:[E]{i}" p:changes="R:{r}"/>
         <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [E]{ia}, L.child = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}" p:changes="R:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>
         <bean parent="graphPolicyRule" p:matches="S:Screen[E].reagents = R:[I]" p:error="may not move {R} without {S}"/>
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!D].parent = [I], L.child = [E]{a}" p:changes="L:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!D].parent = W:[E], L.child = R:[I]"
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [I], L.child = [E]{a}" p:changes="L:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[EI].parent = W:[E], L.child = R:[I]"
                                        p:error="may not move {R} without {W}"/>
 
         <!-- Cannot move screen to a private group if it uses a differently owned reagent. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -187,19 +187,6 @@
         <bean parent="graphPolicyRule" p:matches="LP:LightPath[E]{o}" p:changes="LP:[I]"/>
         <bean parent="graphPolicyRule" p:matches="LP:LightPath[E]{a}" p:error="may not move some but not all of {LP}'s filters"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
-
-        <!-- Ensure that rules with multiple matches may apply for settings. -->
-
-        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[!O]" p:changes="S:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="S:LightSettings[!O]" p:changes="S:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[!O]" p:changes="S:[-]"/>
-
         <!-- ANNOTATIONS -->
 
         <!--
@@ -289,10 +276,6 @@
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].child = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [ED], L.child = [I]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [DI], L.child = [E]{!r}" p:changes="L:[D]/n"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
 
         <!-- CONTAINERS -->
 
@@ -393,13 +376,6 @@
         <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [I], L.child = [E]{ia}" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [E], L.child = [I]" p:changes="L:[D]/n"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[!O]" p:changes="L:[-]"/>
-
         <!-- CORE -->
 
         <!-- Move pixels link to archived files if both pixels and files are to be moved. -->
@@ -495,10 +471,6 @@
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{o}/o" p:changes="I:[I]"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, I:Image[E]{o}/d" p:changes="I:[I]/n"/>
         <bean parent="graphPolicyRule" p:matches="!$to_private, I:Image[E]{o}/m" p:changes="I:[I]/n"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
 
         <!-- DISPLAY -->
 
@@ -596,10 +568,6 @@
         <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = J:[I], L.child = OF:[E]{a}"
                                        p:error="may not move {J} while {OF} remains"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[!O]" p:changes="L:[-]"/>
-
         <!-- META -->
 
         <!-- If an object is deleted or moved then also delete or move its external info regardless of permissions. -->
@@ -645,7 +613,6 @@
 
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Shape[I].transform = T:[E]" p:changes="T:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E], P.image = I:[E]{i}" p:changes="I:{r}"/>
 
         <!-- Delete the shapes of deleted ROIs. -->
@@ -738,12 +705,6 @@
         <bean parent="graphPolicyRule" p:matches="WS:WellSample.well = [I], WS.image = I:[E]{i}" p:changes = "I:{r}"/>
         <bean parent="graphPolicyRule" p:matches="WS:WellSample[E].well = [I], WS.image = I:[E]{o}" p:changes = "WS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="WS:WellSample[E].well = [I], WS.image = I:[I]" p:changes = "WS:[I]"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="WS:WellSample[!O]" p:changes="WS:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[!O]" p:changes="L:[-]"/>
 
         <!-- STATS -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -87,7 +87,7 @@
         <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTFn:[E]" p:changes="OTFn:[I]"/>
 
         <!-- Continue instrument move deeper into subgraph. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chgrp-rules.xml
@@ -682,9 +682,9 @@
         <!-- Move a reagent only if also moving screens and wells that use it. -->
 
         <bean parent="graphPolicyRule" p:matches="Screen[I].reagents = R:[E]{i}" p:changes="R:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!D].parent = [I], L.child = R:[E]{i}" p:changes="R:{r}"/>
         <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].child = R:[E]{i}" p:changes="R:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [E]{ia}, L.child = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}" p:changes="R:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -45,6 +45,12 @@
 
         <!-- ACQUISITION -->
 
+        <!-- Consider all settings in the group. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[E].details.group = [I]" p:changes="S:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="S:LightSettings[E].details.group = [I]" p:changes="S:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[E].details.group = [I]" p:changes="S:[-]"/>
+
         <!-- Delete cross-owner links regardless of permissions. -->
 
         <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = FS:[E], L.child = EF:[E], FS =/!o EF"
@@ -122,6 +128,16 @@
 
         <!-- CORE -->
 
+        <!-- Consider every link in the group. -->
+
+        <bean parent="graphPolicyRule" p:matches="L:ILink[E].details.group = [I]" p:changes="L:[-]"/>
+
+        <!-- Consider every image, pixels and channel in the group. -->
+
+        <bean parent="graphPolicyRule" p:matches="I:Image[E].details.group = [I]" p:changes="I:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="P:Pixels[E].details.group = [I]" p:changes="P:[-]"/>
+        <bean parent="graphPolicyRule" p:matches="C:Channel[E].details.group = [I]" p:changes="C:[-]"/>
+
         <!-- Do not delete an original file that is being used by an object. -->
 
         <bean parent="graphPolicyRule" p:matches="FileAnnotation.file = OF:[E]{r}" p:changes="OF:{a}"/>
@@ -178,10 +194,6 @@
 
         <bean parent="graphPolicyRule" p:matches="[D].details.externalInfo = EI:[E]" p:changes="EI:[D]/n"/>
 
-        <!-- Consider every model object in the group. -->
-
-        <bean parent="graphPolicyRule" p:matches="X:[E].details.group = [I]" p:changes="X:[-]"/>
-
         <!-- ROI -->
 
         <!-- Regardless of permissions delete others' ROIs. -->
@@ -203,6 +215,10 @@
         <bean parent="graphPolicyRule" p:matches="T:AffineTransform[E]{o}" p:changes="T:[D]"/>
 
         <!-- SCREEN -->
+
+        <!-- Consider every screen in the group. -->
+
+        <bean parent="graphPolicyRule" p:matches="S:Screen[E].details.group = [I]" p:changes="S:[-]"/>
 
         <!-- Cannot downgrade to a private group if the image has a differently owned field. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -107,10 +107,6 @@
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].child = [D]" p:changes="L:[D]/n"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
-
         <!-- CONTAINERS -->
 
         <!-- Delete cross-owner links regardless of permissions. -->
@@ -148,10 +144,6 @@
         <bean parent="graphPolicyRule" p:matches="LC:LogicalChannel[E].channels =/!o C:[E]"
                                        p:error="cannot downgrade to private as {LC} is for differently owned {C}"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
-
         <!-- DISPLAY -->
 
         <!-- Regardless of permissions delete others' rendering settings and thumbnails. -->
@@ -179,10 +171,6 @@
 
         <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = J:[E], L.child = OF:[E];group=!user, J =/!o OF"
                                        p:error="cannot downgrade to private as {J} has differently owned {OF}"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[!O]" p:changes="L:[-]"/>
 
         <!-- META -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chmod-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -115,13 +115,13 @@
 
         <!-- Delete cross-owner links regardless of permissions. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink.parent = P:[E], L.child = D:[E], P =/!o D"
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = P:[E], L.child = D:[E], P =/!o D"
                                        p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink.parent = D:[E], L.child = I:[E], D =/!o I"
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = D:[E], L.child = I:[E], D =/!o I"
                                        p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink.parent = F:[E], L.child = I:[E], F =/!o I"
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].parent = F:[E], L.child = I:[E], F =/!o I"
                                        p:changes="L:[D]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink.parent = F:[E], L.child = ROI:[E], F =/!o ROI"
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = F:[E], L.child = ROI:[E], F =/!o ROI"
                                        p:changes="L:[D]/n"/>
 
         <!-- CORE -->
@@ -131,8 +131,8 @@
         <bean parent="graphPolicyRule" p:matches="FileAnnotation.file = OF:[E]{r}" p:changes="OF:{a}"/>
         <bean parent="graphPolicyRule" p:matches="FilesetEntry.originalFile = OF:[E]{r}" p:changes="OF:{a}"/>
         <bean parent="graphPolicyRule" p:matches="Roi[E].source = OF:[E]{r}" p:changes="OF:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = [E], L.child = OF:[E]{r}" p:changes="OF:{a}"/>
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap.child = [E], L.parent = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = [E], L.child = OF:[E]{r}" p:changes="OF:{a}"/>
+        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[E].child = [E], L.parent = OF:[E]{r}" p:changes="OF:{a}"/>
 
         <!-- If an original file is orphaned then delete it. -->
 
@@ -177,7 +177,7 @@
 
         <!-- Cannot downgrade to a private group if jobs have differently owned original files. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink.parent = J:[E], L.child = OF:[E];group=!user, J =/!o OF"
+        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = J:[E], L.child = OF:[E];group=!user, J =/!o OF"
                                        p:error="cannot downgrade to private as {J} has differently owned {OF}"/>
 
         <!-- Ensure that rules with multiple matches may apply for links. -->
@@ -223,7 +223,7 @@
 
         <!-- Cannot downgrade to a private group if wells have differently owned reagents. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink.parent = W:[E], L.child = R:[E], W =/!o R"
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = W:[E], L.child = R:[E], W =/!o R"
                                        p:error="cannot downgrade to private as {W} has differently owned {R}"/>
 
         <!-- Cannot downgrade to a private group if screen has differently owned reagents. -->
@@ -233,7 +233,8 @@
 
         <!-- Delete cross-owner links regardless of permissions. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink.parent = S:[E], L.child = P:[E], S =/!o P" p:changes="L:[D]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = S:[E], L.child = P:[E], S =/!o P"
+                                       p:changes="L:[D]/n"/>
 
         <!-- STATS -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -659,9 +659,9 @@
         <!-- Give a reagent only if also giving screens and wells that use it. -->
 
         <bean parent="graphPolicyRule" p:matches="Screen[I].reagents = R:[E]{i}" p:changes="R:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink.parent = [I], L.child = R:[E]{i}" p:changes="R:{r}"/>
         <bean parent="graphPolicyRule" p:matches="WellReagentLink[I].child = R:[E]{i}" p:changes="R:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [E]{ia}, L.child = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}" p:changes="R:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -666,7 +666,7 @@
         <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}" p:changes="R:[I]"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].child = [I]" p:changes="L:[I]"/>
         <bean parent="graphPolicyRule" p:matches="S:Screen[E].reagents = R:[I]" p:error="may not give {R} without {S}"/>
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!D].parent = W:[E];perms=??-???, L.child = R:[I]"
+        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[EI].parent = W:[E];perms=??-???, L.child = R:[I]"
                                        p:error="may not give {R} without {W}"/>
 
         <!-- Cannot give screen in a private group if it uses a differently owned reagent. -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -207,19 +207,6 @@
         <bean parent="graphPolicyRule" p:matches="LP:LightPath[E]{o}" p:changes="LP:[I]"/>
         <bean parent="graphPolicyRule" p:matches="LP:LightPath[E]{a}" p:error="may not give some but not all of {LP}'s filters"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
-
-        <!-- Ensure that rules with multiple matches may apply for settings. -->
-
-        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[!O]" p:changes="S:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="S:LightSettings[!O]" p:changes="S:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[!O]" p:changes="S:[-]"/>
-
         <!-- ANNOTATIONS -->
 
         <!--
@@ -305,10 +292,6 @@
                                        p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [I];perms=??-???, L.child = [E]{!r}"
                                        p:changes="L:[D]/n"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
 
         <!-- CONTAINERS -->
 
@@ -410,13 +393,6 @@
         <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [E];perms=???a??, L.child = [I]"
                                        p:changes="L:[D]/n"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[!O]" p:changes="L:[-]"/>
-
         <!-- CORE -->
 
         <!-- Give pixels link to archived files if both pixels and files are to be given. -->
@@ -506,10 +482,6 @@
 
         <bean parent="graphPolicyRule" p:matches="I:Image[E]{o}/o" p:changes="I:[I]"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:PixelsOriginalFileMap[!O]" p:changes="L:[-]"/>
-
         <!-- DISPLAY -->
 
         <!-- Give rendering settings only in a private group. -->
@@ -595,10 +567,6 @@
         <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = J:[I], L.child = OF:[E]"
                                        p:error="may not give {J} while {OF} remains"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[!O]" p:changes="L:[-]"/>
-
         <!-- META -->
 
         <!-- If an object is deleted or given then also delete or give its external info regardless of permissions. -->
@@ -614,7 +582,6 @@
         <bean parent="graphPolicyRule" p:matches="Image[I].rois =/o ROI:[E];perms=???r??" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Shape[I].transform = T:[E]" p:changes="T:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels =/o P:[E], P.image = I:[E]" p:changes="I:[I]"/>
 
         <!-- Cannot split affine transforms. -->
@@ -710,11 +677,6 @@
         <bean parent="graphPolicyRule" p:matches="Plate[I].plateAcquisitions = R:[E]" p:changes="R:[I]"/>
         <bean parent="graphPolicyRule" p:matches="PlateAcquisition[I].wellSample = WS:[E]" p:changes="WS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Well[I].wellSamples = WS:[E]" p:changes="WS:[I]"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[!O]" p:changes="L:[-]"/>
 
         <!-- STATS -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -96,7 +96,7 @@
         <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTFn:[E]" p:changes="OTFn:[I]"/>
 
         <!-- Continue instrument give deeper into subgraph. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -145,11 +145,6 @@
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
                                        p:changes="L:[I]"/>
 
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
-
         <!-- ANNOTATIONS -->
 
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [I]" p:changes="L:[I]"/>
@@ -222,7 +217,6 @@
         <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Shape[I].transform = T:[E]" p:changes="T:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI], P.image = I:[E]" p:changes="I:[I]"/>
 
         <!-- SCREEN -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-contained-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -119,7 +119,7 @@
         <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTFn:[E]" p:changes="OTFn:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Filter[I].transmittanceRange = TR:[E]" p:changes="TR:[I]"/>
         <bean parent="graphPolicyRule" p:matches="FilterSet[I].dichroic = D:[E]" p:changes="D:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Laser[I].pump = P:[E]" p:changes="P:[I]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
@@ -143,11 +143,6 @@
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
                                        p:changes="L:[I]"/>
 
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
-
         <!-- ANNOTATIONS -->
 
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[I].parent = X:[E]" p:changes="X:[I]"/>
@@ -220,7 +215,6 @@
         <bean parent="graphPolicyRule" p:matches="I:Image[E].rois = [I]" p:changes="I:[I]"/>
         <bean parent="graphPolicyRule" p:matches="ROI:Roi[E].shapes = [I]" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="S:Shape[E].transform = [I]" p:changes="S:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Image[I].pixels = P:[EI]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="M:Mask[E].pixels = P:[EI], P.image = [I]" p:changes="M:[I]"/>
 
         <!-- SCREEN -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-container-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -131,8 +131,8 @@
         <bean parent="graphPolicyRule" p:matches="Instrument[I].detector = D:[E]" p:changes="D:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="OTF[E].filterSet = [I]" p:changes="OTF:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="OTF[E].objective = [I]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTFn:OTF[E].filterSet = [I]" p:changes="OTFn:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="OTFn:OTF[E].objective = [I]" p:changes="OTFn:[I]"/>
 
         <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[E].parent = [I], L.child = [I]"
                                        p:changes="L:[I]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -261,10 +261,6 @@
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = X:[E]/!d, L.child = A:TagAnnotation[D]"
                                        p:error="may not delete {A} while {X} remains"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
-
         <!-- CONTAINERS -->
 
         <!-- If a container is deleted then consider its contents for deletion. -->
@@ -297,13 +293,6 @@
         <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[E].child = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].parent = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[E].child = [D]" p:changes="L:[D]/n"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[!O]" p:changes="L:[-]"/>
 
         <!-- CORE -->
 
@@ -426,10 +415,6 @@
         <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].parent = [D]" p:changes="L:[D]/n"/>
         <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[E].child = [D]" p:changes="L:[D]/n"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:JobOriginalFileLink[!O]" p:changes="L:[-]"/>
-
         <!-- META -->
 
         <!-- If an object is deleted then also delete its external info regardless of permissions. -->
@@ -453,7 +438,6 @@
         <!-- Delete contained objects: shapes of deleted ROIs, pixels of deleted masks if possible. -->
 
         <bean parent="graphPolicyRule" p:matches="Roi[D].shapes = S:[E]" p:changes="S:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[D].pixels = P:[E], P.image = I:[E]{i}/d" p:changes="I:{r}"/>
 
         <!-- Delete orphaned affine transforms. -->
@@ -507,11 +491,6 @@
         <bean parent="graphPolicyRule" p:matches="Plate[D].plateAcquisitions = R:[E]" p:changes="R:[D]"/>
         <bean parent="graphPolicyRule" p:matches="PlateAcquisition[D].wellSample = WS:[E]" p:changes="WS:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Well[D].wellSamples = WS:[E]" p:changes="WS:[D]"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[!O]" p:changes="L:[-]"/>
 
         <!-- STATS -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -127,7 +127,7 @@
         <bean parent="graphPolicyRule" p:matches="Instrument[D].lightSource = LS:[E]" p:changes="LS:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[D].microscope = M:[E]" p:changes="M:[D]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[D].objective = O:[E]" p:changes="O:[D]"/>
-        <bean parent="graphPolicyRule" p:matches="Instrument[D].otf = OTF:[E]" p:changes="OTF:[D]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[D].otf = OTFn:[E]" p:changes="OTFn:[D]"/>
 
         <!-- Continue instrument deletion deeper into subgraph. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -479,9 +479,9 @@
         <!-- Delete a reagent if it is no longer used by a screen or well. -->
 
         <bean parent="graphPolicyRule" p:matches="Screen[D].reagents = R:[E]{i}/d" p:changes="R:{r}"/>
-        <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink.parent = [D], L.child = R:[E]{i}/d" p:changes="R:{r}"/>
         <bean parent="graphPolicyRule" p:matches="WellReagentLink[D].child = R:[E]{i}/d" p:changes="R:{r}"/>
+        <bean parent="graphPolicyRule" p:matches="Screen[E]{ia}.reagents = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="L:WellReagentLink[E].parent = [E]{ia}, L.child = R:[E]{r}" p:changes="R:{a}"/>
         <bean parent="graphPolicyRule" p:matches="R:Reagent[E]{o}/d" p:changes="R:[D]"/>
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
@@ -145,11 +145,6 @@
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
                                        p:changes="L:[I]"/>
 
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
-
         <!-- ANNOTATIONS -->
 
         <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[E].parent = [I]" p:changes="L:[I]"/>
@@ -293,7 +288,6 @@
         <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Shape[I].transform = T:[E]" p:changes="T:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI], P.image = I:[E]" p:changes="I:[I]"/>
 
         <!-- SCREEN -->

--- a/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-disk-usage-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -119,7 +119,7 @@
         <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTFn:[E]" p:changes="OTFn:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Filter[I].transmittanceRange = TR:[E]" p:changes="TR:[I]"/>
         <bean parent="graphPolicyRule" p:matches="FilterSet[I].dichroic = D:[E]" p:changes="D:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Laser[I].pump = P:[E]" p:changes="P:[I]"/>

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -2,7 +2,7 @@
 
 <!--
 #
-# Copyright (C) 2015-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -118,7 +118,7 @@
         <bean parent="graphPolicyRule" p:matches="Instrument[I].lightSource = LS:[E]" p:changes="LS:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].microscope = M:[E]" p:changes="M:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Instrument[I].objective = O:[E]" p:changes="O:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTF:[E]" p:changes="OTF:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="Instrument[I].otf = OTFn:[E]" p:changes="OTFn:[I]"/>
 
         <!-- Continue instrument duplication deeper into subgraph. -->
 

--- a/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-duplicate-rules.xml
@@ -157,19 +157,6 @@
         <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[E].parent = [I], L.child = [I]"
                                        p:changes="L:[I]"/>
 
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:FilterSetExcitationFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathEmissionFilterLink[!O]" p:changes="L:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="L:LightPathExcitationFilterLink[!O]" p:changes="L:[-]"/>
-
-        <!-- Ensure that rules with multiple matches may apply for settings. -->
-
-        <bean parent="graphPolicyRule" p:matches="S:DetectorSettings[!O]" p:changes="S:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="S:LightSettings[!O]" p:changes="S:[-]"/>
-        <bean parent="graphPolicyRule" p:matches="S:ObjectiveSettings[!O]" p:changes="S:[-]"/>
-
         <!-- ANNOTATIONS -->
 
         <!-- We can't yet duplicate file annotations. -->
@@ -188,10 +175,6 @@
         <!-- If an original file is duplicated then also duplicate the corresponding file annotation -->
 
         <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E].file = [I]" p:changes="A:[I]"/>
-
-        <!-- Ensure that rules with multiple matches may apply for links. -->
-
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[!O]" p:changes="L:[-]"/>
 
         <!-- Respect linking rules outside read-annotate groups. -->
 
@@ -371,7 +354,6 @@
         <bean parent="graphPolicyRule" p:matches="Image[I].rois = ROI:[E]" p:changes="ROI:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Roi[I].shapes = S:[E]" p:changes="S:[I]"/>
         <bean parent="graphPolicyRule" p:matches="Shape[I].transform = T:[E]" p:changes="T:[I]"/>
-        <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI]" p:changes="P:[-]"/>
         <bean parent="graphPolicyRule" p:matches="Mask[I].pixels = P:[EI], P.image = I:[E]" p:changes="I:[I]"/>
 
         <!-- SCREEN -->

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -1207,20 +1207,20 @@ public class GraphPolicyRule {
                     }
                     boolean retry = false;
                     if (isCommonConsistentWithUnmatched) {
-                    for (final String namedCommonTerm : namedCommonTerms) {
-                        /* each common term match may be worth reviewing as root object */
-                        final Details commonTermDetails = namedTerms.get(namedCommonTerm);
-                        if (!commonTermDetails.equals(rootObject)) {
-                            if (LOGGER.isDebugEnabled()) {
-                                LOGGER.debug("matched " + Joiner.on(',').join(namedTerms.keySet()) +
-                                        " so will review " + commonTermDetails + " for rule " + policyRule.asString);
+                        for (final String namedCommonTerm : namedCommonTerms) {
+                            /* each common term match may be worth reviewing as root object */
+                            final Details commonTermDetails = namedTerms.get(namedCommonTerm);
+                            if (!commonTermDetails.equals(rootObject)) {
+                                if (LOGGER.isDebugEnabled()) {
+                                    LOGGER.debug("matched " + Joiner.on(',').join(namedTerms.keySet()) +
+                                            " so will review " + commonTermDetails + " for rule " + policyRule.asString);
+                                }
+                                /* review object that is common across matchers */
+                                changedObjects.add(commonTermDetails);
+                                prohibitedTerms.put(namedCommonTerm, commonTermDetails);
+                                retry = true;
                             }
-                            /* review object that is common across matchers */
-                            changedObjects.add(commonTermDetails);
-                            prohibitedTerms.put(namedCommonTerm, commonTermDetails);
-                            retry = true;
                         }
-                    }
                     }
                     if (retry) {
                         /* check if a different object can match the common term */

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -1179,8 +1179,9 @@ public class GraphPolicyRule {
                     final Set<String> namedCommonTerms = Sets.intersection(namedTerms.keySet(), policyRule.commonTerms);
                     boolean isCommonConsistentWithUnmatched = true;
                     for (final TermMatch matcher : unmatchedTerms) {
-                        if (namedCommonTerms.contains(matcher.getName())) {
-                            final Details object = namedTerms.get(matcher.getName());
+                        final String termName = matcher.getName();
+                        if (termName != null && namedCommonTerms.contains(termName)) {
+                            final Details object = namedTerms.get(termName);
                             if (!matcher.isMatch(predicates, namedTerms, isCheckAllPermissions, object, true)) {
                                 isCommonConsistentWithUnmatched = false;
                                 break;
@@ -1189,15 +1190,17 @@ public class GraphPolicyRule {
                     }
                     if (isCommonConsistentWithUnmatched) {
                         for (final RelationshipMatch matcher : unmatchedRelationships) {
-                            if (namedCommonTerms.contains(matcher.leftTerm.getName())) {
-                                final Details object = namedTerms.get(matcher.leftTerm.getName());
+                            final String leftTermName = matcher.leftTerm.getName();
+                            if (leftTermName != null && namedCommonTerms.contains(leftTermName)) {
+                                final Details object = namedTerms.get(leftTermName);
                                 if (!matcher.leftTerm.isMatch(predicates, namedTerms, isCheckAllPermissions, object, true)) {
                                     isCommonConsistentWithUnmatched = false;
                                     break;
                                 }
                             }
-                            if (namedCommonTerms.contains(matcher.rightTerm.getName())) {
-                                final Details object = namedTerms.get(matcher.rightTerm.getName());
+                            final String rightTermName = matcher.rightTerm.getName();
+                            if (rightTermName != null && namedCommonTerms.contains(rightTermName)) {
+                                final Details object = namedTerms.get(rightTermName);
                                 if (!matcher.rightTerm.isMatch(predicates, namedTerms, isCheckAllPermissions, object, true)) {
                                     isCommonConsistentWithUnmatched = false;
                                     break;

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -478,7 +478,10 @@ public class GraphPolicyRule {
         final Matcher existingTermMatcher = EXISTING_TERM_PATTERN.matcher(term);
 
         if (existingTermMatcher.matches()) {
-            return new ExistingTermMatch(existingTermMatcher.group(1));
+            final String termName = existingTermMatcher.group(1);
+            if (graphPathBean.getClassForSimpleName(termName) == null) {
+                return new ExistingTermMatch(termName);
+            }
         }
 
         final Matcher newTermMatcher = NEW_TERM_PATTERN.matcher(term);
@@ -505,6 +508,9 @@ public class GraphPolicyRule {
             termName = null;
         } else {
             termName = termNameGroup.substring(0, termNameGroup.length() - 1);
+            if (graphPathBean.getClassForSimpleName(termName) != null) {
+                throw new GraphException("redefined known class " + termName + " in " + term);
+            }
         }
 
         /* parse class name, if any */

--- a/components/server/src/ome/services/graphs/GraphPolicyRule.java
+++ b/components/server/src/ome/services/graphs/GraphPolicyRule.java
@@ -1085,7 +1085,7 @@ public class GraphPolicyRule {
                         if (matcher.getName() != null && prohibitedTerms.get(matcher.getName()).contains(object)) {
                             continue;
                         }
-                        if (matcher.isMatch(predicates, namedTerms, isCheckAllPermissions, object, isPossibleMatch)) {
+                        if (matcher.isMatch(predicates, namedTerms, isCheckAllPermissions, object, true)) {
                             unmatchedTermIterator.remove();
                         }
                     }
@@ -1101,7 +1101,7 @@ public class GraphPolicyRule {
                             if (matcher.getName() != null && prohibitedTerms.get(matcher.getName()).contains(linkerObject)) {
                                 continue;
                             }
-                            if (matcher.isMatch(predicates, namedTerms, isCheckAllPermissions, linkerObject, isPossibleMatch)) {
+                            if (matcher.isMatch(predicates, namedTerms, isCheckAllPermissions, linkerObject, true)) {
                                 unmatchedTermIterator.remove();
                             }
                         }
@@ -1130,7 +1130,7 @@ public class GraphPolicyRule {
                             if (matcher.getName() != null && prohibitedTerms.get(matcher.getName()).contains(linkedObject)) {
                                 continue;
                             }
-                            if (matcher.isMatch(predicates, namedTerms, isCheckAllPermissions, linkedObject, isPossibleMatch)) {
+                            if (matcher.isMatch(predicates, namedTerms, isCheckAllPermissions, linkedObject, true)) {
                                 unmatchedTermIterator.remove();
                             }
                         }

--- a/components/server/src/ome/services/graphs/GraphTraversal.java
+++ b/components/server/src/ome/services/graphs/GraphTraversal.java
@@ -1181,8 +1181,7 @@ public class GraphTraversal {
                 planning.findIfLast.remove(instance);
                 planning.foundIfLast.put(instance, change.orphan == Orphan.IS_LAST);
                 planning.toProcess.add(instance);
-            } else if (change.action == Action.EXCLUDE && change.orphan == Orphan.RELEVANT &&
-                    planning.findIfLast.add(instance) && !planning.cached.contains(instance)) {
+            } else if (change.action == Action.EXCLUDE && change.orphan == Orphan.RELEVANT && planning.findIfLast.add(instance)) {
                 /* orphan status is relevant; if just now noted as such then ensure the object is or will be cached */
                 planning.toProcess.add(instance);
             } else if (!(change.action == Action.OUTSIDE || instance.equals(object))) {

--- a/components/server/src/ome/services/graphs/GroupPredicate.java
+++ b/components/server/src/ome/services/graphs/GroupPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -67,7 +67,7 @@ public class GroupPredicate implements GraphPolicyRulePredicate {
     @Override
     public boolean isMatch(Details object, String parameter) throws GraphException {
         if (object.groupId == null) {
-            throw new GraphException("no group for " + object);
+            return false;
         }
         final boolean isInvert;
         if (parameter.startsWith("!")) {

--- a/components/server/src/ome/services/graphs/PermissionsPredicate.java
+++ b/components/server/src/ome/services/graphs/PermissionsPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2015-2017 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -69,7 +69,7 @@ public class PermissionsPredicate implements GraphPolicyRulePredicate {
     @Override
     public boolean isMatch(Details object, String parameter) throws GraphException {
         if (object.groupId == null) {
-            throw new GraphException("no group for " + object);
+            return false;
         }
         final String permissions = groupPermissions.get(object.groupId);
         if (permissions == null) {


### PR DESCRIPTION
# What this PR does

Simplifies the graph policy rules specified in `components/blitz/resources/ome/services/graph-rules/` so that the null state changes to `[-]` are largely no longer needed. Some remain for `Chmod2`: though no longer even necessary there, they linger to keep that ruleset clearer, and are made more specific so that every object in the group need not be visited.

Corresponding graph policy code changes automatically guess where `[-]` rules should be and act accordingly.

Also adjusts a few rules to better fit the pattern by which others are expressed and addresses a minor ambiguity in the rule language that affected `OTF` which was used as both term name and class name.

# Testing this PR

https://10.0.51.154:8443/job/OMERO-test-integration/ should suffice. Graph operations should continue to work as before.

# Related reading

https://trello.com/c/jL8kYW5V/47-automatically-recheck-multi-match-graph-rules