### PR TITLE
remove checks for Ice version < 3.6

### DIFF
--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -331,14 +331,10 @@ public class client {
 
         // Strictly necessary for this class to work
         optionallySetProperty(id, "Ice.ImplicitContext", "Shared");
-        if (Ice.Util.intVersion() >= 30600) {
-            optionallySetProperty(id, "Ice.ACM.Client.Timeout",
-                    ""+omero.constants.ACMCLIENTTIMEOUT.value);
-            optionallySetProperty(id, "Ice.ACM.Client.Heartbeat", ""+
-                    omero.constants.ACMCLIENTHEARTBEAT.value);
-        } else {
-            optionallySetProperty(id, "Ice.ACM.Client", "0");
-        }
+        optionallySetProperty(id, "Ice.ACM.Client.Timeout",
+                ""+omero.constants.ACMCLIENTTIMEOUT.value);
+        optionallySetProperty(id, "Ice.ACM.Client.Heartbeat",
+                ""+omero.constants.ACMCLIENTHEARTBEAT.value);
         optionallySetProperty(id, "Ice.CacheMessageBuffers", "0");
         optionallySetProperty(id, "Ice.RetryIntervals", "-1");
         optionallySetProperty(id, "Ice.Default.EndpointSelection", "Ordered");
@@ -350,11 +346,8 @@ public class client {
         optionallySetProperty(id, "omero.block_size", Integer
             .toString(omero.constants.DEFAULTBLOCKSIZE.value));
 
-        // Set the default encoding if this is Ice 3.5 or later
-        // and none is set.
-        if (Ice.Util.intVersion() >= 30500) {
-            optionallySetProperty(id, "Ice.Default.EncodingVersion", "1.0");
-        }
+        // Set the default encoding if none is set.
+        optionallySetProperty(id, "Ice.Default.EncodingVersion", "1.0");
 
         // Setting MessageSizeMax
         optionallySetProperty(id, "Ice.MessageSizeMax", Integer

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -187,24 +187,18 @@ class BaseClient(object):
 
         # Strictly necessary for this class to work
         self._optSetProp(id, "Ice.ImplicitContext", "Shared")
-        if Ice.intVersion() >= 30600:
-            self._optSetProp(id, "Ice.ACM.Client.Timeout",
-                             str(omero.constants.ACMCLIENTTIMEOUT))
-            self._optSetProp(id, "Ice.ACM.Client.Heartbeat",
-                             str(omero.constants.ACMCLIENTHEARTBEAT))
-        else:
-            self._optSetProp(id, "Ice.ACM.Client", "0")
+        self._optSetProp(id, "Ice.ACM.Client.Timeout",
+                         str(omero.constants.ACMCLIENTTIMEOUT))
+        self._optSetProp(id, "Ice.ACM.Client.Heartbeat",
+                         str(omero.constants.ACMCLIENTHEARTBEAT))
         self._optSetProp(id, "Ice.CacheMessageBuffers", "0")
         self._optSetProp(id, "Ice.RetryIntervals", "-1")
         self._optSetProp(id, "Ice.Default.EndpointSelection", "Ordered")
         self._optSetProp(id, "Ice.Default.PreferSecure", "1")
         self._optSetProp(id, "Ice.Plugin.IceSSL", "IceSSL:createIceSSL")
 
-        if Ice.intVersion() >= 30600:
-            if sys.platform == "darwin":
-                self._optSetProp(id, "IceSSL.Ciphers", "NONE (DH_anon.*AES)")
-            else:
-                self._optSetProp(id, "IceSSL.Ciphers", "ADH")
+        if sys.platform == "darwin":
+            self._optSetProp(id, "IceSSL.Ciphers", "NONE (DH_anon.*AES)")
         else:
             self._optSetProp(id, "IceSSL.Ciphers", "ADH")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
@@ -214,11 +208,9 @@ class BaseClient(object):
         self._optSetProp(
             id, "omero.block_size", str(omero.constants.DEFAULTBLOCKSIZE))
 
-        # Set the default encoding if this is Ice 3.5 or later
-        # and none is set.
-        if Ice.intVersion() >= 30500:
-            self._optSetProp(
-                id, "Ice.Default.EncodingVersion", "1.0")
+        # Set the default encoding if none is set.
+        self._optSetProp(
+            id, "Ice.Default.EncodingVersion", "1.0")
 
         # Setting MessageSizeMax
         self._optSetProp(

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -19,7 +19,6 @@ import sys
 import stat
 import platform
 import datetime
-import Ice
 
 from glob import glob
 from path import path
@@ -1011,12 +1010,8 @@ present, the user will enter a console""")
             self.ctx.rv = 0
 
         # JVM configuration regeneration
-        # Check ice version
-        if Ice.intVersion() >= 30600:
-            if sys.platform == "darwin":
-                templates = self._get_templates_dir()/"grid"/"osxtemplates.xml"
-            else:
-                templates = self._get_templates_dir()/"grid"/"templates.xml"
+        if sys.platform == "darwin":
+            templates = self._get_templates_dir()/"grid"/"osxtemplates.xml"
         else:
             templates = self._get_templates_dir()/"grid"/"templates.xml"
         generated = self._get_grid_dir() / "templates.xml"


### PR DESCRIPTION
# What this PR does

Removes code paths that apply only to Ice < 3.6.

# Testing this PR

CI should remain green. Also check that can still use 5.4 devspace web client and Insight client to connect.

# Related reading

http://www.openmicroscopy.org/site/support/omero5/sysadmins/version-requirements.html#ice