### PR TITLE
Comments cleanup

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -396,8 +396,7 @@ public class AbstractServerTest extends AbstractTest {
             final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
                     " WHERE id = :id";
             final Parameters params = new ParametersI().addId(object.getId());
-            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
-            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ALL_GROUPS_CONTEXT);
             final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -390,7 +390,7 @@ public class AbstractServerTest extends AbstractTest {
      * @param dataset an OMERO Dataset
      * @param image an OMERO Image
      * @return the created link
-     * @throws ServerError if the query caused a server error
+     * @throws ServerError an error possibly occurring during saving of the link
      */
     protected DatasetImageLink linkDatasetImage(Dataset dataset, Image image) throws ServerError {
         if (dataset.isLoaded() && dataset.getId() != null) {
@@ -411,7 +411,7 @@ public class AbstractServerTest extends AbstractTest {
      * @param project an OMERO Project
      * @param dataset an OMERO Dataset
      * @return the created link
-     * @throws ServerError if the query caused a server error
+     * @throws ServerError an error possibly occurring during saving of the link
      */
     protected ProjectDatasetLink linkProjectDataset(Project project, Dataset dataset) throws ServerError {
         if (project.isLoaded() && project.getId() != null) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -314,13 +314,13 @@ public class AbstractServerTest extends AbstractTest {
      * Used in {@link AbstractServerTest.verifyObjectProperty}.
      * @author pwalczysko@dundee.ac.uk
      */
-    private enum Properties {
+    private enum DetailsProperty {
         GROUP("group"),
         OWNER("owner");
 
         private final String name;
 
-        Properties(String name) {
+        DetailsProperty(String name) {
             this.name = name;
         }
 
@@ -420,7 +420,7 @@ public class AbstractServerTest extends AbstractTest {
      * @throws ServerError unexpected
      */
     protected void assertInGroup(Collection<? extends IObject> objects, long expectedGroupId) throws ServerError {
-        verifyObjectProperty(objects, expectedGroupId, Properties.GROUP);
+        verifyObjectProperty(objects, expectedGroupId, DetailsProperty.GROUP);
     }
 
     /**
@@ -431,7 +431,7 @@ public class AbstractServerTest extends AbstractTest {
      * @param property property to examine the testedObjects for (can be GROUP or OWNER)
      * @throws ServerError if query fails
      */
-    protected void verifyObjectProperty(Collection<? extends IObject> testedObjects, long id, Properties property) throws ServerError {
+    protected void verifyObjectProperty(Collection<? extends IObject> testedObjects, long id, DetailsProperty property) throws ServerError {
         if (testedObjects.isEmpty()) {
             throw new IllegalArgumentException("must assert about some objects");
         }
@@ -463,7 +463,7 @@ public class AbstractServerTest extends AbstractTest {
      * @throws ServerError unexpected
      */
     protected void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
-        verifyObjectProperty(objects, expectedOwner.userId, Properties.OWNER);
+        verifyObjectProperty(objects, expectedOwner.userId, DetailsProperty.OWNER);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -298,10 +298,10 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
-     * Cast the map of strings (e.g. the ALL_GROUPS_CONTEXT)
+     * Cast the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
      * into implicit context, which asks for <String, String>
      * @param implicitContext the implicit context to be changed
-     * @param newContext the map of strings (e.g. ALL_GROUPS_CONTEXT)
+     * @param newContext the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
      */
     protected void mergeIntoContext(ImplicitContext implicitContext, Map<String, String> newContext) {
         for (final Entry<String, String> entry : newContext.entrySet()) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -323,6 +323,11 @@ public class AbstractServerTest extends AbstractTest {
         Properties(String name) {
             this.name = name;
         }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -53,6 +53,7 @@ import omero.cmd.State;
 import omero.cmd.Status;
 import omero.grid.RepositoryMap;
 import omero.grid.RepositoryPrx;
+import omero.model.Annotation;
 import omero.model.BooleanAnnotation;
 import omero.model.BooleanAnnotationI;
 import omero.model.ChannelBinding;
@@ -287,6 +288,27 @@ public class AbstractServerTest extends AbstractTest {
                 c.__del__();
             }
         }
+    }
+
+    /**
+     * Add the given annotation to the given image.
+     * @param image an image
+     * @param annotation an annotation
+     * @return the new loaded link from the image to the annotation
+     * @throws ServerError unexpected
+     */
+    protected ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
+        if (image.isLoaded() && image.getId() != null) {
+            image = (Image) image.proxy();
+        }
+        if (annotation.isLoaded() && annotation.getId() != null) {
+            annotation = (Annotation) annotation.proxy();
+        }
+
+        final ImageAnnotationLink link = new ImageAnnotationLinkI();
+        link.setParent(image);
+        link.setChild(annotation);
+        return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -365,8 +365,7 @@ public class AbstractServerTest extends AbstractTest {
             final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
                     " WHERE id = :id";
             final Parameters params = new ParametersI().addId(object.getId());
-            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
-            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ALL_GROUPS_CONTEXT);
             final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -299,7 +299,7 @@ public class AbstractServerTest extends AbstractTest {
 
     /**
      * Cast the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
-     * into implicit context, which asks for <String, String>
+     * into implicit context, which asks for {@code <String, String>}.
      * @param implicitContext the implicit context to be changed
      * @param newContext the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
      */

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -438,7 +438,7 @@ public class AbstractServerTest extends AbstractTest {
             final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ALL_GROUPS_CONTEXT);
             final long actualId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualId, id, testedObjectName);
-         }
+        }
     }
     /**
      * Assert that the given object is owned by the given owner.

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Map.Entry;
 
 import ome.formats.OMEROMetadataStoreClient;
 import ome.formats.importer.IObservable;
@@ -29,6 +30,7 @@ import ome.formats.importer.OMEROWrapper;
 import ome.formats.importer.util.ErrorHandler;
 import ome.io.nio.SimpleBackOff;
 import ome.services.blitz.repo.path.FsFile;
+import ome.system.Login;
 import omero.ApiUsageException;
 import omero.RLong;
 import omero.RType;
@@ -137,6 +139,8 @@ import org.testng.annotations.DataProvider;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
+import Ice.ImplicitContext;
+
 /**
  * Base test for integration tests.
  *
@@ -155,6 +159,9 @@ public class AbstractServerTest extends AbstractTest {
 
     /** Scaling factor used for CmdCallbackI loop timings. */
     protected long scalingFactor;
+
+    /** All groups context to use in cases where errors due to group restriction are to be avoided. */
+    protected static final ImmutableMap<String, String> ALL_GROUPS_CONTEXT = ImmutableMap.of(Login.OMERO_GROUP, "-1");
 
     /** The client object, this is the entry point to the Server. */
     protected omero.client client;
@@ -287,6 +294,18 @@ public class AbstractServerTest extends AbstractTest {
             if (c != null) {
                 c.__del__();
             }
+        }
+    }
+
+    /**
+     * Cast the map of strings (e.g. the ALL_GROUPS_CONTEXT)
+     * into implicit context, which asks for <String, String>
+     * @param implicitContext the implicit context to be changed
+     * @param newContext the map of strings (e.g. ALL_GROUPS_CONTEXT)
+     */
+    protected void mergeIntoContext(ImplicitContext implicitContext, Map<String, String> newContext) {
+        for (final Entry<String, String> entry : newContext.entrySet()) {
+            implicitContext.put(entry.getKey(), entry.getValue());
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -351,7 +351,7 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
-     * Assert that the given objects are in the giver group.
+     * Assert that the given objects are in the given group.
      * @param objects some model objects
      * @param expectedGroupId a group Id
      * @throws ServerError unexpected

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -297,7 +297,7 @@ public class AbstractServerTest extends AbstractTest {
      * @return the new loaded link from the image to the annotation
      * @throws ServerError unexpected
      */
-    protected ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
+    protected ImageAnnotationLink linkImageAnnotation(Image image, Annotation annotation) throws ServerError {
         if (image.isLoaded() && image.getId() != null) {
             image = (Image) image.proxy();
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -61,6 +61,8 @@ import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
 import omero.model.DatasetAnnotationLink;
 import omero.model.DatasetAnnotationLinkI;
+import omero.model.DatasetImageLink;
+import omero.model.DatasetImageLinkI;
 import omero.model.Detector;
 import omero.model.DetectorAnnotationLink;
 import omero.model.DetectorAnnotationLinkI;
@@ -357,6 +359,27 @@ public class AbstractServerTest extends AbstractTest {
             final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
         }
+    }
+
+    /**
+     * Create a link between a Dataset and an Image.
+     * @param dataset an OMERO Dataset
+     * @param image an OMERO Image
+     * @return the created link
+     * @throws ServerError if the query caused a server error
+     */
+    protected DatasetImageLink linkDatasetImage(Dataset dataset, Image image) throws ServerError {
+        if (dataset.isLoaded() && dataset.getId() != null) {
+            dataset = (Dataset) dataset.proxy();
+        }
+        if (image.isLoaded() && image.getId() != null) {
+            image = (Image) image.proxy();
+        }
+
+        final DatasetImageLink link = new DatasetImageLinkI();
+        link.setParent(dataset);
+        link.setChild(image);
+        return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -314,7 +314,7 @@ public class AbstractServerTest extends AbstractTest {
     /**
      * Assert that the given object is in the given group.
      * @param object a model object
-     * @param expectedGroupId a group Id
+     * @param group an ExperimenterGroup
      * @throws ServerError unexpected
      */
     protected void assertInGroup(IObject object, ExperimenterGroup group) throws ServerError {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -106,6 +106,8 @@ import omero.model.PlateAnnotationLinkI;
 import omero.model.Project;
 import omero.model.ProjectAnnotationLink;
 import omero.model.ProjectAnnotationLinkI;
+import omero.model.ProjectDatasetLink;
+import omero.model.ProjectDatasetLinkI;
 import omero.model.QuantumDef;
 import omero.model.RenderingDef;
 import omero.model.Screen;
@@ -380,6 +382,27 @@ public class AbstractServerTest extends AbstractTest {
         link.setParent(dataset);
         link.setChild(image);
         return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
+    }
+
+    /**
+     * Create a link between a Project and a Dataset.
+     * @param project an OMERO Project
+     * @param dataset an OMERO Dataset
+     * @return the created link
+     * @throws ServerError if the query caused a server error
+     */
+    protected ProjectDatasetLink linkProjectDataset(Project project, Dataset dataset) throws ServerError {
+        if (project.isLoaded() && project.getId() != null) {
+            project = (Project) project.proxy();
+        }
+        if (dataset.isLoaded() && dataset.getId() != null) {
+            dataset = (Dataset) dataset.proxy();
+        }
+
+        final ProjectDatasetLink link = new ProjectDatasetLinkI();
+        link.setParent(project);
+        link.setChild(dataset);
+        return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -295,7 +295,7 @@ public class AbstractServerTest extends AbstractTest {
      * @param image an image
      * @param annotation an annotation
      * @return the new loaded link from the image to the annotation
-     * @throws ServerError unexpected
+     * @throws ServerError an error possibly occurring during saving of the link
      */
     protected ImageAnnotationLink linkImageAnnotation(Image image, Annotation annotation) throws ServerError {
         if (image.isLoaded() && image.getId() != null) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -337,7 +337,7 @@ public class AbstractServerTest extends AbstractTest {
      * @return the new loaded link from the image to the annotation
      * @throws ServerError an error possibly occurring during saving of the link
      */
-    protected ImageAnnotationLink linkImageAnnotation(Image image, Annotation annotation) throws ServerError {
+    protected ImageAnnotationLink linkParentToChild(Image image, Annotation annotation) throws ServerError {
         if (image.isLoaded()) {
             image = (Image) image.proxy();
         }
@@ -349,6 +349,48 @@ public class AbstractServerTest extends AbstractTest {
         link.setParent(image);
         link.setChild(annotation);
         return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
+    }
+
+    /**
+     * Create a link between a Project and a Dataset.
+     * @param project an OMERO Project
+     * @param dataset an OMERO Dataset
+     * @return the created link
+     * @throws ServerError an error possibly occurring during saving of the link
+     */
+    protected ProjectDatasetLink linkParentToChild(Project project, Dataset dataset) throws ServerError {
+        if (project.isLoaded() && project.getId() != null) {
+            project = (Project) project.proxy();
+        }
+        if (dataset.isLoaded() && dataset.getId() != null) {
+            dataset = (Dataset) dataset.proxy();
+        }
+
+        final ProjectDatasetLink link = new ProjectDatasetLinkI();
+        link.setParent(project);
+        link.setChild(dataset);
+        return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
+    }
+
+    /**
+     * Create a link between a Dataset and an Image.
+     * @param dataset an OMERO Dataset
+     * @param image an OMERO Image
+     * @return the created link
+     * @throws ServerError an error possibly occurring during saving of the link
+     */
+    protected DatasetImageLink linkParentToChild(Dataset dataset, Image image) throws ServerError {
+        if (dataset.isLoaded() && dataset.getId() != null) {
+            dataset = (Dataset) dataset.proxy();
+        }
+        if (image.isLoaded() && image.getId() != null) {
+            image = (Image) image.proxy();
+        }
+
+        final DatasetImageLink link = new DatasetImageLinkI();
+        link.setParent(dataset);
+        link.setChild(image);
+        return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**
@@ -421,48 +463,6 @@ public class AbstractServerTest extends AbstractTest {
      */
     protected void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
         verifyObjectProperty(objects, expectedOwner.userId, Properties.OWNER);
-    }
-
-    /**
-     * Create a link between a Dataset and an Image.
-     * @param dataset an OMERO Dataset
-     * @param image an OMERO Image
-     * @return the created link
-     * @throws ServerError an error possibly occurring during saving of the link
-     */
-    protected DatasetImageLink linkDatasetImage(Dataset dataset, Image image) throws ServerError {
-        if (dataset.isLoaded() && dataset.getId() != null) {
-            dataset = (Dataset) dataset.proxy();
-        }
-        if (image.isLoaded() && image.getId() != null) {
-            image = (Image) image.proxy();
-        }
-
-        final DatasetImageLink link = new DatasetImageLinkI();
-        link.setParent(dataset);
-        link.setChild(image);
-        return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
-    }
-
-    /**
-     * Create a link between a Project and a Dataset.
-     * @param project an OMERO Project
-     * @param dataset an OMERO Dataset
-     * @return the created link
-     * @throws ServerError an error possibly occurring during saving of the link
-     */
-    protected ProjectDatasetLink linkProjectDataset(Project project, Dataset dataset) throws ServerError {
-        if (project.isLoaded() && project.getId() != null) {
-            project = (Project) project.proxy();
-        }
-        if (dataset.isLoaded() && dataset.getId() != null) {
-            dataset = (Dataset) dataset.proxy();
-        }
-
-        final ProjectDatasetLink link = new ProjectDatasetLinkI();
-        link.setParent(project);
-        link.setChild(dataset);
-        return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -440,6 +440,7 @@ public class AbstractServerTest extends AbstractTest {
             Assert.assertEquals(actualId, id, testedObjectName);
         }
     }
+
     /**
      * Assert that the given object is owned by the given owner.
      * @param object a model object

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -286,6 +286,48 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
+     * Assert that the given object is in the given group.
+     * @param object a model object
+     * @param expectedGroupId a group Id
+     * @throws ServerError unexpected
+     */
+    protected void assertInGroup(IObject object, ExperimenterGroup group) throws ServerError {
+        assertInGroup(Collections.singleton(object), group.getId().getValue());
+    }
+
+    /**
+     * Assert that the given object is in the given group.
+     * @param object a model object
+     * @param expectedGroupId a group Id
+     * @throws ServerError unexpected
+     */
+    protected void assertInGroup(IObject object, long expectedGroupId) throws ServerError {
+        assertInGroup(Collections.singleton(object), expectedGroupId);
+    }
+
+    /**
+     * Assert that the given objects are in the giver group.
+     * @param objects some model objects
+     * @param expectedGroupId a group Id
+     * @throws ServerError unexpected
+     */
+    protected void assertInGroup(Collection<? extends IObject> objects, long expectedGroupId) throws ServerError {
+        if (objects.isEmpty()) {
+            throw new IllegalArgumentException("must assert about some objects");
+        }
+        for (final IObject object : objects) {
+            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
+            final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
+                    " WHERE id = :id";
+            final Parameters params = new ParametersI().addId(object.getId());
+            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
+            final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
+            Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
+        }
+    }
+
+    /**
      * Assert that the given object is owned by the given owner.
      * @param object a model object
      * @param expectedOwner a user's event context

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -285,6 +285,36 @@ public class AbstractServerTest extends AbstractTest {
     }
 
     /**
+     * Assert that the given object is owned by the given owner.
+     * @param object a model object
+     * @param expectedOwner a user's event context
+     * @throws ServerError unexpected
+     */
+    protected void assertOwnedBy(IObject object, EventContext expectedOwner) throws ServerError {
+        assertOwnedBy(Collections.singleton(object), expectedOwner);
+    }
+
+    /**
+     * Assert that the given objects are owned by the given owner.
+     * @param objects some model objects
+     * @param expectedOwner a user's event context
+     * @throws ServerError unexpected
+     */
+    protected void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
+        if (objects.isEmpty()) {
+            throw new IllegalArgumentException("must assert about some objects");
+        }
+        for (final IObject object : objects) {
+            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
+            final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
+                    " WHERE id = " + object.getId().getValue();
+            final List<List<RType>> results = iQuery.projection(query, null);
+            final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
+            Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
+        }
+    }
+
+    /**
      * Creates a new group and experimenter and returns the event context.
      *
      * @param perms

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -317,7 +317,7 @@ public class AbstractServerTest extends AbstractTest {
      * @throws ServerError an error possibly occurring during saving of the link
      */
     protected ImageAnnotationLink linkImageAnnotation(Image image, Annotation annotation) throws ServerError {
-        if (image.isLoaded() && image.getId() != null) {
+        if (image.isLoaded()) {
             image = (Image) image.proxy();
         }
         if (annotation.isLoaded() && annotation.getId() != null) {

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -129,6 +129,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 /**
@@ -307,8 +308,10 @@ public class AbstractServerTest extends AbstractTest {
         for (final IObject object : objects) {
             final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
             final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
+                    " WHERE id = :id";
+            final Parameters params = new ParametersI().addId(object.getId());
+            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
             final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -323,11 +323,6 @@ public class AbstractServerTest extends AbstractTest {
         Properties(String name) {
             this.name = name;
         }
-
-        @Override
-        public String toString() {
-            return this.name;
-        }
     }
 
     /**
@@ -437,7 +432,7 @@ public class AbstractServerTest extends AbstractTest {
         }
         for (final IObject testedObject : testedObjects) {
             final String testedObjectName = testedObject.getClass().getName() + '[' + testedObject.getId().getValue() + ']';
-            final String query = "SELECT details." + property.toString() + ".id FROM " + testedObject.getClass().getSuperclass().getSimpleName() +
+            final String query = "SELECT details." + property + ".id FROM " + testedObject.getClass().getSuperclass().getSimpleName() +
                     " WHERE id = :id";
             final Parameters params = new ParametersI().addId(testedObject.getId());
             final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ALL_GROUPS_CONTEXT);

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -94,7 +94,6 @@ import omero.model.enums.ChecksumAlgorithmSHA1160;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 import omero.sys.Principal;
-import omero.util.TempFileManager;
 
 import org.testng.Assert;
 import org.testng.SkipException;

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -111,14 +111,9 @@ import com.google.common.collect.ImmutableSet;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.4.0
  */
-public class LightAdminPrivilegesTest extends AbstractServerImportTest {
-
-    private static final TempFileManager TEMPORARY_FILE_MANAGER = new TempFileManager(
-            "test-" + LightAdminPrivilegesTest.class.getSimpleName());
+public class LightAdminPrivilegesTest extends RolesTests {
 
     private ImmutableSet<AdminPrivilege> allPrivileges = null;
-
-    private File fakeImageFile = null;
 
     /**
      * Populate the set of available light administrator privileges.
@@ -131,17 +126,6 @@ public class LightAdminPrivilegesTest extends AbstractServerImportTest {
             privileges.add((AdminPrivilege) privilege);
         }
         allPrivileges = privileges.build();
-    }
-
-    /**
-     * Create a fake image file for use in import tests.
-     * @throws IOException unexpected
-     */
-    @BeforeClass
-    public void createFakeImageFile() throws IOException {
-        final File temporaryDirectory = TEMPORARY_FILE_MANAGER.createPath("images", null, true);
-        fakeImageFile = new File(temporaryDirectory, "image.fake");
-        fakeImageFile.createNewFile();
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -155,22 +155,6 @@ public class LightAdminPrivilegesTest extends RolesTests {
     }
 
     /**
-     * Sudo to the given user.
-     * @param targetName the name of a user
-     * @return context for a session owned by the given user
-     * @throws Exception if the sudo could not be performed
-     */
-    private EventContext sudo(String targetName) throws Exception {
-        final Principal principal = new Principal();
-        principal.name = targetName;
-        final Session session = factory.getSessionService().createSessionWithTimeout(principal, 100 * 1000);
-        final omero.client client = newOmeroClient();
-        final String sessionUUID = session.getUuid().getValue();
-        client.createSession(sessionUUID, sessionUUID);
-        return init(client);
-    }
-
-    /**
      * Create a light administrator, possibly without a specific privilege, and log in as them, possibly sudo'ing afterward.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group
      * @param sudoTo the name of the user to whom the new user should then sudo or {@code null} for no sudo

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -231,32 +231,6 @@ public class LightAdminPrivilegesTest extends RolesTests {
         return latestProxy;
     }
 
-    /* these permissions do not permit anything */
-    @SuppressWarnings("serial")
-    private static final Permissions NO_PERMISSIONS = new PermissionsI("------") {
-        @Override
-        public boolean isDisallow(int restriction, Ice.Current c) {
-            return true;
-        }
-    };
-
-    /**
-     * Get the current permissions for the given object.
-     * @param object a model object previously retrieved from the server
-     * @return the permissions for the object in the current context
-     * @throws ServerError if the query caused a server error
-     */
-    private Permissions getCurrentPermissions(IObject object) throws ServerError {
-        final Map<String, String> allGroupsContext = ImmutableMap.of(Login.OMERO_GROUP, "-1");
-        final String objectClass = object.getClass().getSuperclass().getSimpleName();
-        final long objectId = object.getId().getValue();
-        try {
-            return iQuery.get(objectClass, objectId, allGroupsContext).getDetails().getPermissions();
-        } catch (SecurityViolation sv) {
-            return NO_PERMISSIONS;
-        }
-    }
-
     /* -=-=- TEST NECESSITY OF LIGHT ADMINISTRATOR PRIVILEGES -=-=- */
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -933,7 +933,7 @@ public class LightAdminRolesTest extends RolesTests {
         client.getImplicitContext().put("omero.group", Long.toString(lightAdmin.groupId));
         Dataset dat = mmFactory.simpleDataset();
         Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
-        /* Import an image into the created Dataset.*/
+        /* Import an Image into the created Dataset.*/
         List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
         OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
         Image image = (Image) originalFileAndImage.get(1);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1198,8 +1198,8 @@ public class LightAdminRolesTest extends RolesTests {
             Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertFalse(isExpectSuccessCreateROIRndSettings, sv.toString());
         }
-        /* Retrieve the image corresponding to the roi and Rnd settings
-         * (if they could be set) and check the roi and rendering settings
+        /* Retrieve the image corresponding to the ROI and Rnd settings
+         * (if they could be set) and check the ROI and rendering settings
          * belong to lightAdmin, whereas the image belongs to normalUser.*/
         RenderingDef rDef = (RenderingDef) iQuery.findByQuery("FROM RenderingDef WHERE pixels.id = :id",
                 new ParametersI().addId(pixelsOfImage.getId()));
@@ -1224,12 +1224,12 @@ public class LightAdminRolesTest extends RolesTests {
              * the boolean isExpectSuccessCreateAndChownRndSettings.*/
             Assert.assertEquals(getCurrentPermissions(roi).canChown(), isExpectSuccessCreateAndChown);
             Assert.assertEquals(getCurrentPermissions(rDef).canChown(), isExpectSuccessCreateAndChown);
-            /* Note that in read-only group, the chown of roi would fail, see
+            /* Note that in read-only group, the chown of ROI would fail, see
              * https://trello.com/c/7o4q2Tkt/745-fix-graphs-for-mixed-ownership-read-only.
              * The workaround used here is to chown both the image and the ROI.*/
             doChange(client, factory, Requests.chown().target(roi, sentImage).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChown);
             doChange(client, factory, Requests.chown().target(rDef).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChown);
-            /* Retrieve the image corresponding to the roi and Rnd settings.*/
+            /* Retrieve the image corresponding to the ROI and Rnd settings.*/
             long imageId = ((RLong) iQuery.projection(
                     "SELECT rdef.pixels.image.id FROM RenderingDef rdef WHERE rdef.id = :id",
                     new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -775,7 +775,7 @@ public class LightAdminRolesTest extends RolesTests {
          * createDatasetImportNotYourGroupAndChownExpectSuccess.*/
         Assert.assertEquals(getCurrentPermissions(sentDat).canChown(),
                 createDatasetImportNotYourGroupAndChownExpectSuccess);
-        /* lightAdmin tries to change the ownership of the Dataset to normalUser */
+        /* lightAdmin tries to change the ownership of the Dataset to normalUser.*/
         doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(),
                 createDatasetImportNotYourGroupAndChownExpectSuccess);
         final DatasetImageLink link = (DatasetImageLink) iQuery.findByQuery(

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -195,7 +195,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1JX6b9pkPtG-3hZIGSp2bu4WVvNKn6GHqIKdfbbJkiw8/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1JX6b9pkPtG-3hZIGSp2bu4WVvNKn6GHqIKdfbbJkiw8/edit">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testImporterAsSudoCreateImport(boolean isSudoing, boolean permWriteOwned,
@@ -290,7 +290,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit#slide=id.p7">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit">graphical explanation</a>
      */
    @Test(dataProvider = "isSudoing and Delete privileges cases")
    public void testDelete(boolean isSudoing, boolean permDeleteOwned,
@@ -378,7 +378,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/18u5hRD_oFKjGlGQ7x55oUowrmdjS4HXkXKfJSlpbiVY/edit#slide=id.p7">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/18u5hRD_oFKjGlGQ7x55oUowrmdjS4HXkXKfJSlpbiVY/edit">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testEdit(boolean isSudoing, boolean permWriteOwned,
@@ -449,7 +449,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1BUSzGp89en0Y7-5i7DkQbtVM-AgyfCJVa7rLhnMeO5A/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1BUSzGp89en0Y7-5i7DkQbtVM-AgyfCJVa7rLhnMeO5A/edit">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrp(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -529,7 +529,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1c3TGh4bD5_djKO_-lJs5LoBjL0koYsko7QkyEuu-nXY/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1c3TGh4bD5_djKO_-lJs5LoBjL0koYsko7QkyEuu-nXY/edit">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrpNonMember(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -616,7 +616,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1r4qlG9JKLfTgS8s5xWM8SDJJ25t4RwSWuiy6BfFfO_o/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1r4qlG9JKLfTgS8s5xWM8SDJJ25t4RwSWuiy6BfFfO_o/edit">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chown privileges cases")
     public void testChown(boolean isSudoing, boolean permChown, String groupPermissions)
@@ -708,7 +708,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1w_W6g69CV5Uy_rUom2K9O86w2Q2CGkl3rzNj-ZQzSt0/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1w_W6g69CV5Uy_rUom2K9O86w2Q2CGkl3rzNj-ZQzSt0/edit">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
     public void testImporterAsNoSudoChownOnlyWorkflow(boolean permWriteOwned, boolean permWriteFile,
@@ -816,7 +816,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testLinkNoSudo(boolean permWriteOwned, boolean permChown,
@@ -911,7 +911,7 @@ public class LightAdminRolesTest extends RolesTests {
          * @param permChown if to test a user who has the <tt>Chown</tt> privilege
          * @param groupPermissions if to test the effect of group permission level
          * @throws Exception unexpected
-         * @see <a href="https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit#slide=id.p4">graphical explanation</a>
+         * @see <a href="https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit">graphical explanation</a>
          */
         @Test(dataProvider = "Chgrp and Chown privileges cases")
         public void testImporterAsNoSudoChgrpChownWorkflow(boolean permChgrp, boolean permChown,
@@ -1034,7 +1034,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param isPrivileged if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1zbIu5gYPObbVkBSxdD4sMmPFMGgspbtYQEnJ9k8vfCs/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1zbIu5gYPObbVkBSxdD4sMmPFMGgspbtYQEnJ9k8vfCs/edit">graphical explanation</a>
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testChownAllBelongingToUser(boolean isPrivileged, String groupPermissions) throws Exception {
@@ -1137,7 +1137,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testROIAndRenderingSettingsNoSudo(boolean permWriteOwned, boolean permChown,
@@ -1261,7 +1261,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1jfdsPSvqJvBlN18vIFrRsNqh13eAlF5Gjh3G_MiGGAE/edit#slide=id.p4">graphical explanation</a>
+     * @see <a href="https://docs.google.com/presentation/d/1jfdsPSvqJvBlN18vIFrRsNqh13eAlF5Gjh3G_MiGGAE/edit">graphical explanation</a>
      */
     @Test(dataProvider = "fileAttachment privileges cases")
     public void testFileAttachmentNoSudo(boolean permChown, boolean permWriteOwned,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -193,7 +193,7 @@ public class LightAdminRolesTest extends RolesTests {
      * {@link #testImporterAsNoSudoChgrpChownWorkflow testImporterAsNoSudoChgrpChown} and {@link #testLinkNoSudo testLinkNoSudo}).
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1JX6b9pkPtG-3hZIGSp2bu4WVvNKn6GHqIKdfbbJkiw8/edit">graphical explanation</a>
      */
@@ -288,7 +288,7 @@ public class LightAdminRolesTest extends RolesTests {
      * for this action.
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit">graphical explanation</a>
      */
@@ -376,7 +376,7 @@ public class LightAdminRolesTest extends RolesTests {
      * or not using it, but having <tt>WriteOwned</tt> privilege instead.
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/18u5hRD_oFKjGlGQ7x55oUowrmdjS4HXkXKfJSlpbiVY/edit">graphical explanation</a>
      */
@@ -447,7 +447,7 @@ public class LightAdminRolesTest extends RolesTests {
      * to move annotations on the moved objects (tag and file attachment are tested here).
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1BUSzGp89en0Y7-5i7DkQbtVM-AgyfCJVa7rLhnMeO5A/edit">graphical explanation</a>
      */
@@ -527,7 +527,7 @@ public class LightAdminRolesTest extends RolesTests {
      * to move annotations (tag and file attachment are tested here).
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1c3TGh4bD5_djKO_-lJs5LoBjL0koYsko7QkyEuu-nXY/edit">graphical explanation</a>
      */
@@ -614,7 +614,7 @@ public class LightAdminRolesTest extends RolesTests {
      * general behavior of the <tt>Chown</tt> command.
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1r4qlG9JKLfTgS8s5xWM8SDJJ25t4RwSWuiy6BfFfO_o/edit">graphical explanation</a>
      */
@@ -706,7 +706,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
      * @param permWriteManagedRepo if to test a user who has the <tt>WriteManagedRepo</tt> privilege
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1w_W6g69CV5Uy_rUom2K9O86w2Q2CGkl3rzNj-ZQzSt0/edit">graphical explanation</a>
      */
@@ -814,7 +814,7 @@ public class LightAdminRolesTest extends RolesTests {
      * lightAdmin will succeed if they have WriteOwned privilege.
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit">graphical explanation</a>
      */
@@ -909,7 +909,7 @@ public class LightAdminRolesTest extends RolesTests {
          * privileges of lightAdmin are explored.
          * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
          * @param permChown if to test a user who has the <tt>Chown</tt> privilege
-         * @param groupPermissions if to test the effect of group permission level
+         * @param groupPermissions to test the effect of group permission level
          * @throws Exception unexpected
          * @see <a href="https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit">graphical explanation</a>
          */
@@ -1032,7 +1032,7 @@ public class LightAdminRolesTest extends RolesTests {
      * is member, the recipient of the data is member of just one of the groups. Chown privilege
      * is sufficient for lightAdmin to perform the workflow.
      * @param isPrivileged if to test a user who has the <tt>Chown</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1zbIu5gYPObbVkBSxdD4sMmPFMGgspbtYQEnJ9k8vfCs/edit">graphical explanation</a>
      */
@@ -1135,7 +1135,7 @@ public class LightAdminRolesTest extends RolesTests {
      * lightAdmin does not use Sudo in this test.
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit">graphical explanation</a>
      */
@@ -1259,7 +1259,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1jfdsPSvqJvBlN18vIFrRsNqh13eAlF5Gjh3G_MiGGAE/edit">graphical explanation</a>
      */
@@ -1363,7 +1363,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to upload an official script.
      * lightAdmin succeeds in this if they have <tt>WriteScriptRepo</tt> permission.
      * @param isPrivileged if to test a user who has the <tt>WriteScriptRepo</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1423,7 +1423,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to delete official script. 
      * lightAdmin will succeed if they have the <tt>DeleteScriptRepo</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>DeleteScriptRepo</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1503,7 +1503,7 @@ public class LightAdminRolesTest extends RolesTests {
      * To modify the group membership, lightAdmin attempts to add
      * an existing user to an existing group.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1533,7 +1533,7 @@ public class LightAdminRolesTest extends RolesTests {
      * To modify the group membership, lightAdmin attempts to remove
      * an existing user from an existing group.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1561,7 +1561,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to make a user an owner of a group.
      * lightAdmin will succeed if they have the <tt>ModifyGroupMembership</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1587,7 +1587,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to unset a user from being an owner of a group.
      * lightAdmin will succeed if they have the <tt>ModifyGroupMembership</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1622,7 +1622,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to create a new user.
      * lightAdmin will succeed if they have the <tt>ModifyUser</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1654,7 +1654,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to edit an existing user.
      * lightAdmin will succeed if they have the <tt>ModifyUser</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1681,7 +1681,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to create a new group.
      * lightAmin will succeed if they have the <tt>ModifyGroup</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
@@ -1710,7 +1710,7 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin (lightAdmin) tries to edit an existing group.
      * lightAdmin will succeed if they have the <tt>ModifyGroup</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
-     * @param groupPermissions if to test the effect of group permission level
+     * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1594,8 +1594,8 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can create a new user
-     * when the light admin has only the <tt>ModifyUser</tt> privilege.
+     * Light admin (lightAdmin) tries to create a new user.
+     * lightAdmin will succeed if they have the <tt>ModifyUser</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1603,8 +1603,7 @@ public class LightAdminRolesTest extends RolesTests {
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyUserCreate(boolean isPrivileged,
             String groupPermissions) throws Exception {
-        /* the permModifyUser should be a sufficient permission to perform
-         * the creation of a new user */
+        /* isPrivileged translates in this test into ModifyUser permission, see below.*/
         boolean isExpectSuccessCreateUser= isPrivileged;
         final long newGroupId = newUserAndGroup(groupPermissions).groupId;
         List<String> permissions = new ArrayList<String>();
@@ -1627,8 +1626,8 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can edit an existing user
-     * when the light admin has only the <tt>ModifyUser</tt> privilege.
+     * Light admin (ightAdmin) tries to edit an existing user.
+     * lightAdmin will succeed if they have the <tt>ModifyUser</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1636,8 +1635,7 @@ public class LightAdminRolesTest extends RolesTests {
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyUserEdit(boolean isPrivileged,
             String groupPermissions) throws Exception {
-        /* the permModifyUser should be a sufficient permission to perform
-         * the editing of a user */
+        /* isPrivileged translates in this test into ModifyUser permission, see below.*/
         boolean isExpectSuccessEditUser= isPrivileged;
         final long newUserId = newUserAndGroup(groupPermissions).userId;
         List<String> permissions = new ArrayList<String>();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -189,8 +189,8 @@ public class LightAdminRolesTest extends RolesTests {
      * lightAdmin tries to import data on behalf of normalUser into the just created Dataset.
      * lightAdmin, still sudoed as normalUser, tries then to link the Dataset to the Project.
      * Non-sudoing workflows for import and linking are too complicated to be included in this test.
-     * Those two actions are covered by separate tests ({@link #testImporterAsNoSudoChownOnlyWorkflow},
-     * {@link #testImporterAsNoSudoChgrpChownWorkflow} and {@link #testLinkNoSudo}).
+     * Those two actions are covered by separate tests ({@link #testImporterAsNoSudoChownOnlyWorkflow testImporterAsNoSudoChownOnly},
+     * {@link #testImporterAsNoSudoChgrpChownWorkflow testImporterAsNoSudoChgrpChown} and {@link #testLinkNoSudo testLinkNoSudo}).
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -566,42 +566,23 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
        /* Check one of the objects for non-existence after deletion. First, logging
         * in as root, retrieve all the objects to check them later*/
        logRootIntoGroup(normalUser.groupId);
-       OriginalFile retrievedRemoteFile = (OriginalFile) iQuery.findByQuery(
-               "FROM OriginalFile WHERE id = :id",
-               new ParametersI().addId(remoteFileId));
-       Image retrievedImage = (Image) iQuery.findByQuery(
-               "FROM Image WHERE fileset IN "
-               + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
-               new ParametersI().addId(remoteFileId));
-       Dataset retrievedDat = (Dataset) iQuery.findByQuery(
-               "FROM Dataset WHERE id = :id",
-               new ParametersI().addId(sentDat.getId()));
-       Project retrievedProj = (Project) iQuery.findByQuery(
-               "FROM Project WHERE id = :id",
-               new ParametersI().addId(sentProj.getId()));
-       DatasetImageLink retrievedDatasetImageLink = (DatasetImageLink) iQuery.findByQuery(
-               "FROM DatasetImageLink WHERE child.id = :id",
-               new ParametersI().addId(image.getId()));
-       ProjectDatasetLink retrievedProjectDatasetLink = (ProjectDatasetLink) iQuery.findByQuery(
-               "FROM ProjectDatasetLink WHERE child.id = :id",
-               new ParametersI().addId(sentDat.getId()));
        /* now check the existence/non-existence of the objects as appropriate */
        if (deletePassing) {
            /* successful delete expected */
-           Assert.assertNull(retrievedRemoteFile, "original file should be deleted");
-           Assert.assertNull(retrievedImage, "image should be deleted");
-           Assert.assertNull(retrievedDat, "dataset should be deleted");
-           Assert.assertNull(retrievedProj, "project should be deleted");
-           Assert.assertNull(retrievedDatasetImageLink, "Dat-Image link should be deleted");
-           Assert.assertNull(retrievedProjectDatasetLink, "Proj-Dat link should be deleted");
+           assertDoesNotExist((new OriginalFileI(remoteFileId, false)));
+           assertDoesNotExist(image);
+           assertDoesNotExist(sentDat);
+           assertDoesNotExist(sentProj);
+           assertDoesNotExist(datasetImageLink);
+           assertDoesNotExist(projectDatasetLink);
        } else {
            /* no deletion should have been successful without permDeleteOwned */
-           Assert.assertNotNull(retrievedRemoteFile, "original file not deleted");
-           Assert.assertNotNull(retrievedImage, "image not deleted");
-           Assert.assertNotNull(retrievedDat, "dataset not deleted");
-           Assert.assertNotNull(retrievedProj, "project not deleted");
-           Assert.assertNotNull(retrievedDatasetImageLink, "Dat-Image link not deleted");
-           Assert.assertNotNull(retrievedProjectDatasetLink, "Proj-Dat link not deleted");
+           assertExists((new OriginalFileI(remoteFileId, false)));
+           assertExists(image);
+           assertExists(sentDat);
+           assertExists(sentProj);
+           assertExists(datasetImageLink);
+           assertExists(projectDatasetLink);
        }
    }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -767,7 +767,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* In case the import was not successful, Image does not exist.
          * Further testing is not interesting in such case.*/
         } else {
-            Assert.assertNull(originalFile, "if import failed, the remoteFile should be null");
+            Assert.assertNull(originalFile, "if import failed, the originalFile should be null");
             Assert.assertNull(image, "if import failed, the image should be null");
             return;
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -450,7 +450,7 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                 new ParametersI().addId(previousId).add("name", imageName));
         assertOwnedBy(remoteFile, normalUser);
-        Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), normalUser.groupId);
+        assertInGroup(remoteFile, normalUser.groupId);
 
         /* check that the light admin when sudoed, can link the created Dataset
          * to the created Project, check the ownership of the links
@@ -525,9 +525,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                "SELECT id, details.group.id FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                new ParametersI().addId(previousId).add("name", imageName)).get(0);
        final long remoteFileId = ((RLong) resultAfterImport.get(0)).getValue();
-       final long remoteFileGroupId = ((RLong) resultAfterImport.get(1)).getValue();
        assertOwnedBy((new OriginalFileI(remoteFileId, false)), normalUser);
-       Assert.assertEquals(remoteFileGroupId, normalUser.groupId);
+       assertInGroup((new OriginalFileI(remoteFileId, false)), normalUser.groupId);
        /* link the Project and the Dataset */
        ProjectDatasetLink link = linkProjectDataset(sentProj, sentDat);
        Image image = (Image) iQuery.findByQuery(

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -366,8 +366,7 @@ public class LightAdminRolesTest extends RolesTests {
    }
 
     /**
-     * Test that a light admin can
-     * edit the name of a project
+     * Test that a light admin can edit the name of a project
      * on behalf of another user solely with <tt>Sudo</tt> privilege
      * or without it, using permWriteOwned privilege
      * @param isSudoing if to test a success of workflows where Sudoed in

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1355,8 +1355,9 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-    /** Light admin (lightAdming) tries to upload an official script.
-     * The only permission lightAdmin needs for this is WriteScriptRepo.
+    /**
+     * Light admin (lightAdming) tries to upload an official script.
+     * lightAdmin succeeds in this if they have WriteScriptRepo permission.
      * @param isPrivileged if to test a user who has the <tt>WriteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1406,8 +1406,8 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Light admin (lightAdmin) tries to delete official script. They will succeed only if they
-     * have the <tt>DeleteScriptRepo</tt> privilege.
+     * Light admin (lightAdmin) tries to delete official script. 
+     * lightAdmin will succeed if they have the <tt>DeleteScriptRepo</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>DeleteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -399,7 +399,7 @@ public class LightAdminRolesTest extends RolesTests {
         Project sentProj = (Project) iUpdate.saveAndReturnObject(proj);
         String savedOriginalName = sentProj.getName().getValue().toString();
         loginUser(lightAdmin);
-        /* As lightAdmin, sudo as the normalUser if this should be the case */
+        /* As lightAdmin, sudo as the normalUser if this should be the case.*/
         if (isSudoing) sudo(new ExperimenterI(normalUser.userId, false));
         /* Check that the canEdit flag on the created project is as expected */
         Assert.assertEquals(getCurrentPermissions(sentProj).canEdit(), isExpectSuccess);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -523,7 +523,7 @@ public class LightAdminRolesTest extends RolesTests {
      * to sever necessary links for performing the chgrp. This is achieved by
      * having the image which is getting moved into a different group in a dataset
      * in the original group (the chgrp has to sever the DatasetImageLink to perform
-     * the move (chgrp). <tt>Chgrp</tt> privilege is sufficient also
+     * the move (chgrp)). <tt>Chgrp</tt> privilege is sufficient also
      * to move annotations (tag and file attachment are tested here).
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -812,8 +812,8 @@ public class LightAdminRolesTest extends RolesTests {
      * Here, normalUser creates and saves the image, Dataset and Project,
      * then lightAdmin tries to link these objects.
      * lightAdmin will succeed if they have WriteOwned privilege.
-     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit#slide=id.p4">graphical explanation</a>

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -19,8 +19,6 @@
 
 package integration;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +44,6 @@ import omero.model.AdminPrivilege;
 import omero.model.AdminPrivilegeI;
 import omero.model.Annotation;
 import omero.model.Dataset;
-import omero.model.DatasetI;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
 import omero.model.Experimenter;
@@ -69,7 +66,6 @@ import omero.model.Pixels;
 import omero.model.Project;
 import omero.model.ProjectDatasetLink;
 import omero.model.ProjectDatasetLinkI;
-import omero.model.ProjectI;
 import omero.model.RectangleI;
 import omero.model.RenderingDef;
 import omero.model.Roi;
@@ -92,17 +88,13 @@ import omero.model.enums.AdminPrivilegeWriteScriptRepo;
 import omero.sys.EventContext;
 import omero.sys.ParametersI;
 import omero.sys.Principal;
-import omero.util.TempFileManager;
 
 import org.testng.Assert;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Tests the concrete workflows of the light admins
@@ -110,22 +102,6 @@ import com.google.common.collect.ImmutableSet;
  * @since 5.4.0
  */
 public class LightAdminRolesTest extends RolesTests {
-
-    private ImmutableSet<AdminPrivilege> allPrivileges = null;
-
-    /**
-     * Populate the set of available light administrator privileges.
-     * @throws ServerError unexpected
-     */
-    @BeforeClass
-    public void populateAllPrivileges() throws ServerError {
-        final ImmutableSet.Builder<AdminPrivilege> privileges = ImmutableSet.builder();
-        for (final IObject privilege : factory.getTypesService().allEnumerations("AdminPrivilege")) {
-            privileges.add((AdminPrivilege) privilege);
-        }
-        allPrivileges = privileges.build();
-    }
-
 
     /**
      * Assert that the given object is owned by the given owner.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1473,20 +1473,20 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can modify group membership when he/she has
-     * only the <tt>ModifyGroupMembership</tt> privilege.
-     * The addition of a user is being attempted here.
+     * Light admin (lightAdmin) tries to modify group membership.
+     * lightAdmin will succeed if they have <tt>ModifyGroupMembership</tt> privilege.
+     * To modify the group membership, lightAdmin attempts to add
+     * an existing user to an existing group.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipAddUser(boolean isPrivileged, String groupPermissions) throws Exception {
-        /* the permModifyGroupMembership should be a sufficient permission to perform
-         * the user addition into a group */
+        /* isPrivileged translates in this test into ModifyGroupMembership permission, see below.*/
         boolean isExpectSuccessAddUserToGroup = isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
-        /* one extra group is needed to add the existing normalUser to */
+        /* One extra group is needed to add the existing normalUser to.*/
         final EventContext otherUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
@@ -1503,9 +1503,10 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can modify group membership when he/she has
-     * only the <tt>ModifyGroupMembership</tt> privilege.
-     * The removal of a user is being attempted here.
+     * Light admin (lightAdmin) tries to modify group membership.
+     * lightAdmin will succeed if they have <tt>ModifyGroupMembership</tt> privilege.
+     * To modify the group membership, lightAdmin attempts to remove
+     * an existing user from an existing group.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1513,11 +1514,10 @@ public class LightAdminRolesTest extends RolesTests {
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipRemoveUser(boolean isPrivileged,
             String groupPermissions) throws Exception {
-        /* the permModifyGroupMembership should be a sufficient permission to perform
-         * the user removal from a group */
+        /* isPrivileged translates in this test into ModifyGroupMembership permission, see below.*/
         boolean isExpectSuccessRemoveUserFromGroup = isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
-        /* one extra group is needed which the normalUser is also a member of */
+        /* One extra group is needed from which normalUser removal will be attempted.*/
         final ExperimenterGroup otherGroup = newGroupAddUser("rwr-r-", normalUser.userId);
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1787,9 +1787,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testOfficialScriptDeleteNoSudo(boolean isPrivileged, String groupPermissions) throws Exception {
-        if (groupPermissions.equals("rwrw--")) {
-            throw new SkipException("does not work in read-write group");
-        }
         boolean isExpectSuccessDeleteOfficialScript = isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -792,8 +792,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(link, normalUser.groupId);
             assertOwnedBy(originalFile, normalUser);
             assertInGroup(originalFile, normalUser.groupId);
-        /* Check that the image, dataset and link still belongs
-         * to the light admin as the chown failed, but are in the group of normalUser.*/
+        /* Check that the image, dataset and link still belong
+         * to lightAdmin as the chown failed, but are in the group of normalUser.*/
         } else {
             assertOwnedBy(image, lightAdmin);
             assertInGroup(image, normalUser.groupId);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1357,7 +1357,7 @@ public class LightAdminRolesTest extends RolesTests {
 
     /**
      * Light admin (lightAdming) tries to upload an official script.
-     * lightAdmin succeeds in this if they have WriteScriptRepo permission.
+     * lightAdmin succeeds in this if they have <tt>WriteScriptRepo<tt> permission.
      * @param isPrivileged if to test a user who has the <tt>WriteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1308,7 +1308,7 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertEquals(getCurrentPermissions(fileAnnotation).canChown(), isExpectSuccessCreateFileAttAndChown);
         /* lightAdmin tries to link the fileAnnotation to the normalUser's image.
          * This will not work in private group. See definition of the boolean
-         * isExpectSuccessLinkFileAttachemnt.*/
+         * isExpectSuccessLinkFileAttachment.*/
         ImageAnnotationLink link = null;
         try {
             link = (ImageAnnotationLink) linkParentToChild(sentImage, fileAnnotation);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -859,7 +859,7 @@ public class LightAdminRolesTest extends RolesTests {
             linkOfProjectDataset = linkParentToChild(sentProj, sentDat);
             Assert.assertTrue(isExpectLinkingSuccess);
         } catch (ServerError se) {
-            Assert.assertFalse(isExpectLinkingSuccess);
+            Assert.assertFalse(isExpectLinkingSuccess, se.toString());
             return;
         }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1380,10 +1380,15 @@ public class LightAdminRolesTest extends RolesTests {
         IScriptPrx iScript = factory.getScriptService();
         /* lightAdmin fetches a script from the server.*/
         OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scriptFile.getId().getValue());
-        final String actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
+        String actualScript;
+        RawFileStorePrx rfs = null;
+        try {
+            rfs = factory.createRawFileStore();
+            rfs.setFileId(scriptFile.getId().getValue());
+            actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
+        } finally {
+            if (rfs != null) rfs.close();
+        }
         /* lightAdmin tries uploading the script as a new script in normalUser's group.*/
         iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
@@ -1402,10 +1407,15 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertEquals(scriptFile.getDetails().getOwner().getId().getValue(), roles.rootId);
         Assert.assertEquals(scriptFile.getDetails().getGroup().getId().getValue(), roles.userGroupId);
         /* Check if the script is correctly uploaded.*/
-        rfs = factory.createRawFileStore();
-        rfs.setFileId(testScriptId);
-        final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
+        String currentScript;
+        rfs = null;
+        try {
+            rfs = factory.createRawFileStore();
+            rfs.setFileId(testScriptId);
+            currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
+        } finally {
+            if (rfs != null) rfs.close();
+        }
         Assert.assertEquals(currentScript, actualScript);
     }
 
@@ -1427,11 +1437,16 @@ public class LightAdminRolesTest extends RolesTests {
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         IScriptPrx iScript = factory.getScriptService();
         /* lightAdmin fetches a script from the server.*/
-        final OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scriptFile.getId().getValue());
-        final String actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
+        OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
+        String actualScript;
+        RawFileStorePrx rfs = null;
+        try {
+            rfs = factory.createRawFileStore();
+            rfs.setFileId(scriptFile.getId().getValue());
+            actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
+        } finally {
+            if (rfs != null) rfs.close();
+        }
         /* Another light admin (anotherLightAdmin) with appropriate permissions
          * uploads the script as a new script.*/
         final EventContext anotherLightAdmin = loginNewAdmin(true, AdminPrivilegeWriteScriptRepo.value);
@@ -1466,8 +1481,9 @@ public class LightAdminRolesTest extends RolesTests {
         } else {
             assertExists(testScript);
         }
-        rfs = factory.createRawFileStore();
+        rfs = null;
         try {
+            rfs = factory.createRawFileStore();
             rfs.setFileId(testScriptId);
             final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
             Assert.assertEquals(currentScript, actualScript);
@@ -1477,7 +1493,7 @@ public class LightAdminRolesTest extends RolesTests {
              * {@link #RawFileStoreTest.testBadFileId, testBadFileId} is broken.*/
             Assert.assertTrue(isExpectSuccessDeleteOfficialScript);
         } finally {
-            rfs.close();
+            if (rfs != null) rfs.close();
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -985,7 +985,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(originalFile, normalUser.groupId);
             assertInGroup(image, normalUser.groupId);
             assertInGroup(sentDat, normalUser.groupId);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
         /* check that the image, dataset and their link were not moved if
          * the permissions were not sufficient
          */
@@ -1013,8 +1013,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
             /* the image, dataset and link belong to the normalUser, but is in the light admin's group */
@@ -1024,8 +1024,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
@@ -1036,8 +1036,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
             /* the image, dataset and link are in light admin's group and belong to light admin */
@@ -1047,8 +1047,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1123,9 +1123,12 @@ public class LightAdminRolesTest extends RolesTests {
         assertOwnedBy(linkOfProjectDataset2AnotherGroup, recipient);
     }
 
-    /** Light admin (lightAdmin) puts ROI and Rendering Settings on an
-     * image of normalUser and then transfers the ownership of the ROI and settings
-     * to normalUser, all without using Sudo.
+    /**
+     * Light admin (lightAdmin) tries to put ROI and Rendering Settings on an
+     * image of normalUser.
+     * lightAdmin tries then to transfer the ownership of the ROI and Rendering settings
+     * to normalUser.
+     * lightAdmin does not use Sudo in this test.
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -661,7 +661,7 @@ public class LightAdminRolesTest extends RolesTests {
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         /* lightAdmin tries to chown the image.*/
         doChange(client, factory, Requests.chown().target(image).toUser(anotherUser.userId).build(), chownImagePassing);
-        /* Chect the results of the chown when lightAdmin is sudoed,
+        /* ChecK the results of the chown when lightAdmin is sudoed,
          * which should fail in any case.*/
         if (isSudoing) {
             assertOwnedBy(image, normalUser);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -582,7 +582,7 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertEquals(getCurrentPermissions(image).canChgrp(), canChgrpExpectedTrue);
         doChange(client, factory, Requests.chgrp().target(image).toGroup(anotherGroupId).build(),
                 chgrpNonMemberExpectSuccess);
-        if(chgrpNonMemberExpectSuccess) {
+        if (chgrpNonMemberExpectSuccess) {
             /* check that the image and its original file moved to another group */
             assertInGroup(image, anotherGroupId);
             assertInGroup(originalFile, anotherGroupId);
@@ -993,7 +993,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(originalFile, lightAdmin.groupId);
             assertInGroup(image, lightAdmin.groupId);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
+            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
          * try to change the ownership of the dataset to the normalUser.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1330,7 +1330,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* link the file attachment to the image of the user as light admin
          * This will not work in private group. See definition of the boolean
          * isExpectSuccessLinkFileAttachemnt */
-        ImageAnnotationLink link = new ImageAnnotationLinkI();
+        ImageAnnotationLink link = null;
         try {
             link = (ImageAnnotationLink) linkImageAnnotation(sentImage, fileAnnotation);
             /* Check the value of canAnnotate on the image is true in this case.*/

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -195,7 +195,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1JX6b9pkPtG-3hZIGSp2bu4WVvNKn6GHqIKdfbbJkiw8/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1JX6b9pkPtG-3hZIGSp2bu4WVvNKn6GHqIKdfbbJkiw8/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testImporterAsSudoCreateImport(boolean isSudoing, boolean permWriteOwned,
@@ -290,7 +290,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit#slide=id.p7</a>
+     * @see <a href="https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit#slide=id.p7">graphical explanation</a>
      */
    @Test(dataProvider = "isSudoing and Delete privileges cases")
    public void testDelete(boolean isSudoing, boolean permDeleteOwned,
@@ -378,7 +378,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/18u5hRD_oFKjGlGQ7x55oUowrmdjS4HXkXKfJSlpbiVY/edit#slide=id.p7</a>
+     * @see <a href="https://docs.google.com/presentation/d/18u5hRD_oFKjGlGQ7x55oUowrmdjS4HXkXKfJSlpbiVY/edit#slide=id.p7">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testEdit(boolean isSudoing, boolean permWriteOwned,
@@ -449,7 +449,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1BUSzGp89en0Y7-5i7DkQbtVM-AgyfCJVa7rLhnMeO5A/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1BUSzGp89en0Y7-5i7DkQbtVM-AgyfCJVa7rLhnMeO5A/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrp(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -529,7 +529,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1c3TGh4bD5_djKO_-lJs5LoBjL0koYsko7QkyEuu-nXY/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1c3TGh4bD5_djKO_-lJs5LoBjL0koYsko7QkyEuu-nXY/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrpNonMember(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -616,7 +616,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1r4qlG9JKLfTgS8s5xWM8SDJJ25t4RwSWuiy6BfFfO_o/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1r4qlG9JKLfTgS8s5xWM8SDJJ25t4RwSWuiy6BfFfO_o/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chown privileges cases")
     public void testChown(boolean isSudoing, boolean permChown, String groupPermissions)
@@ -708,7 +708,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1w_W6g69CV5Uy_rUom2K9O86w2Q2CGkl3rzNj-ZQzSt0/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1w_W6g69CV5Uy_rUom2K9O86w2Q2CGkl3rzNj-ZQzSt0/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
     public void testImporterAsNoSudoChownOnlyWorkflow(boolean permWriteOwned, boolean permWriteFile,
@@ -816,7 +816,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testLinkNoSudo(boolean permWriteOwned, boolean permChown,
@@ -911,7 +911,7 @@ public class LightAdminRolesTest extends RolesTests {
          * @param permChown if to test a user who has the <tt>Chown</tt> privilege
          * @param groupPermissions if to test the effect of group permission level
          * @throws Exception unexpected
-         * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit#slide=id.p4</a>
+         * @see <a href="https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit#slide=id.p4">graphical explanation</a>
          */
         @Test(dataProvider = "Chgrp and Chown privileges cases")
         public void testImporterAsNoSudoChgrpChownWorkflow(boolean permChgrp, boolean permChown,
@@ -1034,7 +1034,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param isPrivileged if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1zbIu5gYPObbVkBSxdD4sMmPFMGgspbtYQEnJ9k8vfCs/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1zbIu5gYPObbVkBSxdD4sMmPFMGgspbtYQEnJ9k8vfCs/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testChownAllBelongingToUser(boolean isPrivileged, String groupPermissions) throws Exception {
@@ -1137,7 +1137,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testROIAndRenderingSettingsNoSudo(boolean permWriteOwned, boolean permChown,
@@ -1261,7 +1261,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1jfdsPSvqJvBlN18vIFrRsNqh13eAlF5Gjh3G_MiGGAE/edit#slide=id.p4</a>
+     * @see <a href="https://docs.google.com/presentation/d/1jfdsPSvqJvBlN18vIFrRsNqh13eAlF5Gjh3G_MiGGAE/edit#slide=id.p4">graphical explanation</a>
      */
     @Test(dataProvider = "fileAttachment privileges cases")
     public void testFileAttachmentNoSudo(boolean permChown, boolean permWriteOwned,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -220,8 +220,8 @@ public class LightAdminRolesTest extends RolesTests {
         Dataset dat = mmFactory.simpleDataset();
         Project sentProj = null;
         Dataset sentDat = null;
-        /* lightAdmin sets the normalUser as the owner of the newly created P/D but only
-         * in cases in which lightAdmin is not sudoing (if sudoing, the created P/D
+        /* lightAdmin sets the normalUser as the owner of the newly created Project/Dataset but only
+         * in cases in which lightAdmin is not sudoing (if sudoing, the created Project/Dataset
          * already belong to normalUser).*/
         if (!isSudoing) {
             proj.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
@@ -336,7 +336,7 @@ public class LightAdminRolesTest extends RolesTests {
         * Note that deletion of the Project
         * would delete the whole hierarchy, which was successfully tested
         * during writing of this test. The order of the below delete() commands
-        * is intentional, as the ability to delete the links and P/D/I separately is
+        * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
         * tested in this way.
         * Also check that the canDelete boolean
         * on the object retrieved by the lightAdmin matches the deletePassing
@@ -873,7 +873,7 @@ public class LightAdminRolesTest extends RolesTests {
          * operation is captured in boolean isExpectSuccessLinkAndChown. Note that the
          * ownership of the links must be transferred explicitly, as the Chown feature
          * on the Project would not transfer ownership links owned by non-owners
-         * of the P/D/I objects (chown on mixed ownership hierarchy does not chown objects
+         * of the Project/Dataset/Image objects (chown on mixed ownership hierarchy does not chown objects
          * owned by other users).*/
         Chown2 chown = Requests.chown().target(linkOfDatasetImage).toUser(normalUser.userId).build();
         doChange(client, factory, chown, isExpectSuccessLinkAndChown);
@@ -1048,7 +1048,7 @@ public class LightAdminRolesTest extends RolesTests {
         if (isPrivileged) permissions.add(AdminPrivilegeChown.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
-        /* normalUser creates two sets of P/D/I hierarchy in their default group.*/
+        /* normalUser creates two sets of Project/Dataset/Image hierarchy in their default group.*/
         loginUser(normalUser);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Image image1 = mmFactory.createImage();
@@ -1068,7 +1068,7 @@ public class LightAdminRolesTest extends RolesTests {
         ProjectDatasetLink linkOfProjectDataset1 = linkParentToChild(sentProj1, sentDat1);
         ProjectDatasetLink linkOfProjectDataset2 = linkParentToChild(sentProj2, sentDat2);
 
-        /* normalUser creates two sets of P/D?I hierarchy in the other group (anotherGroup).*/
+        /* normalUser creates two sets of Project/Dataset?Image hierarchy in the other group (anotherGroup).*/
         client.getImplicitContext().put("omero.group", Long.toString(anotherGroup.getId().getValue()));
         Image image1AnotherGroup = mmFactory.createImage();
         Image image2AnotherGroup = mmFactory.createImage();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1022,7 +1022,8 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-    /** Light admin (lightAdmin) transfers the ownership of all the data of a user (normalUser)
+    /**
+     * Light admin (lightAdmin) tries to transfer the ownership of all the data of a user (normalUser)
      * to another user. The data are in 2 groups, of which the original data owner (normalUser)
      * is member, the recipient of the data is member of just one of the groups. Chown privilege
      * is sufficient for lightAdmin to perform the workflow.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -560,11 +560,8 @@ public class LightAdminRolesTest extends RolesTests {
         if (permChgrp) permissions.add(AdminPrivilegeChgrp.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
+        sudo(new ExperimenterI(normalUser.userId, false));
 
-        try {
-            sudo(new ExperimenterI(normalUser.userId, false));
-            }catch (SecurityViolation sv) {
-            }
         /* take care of workflows which do not use sudo */
         if (!isSudoing) {
             loginUser(lightAdmin);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -880,7 +880,7 @@ public class LightAdminRolesTest extends RolesTests {
         chown = Requests.chown().target(linkOfProjectDataset).toUser(normalUser.userId).build();
         doChange(client, factory, chown, isExpectSuccessLinkAndChown);
 
-        /* Check the ownership of the links, image, Dataset and Project.*/
+        /* Check the ownership of the links, Image, Dataset and Project.*/
         final long linkDatasetImageId = ((RLong) iQuery.projection(
                 "SELECT id FROM DatasetImageLink WHERE parent.id  = :id",
                 new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -183,14 +183,14 @@ public class LightAdminRolesTest extends RolesTests {
      * Light administrator (lightAdmin) tries to create new Project and Dataset and set normalUser as
      * the owner of the Project and Dataset in a group where lightAdmin is not member (normalUser's group).
      * lightAdmin tries the creation above both sudoing and not sudoing as normalUser
-     * and both having and not having <tt>WriteOwned<tt> privilege.
+     * and both having and not having <tt>WriteOwned</tt> privilege.
      * The test finishes for test cases in which lightAdmin does not sudo after the creation attempt above.
      * For cases in which lightAdmin does Sudo as normalUser:
      * lightAdmin tries to import data on behalf of normalUser into the just created Dataset.
      * lightAdmin, still sudoed as normalUser, tries then to link the Dataset to the Project.
      * Non-sudoing workflows for import and linking are too complicated to be included in this test.
-     * Those two actions are covered by separate tests (testImporterAsNoSudoChownOnlyWorkflow,
-     * testImporterAsNoSudoChgrpChownWorkflow and testLinkNoSudo).
+     * Those two actions are covered by separate tests ({@link #testImporterAsNoSudoChownOnlyWorkflow},
+     * {@link #testImporterAsNoSudoChgrpChownWorkflow} and {@link #testLinkNoSudo}).
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1183,7 +1183,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
 
         /* lightAdmin tries to set rendering settings on normalUser's image
-         * using setOriginalSettingsInSet method */
+         * using setOriginalSettingsInSet method.*/
         IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
         try {
             prx.setOriginalSettingsInSet(Pixels.class.getName(),

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -756,7 +756,7 @@ public class LightAdminRolesTest extends RolesTests {
             image = (Image) originalFileAndImage.get(1);
             Assert.assertTrue(importNotYourGroupExpectSuccess);
         } catch (ServerError se) {
-            Assert.assertFalse(importNotYourGroupExpectSuccess);
+            Assert.assertFalse(importNotYourGroupExpectSuccess, se.toString());
         }
         /* Check the ownership and group of the original file and the image.*/
         if (importNotYourGroupExpectSuccess) {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -423,7 +423,7 @@ public class LightAdminRolesTest extends RolesTests {
                 "SELECT name FROM Project p WHERE p.id = :id",
                 new ParametersI().addId(sentProj.getId())).get(0).get(0)).getValue();
         /* Check that the Project still belongs to normalUser and the name of the Project
-         * was changed and saved or original name is retained as appropriate */
+         * was changed and saved or original name is retained as appropriate.*/
         assertOwnedBy(sentProj, normalUser);
         if (isExpectSuccess) {
             Assert.assertEquals(savedChangedName, retrievedName);
@@ -465,7 +465,7 @@ public class LightAdminRolesTest extends RolesTests {
          * A successful chgrp action will also move all annotations on the moved image,
          * which are unique on the image.*/
         boolean isExpectSuccessInMemberGroup = permChgrp || isSudoing;
-        /* create a Dataset as normalUser and import into it */
+        /* Create a Dataset as normalUser and import into it.*/
         loginUser(normalUser);
         Dataset dat = mmFactory.simpleDataset();
         Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -639,7 +639,7 @@ public class LightAdminRolesTest extends RolesTests {
         OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
         Image image = (Image) originalFileAndImage.get(1);
 
-        /* Annotate the imported image with Tag and file attachment */
+        /* Annotate the imported image with Tag and file attachment.*/
         List<IObject> annotOriginalFileAnnotationTagAndLinks = annotateImageWithTagAndFile(image);
 
         /* Set up the basic permissions for this test.*/

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -657,7 +657,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Check that the value of canChown boolean matches chownPassingWhenNotSudoing
          * boolean in each case.*/
         Assert.assertEquals(getCurrentPermissions(image).canChown(), chownImagePassing);
-        /* Get inot correct group context and check all cases.*/
+        /* Get into correct group context and check all cases.*/
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         /* lightAdmin tries to chown the image.*/
         doChange(client, factory, Requests.chown().target(image).toUser(anotherUser.userId).build(), chownImagePassing);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -86,6 +86,7 @@ import omero.model.enums.AdminPrivilegeWriteManagedRepo;
 import omero.model.enums.AdminPrivilegeWriteOwned;
 import omero.model.enums.AdminPrivilegeWriteScriptRepo;
 import omero.sys.EventContext;
+import omero.sys.Parameters;
 import omero.sys.ParametersI;
 import omero.sys.Principal;
 
@@ -126,8 +127,10 @@ public class LightAdminRolesTest extends RolesTests {
         for (final IObject object : objects) {
             final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
             final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
+                    " WHERE id = :id";
+            final Parameters params = new ParametersI().addId(object.getId());
+            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
+            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
             final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
             Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -105,40 +105,6 @@ import com.google.common.collect.ImmutableMap;
 public class LightAdminRolesTest extends RolesTests {
 
     /**
-     * Assert that the given object is in the given group.
-     * @param object a model object
-     * @param expectedGroupId a group Id
-     * @throws ServerError unexpected
-     */
-    private void assertInGroup(IObject object, long expectedGroupId) throws ServerError {
-        assertInGroup(Collections.singleton(object), expectedGroupId);
-    }
-
-    /**
-     * Assert that the given objects are in the giver group.
-     * @param objects some model objects
-     * @param expectedGroupId a group Id
-     * @throws ServerError unexpected
-     */
-    private void assertInGroup(Collection<? extends IObject> objects, long expectedGroupId) throws ServerError {
-        if (objects.isEmpty()) {
-            throw new IllegalArgumentException("must assert about some objects");
-        }
-        for (final IObject object : objects) {
-            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
-            final String query = "SELECT details.group.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = :id";
-            final Parameters params = new ParametersI().addId(object.getId());
-            final Map<String, String> ctx = ImmutableMap.of("omero.group", "-1");
-            final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ctx);
-            final long actualGroupId = ((RLong) results.get(0).get(0)).getValue();
-            Assert.assertEquals(actualGroupId, expectedGroupId, objectName);
-        }
-    }
-
-
-
-    /**
      * Add a FileAnnotation with Original File to the given image.
      * @param image an image
      * @return the new model objects

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -415,7 +415,7 @@ public class LightAdminRolesTest extends RolesTests {
             sentProj = (Project) iUpdate.saveAndReturnObject(retrievedUnrenamedProject);
             Assert.assertTrue(isExpectSuccess);
         } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
+            Assert.assertFalse(isExpectSuccess, se.toString());
         }
         String savedChangedName = sentProj.getName().getValue().toString();
         logRootIntoGroup(normalUser.groupId);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -977,14 +977,14 @@ public class LightAdminRolesTest extends RolesTests {
 
         /* check that the image, dataset, and their link was moved too if the permissions
          * were sufficient */
-        long datasetImageLinkId = ((RLong) iQuery.projection(
-                "SELECT id FROM DatasetImageLink WHERE parent.id = :id",
-                new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
+        final DatasetImageLink datasetImageLink = (DatasetImageLink) iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE parent.id = :id",
+                new ParametersI().addId(sentDat.getId()));
         if (permChgrp) {
             assertInGroup(originalFile, normalUser.groupId);
             assertInGroup(image, normalUser.groupId);
             assertInGroup(sentDat, normalUser.groupId);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
+            assertInGroup(datasetImageLink, normalUser.groupId);
         /* check that the image, dataset and their link were not moved if
          * the permissions were not sufficient
          */
@@ -992,7 +992,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(originalFile, lightAdmin.groupId);
             assertInGroup(image, lightAdmin.groupId);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
+            assertInGroup(datasetImageLink, lightAdmin.groupId);
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
          * try to change the ownership of the dataset to the normalUser.
@@ -1012,8 +1012,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy(datasetImageLink, normalUser);
+            assertInGroup(datasetImageLink, normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
             /* the image, dataset and link belong to the normalUser, but is in the light admin's group */
@@ -1023,8 +1023,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy(datasetImageLink, normalUser);
+            assertInGroup(datasetImageLink, lightAdmin.groupId);
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
@@ -1035,8 +1035,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), normalUser.groupId);
+            assertOwnedBy(datasetImageLink, lightAdmin);
+            assertInGroup(datasetImageLink, normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
             /* the image, dataset and link are in light admin's group and belong to light admin */
@@ -1046,8 +1046,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, lightAdmin.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI(datasetImageLinkId, false)), lightAdmin.groupId);
+            assertOwnedBy(datasetImageLink, lightAdmin);
+            assertInGroup(datasetImageLink, lightAdmin.groupId);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1303,6 +1303,9 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         image = (Image) iQuery.findByQuery("FROM Image WHERE fileset IN "
                 + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
                 new ParametersI().addId(remoteFile.getId()));
+        long datasetImageLinkId = ((RLong) iQuery.projection(
+                "SELECT id FROM DatasetImageLink WHERE parent.id = :id",
+                new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
         assertOwnedBy(image, lightAdmin);
         assertInGroup(image, lightAdmin.groupId);
 
@@ -1323,10 +1326,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
          * and thus the canChgrp must be "true".*/
         Assert.assertTrue(getCurrentPermissions(sentDat).canChgrp());
 
-        /* retrieve again the image, dataset and link */
-        long datasetImageLinkId = ((RLong) iQuery.projection(
-                "SELECT id FROM DatasetImageLink WHERE parent.id = :id",
-                new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
         /* check that the image, dataset, and their link was moved too if the permissions
          * were sufficient */
         if (permChgrp) {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -163,30 +163,6 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-    /**
-     * Get the current permissions for the given object.
-     * @param object a model object previously retrieved from the server
-     * @return the permissions for the object in the current context
-     * @throws Exception 
-     */
-    private Permissions getCurrentPermissions(IObject object) throws Exception {
-        assertExists(object);
-        final String objectClass = object.getClass().getSuperclass().getSimpleName();
-        final long objectId = object.getId().getValue();
-        try {
-            final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
-            final IObject objectRetrieved;
-            if (objectClass.endsWith("Link")) {
-                objectRetrieved = iQuery.findByQuery("FROM " + objectClass + " link JOIN FETCH link.child WHERE link.id = :id",
-                        new ParametersI().addId(objectId), allGroupsContext);
-            } else {
-                objectRetrieved = iQuery.get(objectClass, objectId, allGroupsContext);
-            }
-            return objectRetrieved.getDetails().getPermissions();
-        } catch (SecurityViolation sv) {
-            return new PermissionsI("------");
-        }
-    }
 
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -293,20 +293,13 @@ public class LightAdminRolesTest extends RolesTests {
     /**
      * Sudo to the given user.
      * @param target a user
-     * @return context for a session owned by the given user
      * @throws Exception if the sudo could not be performed
      */
-    private EventContext sudo(Experimenter target) throws Exception {
+    private void sudo(Experimenter target) throws Exception {
         if (!target.isLoaded()) {
             target = iAdmin.getExperimenter(target.getId().getValue());
         }
-        final Principal principal = new Principal();
-        principal.name = target.getOmeName().getValue();
-        final Session session = factory.getSessionService().createSessionWithTimeout(principal, 100 * 1000);
-        final omero.client client = newOmeroClient();
-        final String sessionUUID = session.getUuid().getValue();
-        client.createSession(sessionUUID, sessionUUID);
-        return init(client);
+        sudo(target.getOmeName().getValue());
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -851,7 +851,7 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccess);
         /* lightAdmin tries to create links between the image and Dataset
          * and between Dataset and Project.
-         * If links could not be created, finish the test */
+         * If links could not be created, finish the test.*/
         DatasetImageLink linkOfDatasetImage = new DatasetImageLinkI();
         ProjectDatasetLink linkOfProjectDataset = new ProjectDatasetLinkI();
         try {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -401,7 +401,7 @@ public class LightAdminRolesTest extends RolesTests {
         loginUser(lightAdmin);
         /* As lightAdmin, sudo as the normalUser if this should be the case.*/
         if (isSudoing) sudo(new ExperimenterI(normalUser.userId, false));
-        /* Check that the canEdit flag on the created project is as expected */
+        /* Check that the canEdit flag on the created project is as expected.*/
         Assert.assertEquals(getCurrentPermissions(sentProj).canEdit(), isExpectSuccess);
         /* Try to rename the Project.*/
         final String changedName = "ChangedNameOfLightAdmin";

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1651,7 +1651,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Light admin (ightAdmin) tries to edit an existing user.
+     * Light admin (lightAdmin) tries to edit an existing user.
      * lightAdmin will succeed if they have the <tt>ModifyUser</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyUser</tt> privilege
      * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1361,7 +1361,7 @@ public class LightAdminRolesTest extends RolesTests {
 
     /**
      * Light admin (lightAdming) tries to upload an official script.
-     * lightAdmin succeeds in this if they have <tt>WriteScriptRepo<tt> permission.
+     * lightAdmin succeeds in this if they have <tt>WriteScriptRepo</tt> permission.
      * @param isPrivileged if to test a user who has the <tt>WriteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1360,7 +1360,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Light admin (lightAdming) tries to upload an official script.
+     * Light admin (lightAdmin) tries to upload an official script.
      * lightAdmin succeeds in this if they have <tt>WriteScriptRepo</tt> permission.
      * @param isPrivileged if to test a user who has the <tt>WriteScriptRepo</tt> privilege
      * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -901,7 +901,7 @@ public class LightAdminRolesTest extends RolesTests {
 
         /**
          * Light admin (lightAdmin) imports data for others (normalUser) without using Sudo.
-         * lightAdmin first creates a Dataset and imports an image into it in lightAdmin's group
+         * lightAdmin first creates a Dataset and imports an Image into it in lightAdmin's group
          * (normalUser is not member of lightAdmin's group).
          * Then, lightAdmin tries to move the Dataset into normalUser's group.
          * Then, lightAdmin tries to chown the Dataset to normalUser.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -754,6 +754,7 @@ public class LightAdminRolesTest extends RolesTests {
             List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
             originalFile = (OriginalFile) originalFileAndImage.get(0);
             image = (Image) originalFileAndImage.get(1);
+            Assert.assertTrue(importNotYourGroupExpectSuccess);
         } catch (ServerError se) {
             Assert.assertFalse(importNotYourGroupExpectSuccess);
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1533,16 +1533,15 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can make a user an owner of a group
-     * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
+     * Light admin (lightAdmin) tries to make a user an owner of a group.
+     * lightAdmin will succeed if they have the <tt>ModifyGroupMembership</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipMakeOwner(boolean isPrivileged, String groupPermissions) throws Exception {
-        /* the permModifyGroupMembership should be a sufficient permission to perform
-         * the setting of a new group owner */
+        /* isPrivileged translates in this test into ModifyGroupMembership permission, see below.*/
         boolean isExpectSuccessMakeOwnerOfGroup= isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();
@@ -1560,8 +1559,8 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can unset a user to be an owner of a group
-     * when the light admin has only the <tt>ModifyGroupMembership</tt> privilege.
+     * Light admin (lightAdmin) tries to unset a user from being an owner of a group.
+     * lightAdmin will succeed if they have the <tt>ModifyGroupMembership</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroupMembership</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1569,11 +1568,10 @@ public class LightAdminRolesTest extends RolesTests {
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupMembershipUnsetOwner(boolean isPrivileged,
             String groupPermissions) throws Exception {
-        /* the permModifyGroupMembership should be a sufficient permission to perform
-         * the unsetting of a new group owner */
+        /* isPrivileged translates in this test into ModifyGroupMembership permission, see below.*/
         boolean isExpectSuccessUnsetOwnerOfGroup= isPrivileged;
-        /* set up the normalUser and make him an Owner by passing "true" in the
-         * newUserAndGroup method argument */
+        /* Set up the normalUser and make him an Owner by passing "true" in the
+         * newUserAndGroup method argument.*/
         final EventContext normalUser = newUserAndGroup(groupPermissions, true);
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
@@ -1587,7 +1585,7 @@ public class LightAdminRolesTest extends RolesTests {
         } catch (ServerError se) {
             Assert.assertFalse(isExpectSuccessUnsetOwnerOfGroup);
         }
-        /* check that the normalUser was unset as the owner of group when appropriate */
+        /* Check that normalUser was unset as the owner of group when appropriate.*/
         if (isExpectSuccessUnsetOwnerOfGroup) {
             Assert.assertTrue(iAdmin.getLeaderOfGroupIds(user).isEmpty());
         } else {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -895,14 +895,14 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-        /** Light admin (lightAdmin) imports data for others (normalUser) without using Sudo.
-         * The data will be imported by lightAdmin to lightAdmin's group (normalUser is not member
-         * of lightAdmin's group). lightAdmin moves the data into normalUser's group
-         * and chowns the data to normalUser.
+        /**
+         * Light admin (lightAdmin) imports data for others (normalUser) without using Sudo.
+         * lightAdmin first creates a Dataset and imports an image into it in lightAdmin's group
+         * (normalUser is not member of lightAdmin's group).
+         * Then, lightAdmin tries to move the Dataset into normalUser's group.
+         * Then, lightAdmin tries to chown the Dataset to normalUser.
          * For this test, combinations of <tt>Chown</tt>, <tt>Chgrp</tt>,
-         * privileges is explored for the light admin.
-         * For this workflow the creation and targeting of a Dataset
-         * is tested too.
+         * privileges of lightAdmin are explored.
          * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
          * @param permChown if to test a user who has the <tt>Chown</tt> privilege
          * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -166,9 +166,9 @@ public class LightAdminRolesTest extends RolesTests {
     private List<IObject> annotateImageWithTagAndFile(Image image) throws Exception {
         TagAnnotation tagAnnotation = new TagAnnotationI();
         tagAnnotation = (TagAnnotation) iUpdate.saveAndReturnObject(tagAnnotation);
-        final ImageAnnotationLink tagAnnotationLink = linkImageAnnotation(image, tagAnnotation);
+        final ImageAnnotationLink tagAnnotationLink = linkParentToChild(image, tagAnnotation);
         /* add a file attachment with original file to the imported image.*/
-        final ImageAnnotationLink fileAnnotationLink = linkImageAnnotation(image, mmFactory.createFileAnnotation());
+        final ImageAnnotationLink fileAnnotationLink = linkParentToChild(image, mmFactory.createFileAnnotation());
         /* link was saved in previous step with the whole graph, including fileAnnotation and original file */
         final FileAnnotation fileAnnotation = (FileAnnotation) fileAnnotationLink.getChild();
         final OriginalFile annotOriginalFile = fileAnnotation.getFile();
@@ -265,7 +265,7 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertTrue(getCurrentPermissions(sentProj).canLink());
         Assert.assertTrue(getCurrentPermissions(sentDat).canLink());
         /* Check that being sudoed, lightAdmin can link the Project and Dataset of normalUser.*/
-        ProjectDatasetLink projectDatasetLink = linkProjectDataset(sentProj, sentDat);
+        ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
 
         /* Check the owner of the image, its originalFile, imageDatasetLink and projectDatasetLink
          * is normalUser and the image and its originalFile are in normalUser's group.*/
@@ -322,7 +322,7 @@ public class LightAdminRolesTest extends RolesTests {
        Image image = (Image) originalFileAndImage.get(1);
        assertOwnedBy(image, normalUser);
        /* Link the Project and the Dataset.*/
-       ProjectDatasetLink projectDatasetLink = linkProjectDataset(sentProj, sentDat);
+       ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
        IObject datasetImageLink = iQuery.findByQuery(
                "FROM DatasetImageLink WHERE child.id = :id",
                new ParametersI().addId(image.getId()));
@@ -855,8 +855,8 @@ public class LightAdminRolesTest extends RolesTests {
         DatasetImageLink linkOfDatasetImage = new DatasetImageLinkI();
         ProjectDatasetLink linkOfProjectDataset = new ProjectDatasetLinkI();
         try {
-            linkOfDatasetImage = linkDatasetImage(sentDat, sentImage);
-            linkOfProjectDataset = linkProjectDataset(sentProj, sentDat);
+            linkOfDatasetImage = linkParentToChild(sentDat, sentImage);
+            linkOfProjectDataset = linkParentToChild(sentProj, sentDat);
             Assert.assertTrue(isExpectLinkingSuccess);
         } catch (ServerError se) {
             Assert.assertFalse(isExpectLinkingSuccess);
@@ -1063,10 +1063,10 @@ public class LightAdminRolesTest extends RolesTests {
         Project proj2 = mmFactory.simpleProject();
         Project sentProj1 = (Project) iUpdate.saveAndReturnObject(proj1);
         Project sentProj2 = (Project) iUpdate.saveAndReturnObject(proj2);
-        DatasetImageLink linkOfDatasetImage1 = linkDatasetImage(sentDat1, sentImage1);
-        DatasetImageLink linkOfDatasetImage2 = linkDatasetImage(sentDat2, sentImage2);
-        ProjectDatasetLink linkOfProjectDataset1 = linkProjectDataset(sentProj1, sentDat1);
-        ProjectDatasetLink linkOfProjectDataset2 = linkProjectDataset(sentProj2, sentDat2);
+        DatasetImageLink linkOfDatasetImage1 = linkParentToChild(sentDat1, sentImage1);
+        DatasetImageLink linkOfDatasetImage2 = linkParentToChild(sentDat2, sentImage2);
+        ProjectDatasetLink linkOfProjectDataset1 = linkParentToChild(sentProj1, sentDat1);
+        ProjectDatasetLink linkOfProjectDataset2 = linkParentToChild(sentProj2, sentDat2);
 
         /* normalUser creates two sets of P/D?I hierarchy in the other group (anotherGroup).*/
         client.getImplicitContext().put("omero.group", Long.toString(anotherGroup.getId().getValue()));
@@ -1082,10 +1082,10 @@ public class LightAdminRolesTest extends RolesTests {
         Project proj2AnotherGroup = mmFactory.simpleProject();
         Project sentProj1AnootherGroup = (Project) iUpdate.saveAndReturnObject(proj1AnotherGroup);
         Project sentProj2AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj2AnotherGroup);
-        DatasetImageLink linkOfDatasetImage1AnotherGroup = linkDatasetImage(sentDat1AnotherGroup, sentImage1AnootherGroup);
-        DatasetImageLink linkOfDatasetImage2AnotherGroup = linkDatasetImage(sentDat2AnotherGroup, sentImage2AnotherGroup);
-        ProjectDatasetLink linkOfProjectDataset1AnotherGroup = linkProjectDataset(sentProj1AnootherGroup, sentDat1AnotherGroup);
-        ProjectDatasetLink linkOfProjectDataset2AnotherGroup = linkProjectDataset(sentProj2AnotherGroup, sentDat2AnotherGroup);
+        DatasetImageLink linkOfDatasetImage1AnotherGroup = linkParentToChild(sentDat1AnotherGroup, sentImage1AnootherGroup);
+        DatasetImageLink linkOfDatasetImage2AnotherGroup = linkParentToChild(sentDat2AnotherGroup, sentImage2AnotherGroup);
+        ProjectDatasetLink linkOfProjectDataset1AnotherGroup = linkParentToChild(sentProj1AnootherGroup, sentDat1AnotherGroup);
+        ProjectDatasetLink linkOfProjectDataset2AnotherGroup = linkParentToChild(sentProj2AnotherGroup, sentDat2AnotherGroup);
         /* lightAdmin tries to transfers all normalUser's data to recipient.*/
         loginUser(lightAdmin);
         /* In order to be able to operate in both groups, get all groups context.*/
@@ -1311,7 +1311,7 @@ public class LightAdminRolesTest extends RolesTests {
          * isExpectSuccessLinkFileAttachemnt.*/
         ImageAnnotationLink link = null;
         try {
-            link = (ImageAnnotationLink) linkImageAnnotation(sentImage, fileAnnotation);
+            link = (ImageAnnotationLink) linkParentToChild(sentImage, fileAnnotation);
             /* Check the value of canAnnotate on the image is true in successful linking case.*/
             Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertTrue(isExpectSuccessLinkFileAttachemnt);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -122,7 +122,7 @@ public class LightAdminRolesTest extends RolesTests {
         fileAnnotation = (FileAnnotation) iUpdate.saveAndReturnObject(fileAnnotation);
         originalFileAnnotationAndLink.add(originalFile.proxy());
         originalFileAnnotationAndLink.add(fileAnnotation.proxy());
-        final ImageAnnotationLink link = annotateImage(image, fileAnnotation);
+        final ImageAnnotationLink link = linkImageAnnotation(image, fileAnnotation);
         originalFileAnnotationAndLink.add(link.proxy());
         return originalFileAnnotationAndLink;
     }
@@ -467,7 +467,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Tag the imported image */
         TagAnnotation tagAnnotation = new TagAnnotationI();
         tagAnnotation = (TagAnnotation) iUpdate.saveAndReturnObject(tagAnnotation);
-        final ImageAnnotationLink tagAnnotationLink = annotateImage(image, tagAnnotation);
+        final ImageAnnotationLink tagAnnotationLink = linkImageAnnotation(image, tagAnnotation);
         /* add a file attachment with original file to the imported image.*/
         List<IObject> originalFileAnnotationAndLink = createFileAnnotationWithOriginalFileAndLink(image);
         final OriginalFile annotOriginalFile = (OriginalFile) originalFileAnnotationAndLink.get(0);
@@ -564,7 +564,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Tag the imported image */
         TagAnnotation tagAnnotation = new TagAnnotationI();
         tagAnnotation = (TagAnnotation) iUpdate.saveAndReturnObject(tagAnnotation);
-        final ImageAnnotationLink tagAnnotationLink = annotateImage(image, tagAnnotation);
+        final ImageAnnotationLink tagAnnotationLink = linkImageAnnotation(image, tagAnnotation);
         /* add a file attachment with original file to the imported image.*/
         List<IObject> originalFileAnnotationAndLink = createFileAnnotationWithOriginalFileAndLink(image);
         final OriginalFile annotOriginalFile = (OriginalFile) originalFileAnnotationAndLink.get(0);
@@ -664,7 +664,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Tag the imported image */
         TagAnnotation tagAnnotation = new TagAnnotationI();
         tagAnnotation = (TagAnnotation) iUpdate.saveAndReturnObject(tagAnnotation);
-        final ImageAnnotationLink tagAnnotationLink = annotateImage(image, tagAnnotation);
+        final ImageAnnotationLink tagAnnotationLink = linkImageAnnotation(image, tagAnnotation);
 
         /* add a file attachment with original file to the imported image.*/
         List<IObject> originalFileAnnotationAndLink = createFileAnnotationWithOriginalFileAndLink(image);
@@ -1370,7 +1370,7 @@ public class LightAdminRolesTest extends RolesTests {
          * isExpectSuccessLinkFileAttachemnt */
         ImageAnnotationLink link = new ImageAnnotationLinkI();
         try {
-            link = (ImageAnnotationLink) annotateImage(sentImage, fileAnnotation);
+            link = (ImageAnnotationLink) linkImageAnnotation(sentImage, fileAnnotation);
             /* Check the value of canAnnotate on the image is true in this case.*/
             Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
             Assert.assertTrue(isExpectSuccessLinkFileAttachemnt);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1008,9 +1008,14 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Dataset dat = mmFactory.simpleDataset();
         Dataset sentDat = null;
-        if (createDatasetExpectSuccess) {/* you are allowed to create the dataset only
-        with sufficient permissions, which are captured in createDatasetExpectSuccess.*/
+        /* lightAdmin is allowed to create the dataset only
+         * with sufficient permissions, which are captured
+         * in createDatasetExpectSuccess boolean.*/
+        try {
             sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+            Assert.assertTrue(createDatasetExpectSuccess);
+        } catch (ServerError se) {
+            Assert.assertFalse(createDatasetExpectSuccess);
         }
         /* import an image into the created Dataset */
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -104,36 +104,6 @@ import com.google.common.collect.ImmutableMap;
 public class LightAdminRolesTest extends RolesTests {
 
     /**
-     * Assert that the given object is owned by the given owner.
-     * @param object a model object
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(IObject object, EventContext expectedOwner) throws ServerError {
-        assertOwnedBy(Collections.singleton(object), expectedOwner);
-    }
-
-    /**
-     * Assert that the given objects are owned by the given owner.
-     * @param objects some model objects
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
-        if (objects.isEmpty()) {
-            throw new IllegalArgumentException("must assert about some objects");
-        }
-        for (final IObject object : objects) {
-            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
-            final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
-            final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
-            Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
-        }
-    }
-
-    /**
      * Assert that the given object is in the given group.
      * @param object a model object
      * @param expectedGroupId a group Id

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1133,8 +1133,8 @@ public class LightAdminRolesTest extends RolesTests {
      * lightAdmin tries then to transfer the ownership of the ROI and Rendering settings
      * to normalUser.
      * lightAdmin does not use Sudo in this test.
-     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit#slide=id.p4">graphical explanation</a>

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1234,7 +1234,7 @@ public class LightAdminRolesTest extends RolesTests {
                     "SELECT rdef.pixels.image.id FROM RenderingDef rdef WHERE rdef.id = :id",
                     new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();
             if (isExpectSuccessCreateAndChown) {
-                /* First case: Workflow succeeded for creation and chown, all belongs to normalUser */
+                /* First case: Workflow succeeded for creation and chown, all belongs to normalUser.*/
                 assertOwnedBy(roi, normalUser);
                 assertOwnedBy(rDef, normalUser);
                 assertOwnedBy((new ImageI (imageId, false)), normalUser);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -473,7 +473,7 @@ public class LightAdminRolesTest extends RolesTests {
         OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
         Image image = (Image) originalFileAndImage.get(1);
 
-        /* Annotate the imported image with Tag and file attachment */
+        /* Annotate the imported image with Tag and file attachment.*/
         List<IObject> annotOriginalFileAnnotationTagAndLinks = annotateImageWithTagAndFile(image);
 
         /* Set up the light admin's permissions for this test.*/
@@ -550,7 +550,7 @@ public class LightAdminRolesTest extends RolesTests {
          * move is intended, it must show "true" in every case in which SOME
          * chgrp might be successful.*/
         final boolean canChgrpExpectedTrue = permChgrp || isSudoing;
-        /* Create a Dataset as the normalUser and import into it */
+        /* Create a Dataset as the normalUser and import into it.*/
         loginUser(normalUser);
         Dataset dat = mmFactory.simpleDataset();
         Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
@@ -558,7 +558,7 @@ public class LightAdminRolesTest extends RolesTests {
         OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
         Image image = (Image) originalFileAndImage.get(1);
 
-        /* Annotate the imported image with Tag and file attachment */
+        /* Annotate the imported image with Tag and file attachment.*/
         List<IObject> annotOriginalFileAnnotationTagAndLinks = annotateImageWithTagAndFile(image);
 
         /* Set up the light admin's permissions for this test.*/

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -800,14 +800,14 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-    /** lightAdmin tries to link an object to a pre-existing container (image or Dataset)
-     * in the target group (of normalUser where lightAdmin is not member)
-     * and linking of the image or dataset to this container
-     * (Dataset or Project). The image import (by lightAdmin for others)
-     * has been tested in other tests,
-     * here the image, Dataset and Project is created by normalUser and saved, then
-     * the linking to a container by lightAdmin is tested. Only when lightAdmin has
-     * WriteOwned privilege is the linking possible.
+    /**
+     * lightAdmin tries to link an object to a pre-existing container (Dataset or Project)
+     * in the target group (of normalUser where lightAdmin is not member).
+     * lightAdmin tries to link image or Dataset to Dataset or Project.
+     * The image import (by lightAdmin for others) has been tested in other tests.
+     * Here, normalUser creates and saves the image, Dataset and Project,
+     * then lightAdmin tries to link these objects.
+     * lightAdmin will succeed if they have WriteOwned privilege.
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -149,29 +149,6 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Create a link between a Project and a Dataset.
-     * @param project an OMERO Project
-     * @param dataset an OMERO Dataset
-     * @return the created link
-     * @throws ServerError if the query caused a server error
-     */
-    private ProjectDatasetLink linkProjectDataset(Project project, Dataset dataset) throws ServerError {
-        if (project.isLoaded() && project.getId() != null) {
-            project = (Project) project.proxy();
-        }
-        if (dataset.isLoaded() && dataset.getId() != null) {
-            dataset = (Dataset) dataset.proxy();
-        }
-
-        final ProjectDatasetLink link = new ProjectDatasetLinkI();
-        link.setParent(project);
-        link.setChild(dataset);
-        return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
-    }
-
-
-
-    /**
      * Create a light administrator, with a specific privilege, and log in as them.
      * All the other privileges will be set to False.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1196,7 +1196,7 @@ public class LightAdminRolesTest extends RolesTests {
             /* Check the value of canAnnotate on the sentImage.
              * The value must be false as the Rnd settings cannot be saved.*/
             Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
-            Assert.assertFalse(isExpectSuccessCreateROIRndSettings);
+            Assert.assertFalse(isExpectSuccessCreateROIRndSettings, sv.toString());
         }
         /* Retrieve the image corresponding to the roi and Rnd settings
          * (if they could be set) and check the roi and rendering settings

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1247,10 +1247,11 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-    /** Light admin (lightAdmin) uploads a File Attachment (fileAnnotation)
-     * with original file (originalFile) in a group they are not member of (normalUser's group)
-     * and tries to link it to an image of the user (normalUser) and then tries to transfer
-     * the ownership of the fileAnnotation and link to normalUser.
+    /**
+     * Light admin (lightAdmin) tries to upload a File Attachment (fileAnnotation)
+     * with original file (originalFile) into a group they are not member of (normalUser's group).
+     * lightAdmin then tries to link fileAnnotation to an image of the user (normalUser).
+     * lightAdmin then tries to transfer the ownership of the fileAnnotation and link to normalUser.
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1289,10 +1289,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
                 "SELECT id FROM OriginalFile WHERE name = :name ORDER BY id DESC LIMIT 1",
                 new ParametersI().add("name", imageName));
         final long previousId = result.isEmpty() ? -1 : ((RLong) result.get(0).get(0)).getValue();
-        try { /* expected */
-            List<String> path = Collections.singletonList(fakeImageFile.getPath());
-            importFileset(path, path.size(), sentDat);
-        } catch (ServerError se) { /* not expected */}
+        List<String> path = Collections.singletonList(fakeImageFile.getPath());
+        importFileset(path, path.size(), sentDat);
         OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
                 "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                 new ParametersI().addId(previousId).add("name", imageName));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -128,27 +128,6 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Add the given annotation to the given image.
-     * @param image an image
-     * @param annotation an annotation
-     * @return the new loaded link from the image to the annotation
-     * @throws ServerError unexpected
-     */
-    private ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
-        if (image.isLoaded() && image.getId() != null) {
-            image = (Image) image.proxy();
-        }
-        if (annotation.isLoaded() && annotation.getId() != null) {
-            annotation = (Annotation) annotation.proxy();
-        }
-
-        final ImageAnnotationLink link = new ImageAnnotationLinkI();
-        link.setParent(image);
-        link.setChild(annotation);
-        return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
-    }
-
-    /**
      * Create a light administrator, with a specific privilege, and log in as them.
      * All the other privileges will be set to False.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -778,10 +778,9 @@ public class LightAdminRolesTest extends RolesTests {
         /* lightAdmin tries to change the ownership of the Dataset to normalUser */
         doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(),
                 createDatasetImportNotYourGroupAndChownExpectSuccess);
-        final List<RType> resultForLink = iQuery.projection(
-                "SELECT id FROM DatasetImageLink WHERE parent.id  = :id",
-                new ParametersI().addId(sentDat.getId())).get(0);
-        final long linkId = ((RLong) resultForLink.get(0)).getValue();
+        final DatasetImageLink link = (DatasetImageLink) iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE parent.id = :id",
+                new ParametersI().addId(sentDat.getId()));
         /* Check that image, dataset and link are in the normalUser's group
          * and belong to normalUser in case the workflow succeeded.*/
         if (createDatasetImportNotYourGroupAndChownExpectSuccess) {
@@ -789,8 +788,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, normalUser);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI(linkId, false)), normalUser);
-            assertInGroup((new DatasetImageLinkI(linkId, false)), normalUser.groupId);
+            assertOwnedBy(link, normalUser);
+            assertInGroup(link, normalUser.groupId);
             assertOwnedBy(originalFile, normalUser);
             assertInGroup(originalFile, normalUser.groupId);
         /* Check that the image, dataset and link still belongs
@@ -800,8 +799,8 @@ public class LightAdminRolesTest extends RolesTests {
             assertInGroup(image, normalUser.groupId);
             assertOwnedBy(sentDat, lightAdmin);
             assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy((new DatasetImageLinkI(linkId, false)), lightAdmin);
-            assertInGroup((new DatasetImageLinkI(linkId, false)), normalUser.groupId);
+            assertOwnedBy(link, lightAdmin);
+            assertInGroup(link, normalUser.groupId);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2020,7 +2020,7 @@ public class LightAdminRolesTest extends RolesTests {
      * means specifically WriteScriptRepo privilege).
      */
     @DataProvider(name = "isPrivileged cases")
-    public Object[][] provideIsPrivilegesCases() {
+    public Object[][] provideIsPrivilegedCases() {
         int index = 0;
         final int IS_PRIVILEGED = index++;
         final int GROUP_PERMS = index++;

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1218,7 +1218,7 @@ public class LightAdminRolesTest extends RolesTests {
             Assert.assertNull(rDef);
         }
         /* lightAdmin tries to chown the ROI and the rendering settings (rDef) to normalUser.
-         * Only attempt the canChown check and the chown if the ROI and rendering settings exist */
+         * Only attempt the canChown check and the chown if the ROI and rendering settings exist.*/
         if (isExpectSuccessCreateROIRndSettings) {
             /* Check the value of canChown on the ROI and rendering settings (rDef) matches
              * the boolean isExpectSuccessCreateAndChownRndSettings.*/

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1715,7 +1715,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * @return test cases for File Attachment workflow testFileAttachmentNoSudo
+     * @return test cases for fileAnnotation workflow in testFileAttachmentNoSudo
      */
     @DataProvider(name = "fileAttachment privileges cases")
     public Object[][] provideFileAttachmentPrivilegesCases() {
@@ -1812,7 +1812,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * @return isSudoing, Chgrp and DeleteOwned test cases for testChgrp
+     * @return test cases for testChgrp and testChgrpNonMember
      */
     @DataProvider(name = "isSudoing and Chgrp privileges cases")
     public Object[][] provideIsSudoingAndChgrpOwned() {
@@ -1829,7 +1829,7 @@ public class LightAdminRolesTest extends RolesTests {
                 for (final boolean permChgrp : booleanCases) {
                     for (final String groupPerms : permsCases) {
                         final Object[] testCase = new Object[index];
-                        /* no test cases are excluded here, because isSudoing
+                        /* No test cases are excluded here, because isSudoing
                          * is in a sense acting to annule Chgrp permission
                          * which is tested in the testChgrp and is an interesting case.*/
                         testCase[IS_SUDOING] = isSudoing;
@@ -1861,7 +1861,7 @@ public class LightAdminRolesTest extends RolesTests {
                 for (final boolean permChown : booleanCases) {
                     for (final String groupPerms : permsCases) {
                         final Object[] testCase = new Object[index];
-                        /* no test cases are excluded here, because isSudoing
+                        /* No test cases are excluded here, because isSudoing
                          * is in a sense acting to annule Chown permission
                          * which is tested in the testChown and is an interesting case.*/
                         testCase[IS_SUDOING] = isSudoing;
@@ -1877,7 +1877,7 @@ public class LightAdminRolesTest extends RolesTests {
 
     /**
      * @return provide WriteOwned, WriteFile, WriteManagedRepo and Chown cases
-     * for testImporterAsNoSudoChownOnly
+     * for testImporterAsNoSudoChownOnlyWorkflow
      */
     @DataProvider(name = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
     public Object[][] provideWriteOwnedWriteFileWriteManagedRepoAndChown() {
@@ -1956,7 +1956,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * @return Chgrp and Chown test cases for testImporterAsNoSudoChgrpChown
+     * @return Chgrp and Chown test cases for testImporterAsNoSudoChgrpChownWorkflow
      */
     @DataProvider(name = "Chgrp and Chown privileges cases")
     public Object[][] provideChgrpAndChown() {
@@ -1991,7 +1991,7 @@ public class LightAdminRolesTest extends RolesTests {
     /**
      * @return isPrivileged test cases. The isPrivileged parameter translates into one
      * tested privilege in particular tests (for example in testScriptUpload isPrivileged
-     * concerns WriteScriptRepo privilege specifically)
+     * means specifically WriteScriptRepo privilege).
      */
     @DataProvider(name = "isPrivileged cases")
     public Object[][] provideIsPrivilegesCases() {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1653,8 +1653,8 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can create a new group
-     * when the light admin has only the <tt>ModifyGroup</tt> privilege.
+     * Light admin (lightAdmin) tries to create a new group.
+     * lightAmin will succeed if they have the <tt>ModifyGroup</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1662,14 +1662,13 @@ public class LightAdminRolesTest extends RolesTests {
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupCreate(boolean isPrivileged,
             String groupPermissions) throws Exception {
-        /* the permModifyGroup should be a sufficient permission to perform
-         * a group creation */
+        /* isPrivileged translates in this test into ModifyGroup permission, see below.*/
         boolean isExpectSuccessCreateGroup = isPrivileged;
         final ExperimenterGroup newGroup = new ExperimenterGroupI();
         newGroup.setLdap(omero.rtypes.rbool(false));
         newGroup.setName(omero.rtypes.rstring(UUID.randomUUID().toString()));
         newGroup.getDetails().setPermissions(new PermissionsI(groupPermissions));
-        /* set up the permissions for the light admin */
+        /* Set up the permissions for lightAdmin.*/
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroup.value);
         final EventContext lightAdmin;
@@ -1683,8 +1682,8 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin can edit an existing group
-     * when the light admin has only the <tt>ModifyGroup</tt> privilege.
+     * Light admin (lightAdmin) tries to edit an existing group.
+     * lightAdmin will succeed if they have the <tt>ModifyGroup</tt> privilege.
      * @param isPrivileged if to test a user who has the <tt>ModifyGroup</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
@@ -1692,19 +1691,18 @@ public class LightAdminRolesTest extends RolesTests {
     @Test(dataProvider = "isPrivileged cases")
     public void testModifyGroupEdit(boolean isPrivileged,
             String groupPermissions) throws Exception {
-        /* the permModifyGroup should be a sufficient permission to perform
-         * group editing */
+        /* isPrivileged translates in this test into ModifyGroup permission, see below.*/
         boolean isExpectSuccessEditGroup = isPrivileged;
-        /* set up the new group as Read-Write as the downgrade (edit) to all group
-         * types by the light admin will be tested later in the test */
+        /* Set up the new group as Read-Write as part of the edit test will be a downgrade
+         * of that group to all group types by the lightAdmin.*/
         final long newGroupId = newUserAndGroup("rwrw--").groupId;
-        /* set up the permissions for the light admin */
+        /* Set up the permissions for the lightAdmin.*/
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroup.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
-        /* light admin will downgrade the group to all possible permission levels and
-         * also will edit the ldap settings */
+        /* lightAdmin tries to downgrade the group to all possible permission levels and
+         * also tries to edit the LDAP settings.*/
         final ExperimenterGroup newGroup = (ExperimenterGroup) iQuery.get("ExperimenterGroup", newGroupId);
         newGroup.getDetails().setPermissions(new PermissionsI(groupPermissions));
         newGroup.setLdap(omero.rtypes.rbool(true));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -482,7 +482,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /*in order to find the image in whatever group, get context with group
          * set to -1 (=all groups) */
-        client.getImplicitContext().put("omero.group", "-1");
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
         /* try to move the image into another group of the normalUser
          * which should succeed if sudoing and also in case
          * the light admin has Chgrp permissions
@@ -568,7 +568,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /*in order to find the image in whatever group, get context with group
          * set to -1 (=all groups) */
-        client.getImplicitContext().put("omero.group", Long.toString(-1));
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
 
         /* try to move into another group the normalUser
          * is not a member of, which should fail in all cases
@@ -963,7 +963,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* in order to find the image in whatever group, get context with group
          * set to -1 (=all groups)
          */
-        client.getImplicitContext().put("omero.group", "-1");
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
         /* try to move the dataset (and with it the linked image)
          * from light admin's default group
          * into the default group of the normalUser
@@ -1127,7 +1127,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /* check the transfer of all the data in the first group was successful */
         /* check ownership of the first hierarchy set*/
-        client.getImplicitContext().put("omero.group", "-1");
+        mergeIntoContext(client.getImplicitContext(), ALL_GROUPS_CONTEXT);
         assertOwnedBy(sentProj1, recipient);
         assertOwnedBy(sentDat1, recipient);
         assertOwnedBy(sentImage1, recipient);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -744,7 +744,7 @@ public class LightAdminRolesTest extends RolesTests {
             sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
             Assert.assertTrue(createDatasetExpectSuccess);
         } catch (ServerError se) {
-            Assert.assertFalse(createDatasetExpectSuccess);
+            Assert.assertFalse(createDatasetExpectSuccess, se.toString());
         }
         /* As lightAdmin, import an Image into the created Dataset.*/
         OriginalFile originalFile = null;

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -605,13 +605,13 @@ public class LightAdminRolesTest extends RolesTests {
      * Test that light admin can, having the <tt>Chown</tt> privilege,
      * transfer the data between two users (normalUser and anotherUser).
      * Test also that light admin, if sudoed, cannot transfer ownership,
-     * because light admin sudoes as a non-admin non-group owner user.
+     * because light admin sudoes as a non-admin non-group-owner user.
      * In case of private group the transfer of an Image severs the link between the Dataset and Image.
      * For this unlinking, only the Chown permissions are sufficient, no other permissions are necessary.
      * <tt>Chown</tt> privilege is sufficient also
      * to transfer ownership of annotations (tag and file attachment are tested here),
      * but just in case of private and read-only groups, which is in line with the
-     * general behaviour of the <tt>Chown</tt> command.
+     * general behavior of the <tt>Chown</tt> command.
      * @param isSudoing if to test a success of workflows where Sudoed in
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -691,8 +691,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that light admin "importing for others" workflow
-     * without using Sudo.
+     * Light admin is trying to "import for others" without using Sudo in following manner.
      * lightAdmin imports into group of the normalUser (future owner of the data).
      * lightAdmin then transfers the ownership of the imported data to normalUser.
      * For this test, combinations of <tt>Chown</tt>, <tt>WriteOwned</tt>,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -106,7 +106,7 @@ public class LightAdminRolesTest extends RolesTests {
 
     /**
      * Create a light administrator, with a specific privilege, and log in as them.
-     * All the other privileges will be set to False.
+     * All the other privileges will be set to false.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group
      * @param permission the privilege that the user should have, or {@code null} if they should have no privileges
      * @return the new user's context
@@ -118,7 +118,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Create a light administrator, with a specific privilege, and log in as them.
+     * Create a light administrator, with a specific list of privileges, and log in as them.
      * All the other privileges will be set to False.
      * @param isAdmin if the user should be a member of the <tt>system</tt> group
      * @param permissions the privileges that the user should have, or {@code null} if they should have no privileges
@@ -156,7 +156,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Annotate image with tag and file annotation only and return the annotation objects
+     * Annotate image with tag and file annotation and return the annotation objects
      * including the original file of the file annotation and the links
      * @param image the image to be annotated
      * @return the list of the tag, original file of the file annotation, file annotation
@@ -180,10 +180,10 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Test that an ImporterAs can create new Project and Dataset
+     * Test that a light administrator can create new Project and Dataset
      * and import data on behalf of another user solely with <tt>Sudo</tt> privilege
      * into this Dataset. Further link the Dataset to the Project, check
-     * that the link belongs to the user (not to the ImporterAs).
+     * that the link belongs to the user (not to the light admin).
      * All workflows are tested here both when light admin is sudoing
      * and when he/she is not sudoing, except for Link and Import (both tested
      * only when sudoing, as the non-sudoing workflows are too complicated
@@ -192,6 +192,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected
+     * @see <a href="graphical explanation">https://docs.google.com/presentation/d/1JX6b9pkPtG-3hZIGSp2bu4WVvNKn6GHqIKdfbbJkiw8/edit#slide=id.p4</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testImporterAsSudoCreateImport(boolean isSudoing, boolean permWriteOwned,
@@ -206,7 +207,7 @@ public class LightAdminRolesTest extends RolesTests {
         lightAdmin = loginNewAdmin(true, permissions);
         if (isSudoing) sudo(new ExperimenterI(normalUser.userId, false));
 
-        /* First, check that the light admin (=importer As)
+        /* First, check that the lightAdmin
          * can create Project and Dataset on behalf of the normalUser
          * in the group of the normalUser in anticipation of importing
          * data for the normalUser in the next step into these containers */
@@ -238,34 +239,31 @@ public class LightAdminRolesTest extends RolesTests {
             Assert.assertNull(sentProj);
             Assert.assertNull(sentDat);
         }
-        /* finish the test if light admin is not sudoing, the further part
-        of the test deals with the imports. Imports when not sudoing workflows are covered in
-        other tests in this class */
+        /* Finish the test if light admin is not sudoing, the further part
+         * of the test deals with the imports. Imports when not sudoing workflows
+         * are covered in other tests in this class.*/
         if (!isSudoing) return;
 
-        /* check that after sudo, the light admin is able to ImportAs and target
+        /* check that after sudo, the lightAdmin is able to ImportAs and target
          * the import into the just created Dataset.
-         * Check thus that the light admin can import and write the original file
+         * Check thus that the lightAdmin can import and write the original file
          * on behalf of the normalUser and into the group of normalUser */
         List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
         OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
         Image image = (Image) originalFileAndImage.get(1);
 
-        /* check that the light admin when sudoed, can link the created Dataset
-         * to the created Project, check the ownership of the links
-         * is of the simple user.*/
-
-        /* check that the canLink() method is delivering true on both the Dataset
+        /* Check that the canLink() method is delivering true on both the Dataset
          * and Project to be linked. As the cases where the light admin was not sudoing
          * are not tested in this part of the test, the canLink() is always true
          * for the owner of the objects (the normalUser as who the light admin is
-         * sudoed for) */
+         * sudoed for).*/
         Assert.assertTrue(getCurrentPermissions(sentProj).canLink());
         Assert.assertTrue(getCurrentPermissions(sentDat).canLink());
         ProjectDatasetLink projectDatasetLink = linkProjectDataset(sentProj, sentDat);
 
-        /* Now check the ownership of image and links
-         * between image and Dataset and Dataset and Project */
+        /* Check the owner of the links between image and Dataset and
+         * Dataset and Project is normalUser
+         * and the image and its original file are in the group of normalUser.*/
         final IObject imageDatasetLink = iQuery.findByQuery(
                 "FROM DatasetImageLink WHERE child.id = :id",
                 new ParametersI().addId(image.getId().getValue()));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1293,7 +1293,7 @@ public class LightAdminRolesTest extends RolesTests {
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         /* lightAdmin tries to create a fileAttachment in normalUser's group.*/
         FileAnnotation fileAnnotation = mmFactory.createFileAnnotation();
-        OriginalFile originalFile = new OriginalFileI();
+        OriginalFile originalFile;
         try {
             fileAnnotation = (FileAnnotation) iUpdate.saveAndReturnObject(fileAnnotation);
             originalFile = (OriginalFile) fileAnnotation.getFile();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1343,9 +1343,8 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), lightAdmin.groupId);
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
-         * try to change the ownership of the dataset to the normalUser */
-        /* Chowning the dataset should fail in case you have not both of
-         * isAdmin & Chown permissions which are
+         * try to change the ownership of the dataset to the normalUser.
+         * Chowning the dataset should fail in case you have not Chown permissions which are
          * captured in the boolean importYourGroupAndChgrpAndChownExpectSuccess.
          * Additionally, in this boolean is permChgrp, which was necessary for the
          * previous step of moving the data into normalUser's group.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1780,7 +1780,7 @@ public class LightAdminRolesTest extends RolesTests {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_WRITEOWNED] = permWriteOwned;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isSudoing == true && permWriteOwned == true)
+                        // DEBUG if (isSudoing == true && permWriteOwned == true && groupPerms.equals("rwr---")))
                         testCases.add(testCase);
                     }
                 }
@@ -1812,7 +1812,7 @@ public class LightAdminRolesTest extends RolesTests {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_DELETEOWNED] = permDeleteOwned;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isSudoing == true && permDeleteOwned == true)
+                        // DEBUG if (isSudoing == true && permDeleteOwned == true && groupPerms.equals("rwr---"))
                         testCases.add(testCase);
                     }
                 }
@@ -1844,7 +1844,7 @@ public class LightAdminRolesTest extends RolesTests {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_CHGRP] = permChgrp;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isSudoing == true && permChgrp == true)
+                        // DEBUG  if (isSudoing == true && permChgrp == true && groupPerms.equals("rwr---"))
                         testCases.add(testCase);
                     }
                 }
@@ -1876,7 +1876,7 @@ public class LightAdminRolesTest extends RolesTests {
                         testCase[IS_SUDOING] = isSudoing;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isSudoing == true && permChown == true)
+                        // DEBUG  if (isSudoing == true && permChown == true && groupPerms.equals("rwr---"))
                         testCases.add(testCase);
                     }
                 }
@@ -1921,7 +1921,8 @@ public class LightAdminRolesTest extends RolesTests {
                                 testCase[PERM_WRITEMANAGEDREPO] = permWriteManagedRepo;
                                 testCase[PERM_CHOWN] = permChown;
                                 testCase[GROUP_PERMS] = groupPerms;
-                                // DEBUG if (permWriteOwned == true && permWriteFile == true && permWriteManagedRepo == true && permChown == true)
+                                // DEBUG if (permWriteOwned == true && permWriteFile == true && permWriteManagedRepo == true
+                                // && permChown == true && groupPerms.equals("rwr---"))
                                 testCases.add(testCase);
                             }
                         }
@@ -1989,7 +1990,7 @@ public class LightAdminRolesTest extends RolesTests {
                         testCase[PERM_CHGRP] = permChgrp;
                         testCase[PERM_CHOWN] = permChown;
                         testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (permChgrp == true && permChown == true)
+                        // DEBUG if (permChgrp == true && permChown == true && groupPerms.equals("rwr---"))
                         testCases.add(testCase);
                     }
                 }
@@ -2017,7 +2018,7 @@ public class LightAdminRolesTest extends RolesTests {
                     final Object[] testCase = new Object[index];
                     testCase[IS_PRIVILEGED] = isPrivileged;
                     testCase[GROUP_PERMS] = groupPerms;
-                    // DEBUG if (isPrivileged == true)
+                    // DEBUG if (isPrivileged == true && groupPerms.equals("rwr---"))
                     testCases.add(testCase);
                 }
             }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -698,13 +698,13 @@ public class LightAdminRolesTest extends RolesTests {
      * Light admin is trying to "import for others" without using Sudo in following manner.
      * lightAdmin imports into group of the normalUser (future owner of the data).
      * lightAdmin then transfers the ownership of the imported data to normalUser.
-     * For this test, combinations of <tt>Chown</tt>, <tt>WriteOwned</tt>,
-     *  <tt>WriteFile</tt> and <tt>WriteManagedRepo</tt> privileges will be explored
+     * For this test, combinations of <tt>WriteOwned</tt>, <tt>WriteFile</tt>,
+     * <tt>WriteManagedRepo</tt> and <tt>Chown</tt> privileges will be explored
      * for lightAdmin. For this workflow the creation and targeting of a Dataset
      * is tested too.
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
-     * @param permWriteManagedRepo if to test a user who has the <tt>WriteManagedRepo</tt> privilege
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
+     * @param permWriteManagedRepo if to test a user who has the <tt>WriteManagedRepo</tt> privilege
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions if to test the effect of group permission level
      * @throws Exception unexpected

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1344,16 +1344,15 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         }
         /* now, having moved the dataset, image, original file and link in the group of normalUser,
          * try to change the ownership of the dataset to the normalUser.
-         * Chowning the dataset should fail in case you have not Chown permissions which are
-         * captured in the boolean importYourGroupAndChgrpAndChownExpectSuccess.
-         * Additionally, in this boolean is permChgrp, which was necessary for the
-         * previous step of moving the data into normalUser's group.
+         * Chowning the dataset should fail in case you have not Chown permissions.
          * A successful chowning of the dataset will chown the linked image
-         * and the link too.*/
+         * and the link too. Also check that the canChown boolean on the Dataset must be in
+         * sync with the permChown.*/
+        Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), permChown);
+        doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), permChown);
+        /* boolean importYourGroupAndChgrpAndChownExpectSuccess
+         * captures permChown and permChgrp. Check the objects ownership and groups.*/
         if (importYourGroupAndChgrpAndChownExpectSuccess) {/* whole workflow2 succeeded */
-            /* Check the value of canChown on the dataset is true in this case.*/
-            Assert.assertTrue(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             /* image, dataset and link are in the normalUser's group and belong to normalUser */
             assertOwnedBy(remoteFile, normalUser);
             assertInGroup(remoteFile, normalUser.groupId);
@@ -1365,9 +1364,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
         } else if (permChown) {
             /* even if the workflow2 as a whole failed, the chown might be successful */
-            /* Check the value of canChown on the dataset is true in this case.*/
-            Assert.assertTrue(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), true);
             /* the image, dataset and link belong to the normalUser, but is in the light admin's group */
             assertOwnedBy(remoteFile, normalUser);
             assertInGroup(remoteFile, lightAdmin.groupId);
@@ -1380,9 +1376,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
         } else if (permChgrp) {
             /* as workflow2 as a whole failed, in case the chgrp was successful,
              * the chown must be failing */
-            /* Check the value of canChown on the dataset is false in this case.*/
-            Assert.assertFalse(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             /* the image, dataset and link are in normalUser's group but still belong to light admin */
             assertOwnedBy(remoteFile, lightAdmin);
             assertInGroup(remoteFile, normalUser.groupId);
@@ -1394,9 +1387,6 @@ public class LightAdminRolesTest extends AbstractServerImportTest {
             assertInGroup((new DatasetImageLinkI (datasetImageLinkId, false)), normalUser.groupId);
         } else {
             /* the remaining option when the previous chgrp as well as this chown fail */
-            /* Check the value of canChown on the dataset is false in this case.*/
-            Assert.assertFalse(getCurrentPermissions(sentDat).canChown());
-            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), false);
             /* the image, dataset and link are in light admin's group and belong to light admin */
             assertOwnedBy(remoteFile, lightAdmin);
             assertInGroup(remoteFile, lightAdmin.groupId);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -169,26 +169,7 @@ public class LightAdminRolesTest extends RolesTests {
         return (ProjectDatasetLink) iUpdate.saveAndReturnObject(link);
     }
 
-    /**
-     * Create a link between a Dataset and an Image.
-     * @param dataset an OMERO Dataset
-     * @param image an OMERO Image
-     * @return the created link
-     * @throws ServerError if the query caused a server error
-     */
-    private DatasetImageLink linkDatasetImage(Dataset dataset, Image image) throws ServerError {
-        if (dataset.isLoaded() && dataset.getId() != null) {
-            dataset = (Dataset) dataset.proxy();
-        }
-        if (image.isLoaded() && image.getId() != null) {
-            image = (Image) image.proxy();
-        }
 
-        final DatasetImageLink link = new DatasetImageLinkI();
-        link.setParent(dataset);
-        link.setChild(image);
-        return (DatasetImageLink) iUpdate.saveAndReturnObject(link);
-    }
 
     /**
      * Create a light administrator, with a specific privilege, and log in as them.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -675,7 +675,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertOwnedBy(originalFile, anotherUser);
             /* Annotations will be chowned because
              * groupPermissions are private or read-only (captured in boolean
-             * annotationsChownExpectSuccess) */
+             * annotationsChownExpectSuccess).*/
             assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, anotherUser);
         /* Check the chown was successful for the image but not the annotations
          * in case the annotationsChownExpectSuccess is false, i.e. in read-only and private group.*/
@@ -690,7 +690,7 @@ public class LightAdminRolesTest extends RolesTests {
             assertOwnedBy(originalFile, normalUser);
             assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, normalUser);
         }
-        /* In any case, the image must be in the right group */
+        /* In any case, the image must be in the right group.*/
         assertInGroup(image, normalUser.groupId);
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1473,8 +1473,8 @@ public class LightAdminRolesTest extends RolesTests {
             Assert.assertEquals(currentScript, actualScript);
             Assert.assertFalse(isExpectSuccessDeleteOfficialScript);
         } catch (Ice.LocalException | ServerError se) {
-            /* Have to catch both types of exceptions because of
-             * RawFileStoreTest.testBadFileId behavior.*/
+            /* Have to catch both types of exceptions because
+             * {@link #RawFileStoreTest.testBadFileId, testBadFileId} is broken.*/
             Assert.assertTrue(isExpectSuccessDeleteOfficialScript);
         } finally {
             rfs.close();

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -311,6 +311,18 @@ public class ModelMockFactory {
     }
 
     /**
+     * Create a FileAnnotation with Original File.
+     * @return the FileAnnotation
+     * @throws Exception unexpected
+     */
+    protected FileAnnotation createFileAnnotation() throws Exception {
+        FileAnnotation fileAnnotation = new FileAnnotationI();
+        OriginalFile originalFile = createOriginalFile();
+        fileAnnotation.setFile(originalFile);
+        return fileAnnotation;
+    }
+
+    /**
      * Creates and returns an original file object.
      *
      * @return See above.

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -313,9 +313,8 @@ public class ModelMockFactory {
     /**
      * Create a FileAnnotation with Original File.
      * @return the FileAnnotation
-     * @throws Exception unexpected
      */
-    protected FileAnnotation createFileAnnotation() throws Exception {
+    protected FileAnnotation createFileAnnotation() {
         FileAnnotation fileAnnotation = new FileAnnotationI();
         OriginalFile originalFile = createOriginalFile();
         fileAnnotation.setFile(originalFile);
@@ -324,12 +323,9 @@ public class ModelMockFactory {
 
     /**
      * Creates and returns an original file object.
-     *
      * @return See above.
-     * @throws Exception
-     *             Thrown if an error occurred.
      */
-    public OriginalFile createOriginalFile() throws Exception {
+    public OriginalFile createOriginalFile() {
         OriginalFileI oFile = new OriginalFileI();
         oFile.setName(omero.rtypes.rstring("Test_" + UUID.randomUUID().toString()));
         oFile.setPath(omero.rtypes.rstring("/omero/"));

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -42,7 +42,10 @@ import omero.model.Image;
 import omero.model.OriginalFile;
 import omero.model.Permissions;
 import omero.model.PermissionsI;
+import omero.model.Session;
+import omero.sys.EventContext;
 import omero.sys.ParametersI;
+import omero.sys.Principal;
 import omero.util.TempFileManager;
 
 /**
@@ -130,4 +133,19 @@ public class RolesTests extends AbstractServerImportTest {
         return originalFileAndImage;
     }
 
+    /**
+     * Sudo to the given user.
+     * @param targetName the name of a user
+     * @return context for a session owned by the given user
+     * @throws Exception if the sudo could not be performed
+     */
+    protected EventContext sudo(String targetName) throws Exception {
+        final Principal principal = new Principal();
+        principal.name = targetName;
+        final Session session = factory.getSessionService().createSessionWithTimeout(principal, 100 * 1000);
+        final omero.client client = newOmeroClient();
+        final String sessionUUID = session.getUuid().getValue();
+        client.createSession(sessionUUID, sessionUUID);
+        return init(client);
+    }
 }

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -86,6 +86,7 @@ public class RolesTests extends AbstractServerImportTest {
      * @param object a model object previously retrieved from the server
      * @return the permissions for the object in the current context
      * @throws ServerError if the query caused a server error
+     * (except for security violations, returns NO_PERMISSIONS)
      */
     protected Permissions getCurrentPermissions(IObject object) throws ServerError {
         final String objectClass = object.getClass().getSuperclass().getSimpleName();

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -107,11 +107,11 @@ public class RolesTests extends AbstractServerImportTest {
 
     /**
      * Import an image with original file into a given dataset.
-     * @param dat dataset to which to import the image if not null
+     * @param dataset dataset to which to import the image if not null
      * @return the original file and the imported image
      * @throws Exception if the import fails
      */
-    protected List<IObject> importImageWithOriginalFile(Dataset dat) throws Exception {
+    protected List<IObject> importImageWithOriginalFile(Dataset dataset) throws Exception {
         final List<IObject> originalFileAndImage = new ArrayList<IObject>();
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
         final List<List<RType>> result = iQuery.projection(
@@ -119,7 +119,7 @@ public class RolesTests extends AbstractServerImportTest {
                 new ParametersI().add("name", imageName));
         final long previousId = result.isEmpty() ? -1 : ((RLong) result.get(0).get(0)).getValue();
         List<String> path = Collections.singletonList(fakeImageFile.getPath());
-        importFileset(path, path.size(), dat);
+        importFileset(path, path.size(), dataset);
         final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
                 "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
                 new ParametersI().addId(previousId).add("name", imageName));

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -109,7 +109,7 @@ public class RolesTests extends AbstractServerImportTest {
      * Import an image with original file into a given dataset.
      * @param dat dataset to which to import the image if not null
      * @return the original file and the imported image
-     * @throws Exception unexpected
+     * @throws Exception if the import fails
      */
     protected List<IObject> importImageWithOriginalFile(Dataset dat) throws Exception {
         final List<IObject> originalFileAndImage = new ArrayList<IObject>();

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -72,7 +72,7 @@ public class RolesTests extends AbstractServerImportTest {
         fakeImageFile.createNewFile();
     }
 
-    /* these permissions do not permit anything */
+    /* These permissions do not permit anything.*/
     @SuppressWarnings("serial")
     private static final Permissions NO_PERMISSIONS = new PermissionsI("------") {
         @Override

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -91,13 +91,12 @@ public class RolesTests extends AbstractServerImportTest {
         final String objectClass = object.getClass().getSuperclass().getSimpleName();
         final long objectId = object.getId().getValue();
         try {
-            final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
             final IObject objectRetrieved;
             if (objectClass.endsWith("Link")) {
                 objectRetrieved = iQuery.findByQuery("FROM " + objectClass + " link JOIN FETCH link.child WHERE link.id = :id",
-                        new ParametersI().addId(objectId), allGroupsContext);
+                        new ParametersI().addId(objectId), ALL_GROUPS_CONTEXT);
             } else {
-                objectRetrieved = iQuery.get(objectClass, objectId, allGroupsContext);
+                objectRetrieved = iQuery.get(objectClass, objectId, ALL_GROUPS_CONTEXT);
             }
 
             return objectRetrieved.getDetails().getPermissions();

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.annotations.BeforeClass;
+
+import omero.RLong;
+import omero.RString;
+import omero.RType;
+import omero.model.Dataset;
+import omero.model.IObject;
+import omero.model.Image;
+import omero.model.OriginalFile;
+import omero.sys.ParametersI;
+import omero.util.TempFileManager;
+
+/**
+ * Helper methods class for supporting of "new role" workflow
+ * and security tests.
+ * @author p.walczysko@dundee.ac.uk
+ * @since 5.4.0
+ */
+public class RolesTests extends AbstractServerImportTest {
+
+    private static final TempFileManager TEMPORARY_FILE_MANAGER = new TempFileManager(
+            "test-" + LightAdminRolesTest.class.getSimpleName());
+
+    protected File fakeImageFile = null;
+
+    /**
+     * Create a fake image file for use in import tests.
+     * @throws IOException unexpected
+     */
+    @BeforeClass
+    public void createFakeImageFile() throws IOException {
+        final File temporaryDirectory = TEMPORARY_FILE_MANAGER.createPath("images", null, true);
+        fakeImageFile = new File(temporaryDirectory, "image.fake");
+        fakeImageFile.createNewFile();
+    }
+
+    /**
+     * Import an image with original file into a given dataset.
+     * @param dat dataset to which to import the image if not null
+     * @return the original file and the imported image
+     * @throws Exception unexpected
+     */
+    protected List<IObject> importImageWithOriginalFile(Dataset dat) throws Exception {
+        final List<IObject> originalFileAndImage = new ArrayList<IObject>();
+        final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
+        final List<List<RType>> result = iQuery.projection(
+                "SELECT id FROM OriginalFile WHERE name = :name ORDER BY id DESC LIMIT 1",
+                new ParametersI().add("name", imageName));
+        final long previousId = result.isEmpty() ? -1 : ((RLong) result.get(0).get(0)).getValue();
+        List<String> path = Collections.singletonList(fakeImageFile.getPath());
+        importFileset(path, path.size(), dat);
+        final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
+                "FROM OriginalFile o WHERE o.id > :id AND o.name = :name",
+                new ParametersI().addId(previousId).add("name", imageName));
+        originalFileAndImage.add(remoteFile);
+        final Image image = (Image) iQuery.findByQuery(
+                "FROM Image WHERE fileset IN "
+                + "(SELECT fileset FROM FilesetEntry WHERE originalFile.id = :id)",
+                new ParametersI().addId(remoteFile.getId()));
+        originalFileAndImage.add(image);
+        return originalFileAndImage;
+    }
+
+}

--- a/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/ThumbnailStoreTest.java
@@ -269,9 +269,8 @@ public class ThumbnailStoreTest extends AbstractServerTest {
         try {
             /* use all-groups context to fetch both thumbnails at once */
             final List<Long> pixelsIdsαβ = ImmutableList.of(pixelsIdα, pixelsIdβ);
-            final Map<String, String> allGroupsContext = ImmutableMap.of("omero.group", "-1");
             svc = factory.createThumbnailStore();
-            thumbnails = svc.getThumbnailByLongestSideSet(null, pixelsIdsαβ, allGroupsContext);
+            thumbnails = svc.getThumbnailByLongestSideSet(null, pixelsIdsαβ, ALL_GROUPS_CONTEXT);
         } finally {
             if (svc != null) {
                 {

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -489,10 +489,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
         disconnect();
         ctx = init(ctx);
 
@@ -556,10 +553,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
         disconnect();
         ctx = init(ctx);
 
@@ -623,10 +617,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
 
         disconnect();
         ctx = init(ctx);
@@ -699,10 +690,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild((Image) image.proxy());
-        link.setParent((Dataset) dataset.proxy());
-        iUpdate.saveAndReturnObject(link);
+        linkDatasetImage(dataset, image);
 
         disconnect();
         ctx = init(ctx);

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -875,24 +875,6 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Assert that the given object is in the given group.
-     * @param object a model object
-     * @param group an experimenter group
-     * @throws Exception unexpected
-     */
-    private void assertObjectInGroup(IObject object, ExperimenterGroup group) throws Exception {
-        if (iAdmin.getEventContext().groupId != group.getId().getValue()) {
-            loginUser(group);
-        }
-        Class <? extends IObject> objectClass = object.getClass();
-        while (objectClass.getSuperclass() != IObject.class) {
-            objectClass = objectClass.getSuperclass().asSubclass(IObject.class);
-        }
-        object = iQuery.get(objectClass.getSimpleName(), object.getId().getValue());
-        Assert.assertEquals(object.getDetails().getGroup().getId().getValue(), group.getId().getValue());
-    }
-
-    /**
      * Test moving folder hierarchies.
      * @param folderOption if the child option should target folders
      * @param includeOrphans how to set child options
@@ -974,9 +956,9 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
 
         /* check which objects are now in which groups */
 
-        assertObjectInGroup(parentFolder, toGroup);
-        assertObjectInGroup(childFolder, childFolderMoves ? toGroup : fromGroup);
-        assertObjectInGroup(roi, roiMoves ? toGroup : fromGroup);
+        assertInGroup(parentFolder, toGroup);
+        assertInGroup(childFolder, childFolderMoves ? toGroup : fromGroup);
+        assertInGroup(roi, roiMoves ? toGroup : fromGroup);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -943,7 +943,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
         }
         doChange(move);
 
-        /* check which objects are now in which groups */
+        /* Check which objects are now in which groups.*/
 
         assertInGroup(parentFolder, toGroup);
         assertInGroup(childFolder, childFolderMoves ? toGroup : fromGroup);

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -473,6 +473,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
      * @throws Exception
      *             Thrown if an error occurred.
      */
+    @Test
     public void testMoveDatasetImageGraphLinkDoneByImageOwnerRWRWtoRW()
             throws Exception {
         String perms = "rw----"; // destination

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveAndPermissionsTest.java
@@ -489,7 +489,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        linkDatasetImage(dataset, image);
+        linkParentToChild(dataset, image);
         disconnect();
         ctx = init(ctx);
 
@@ -553,7 +553,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        linkDatasetImage(dataset, image);
+        linkParentToChild(dataset, image);
         disconnect();
         ctx = init(ctx);
 
@@ -617,7 +617,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        linkDatasetImage(dataset, image);
+        linkParentToChild(dataset, image);
 
         disconnect();
         ctx = init(ctx);
@@ -690,7 +690,7 @@ public class HierarchyMoveAndPermissionsTest extends AbstractServerTest {
                 .simpleImage());
         long imageId = image.getId().getValue();
         // now link the image and dataset.
-        linkDatasetImage(dataset, image);
+        linkParentToChild(dataset, image);
 
         disconnect();
         ctx = init(ctx);

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -866,23 +866,16 @@ public class HierarchyMoveTest extends AbstractServerTest {
         iAdmin.getEventContext(); // Refresh
 
         Project p = (Project) iUpdate.saveAndReturnObject(mmFactory
-                .simpleProjectData().asIObject());
+                .simpleProjectData().asIObject()).proxy();
         Dataset d = (Dataset) iUpdate.saveAndReturnObject(mmFactory
-                .simpleDatasetData().asIObject());
+                .simpleDatasetData().asIObject()).proxy();
         Image image1 = (Image) iUpdate.saveAndReturnObject(mmFactory
-                .simpleImage());
+                .simpleImage()).proxy();
         Image image2 = (Image) iUpdate.saveAndReturnObject(mmFactory
-                .simpleImage());
+                .simpleImage()).proxy();
         List<IObject> links = new ArrayList<IObject>();
-        DatasetImageLink link = new DatasetImageLinkI();
-        link.setChild(image1);
-        link.setParent(d);
-        links.add(link);
-
-        link = new DatasetImageLinkI();
-        link.setChild(image2);
-        link.setParent(d);
-        links.add(link);
+        links.add(linkDatasetImage(d, image1));
+        links.add(linkDatasetImage(d, image2));
 
         ProjectDatasetLink l = new ProjectDatasetLinkI();
         l.setChild(d);
@@ -1049,10 +1042,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
 
         /* only the original and the other are in the dataset; the projection is not */
         for (final Image image : new Image[] {original, other}) {
-            final DatasetImageLink link = new DatasetImageLinkI();
-            link.setParent(dataset);
-            link.setChild(image);
-            iUpdate.saveAndReturnObject(link);
+            linkDatasetImage(dataset, image);
         }
 
         /* move the dataset */

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -874,10 +874,10 @@ public class HierarchyMoveTest extends AbstractServerTest {
         Image image2 = (Image) iUpdate.saveAndReturnObject(mmFactory
                 .simpleImage()).proxy();
         List<IObject> links = new ArrayList<IObject>();
-        links.add(linkDatasetImage(d, image1));
-        links.add(linkDatasetImage(d, image2));
+        links.add(linkParentToChild(d, image1));
+        links.add(linkParentToChild(d, image2));
 
-        links.add(linkProjectDataset(p, d));
+        links.add(linkParentToChild(p, d));
         iUpdate.saveAndReturnArray(links);
 
         List<Long> ids = new ArrayList<Long>();
@@ -1039,7 +1039,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
 
         /* only the original and the other are in the dataset; the projection is not */
         for (final Image image : new Image[] {original, other}) {
-            linkDatasetImage(dataset, image);
+            linkParentToChild(dataset, image);
         }
 
         /* move the dataset */

--- a/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/HierarchyMoveTest.java
@@ -877,10 +877,7 @@ public class HierarchyMoveTest extends AbstractServerTest {
         links.add(linkDatasetImage(d, image1));
         links.add(linkDatasetImage(d, image2));
 
-        ProjectDatasetLink l = new ProjectDatasetLinkI();
-        l.setChild(d);
-        l.setParent(p);
-        links.add(l);
+        links.add(linkProjectDataset(p, d));
         iUpdate.saveAndReturnArray(links);
 
         List<Long> ids = new ArrayList<Long>();

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -142,7 +142,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(),
              new TagAnnotationI(), new FileAnnotationI(), new MapAnnotationI()}) {
-            final ImageAnnotationLink link = annotateImage(image, annotation);
+            final ImageAnnotationLink link = linkImageAnnotation(image, annotation);
             annotationObjects.add(link.proxy());
             annotationObjects.add(link.getChild().proxy());
         }
@@ -291,13 +291,13 @@ public class PermissionsTest extends AbstractServerTest {
         testImages.add(otherImage.getId().getValue());
         for (final IObject annotation : annotationsDoublyLinked) {
             if (annotation instanceof TagAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (TagAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (TagAnnotation) annotation);
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             } else if (annotation instanceof FileAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (FileAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (FileAnnotation) annotation);
                 fileAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             } else if (annotation instanceof MapAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) annotateImage(otherImage, (MapAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (MapAnnotation) annotation);
                 mapAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             }
         }
@@ -641,9 +641,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users1CanAnnotateOthers) {
             for (final IObject annotation : annotationsOthersForTripleLinking1) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image1, (Annotation) annotation);
                     linksOwnToOthersAnnOwnImage1.add((ImageAnnotationLink) linkOwnImage.proxy());
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage1, (Annotation) annotation);
                     linksOwnToOthersAnnOthersImage1.add((ImageAnnotationLink) linkOtherImage.proxy());
                 }
             }
@@ -653,9 +653,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users2CanAnnotateOthers) {
             for (final IObject annotation : annotationsOthersForTripleLinking2) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image2, (Annotation) annotation);
                     linksOwnToOthersAnnOwnImage2.add((ImageAnnotationLink) linkOwnImage.proxy());
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage2, (Annotation) annotation);
                     linksOwnToOthersAnnOthersImage2.add((ImageAnnotationLink) linkOtherImage.proxy());
                 }
             }
@@ -673,9 +673,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users1CanAnnotateOthers) {
             for (final IObject annotation : annotationsOwnForTripleLinking1) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage1, (Annotation) annotation);
                     linksOthersToOwnAnnOthersImage1.add((ImageAnnotationLink) linkOtherImage.proxy());
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image1, (Annotation) annotation);
                     linksOthersToOwnAnnOwnImage1.add((ImageAnnotationLink) linkOwnImage.proxy());
                 }
             }
@@ -684,9 +684,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users2CanAnnotateOthers) {
             for (final IObject annotation : annotationsOwnForTripleLinking2) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) annotateImage(otherImage2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage2, (Annotation) annotation);
                     linksOthersToOwnAnnOthersImage2.add((ImageAnnotationLink) linkOtherImage.proxy());
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) annotateImage(image2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image2, (Annotation) annotation);
                     linksOthersToOwnAnnOwnImage2.add((ImageAnnotationLink) linkOwnImage.proxy());
                 }
             }

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -142,7 +142,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         for (final Annotation annotation : new Annotation[] {new CommentAnnotationI(),
              new TagAnnotationI(), new FileAnnotationI(), new MapAnnotationI()}) {
-            final ImageAnnotationLink link = linkImageAnnotation(image, annotation);
+            final ImageAnnotationLink link = linkParentToChild(image, annotation);
             annotationObjects.add(link.proxy());
             annotationObjects.add(link.getChild().proxy());
         }
@@ -291,13 +291,13 @@ public class PermissionsTest extends AbstractServerTest {
         testImages.add(otherImage.getId().getValue());
         for (final IObject annotation : annotationsDoublyLinked) {
             if (annotation instanceof TagAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (TagAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkParentToChild(otherImage, (TagAnnotation) annotation);
                 tagLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             } else if (annotation instanceof FileAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (FileAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkParentToChild(otherImage, (FileAnnotation) annotation);
                 fileAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             } else if (annotation instanceof MapAnnotation) {
-                final ImageAnnotationLink link = (ImageAnnotationLink) linkImageAnnotation(otherImage, (MapAnnotation) annotation);
+                final ImageAnnotationLink link = (ImageAnnotationLink) linkParentToChild(otherImage, (MapAnnotation) annotation);
                 mapAnnLinksOnOtherImage.add((ImageAnnotationLink) link.proxy());
             }
         }
@@ -641,9 +641,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users1CanAnnotateOthers) {
             for (final IObject annotation : annotationsOthersForTripleLinking1) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkParentToChild(image1, (Annotation) annotation);
                     linksOwnToOthersAnnOwnImage1.add((ImageAnnotationLink) linkOwnImage.proxy());
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkParentToChild(otherImage1, (Annotation) annotation);
                     linksOwnToOthersAnnOthersImage1.add((ImageAnnotationLink) linkOtherImage.proxy());
                 }
             }
@@ -653,9 +653,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users2CanAnnotateOthers) {
             for (final IObject annotation : annotationsOthersForTripleLinking2) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkParentToChild(image2, (Annotation) annotation);
                     linksOwnToOthersAnnOwnImage2.add((ImageAnnotationLink) linkOwnImage.proxy());
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkParentToChild(otherImage2, (Annotation) annotation);
                     linksOwnToOthersAnnOthersImage2.add((ImageAnnotationLink) linkOtherImage.proxy());
                 }
             }
@@ -673,9 +673,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users1CanAnnotateOthers) {
             for (final IObject annotation : annotationsOwnForTripleLinking1) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkParentToChild(otherImage1, (Annotation) annotation);
                     linksOthersToOwnAnnOthersImage1.add((ImageAnnotationLink) linkOtherImage.proxy());
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image1, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkParentToChild(image1, (Annotation) annotation);
                     linksOthersToOwnAnnOwnImage1.add((ImageAnnotationLink) linkOwnImage.proxy());
                 }
             }
@@ -684,9 +684,9 @@ public class PermissionsTest extends AbstractServerTest {
         if (users2CanAnnotateOthers) {
             for (final IObject annotation : annotationsOwnForTripleLinking2) {
                 if (!(annotation instanceof Roi || annotation instanceof Thumbnail || annotation instanceof RectangleI)) {
-                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkImageAnnotation(otherImage2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOtherImage = (ImageAnnotationLink) linkParentToChild(otherImage2, (Annotation) annotation);
                     linksOthersToOwnAnnOthersImage2.add((ImageAnnotationLink) linkOtherImage.proxy());
-                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkImageAnnotation(image2, (Annotation) annotation);
+                    final ImageAnnotationLink linkOwnImage = (ImageAnnotationLink) linkParentToChild(image2, (Annotation) annotation);
                     linksOthersToOwnAnnOwnImage2.add((ImageAnnotationLink) linkOwnImage.proxy());
                 }
             }
@@ -1213,7 +1213,7 @@ public class PermissionsTest extends AbstractServerTest {
         init(linkOwner);
         final IObject link;
         if (isInDataset) {
-            link = linkDatasetImage((Dataset) container, image);
+            link = linkParentToChild((Dataset) container, image);
         } else {
             final FolderImageLink linkFI = new FolderImageLinkI();
             linkFI.setParent((Folder) container);
@@ -1291,7 +1291,7 @@ public class PermissionsTest extends AbstractServerTest {
         init(linkOwner);
         final IObject link;
         if (isInDataset) {
-            link = linkDatasetImage((Dataset) container, image);
+            link = linkParentToChild((Dataset) container, image);
         } else {
             final FolderImageLink linkFI = new FolderImageLinkI();
             linkFI.setParent((Folder) container);
@@ -1560,7 +1560,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         final List<DatasetImageLink> links = new ArrayList<DatasetImageLink>(images.size());
         for (final IObject image : images) {
-            links.add(linkDatasetImage(dataset, (Image) image));
+            links.add(linkParentToChild(dataset, (Image) image));
         }
 
         /* check that the objects' ownership is all as expected */

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -44,7 +44,6 @@ import omero.model.AnnotationAnnotationLinkI;
 import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
-import omero.model.DatasetImageLinkI;
 import omero.model.Experiment;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
@@ -1235,10 +1234,7 @@ public class PermissionsTest extends AbstractServerTest {
         init(linkOwner);
         final IObject link;
         if (isInDataset) {
-            final DatasetImageLink linkDI = new DatasetImageLinkI();
-            linkDI.setParent((Dataset) container);
-            linkDI.setChild(image);
-            link = iUpdate.saveAndReturnObject(linkDI);
+            link = linkDatasetImage((Dataset) container, image);
         } else {
             final FolderImageLink linkFI = new FolderImageLinkI();
             linkFI.setParent((Folder) container);
@@ -1316,10 +1312,7 @@ public class PermissionsTest extends AbstractServerTest {
         init(linkOwner);
         final IObject link;
         if (isInDataset) {
-            final DatasetImageLink linkDI = new DatasetImageLinkI();
-            linkDI.setParent((Dataset) container);
-            linkDI.setChild(image);
-            link = iUpdate.saveAndReturnObject(linkDI);
+            link = linkDatasetImage((Dataset) container, image);
         } else {
             final FolderImageLink linkFI = new FolderImageLinkI();
             linkFI.setParent((Folder) container);
@@ -1588,10 +1581,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         final List<DatasetImageLink> links = new ArrayList<DatasetImageLink>(images.size());
         for (final IObject image : images) {
-            DatasetImageLink link = new DatasetImageLinkI();
-            link.setParent(dataset);
-            link.setChild((Image) image.proxy());
-            links.add((DatasetImageLink) iUpdate.saveAndReturnObject(link).proxy());
+            links.add(linkDatasetImage(dataset, (Image) image));
         }
 
         /* check that the objects' ownership is all as expected */

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -127,27 +127,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Add the given annotation to the given image.
-     * @param image an image
-     * @param annotation an annotation
-     * @return the new loaded link from the image to the annotation
-     * @throws ServerError unexpected
-     */
-    private ImageAnnotationLink annotateImage(Image image, Annotation annotation) throws ServerError {
-        if (image.isLoaded() && image.getId() != null) {
-            image = (Image) image.proxy();
-        }
-        if (annotation.isLoaded() && annotation.getId() != null) {
-            annotation = (Annotation) annotation.proxy();
-        }
-
-        final ImageAnnotationLink link = new ImageAnnotationLinkI();
-        link.setParent(image);
-        link.setChild(annotation);
-        return (ImageAnnotationLink) iUpdate.saveAndReturnObject(link);
-    }
-
-    /**
      * Add a comment, tag, MapAnnotation, FileAnnotation,
      * Thumbnail and a ROI to the given image.
      * @param image an image

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -252,36 +252,6 @@ public class PermissionsTest extends AbstractServerTest {
     }
 
     /**
-     * Assert that the given object is owned by the given owner.
-     * @param object a model object
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(IObject object, EventContext expectedOwner) throws ServerError {
-        assertOwnedBy(Collections.singleton(object), expectedOwner);
-    }
-
-    /**
-     * Assert that the given objects are owned by the given owner.
-     * @param objects some model objects
-     * @param expectedOwner a user's event context
-     * @throws ServerError unexpected
-     */
-    private void assertOwnedBy(Collection<? extends IObject> objects, EventContext expectedOwner) throws ServerError {
-        if (objects.isEmpty()) {
-            throw new IllegalArgumentException("must assert about some objects");
-        }
-        for (final IObject object : objects) {
-            final String objectName = object.getClass().getName() + '[' + object.getId().getValue() + ']';
-            final String query = "SELECT details.owner.id FROM " + object.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = " + object.getId().getValue();
-            final List<List<RType>> results = iQuery.projection(query, null);
-            final long actualOwnerId = ((RLong) results.get(0).get(0)).getValue();
-            Assert.assertEquals(actualOwnerId, expectedOwner.userId, objectName);
-        }
-    }
-
-    /**
      * Test a specific case of using {@link Chown2} with owner's shared annotations in a private group.
      * @param isDataOwner if the user submitting the {@link Chown2} request owns the data in the group
      * @param isAdmin if the user submitting the {@link Chown2} request is a member of the system group


### PR DESCRIPTION
# What this PR does
Cleans up the tests created in https://github.com/openmicroscopy/openmicroscopy/pull/5159, https://github.com/openmicroscopy/openmicroscopy/pull/5248 and https://github.com/openmicroscopy/openmicroscopy/pull/5275


# Testing this PR
 - Make sure the integration tests on roles still pass. 
 - Read the diff here and make sure the comments and javadoc for single tests make sense.
 - Check the ``@see`` parts for the javadoc first 12 tests in ``...integration/LightAdminRolesTest.java`` which should bring you to the PowerPoints explanation of these tests as g.doc, for example https://github.com/pwalczysko/openmicroscopy/blob/comments-cleanup/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java#L198



# Related reading
https://trello.com/c/ygDN23CC/41-new-role-integration-tests-petr
https://trello.com/c/fdiVZar7/38-add-to-javadoc-the-link-to-test-explanations



cc @joshmoore @jburel @mtbc 