### PR TITLE
Openssl

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -204,9 +204,9 @@ class BaseClient(object):
             if sys.platform == "darwin":
                 self._optSetProp(id, "IceSSL.Ciphers", "NONE (DH_anon.*AES)")
             else:
-                self._optSetProp(id, "IceSSL.Ciphers", "ADH")
+                self._optSetProp(id, "IceSSL.Ciphers", "ADH;@SECLEVEL=0")
         else:
-            self._optSetProp(id, "IceSSL.Ciphers", "ADH")
+            self._optSetProp(id, "IceSSL.Ciphers", "ADH;@SECLEVEL=0")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")
 

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -204,9 +204,9 @@ class BaseClient(object):
             if sys.platform == "darwin":
                 self._optSetProp(id, "IceSSL.Ciphers", "NONE (DH_anon.*AES)")
             else:
-                self._optSetProp(id, "IceSSL.Ciphers", "ADH;@SECLEVEL=0")
+                self._optSetProp(id, "IceSSL.Ciphers", "ADH:@SECLEVEL=0")
         else:
-            self._optSetProp(id, "IceSSL.Ciphers", "ADH;@SECLEVEL=0")
+            self._optSetProp(id, "IceSSL.Ciphers", "ADH:@SECLEVEL=0")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")
 

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -206,7 +206,7 @@ class BaseClient(object):
             else:
                 self._optSetProp(id, "IceSSL.Ciphers", "ADH:@SECLEVEL=0")
         else:
-            self._optSetProp(id, "IceSSL.Ciphers", "ADH:@SECLEVEL=0")
+            self._optSetProp(id, "IceSSL.Ciphers", "ADH")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")
 

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -105,7 +105,7 @@
       <target name="adh">
         <property name="Ice.Default.Protocol" value="ssl"/>
         <property name="Ice.Plugin.IceSSL" value="IceSSL:createIceSSL"/>
-        <property name="IceSSL.Ciphers" value="ADH"/>
+        <property name="IceSSL.Ciphers" value="ADH;@SECLEVEL=0"/>
         <property name="IceSSL.VerifyPeer" value="0"/>
       </target>
       <target name="ssl">
@@ -475,7 +475,7 @@
           <properties refid="Profile"/>
           <property name="Ice.Plugin.IceSSL" value="IceSSL:createIceSSL"/>
           <property name="IceSSL.ProtocolVersionMax" value="tls1_1"/><!-- mac bug -->
-          <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH"/>
+          <property name="IceSSL.Ciphers" value="ADH;@SECLEVEL=0:!LOW:!MD5:!EXP:!3DES:@STRENGTH"/>
           <property name="IceSSL.VerifyPeer" value="0"/>
           <property name="IceSSL.Protocols" value="tls1"/>
           <property name="Glacier2.Client.Endpoints" value="${client-endpoints}"/>

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -105,7 +105,7 @@
       <target name="adh">
         <property name="Ice.Default.Protocol" value="ssl"/>
         <property name="Ice.Plugin.IceSSL" value="IceSSL:createIceSSL"/>
-        <property name="IceSSL.Ciphers" value="ADH;@SECLEVEL=0"/>
+        <property name="IceSSL.Ciphers" value="ADH:@SECLEVEL=0"/>
         <property name="IceSSL.VerifyPeer" value="0"/>
       </target>
       <target name="ssl">
@@ -475,7 +475,7 @@
           <properties refid="Profile"/>
           <property name="Ice.Plugin.IceSSL" value="IceSSL:createIceSSL"/>
           <property name="IceSSL.ProtocolVersionMax" value="tls1_1"/><!-- mac bug -->
-          <property name="IceSSL.Ciphers" value="ADH;@SECLEVEL=0:!LOW:!MD5:!EXP:!3DES:@STRENGTH"/>
+          <property name="IceSSL.Ciphers" value="ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH:@SECLEVEL=0"/>
           <property name="IceSSL.VerifyPeer" value="0"/>
           <property name="IceSSL.Protocols" value="tls1"/>
           <property name="Glacier2.Client.Endpoints" value="${client-endpoints}"/>


### PR DESCRIPTION
# What this PR does

Adjust the ciphers so OMERO can run on OS using openSSL 1.1.0 (e.g. Debian 9 coming out tomorrow)

# Testing this PR
Check that you can connect to server with older version of open SSL 
Check that you can connect to a "debian9" server. I will made some change in omero-install to allow that
https://github.com/jburel/omero-install/tree/debian9


# Related reading

https://trello.com/c/rPstbt4z/1-open-ssl-110
https://www.openmicroscopy.org/community/viewtopic.php?f=5&t=8295&sid=4afb25bfe7420a427432d3c320e664e2

cc @mtbc @joshmoore @carandraug 
