### PR TITLE
have periodic light admin privileges cleanup use quartz

### DIFF
--- a/components/server/resources/ome/services/sec-system.xml
+++ b/components/server/resources/ome/services/sec-system.xml
@@ -98,9 +98,20 @@
     <constructor-arg ref="scriptRepoUuids"/>
   </bean>
 
-  <bean id="adminPrivilegesCleanup" class="ome.security.basic.LightAdminPrivilegesCleanup" destroy-method="close">
+  <bean id="adminPrivilegesCleanup" class="ome.security.basic.LightAdminPrivilegesCleanup">
     <constructor-arg ref="simpleSqlAction"/>
-    <constructor-arg value="10"></constructor-arg>  <!-- seconds -->
+    <constructor-arg value="5"></constructor-arg>  <!-- seconds -->
+  </bean>
+
+  <bean id="adminPrivilegesCleanupTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
+    <property name="jobDetail" ref="adminPrivilegesCleanupRun"/>
+    <property name="cronExpression" value="*/10 * * * * ?"/>
+  </bean>
+
+  <bean id="adminPrivilegesCleanupRun" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+    <property name="targetObject" ref="adminPrivilegesCleanup"/>
+    <property name="targetMethod" value="run"/>
+    <property name="concurrent" value="false"/>
   </bean>
 
 </beans>

--- a/components/server/resources/ome/services/sec-system.xml
+++ b/components/server/resources/ome/services/sec-system.xml
@@ -100,7 +100,7 @@
 
   <bean id="adminPrivilegesCleanup" class="ome.security.basic.LightAdminPrivilegesCleanup">
     <constructor-arg ref="simpleSqlAction"/>
-    <constructor-arg value="5"></constructor-arg>  <!-- seconds -->
+    <constructor-arg value="10"></constructor-arg>  <!-- seconds, matching cron expression below -->
   </bean>
 
   <bean id="adminPrivilegesCleanupTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">


### PR DESCRIPTION
# What this PR does

Adjusts the scheduling of the `_current_admin_privileges` database table cleanup to be done via the server's existing Quartz machinery instead of via a separate thread pool.

# Testing this PR

Keep an eye on the `_current_admin_privileges` table. If the server isn't doing anything then after ten seconds or so the table should be pretty much empty, old rows certainly shouldn't linger. Also can add to `etc/logback.xml` a line,

```xml
<logger name="ome.security.basic.LightAdminPrivilegesCleanup" level="DEBUG"/>
```

then in `var/log/Blitz-0.log` an entry should appear every ten seconds,

`running periodic cleanup of _current_admin_privileges table`

# Related reading

https://trello.com/c/12q3mmA3/24-scheduler-for-currentadminprivileges-table-cleanup