### PR TITLE
connection logging improvements

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/filesessionstore.py
+++ b/components/tools/OmeroWeb/omeroweb/filesessionstore.py
@@ -1,7 +1,6 @@
 import datetime
 import errno
 import logging
-import traceback
 import os
 import shutil
 import tempfile
@@ -117,7 +116,7 @@ class SessionStore(SessionBase):
                 logger.debug("No file_data for session: %s" %
                              self._key_to_file())
         except (IOError, SuspiciousOperation):
-            logger.debug(traceback.format_exc())
+            logger.debug("Failed to load session data", exc_info=True)
             self.create()
         return session_data
 
@@ -195,7 +194,7 @@ class SessionStore(SessionBase):
                     os.unlink(output_file_name)
 
         except (OSError, IOError, EOFError):
-            logger.debug(traceback.format_exc())
+            pass
 
     def exists(self, session_key):
         return os.path.exists(self._key_to_file(session_key))

--- a/components/tools/OmeroWeb/omeroweb/filesessionstore.py
+++ b/components/tools/OmeroWeb/omeroweb/filesessionstore.py
@@ -194,7 +194,7 @@ class SessionStore(SessionBase):
                     os.unlink(output_file_name)
 
         except (OSError, IOError, EOFError):
-            pass
+            logger.debug("Failed to save session data", exc_info=True)
 
     def exists(self, session_key):
         return os.path.exists(self._key_to_file(session_key))


### PR DESCRIPTION
# What this PR does

As part of debugging connection failures reported in https://trello.com/c/YMv4rVNs/52-web-login-failures, we want to know why ```connector = session.get('connector', None)``` is failing in ```loging_required at omeroweb/decorators.py```.
Since the default session is ```omeroweb.filesessionstore``` (our modified version of django's file session store) I've added more logging to that class to see what errors may be preventing retrieval of a connector.

However, with public user enabled, failure to retrieve an existing connector should not cause failure to login since we can always create a new connection from username and password in settings.

Probably don't want to include this in 5.3.3 release?

cc @joshmoore @chris-allan @jburel 