### PR TITLE
Allow Artifactory base URL to be configured

### DIFF
--- a/etc/build.properties
+++ b/etc/build.properties
@@ -29,6 +29,7 @@ package-extra=true
 
 artifactory.username=hudson
 artifactory.username=SECRET
+artifactory.baseurl=http://artifacts.openmicroscopy.org/artifactory
 artifactory.repository=ome.staging
 
 # Which version of Ice this build of OMERO is

--- a/etc/build.properties
+++ b/etc/build.properties
@@ -29,7 +29,7 @@ package-extra=true
 
 artifactory.username=hudson
 artifactory.username=SECRET
-artifactory.baseurl=http://artifacts.openmicroscopy.org/artifactory
+artifactory.baseurl=https://artifacts.openmicroscopy.org/artifactory
 artifactory.repository=ome.staging
 
 # Which version of Ice this build of OMERO is

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -126,8 +126,8 @@
     </filesystem>
 
     <url name="artifactory-publish">
-        <artifact pattern="http://artifacts.openmicroscopy.org/artifactory/${artifactory.repository}/[organization]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
-        <ivy pattern="http://artifacts.openmicroscopy.org/artifactory/${artifactory.repository}/[organization]/[module]/[revision]/ivy-[revision](-[classifier]).xml" />
+        <artifact pattern="${artifactory.baseurl}/${artifactory.repository}/[organization]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
+        <ivy pattern="${artifactory.baseurl}/${artifactory.repository}/[organization]/[module]/[revision]/ivy-[revision](-[classifier]).xml" />
     </url>
   </resolvers>
 


### PR DESCRIPTION
# What this PR does

Allow the Artifactory base URL to be configured in the build infrastructure.

# Testing this PR

Perform a test deployment of Artifacts via the `release-hudson` Ant target.

/cc @sbesson 