### PR TITLE
Add link to graphical explanation to testChownAllBelongingToUser

### DIFF
--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -488,6 +488,7 @@ public class PermissionsTest extends AbstractServerTest {
      * @param isExpectSuccessOneTargetUser if the one-user chown is expected to succeed
      * @param isExpectSuccessTwoTargetUsers if the two-users chown is expected to succeed
      * @throws Exception unexpected
+     * @see <a href="https://docs.google.com/presentation/d/1b91OMuzs19q-e7obtr4-fWx4MMkickNwPUlf07LDGAc/edit">graphical explanation</a>
      */
     @Test(dataProvider = "chown targetUser test cases")
     public void testChownAllBelongingToUser(boolean areDataOwnersInOneGroup, boolean isAdmin, boolean isGroupOwner, boolean isRecipientInGroup,


### PR DESCRIPTION
# What this PR does

Adds linking of the accompanying ``graphical explanation`` ppt to the particular test. This is in line with the tactics suggested on https://trello.com/c/fdiVZar7/38-add-to-javadoc-the-link-to-test-explanations for the roles tests. This PR adds a similar link to an already existing ppt which was hosted on squig. See https://github.com/openmicroscopy/openmicroscopy/pull/4911#issuecomment-272190581


# Testing this PR
Build the javadoc in Eclipse.
  - navigate to the test edited in this PR and open it in central pane of Eclipse
  - Project > Generate javadoc
  - you can (but do not have to, this is just to spare time) expand the ``openmicroscopy`` project in the left-hand side box ``Select types for which javadoc will be generated`` and uncheck all the boxes except ``components/tools/OmeroJava/test``
  - click ``Finish``, the javadoc will be generated
  - open the index.html in browser (location indicated in the eclipse output in the Console
  - navigate to test method testChownAllBelongingToUser in javadoc
  - click on ``graphical description`` link and Check you get brought to a ppt in google drive



