### PR TITLE
offer query caching to clients

### DIFF
--- a/components/blitz/resources/omero/System.ice
+++ b/components/blitz/resources/omero/System.ice
@@ -95,12 +95,16 @@ module omero {
      *  acquisition...:= whether or not acquisitionData (objectives, etc.)
      *                  should be loaded
      *
+     * cacheable      := whether or not the query is cacheable by Hibernate
+     *                   (use with caution: caching may be counterproductive)
      **/
     class Options
     {
       omero::RBool  leaves;
       omero::RBool  orphan;
       omero::RBool  acquisitionData;
+      ["deprecated:experimental: may be wholly removed in next major version"]
+      omero::RBool  cacheable;
     };
 
     /**

--- a/components/blitz/src/omero/sys/ParametersI.java
+++ b/components/blitz/src/omero/sys/ParametersI.java
@@ -1,9 +1,6 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
- *
  */
 
 package omero.sys;
@@ -358,7 +355,7 @@ public class ParametersI extends omero.sys.Parameters {
         return null;
     }
 
-    // ~ Parameters.theOption.leaves, orphan, acquisitionData
+    // ~ Parameters.theOption.leaves, orphan, acquisitionData, cacheable
     // =========================================================================
 
     /**
@@ -458,6 +455,38 @@ public class ParametersI extends omero.sys.Parameters {
             return this.theOptions.acquisitionData;
         }
         return null;
+    }
+
+    /**
+     * Set queries to be cacheable. Use with caution.
+     * @return this instance, for method chaining
+     * @deprecated experimental: may be wholly removed in next major version
+     */
+    public ParametersI cache() {
+        if (theOptions == null) {
+            theOptions = new Options();
+        }
+        theOptions.cacheable = rbool(true);
+        return this;
+    }
+
+    /**
+     * Set queries to not be cacheable. This is the default.
+     * @return this instance, for method chaining
+     */
+    public ParametersI noCache() {
+        if (theOptions == null) {
+            theOptions = new Options();
+        }
+        theOptions.cacheable = rbool(false);
+        return this;
+    }
+
+    /**
+     * @return if queries are cacheable
+     */
+    public omero.RBool getCache() {
+        return theOptions == null ? null : theOptions.cacheable;
     }
 
     // ~ Parameters.map

--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -728,6 +728,10 @@ public class IceMapper extends ome.util.ModelMapper implements
             options.leaves= o.leaves.getValue();
         }
 
+        if (o.cacheable != null) {
+            options.cacheable = o.cacheable.getValue();
+        }
+
         if (o.acquisitionData != null) {
             options.acquisitionData = o.acquisitionData.getValue();
         }

--- a/components/model/src/ome/parameters/Options.java
+++ b/components/model/src/ome/parameters/Options.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2009 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -20,21 +18,25 @@ public class Options {
     public boolean acquisitionData;
     public boolean leaves;
     public boolean orphan;
+    public boolean cacheable;
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("O[");
         if (acquisitionData) {
-            sb.append("A");
+            sb.append('A');
         }
         if (leaves) {
-            sb.append("L");
+            sb.append('L');
         }
         if (orphan) {
-            sb.append("O");
+            sb.append('O');
         }
-        sb.append("]");
+        if (cacheable) {
+            sb.append('C');
+        }
+        sb.append(']');
         return sb.toString();
     }
 }

--- a/components/model/src/ome/parameters/Parameters.java
+++ b/components/model/src/ome/parameters/Parameters.java
@@ -1,7 +1,5 @@
 /*
- * ome.parameters.Parameters
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -510,6 +508,38 @@ public class Parameters implements Serializable {
             return this.options.orphan;
         }
         return false;
+    }
+
+    /**
+     * Set queries to be cacheable. Use with caution.
+     * @return this instance, for method chaining
+     * @deprecated experimental: may be wholly removed in next major version
+     */
+    public Parameters cache() {
+        if (options == null) {
+            options = new Options();
+        }
+        options.cacheable = true;
+        return this;
+    }
+
+    /**
+     * Set queries to not be cacheable. This is the default.
+     * @return this instance, for method chaining
+     */
+    public Parameters noCache() {
+        if (options == null) {
+            options = new Options();
+        }
+        options.cacheable = false;
+        return this;
+    }
+
+    /**
+     * @return if queries are cacheable
+     */
+    public boolean isCache() {
+        return options == null ? false : options.cacheable;
     }
 
     // ~ Serialization

--- a/components/server/src/ome/api/local/LocalQuery.java
+++ b/components/server/src/ome/api/local/LocalQuery.java
@@ -7,11 +7,6 @@ package ome.api.local;
 
 import org.springframework.orm.hibernate3.HibernateCallback;
 
-import ome.annotations.NotNull;
-import ome.conditions.ValidationException;
-import ome.model.IObject;
-import ome.parameters.Parameters;
-import ome.parameters.QueryParameter;
 import ome.services.query.Query;
 
 /**
@@ -103,26 +98,4 @@ public interface LocalQuery extends ome.api.IQuery {
      * @return yes or no.
      */
     boolean checkProperty(String type, String property);
-
-    /**
-     * Executes the stored query with the given name. If a query with the name
-     * cannot be found, an exception will be thrown.
-     * Differs from {@link #findByQuery(String, Parameters)} in that it enables
-     * Hibernate's level two cache for the query.
-     *
-     * The queryName parameter can be an actual query String if the
-     * StringQuerySource is configured on the server and the user running the
-     * query has proper permissions.
-     *
-     * @param queryName
-     *            String identifier of the query to execute
-     * @param parameters
-     *            array of {@link QueryParameter}. Not null. The
-     *            {@link QueryParameter#name} field maps to a field-name which
-     *            is then matched against the {@link QueryParameter#value}
-     * @return Possibly null IObject result.
-     * @throws ValidationException
-     */
-    <T extends IObject> T findByQueryCached(@NotNull
-    String queryName, Parameters parameters) throws ValidationException;
 }

--- a/components/server/src/ome/logic/QueryImpl.java
+++ b/components/server/src/ome/logic/QueryImpl.java
@@ -317,18 +317,6 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     @RolesAllowed("user")
     public <T extends IObject> T findByQuery(String queryName, Parameters params)
             throws ValidationException {
-        return findByQuery(queryName, params, false);
-    }
-
-    @Override
-    @RolesAllowed("user")
-    public <T extends IObject> T findByQueryCached(String queryName, Parameters params)
-            throws ValidationException {
-        return findByQuery(queryName, params, true);
-    }
-
-    private <T extends IObject> T findByQuery(String queryName, Parameters params, boolean enableCaching)
-            throws ValidationException {
 
         if (params == null) {
             params = new Parameters();
@@ -338,7 +326,7 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
         params.unique();
 
         final Query<T> q = getQueryFactory().<T>lookup(queryName, params);
-        if (enableCaching) {
+        if (params.isCache()) {
             q.enableQueryCache();
         }
         T result = null;
@@ -377,6 +365,9 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     public <T extends IObject> List<T> findAllByQuery(String queryName,
             Parameters params) {
         Query<List<T>> q = getQueryFactory().lookup(queryName, params);
+        if (params != null && params.isCache()) {
+            q.enableQueryCache();
+        }
         return execute(q);
     }
 
@@ -424,6 +415,9 @@ public class QueryImpl extends AbstractLevel1Service implements LocalQuery {
     public List<Object[]> projection(final String query, Parameters p) {
         final Parameters params = (p == null ? new Parameters() : p);
         final Query<List<Object>> q = getQueryFactory().lookup(query, params);
+        if (params.isCache()) {
+            q.enableQueryCache();
+        }
 
         @SuppressWarnings("rawtypes")
         final List rv = (List) getHibernateTemplate().execute(q);

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -452,8 +452,8 @@ public class BasicSecuritySystem implements SecuritySystem,
             final LocalQuery iQuery = (LocalQuery) sf.getQueryService();
             final String sessionClass = iQuery.find(Share.class, sessionId) == null ? "Session" : "Share";
             final String hql = "FROM " + sessionClass + " s LEFT OUTER JOIN FETCH s.sudoer WHERE s.id = :id";
-            final Parameters params = new Parameters().addId(sessionId);
-            sess = iQuery.findByQueryCached(hql, params);
+            final Parameters params = new Parameters().addId(sessionId).cache();
+            sess = iQuery.findByQuery(hql, params);
         }
 
         tokenHolder.setToken(callGroup.getGraphHolder());

--- a/components/server/src/ome/services/sessions/SessionManagerImpl.java
+++ b/components/server/src/ome/services/sessions/SessionManagerImpl.java
@@ -1466,12 +1466,12 @@ public class SessionManagerImpl implements SessionManager, SessionCache.StaleCac
             final List<String> userRoles = admin.getUserRoles(exp);
             final LocalQuery iQuery = (LocalQuery) sf.getQueryService();
             final String sessionClass = iQuery.find(Share.class, session.getId()) == null ? "Session" : "Share";
-            final Session reloaded = (Session) iQuery.findByQueryCached(
+            final Session reloaded = (Session) iQuery.findByQuery(
                             "select s from " + sessionClass + " s "
                             + "left outer join fetch s.sudoer "
                             + "left outer join fetch s.annotationLinks l "
                             + "left outer join fetch l.child a where s.id = :id",
-                            new Parameters().addId(session.getId()));
+                            new Parameters().addId(session.getId()).cache());
             final Experimenter sudoer = reloaded.getSudoer();
             boolean hasAdminPrivileges = memberOfGroupsIds.contains(roles.getSystemGroupId());
             if (sudoer != null) {

--- a/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -247,7 +247,7 @@ public abstract class AbstractBasicSecuritySystemTest extends
                 returnValue(group));
         if (!readOnly) {
             sf.mockQuery.expects(once()).method("find").will(returnValue(event.getSession()));
-            sf.mockQuery.expects(once()).method("findByQueryCached").will(returnValue(event.getSession()));
+            sf.mockQuery.expects(once()).method("findByQuery").will(returnValue(event.getSession()));
             sf.mockAdmin.expects(once()).method("userProxy").will(
                     returnValue(user));
             sf.mockUpdate.expects(once()).method("saveAndReturnObject").will(

--- a/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
+++ b/components/server/test/ome/server/utests/sessions/SessMgrUnitTest.java
@@ -356,7 +356,7 @@ public class SessMgrUnitTest extends MockObjectTestCase {
         sf.mockQuery.expects(atLeastOnce()).method("find")
             .with(new IsEqual(Share.class), new IsEqual(session.getId()))
             .will(returnValue(null));
-        sf.mockQuery.expects(atLeastOnce()).method("findByQueryCached")
+        sf.mockQuery.expects(atLeastOnce()).method("findByQuery")
             .with(new StringContains("Session"), ANYTHING)
             .will(returnValue(session));
         sf.mockQuery.expects(once()).method("projection").will(

--- a/components/tools/OmeroPy/src/omero_sys_ParametersI.py
+++ b/components/tools/OmeroPy/src/omero_sys_ParametersI.py
@@ -258,7 +258,7 @@ class ParametersI(omero.sys.Parameters):
             return self.theFilter.endTime
         return None
 
-    # ~ Parameters.theOption.leaves, orphan, acquisitionData
+    # ~ Parameters.theOption.leaves, orphan, acquisitionData, cacheable
     # ====================================================================
 
     def leaves(self):
@@ -310,6 +310,23 @@ class ParametersI(omero.sys.Parameters):
     def getAcquisitionData(self):
         if self.theOptions:
             return self.theOptions.acquisitionData
+        return None
+
+    def cache(self):
+        if not self.theOptions:
+            self.theOptions = omero.sys.Options()
+        self.theOptions.cache = rbool(True)
+        return self
+
+    def noCache(self):
+        if not self.theOptions:
+            self.theOptions = omero.sys.Options()
+        self.theOptions.cache = rbool(False)
+        return self
+
+    def getCache(self):
+        if self.theOptions:
+            return self.theOptions.cache
         return None
 
     # Parameters.map


### PR DESCRIPTION
# What this PR does

Offers via the `Parameters` object a `cache()` method for enabling caching of queries by Hibernate. Applies to the query service's `findByQuery`, `findAllByQuery`, `projection` methods.

This is an *experimental* offering that may be included in OMERO 5.4 but removed in OMERO 5.5.

# Testing this PR

Requires repeated performance testing of challenging queries both with and without using `cache()` for the parameters object in client scripts.

# Related reading

https://trello.com/c/7YxTcHyA/23-expose-query-caching