### PR TITLE
Add login_required to open_with_options

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1683,6 +1683,7 @@ def projectDetail_json(request, pid, conn=None, **kwargs):
     return rv
 
 
+@login_required()
 @jsonp
 def open_with_options(request, **kwargs):
     """


### PR DESCRIPTION
# What this PR does

See https://trello.com/c/gl7lsY2C/45-openwith-jsonp-without-loginrequired
