### PR TITLE
Split view figure bugfix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FigureParam.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/FigureParam.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -327,17 +327,17 @@ public class FigureParam
 		this.name = name;
 		Color c;
 		mergeChannels = new LinkedHashMap<Integer, Integer>(channels.size());
-		int value;
 		Entry<Integer, Color> entry;
 		Iterator<Entry<Integer, Color>> i = channels.entrySet().iterator();
 		while (i.hasNext()) {
 			entry = i.next();
 			c = entry.getValue();
-			value = ((c.getAlpha() & 0xFF) << 24) |
-            	((c.getRed() & 0xFF) << 16) |
-            ((c.getGreen() & 0xFF) << 8) |
-            ((c.getBlue() & 0xFF) << 0);
-			mergeChannels.put(entry.getKey(), value);
+			int rgba = 0;
+			rgba |= (c.getRed() & 255) << 24;
+			rgba |= (c.getGreen() & 255) << 16;
+			rgba |= (c.getBlue() & 255) << 8;
+			rgba |= (c.getAlpha() & 255);
+			mergeChannels.put(entry.getKey(), rgba);
 		}
 	}
 	


### PR DESCRIPTION
# What this PR does
When the Split View Figure script was called from the 'Publishing' option (right hand side metadata panel), the colors in the created figure were wrong, because the channel colors were interpreted as ARGB instead of RGBA. This PR should fix the problem.

# Testing this PR
Create a split view figure and check that the colors are correct (e.g. compare to a split view figure created from web)

# Related reading

https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8303&p=18252

https://trello.com/c/kOxAdxvG/13-insight

/cc @will-moore 
