### PR TITLE
Fix robot test missed from PR #5203

### DIFF
--- a/components/tests/ui/testcases/web/view_image.txt
+++ b/components/tests/ui/testcases/web/view_image.txt
@@ -57,7 +57,7 @@ Test Open Viewer
     Click Element                       xpath=//button[contains(@class, 'btn_openwith')]
     Wait Until Element Is Visible       xpath=//a[@title='Open image with Image viewer']
     Click Element                       xpath=//a[@title='Open image with Image viewer']
-    Check Image Viewer                  ${imageName}
+    Check Image Viewer                  ${imageName}                ${dId}
     # And jsTree
     Right Click Open With               ${nodeId}      Image viewer
     Check Image Viewer                  ${imageName}                ${dId}


### PR DESCRIPTION
# What this PR does

Fixes robot test that was caused by #5203.
Not sure why this fix wasn't included originally, possibly because the failing line
wasn't in the code at the time and was added by merging origin?

# Testing this PR

1. Should fix this test: https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/638/robot/Web%20&%20Web/Web_1/View%20Image/Test%20Open%20Viewer/