### PR TITLE
Privileges create pdi

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -127,7 +127,8 @@ class render_response(omeroweb.decorators.render_response):
         }}
 
         context.setdefault('ome', {})   # don't overwrite existing ome
-        context['ome']['eventContext'] = eventContextMarshal(conn.getEventContext())
+        context['ome']['eventContext'] = eventContextMarshal(
+            conn.getEventContext())
         context['ome']['user'] = conn.getUser
         context['ome']['user_id'] = request.session.get('user_id', None)
         context['ome']['group_id'] = request.session.get('group_id', None)

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -35,6 +35,7 @@ from django.core.urlresolvers import NoReverseMatch
 
 from omeroweb.webclient.forms import GlobalSearchForm
 from omeroweb.utils import reverse_with_params
+from omeroweb.webgateway.marshal import eventContextMarshal
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,7 @@ class render_response(omeroweb.decorators.render_response):
         }}
 
         context.setdefault('ome', {})   # don't overwrite existing ome
-        context['ome']['eventContext'] = conn.getEventContext
+        context['ome']['eventContext'] = eventContextMarshal(conn.getEventContext())
         context['ome']['user'] = conn.getUser
         context['ome']['user_id'] = request.session.get('user_id', None)
         context['ome']['group_id'] = request.session.get('group_id', None)

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1096,7 +1096,11 @@ $(function() {
                 // use canLink, canDelete etc classes on each node to enable/disable right-click menu
 
                 var userId = WEBCLIENT.active_user_id,
-                    canCreate = (userId === WEBCLIENT.USER.id || userId === -1),
+                    // admin may be viewing a Group that they are not a member of
+                    memberOfGroup = WEBCLIENT.eventContext.memberOfGroups.indexOf(WEBCLIENT.active_group_id) > -1,
+                    writeOwned = WEBCLIENT.eventContext.adminPrivileges.indexOf("WriteOwned") > -1,
+                    // canCreate if looking at your own data or 'All Members' AND have permissions
+                    canCreate = ((userId === WEBCLIENT.USER.id || userId === -1) && (memberOfGroup || writeOwned)),
                     canLink = OME.nodeHasPermission(node, 'canLink'),
                     parentAllowsCreate = (node.type === "orphaned" || node.type === "experimenter");
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -166,6 +166,7 @@
         WEBCLIENT.active_group_id = {{ active_group.id }};
         WEBCLIENT.USER = {'id': {{ ome.user.id }} };
         WEBCLIENT.active_user_id = {{ ome.user_id }};
+        WEBCLIENT.eventContext = {{ ome.eventContext|json_dumps|safe }};
 
         WEBCLIENT.URLS = {};
         WEBCLIENT.URLS.webindex = "{% url 'webindex' %}";

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -257,7 +257,10 @@
 
             // We 'canCreate' top level items, E.g. Project, Dataset, Screen, if the current userId is self or 'All Members'
             var userId = {{ ome.user_id }},
-                canCreate = (userId === {{ ome.user.id }} || userId === -1);
+                memberOfGroup = WEBCLIENT.eventContext.memberOfGroups.indexOf(WEBCLIENT.active_group_id) > -1,
+                writeOwned = WEBCLIENT.eventContext.adminPrivileges.indexOf("WriteOwned") > -1,
+                // canCreate if looking at your own data or 'All Members' AND have permissions
+                canCreate = ((userId === WEBCLIENT.USER.id || userId === -1) && (memberOfGroup || writeOwned));
 
             // Also need all selected items to allow linking,
             // because new objects are sometimes linked under selected items

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -27,12 +27,37 @@ import traceback
 logger = logging.getLogger(__name__)
 
 from omero.rtypes import unwrap
+from omero_marshal import get_encoder
 
 # OMERO.insight point list regular expression
 INSIGHT_POINT_LIST_RE = re.compile(r'points\[([^\]]+)\]')
 
 # OME model point list regular expression
 OME_MODEL_POINT_LIST_RE = re.compile(r'([\d.]+),([\d.]+)')
+
+
+def eventContextMarshal(event_context):
+    """
+    Marshals the omero::sys::EventContext as a dict.
+
+    @param event_context:   omero::sys::EventContext
+    @return:                Dict
+    """
+
+    ctx = {}
+    for a in ['shareId', 'sessionId', 'sessionUuid', 'userId', 'userName',
+              'sudoerId', 'sudoerName', 'groupId',
+              'groupName', 'isAdmin', 'eventId', 'eventType',
+              'memberOfGroups', 'leaderOfGroups',
+              'adminPrivileges']:
+            if (hasattr(event_context, a)):
+                ctx[a] = getattr(event_context, a)
+
+    perms = event_context.groupPermissions
+    encoder = get_encoder(perms.__class__)
+    ctx['groupPermissions'] = encoder.encode(perms)
+
+    return ctx
 
 
 def channelMarshal(channel):


### PR DESCRIPTION
# What this PR does

Prevents Light Admins without 'WriteOwned' privilege from creating P/D/S in webclient.
Fixes "crash on create in not-your-group" at https://trello.com/c/LUzfIhaU/46-crashes-in-webclient 

# Testing this PR
 - Create a Light Admin who doesn't have ```WriteOwned``` privilege.
 - Login as this user and view "All Members" data in a group that they are not a member of.
 - Toolbar buttons and right-click options to create Project/Dataset/Screen should be disabled.
 - They should still be enabled for full Admins or those with ```WriteOwned``` privilege or if the LightAdmin without ```WriteOwned``` is viewing a group that they *are* a member of.

cc @pwalczysko @mtbc 