### PR TITLE
Fix canAnnotate logic for ratings

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_rating.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/metadata_general_rating.html
@@ -25,6 +25,12 @@
         <span class="annotationCount">{{ annotationCounts.LongAnnotation }}</span>
     </h1>
     <div class="annotations_section" style="display: none">
-        <div id="rating_annotations" {% if manager.canAnnotate or not annotationBlocked %}class="canAnnotate"{% endif %}></div>
+        <!-- If we're in 'batch annotate' (obj_string) use annotationBlocked -->
+        <div id="rating_annotations"
+          {% if obj_string and not annotationBlocked %}
+              class="canAnnotate"
+          {% elif manager.canAnnotate %}
+              class="canAnnotate"
+          {% endif %}></div>
      </div>
      </div>


### PR DESCRIPTION
# What this PR does

Fixes canAnnotate logic for Ratings.
As reported in https://trello.com/c/LUzfIhaU/46-crashes-in-webclient 
"crash on editing of ratings (light admin edits - adds a star - a rating of another user on another user's image, light admin has no permissions to do it"

# Testing this PR

1. Users who don't have ```canAnnotate``` permissions on an object shouldn't be able to attempt to add rating. Should see tooltip "You don't have permissions.." on ratings.