### PR TITLE
Chown all

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1601,7 +1601,7 @@ class GraphArg(object):
             # Allow also experimenters to be processed by this method
             # Note thoiugh that Expermienter cannot be combined with
             # other graph objects in the combine_commands method.
-            #.Either only Experimenter is used in the arguments or
+            # Either only Experimenter is used in the arguments or
             # other objects (like Datasets, Images etc.)
             if "Experimenter" in graph:
                 targetUsers = ids
@@ -1915,12 +1915,12 @@ class GraphControl(CmdControl):
             rv.extend(others)
         elif len(others) > 1:
             for req in others[1:]:
-                #.Catch eventuality that in GraphArg __call__ method
+                # Catch eventuality that in GraphArg __call__ method
                 # the targetObjects were left empty.
                 try:
                     type, ids = req.targetObjects.items()[0]
                 except IndexError:
-                    self.ctx.die(196, "Cannot combine object and non-object commands")
+                    self.ctx.die(196, "Cannot combine commands")
                 others[0].targetObjects.setdefault(type, []).extend(ids)
             rv.append(others[0])
 

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -13,11 +13,16 @@
    defined here will be added to the Cli class for later use.
 """
 
-from omero.cli import CLI, GraphControl, ExperimenterArg
+from omero.cli import CLI, GraphControl, ExperimenterArg, GraphArg
+from omero_ext.argparse import SUPPRESS
 import sys
 
 HELP = """Transfer ownership of data between users. Entire graphs of data,
 based on the ID of the top-node, are transferred.
+
+There are two ways to use this command, either specify the data to be
+transferred or specify users from whom the ownership of all their data
+will be transferred. These two usage ways cannot be combined.
 
 This command can only be used by OMERO administrators and group owners.
 
@@ -48,6 +53,11 @@ Examples:
     # Transfer all images contained under two projects
     omero chown 101 Project/Image:201,202
 
+    # Transfer ownership of all data owned in OMERO by user 111 to user 4
+    omero chown 4 Experimenter:111
+    # Transfer ownership of all data of users 1,2,3 and 7 to user 10
+    omero chown 10 Experimenter:1-3,7
+
     # Do a dry run of a transfer reporting the outcome
     # if the transfer had been run
     omero chown 101 Dataset:53 --dry-run
@@ -65,10 +75,44 @@ class ChownControl(GraphControl):
         import omero.all
         return omero.cmd.Chown2
 
+    def _configure(self, parser):
+        parser.set_defaults(func=self.main_method)
+        self._add_wait(parser, default=-1)
+        parser.add_argument(
+            "--include",
+            help="Modifies the given option by including a list of objects")
+        parser.add_argument(
+            "--exclude",
+            help="Modifies the given option by excluding a list of objects")
+        parser.add_argument(
+            "--ordered", action="store_true",
+            help=("Pass multiple objects to commands strictly in the order "
+                  "given, otherwise group into as few commands as possible."))
+        parser.add_argument(
+            "--list", action="store_true",
+            help="Print a list of all available graph specs")
+        parser.add_argument(
+            "--list-details", action="store_true", help=SUPPRESS)
+        parser.add_argument(
+            "--report", action="store_true",
+            help="Print more detailed report of each action")
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help=("Do a dry run of the command, providing a "
+                  "report of what would have been done"))
+        parser.add_argument(
+            "--force", action="store_true",
+            help=("Force an action that otherwise defaults to a dry run"))
+        self._pre_objects(parser)
+        parser.add_argument(
+            "obj", nargs="*", type=GraphArg(self.cmd_type()),
+            help="either objects to be processed in the form <Class>:<Id>"
+                 " or user(s) to transfer ownership of all data from in the form Experimenter:<Id>")
+
     def _pre_objects(self, parser):
         parser.add_argument(
             "usr", nargs="?", type=ExperimenterArg,
-            help="""user to transfer ownership of objects to""")
+            help="""user to transfer ownership of specified objects or all objects owned by specified user(s) to""")
 
     def _process_request(self, req, args, client):
         # Retrieve user id

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -107,12 +107,14 @@ class ChownControl(GraphControl):
         parser.add_argument(
             "obj", nargs="*", type=GraphArg(self.cmd_type()),
             help="either objects to be processed in the form <Class>:<Id>"
-                 " or user(s) to transfer ownership of all data from in the form Experimenter:<Id>")
+                 " or user(s) to transfer ownership of all data from in the"
+                 " form Experimenter:<Id>")
 
     def _pre_objects(self, parser):
         parser.add_argument(
             "usr", nargs="?", type=ExperimenterArg,
-            help="""user to transfer ownership of specified objects or all objects owned by specified user(s) to""")
+            help="user to transfer ownership of specified objects or all"
+                 " objects owned by specified user(s) to")
 
     def _process_request(self, req, args, client):
         # Retrieve user id


### PR DESCRIPTION
# What this PR does

Implements the feature of ``Chown2`` command which allows to transfer ownership of all data owned by user(s) to another user in one step on the CLI.


# Testing this PR
This is just a suggestion. 

Will write integration test when this approach is okayed. 

The things to test are

``bin/omero chown 6 Image:3,4 Dataset:6,9 Project:1-4,6`` should work as previously, i.e. the named objects will be chowned to user 6.
``bin/omero chown 6 Experimenter:1,2,5-8`` shoiuld chown all what users 1,2,5,6,7,8 own, but run ``dry-run`` by default, which has to be overcome by ``--force`` (I think similar logic is on ``delete`` and it makes sense for me to have it here too)
``bin/omero chown 6 Experimenter:1,2`` shoiuld chown all what users 1,2 own and execute immeditately (no need for ``--force``
``bin/omero chown 6  Image:3,4 Dataset:6,9 Project:1-4,6 Experimenter:4`` should give an output ``Cannot combine commands`` and no chown shoiuld proceed at all.

All the integration tests should still pass.

Note that this command is a bit "out of the range" with respect of CLI structure, because it 
1. needs the "obj" machinery to work as it was up till now
2. needs some "user" machinery to cater for the fact that here, users are being passed in place of objects like P/D/Is

I hope I made the best compromise without too much hacking.

# Related reading

https://trello.com/c/eaTcjBfW/194-cli-chown-hand-over-all-users-data

1. background for understanding this PR

2. what this PR assists, fixes, or otherwise affects

@joshmoore @jburel @mtbc 

Superseded by https://github.com/openmicroscopy/openmicroscopy/pull/5357