### PR TITLE
Disable test_parse.py::TestParse::testValidateRoiMovieCall

### DIFF
--- a/components/tools/OmeroPy/test/unit/scriptstest/test_parse.py
+++ b/components/tools/OmeroPy/test/unit/scriptstest/test_parse.py
@@ -188,6 +188,9 @@ if True:
             except Exception, e:
                 assert False, "%s\n%s" % (script, e)
 
+    @pytest.mark.broken(
+        reason=('Scripts are disabled on the metadata branch: '
+                'https://github.com/ome/scripts/pull/129'))
     def testValidateRoiMovieCall(self):
         script = SCRIPTS / "figure_scripts" / "Movie_ROI_Figure.py"
         params = parse_file(str(script))


### PR DESCRIPTION
The `metadata53` branch is currently broken: https://travis-ci.org/openmicroscopy/openmicroscopy/builds/244483997

Scripts are disabled on the metadata53 branch: https://github.com/ome/scripts/pull/129 so this PR marks the test as `broken`.