### PR TITLE
Enable chown-all-belonging-to-user on CLI in and/or way with objects

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1766,15 +1766,21 @@ class GraphControl(CmdControl):
             "--force", action="store_true",
             help=("Force an action that otherwise defaults to a dry run"))
         self._pre_objects(parser)
-        parser.add_argument(
-            "obj", nargs="*", type=GraphArg(self.cmd_type()),
-            help="Objects to be processed in the form <Class>:<Id>")
+        self._objects(parser)
 
     def _pre_objects(self, parser):
         """
         Allows configuring before the "obj" n-argument is added.
         """
         pass
+
+    def _objects(self, parser):
+        """
+        Allows configuring the "obj" n-argument by overriding this method.
+        """
+        parser.add_argument(
+            "obj", nargs="*", type=GraphArg(self.cmd_type()),
+            help="Objects to be processed in the form <Class>:<Id>")
 
     def as_doall(self, req_or_doall):
         if not isinstance(req_or_doall, omero.cmd.DoAll):

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -87,7 +87,7 @@ class ChownControl(GraphControl):
                  " and/or user(s) to transfer all data from in the"
                  " form Experimenter:<Id>")
 
-    def populate_targetUsers(self, command_check):
+    def populate_target_users(self, command_check):
         """
         Move the Experimenters whose data are to be
         transferred from targetObjects
@@ -107,7 +107,7 @@ class ChownControl(GraphControl):
         as well as the possibility to adjust the command.
         """
         super(ChownControl, self)._check_command(command_check)
-        self.populate_targetUsers(command_check)
+        self.populate_target_users(command_check)
 
     def _process_request(self, req, args, client):
         # Retrieve user id

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -23,6 +23,9 @@ There are two ways to use this command, either specify the data to be
 transferred or specify users from whom the ownership of all their data
 will be transferred. These two usage ways can be combined.
 
+The usage with specified users has to be considered as advanced usage
+and might potentially be slow.
+
 This command can only be used by OMERO administrators and group owners.
 
 Group owners can only transfer ownership between members of the owned group.
@@ -52,8 +55,10 @@ Examples:
     # Transfer all images contained under two projects
     omero chown 101 Project/Image:201,202
 
+    # Advanced usage & potentially slow:
     # Transfer all data owned by user 111 and one image to user 4
     omero chown 4 Experimenter:111 Image:17
+    # Advanced usage & potentially slow:
     # Transfer all data of users 1,3 and 7 to user 10
     omero chown 10 Experimenter:1,3,7
 

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -88,11 +88,13 @@ class ChownControl(GraphControl):
                  " form Experimenter:<Id>")
 
     def populate_targetUsers(self, command_check):
-        # Move the Experimenters whose data are to be
-        # transferred from targetObjects
-        # to targetUsers. The rewritten _check_command
-        # method checked these Experiments when they were
-        # in targetObjects, but Chown2 needs them in targetUsers
+        """
+        Move the Experimenters whose data are to be
+        transferred from targetObjects
+        to targetUsers. The rewritten _check_command
+        method checked these Experimenters when they were
+        in targetObjects, but Chown2 needs them in targetUsers.
+        """
         try:
             command_check.targetUsers = command_check.targetObjects.pop(
                 "Experimenter")
@@ -100,8 +102,10 @@ class ChownControl(GraphControl):
             pass
 
     def _check_command(self, command_check):
-        # Rewrite higher class method to have command check
-        # as well as the possibility to adjust the command
+        """
+        Rewrite higher class method to have command check
+        as well as the possibility to adjust the command.
+        """
         super(ChownControl, self)._check_command(command_check)
         self.populate_targetUsers(command_check)
 

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -59,7 +59,7 @@ Examples:
     # Transfer all data owned by user 111 and one image to user 4
     omero chown 4 Experimenter:111 Image:17
     # Advanced usage & potentially slow:
-    # Transfer all data of users 1,3 and 7 to user 10
+    # Transfer all data of users 1, 3 and 7 to user 10
     omero chown 10 Experimenter:1,3,7
 
     # Do a dry run of a transfer reporting the outcome

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -62,7 +62,7 @@ class TestChown(CLITest):
         proj, dset, img = simpleHierarchy
         argument = "Experimenter"
 
-        # create a new user  in the same group
+        # create a new user in the same group
         # and transfer all owned by self.user to the new user
         client1, user1 = self.new_client_and_user(group=self.group)
         args_user = self.args + ['%s' % (user1.omeName.val),
@@ -85,7 +85,7 @@ class TestChown(CLITest):
         oid = self.create_object(object_name)
 
         # now create a second user (user2) in the same group
-        # and trasfer all owned by user1 first step to user2 and
+        # and transfer all owned by user1 and
         # the dataset (owned by self.user) to user2 in one step
         client2, user2 = self.new_client_and_user(group=self.group)
         self.args += ['%s' % (user2.omeName.val),

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -58,15 +58,14 @@ class TestChown(CLITest):
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
 
-    @pytest.mark.parametrize("user_prefix", user_prefixes)
-    def testChownBasicUsageTargetUser(self, simpleHierarchy, user_prefix):
+    def testChownBasicUsageTargetUser(self, simpleHierarchy):
         proj, dset, img = simpleHierarchy
         argument = "Experimenter"
 
         # create a new user  in the same group
         # and transfer all owned by self.user to the new user
         client1, user1 = self.new_client_and_user(group=self.group)
-        args_user = self.args + ['%s%s' % (user_prefix, user1.id.val),
+        args_user = self.args + ['%s' % (user1.omeName.val),
                                  '%s:%s' % (argument, self.user.id.val)]
         self.cli.invoke(args_user, strict=True)
 
@@ -89,7 +88,7 @@ class TestChown(CLITest):
         # and trasfer all owned by user1 first step to user2 and
         # the dataset (owned by self.user) to user2 in one step
         client2, user2 = self.new_client_and_user(group=self.group)
-        self.args += ['%s%s' % (user_prefix, user2.id.val),
+        self.args += ['%s' % (user2.omeName.val),
                       '%s:%s' % (object_name, oid),
                       '%s:%s' % (argument, user1.id.val)]
         self.cli.invoke(self.args, strict=True)


### PR DESCRIPTION
# What this PR does

Implements the feature of ``Chown2`` command which allows to transfer ownership of all data owned by user(s) to another user in one step on the CLI.


# Testing this PR
This is just a suggestion. 

Will write integration test when this approach is okayed. 

The things to test are

``bin/omero chown 6 Image:3,4 Dataset:6,9 Project:1-4,6`` should work as previously, i.e. the named objects will be chowned to user 6.
``bin/omero chown 6 Experimenter:1,2,5-8`` shoiuld chown all what users 1,2,5,6,7,8 own, but run ``dry-run`` by default, which has to be overcome by ``--force`` (I think similar logic is on ``delete`` and it makes sense for me to have it here too)
``bin/omero chown 6 Experimenter:1,2`` shoiuld chown all what users 1,2 own and execute immeditately (no need for ``--force``
``bin/omero chown 6  Image:3,4 Dataset:6,9 Project:1,4,6 Experimenter:4`` should chown the data as specified
``bin/omero chown Experimenter:0 Experimenter:7`` should chown the data of user 7 to user 0
``bin/omero chown Image:1000`` where image 1000 does not exist should fail
``bin/omero delete Experimenter:4`` should fail
``bin/omero chown 5 Experimenter:4 Expermenter:19 --ordered`` should chown the data of users 4 and 19 to user 5 in two separate commands
``bin/omero chown 5 Experimenter:17 Dataset:1,5 Expermienter:19`` shoiuld chown the data of users 17, 19 and Datasets 1,5 to user5

All the integration tests should still pass.

# Related reading

https://trello.com/c/eaTcjBfW/194-cli-chown-hand-over-all-users-data

1. background for understanding this PR

2. what this PR assists, fixes, or otherwise affects

@joshmoore @jburel @mtbc 

This supersedes https://github.com/openmicroscopy/openmicroscopy/pull/5354 - all the [suggestions](https://github.com/openmicroscopy/openmicroscopy/pull/5354#issuecomment-312654309) of @mtbc are implemented in this PR