### PR TITLE
CLI: require stdin.isatty before using cli.input

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -448,6 +448,9 @@ class SessionsControl(BaseControl):
                 action = "Reconnected to"
 
         if not rv:
+
+            self._require_tty("cannot request password")
+
             tries = 3
             while True:
                 try:
@@ -883,6 +886,7 @@ class SessionsControl(BaseControl):
         defserver = store.last_host()
         if not port:
             port = str(omero.constants.GLACIER2PORT)
+        self._require_tty("cannot request server")
         rv = self.ctx.input("Server: [%s:%s]" % (defserver, port))
         if not rv:
             return defserver, name, port
@@ -892,11 +896,17 @@ class SessionsControl(BaseControl):
     def _get_username(self, defuser):
         if defuser is None:
             defuser = get_user("root")
+        self._require_tty("cannot request username")
         rv = self.ctx.input("Username: [%s]" % defuser)
         if not rv:
             return defuser
         else:
             return rv
+
+    def _require_tty(self, msg):
+        if sys.stdin.isatty():
+            return
+        self.ctx.die(564, "stdin is not a terminal: %s" % msg)
 
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -449,7 +449,10 @@ class SessionsControl(BaseControl):
 
         if not rv:
 
-            self._require_tty("cannot request password")
+            if not pasw:
+                # Note: duplicating the `not pasw` check here
+                # for an overall nicer error message.
+                self._require_tty("cannot request password")
 
             tries = 3
             while True:

--- a/components/tools/OmeroPy/test/unit/clitest/test_sess.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_sess.py
@@ -10,6 +10,7 @@
 """
 
 import os
+import sys
 import pytest
 import Glacier2
 import uuid
@@ -26,6 +27,14 @@ omeroDir = path(os.getcwd()) / "build"
 testsess = "testsess"
 testuser = "testuser"
 testhost = "testhost"
+
+
+@pytest.fixture(autouse=True)
+def istty(monkeypatch):
+    def isatty(*args, **kwargs):
+        return True
+    monkeypatch.setattr(sys.stdin, 'isatty', isatty)
+    assert sys.stdin.isatty()
 
 
 class MyStore(SessionsStore):


### PR DESCRIPTION
The cli.input method currently blindly calls either
raw_input or getpass both of which hang if stdin is
piped into the bin/omero command. A further fix here
would be to teach the input method itself how to check
stdin, but this require a more further review.

See
https://trello.com/c/mUAfr6kf/200-bin-omero-should-fail-if-not-logged-in-and-no-stdin

# What this PR does

fails fast if `echo foo | bin/omero login ...` is used.


# Testing this PR

The following should now all fail with a useful comment:

 * `echo foo | bin/omero login`
 * `echo foo | bin/omero login localhost`
 * `echo foo | bin/omero login root@localhost`

but *not*

 * `echo foo | bin/omero -w mypassword login root@localhost`

# Related reading

* https://trello.com/c/mUAfr6kf/200-bin-omero-should-fail-if-not-logged-in-and-no-stdin