### PR TITLE
add to CurrentDetails the ability to adjust for light admins

### DIFF
--- a/components/server/resources/ome/services/sec-primitives.xml
+++ b/components/server/resources/ome/services/sec-primitives.xml
@@ -33,6 +33,10 @@
   <bean id="currentDetails" class="ome.security.basic.CurrentDetails">
     <constructor-arg ref="sessionCache"/>
     <constructor-arg ref="roles"/>
+    <constructor-arg ref="systemTypes"/>
+    <constructor-arg ref="adminPrivileges"/>
+    <constructor-arg ref="managedRepoUuids"/>
+    <constructor-arg ref="scriptRepoUuids"/>
   </bean>
 
   <alias name="currentDetails" alias="principalHolder"/>


### PR DESCRIPTION
# What this PR does

`CurrentDetails.isOwnerOrSupervisor` paid no heed of administrator restrictions in judging if an administrator is a "supervisor" of the given object. This PR gives `CurrentDetails` the necessary information and conditionals to account for light administrators.

# Testing this PR

CI should show no regressions. Further, @pwalczysko has been developing extra tests on https://github.com/pwalczysko/openmicroscopy/tree/add-member-of-group-tests that reproduce situations affected by this bug.