### PR TITLE
OMERO.web backend SSL is controlled by OMERO.web administrator (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -297,7 +297,9 @@ class login_required(object):
                 server_id = settings.PUBLIC_SERVER_ID
             username = settings.PUBLIC_USER
             password = settings.PUBLIC_PASSWORD
-            is_secure = request.GET.get('ssl', False)
+            is_secure = settings.SECURE
+            if not is_secure:
+                is_secure = request.GET.get('ssl', False)
             logger.debug('Is SSL? %s' % is_secure)
             # Try and use a cached OMERO.webpublic user session key.
             public_user_connector = self.get_public_user_connector()

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -298,8 +298,6 @@ class login_required(object):
             username = settings.PUBLIC_USER
             password = settings.PUBLIC_PASSWORD
             is_secure = settings.SECURE
-            if not is_secure:
-                is_secure = request.GET.get('ssl', False)
             logger.debug('Is SSL? %s' % is_secure)
             # Try and use a cached OMERO.webpublic user session key.
             public_user_connector = self.get_public_user_connector()
@@ -341,7 +339,7 @@ class login_required(object):
         userip = get_client_ip(request)
         session = request.session
         request = request.GET
-        is_secure = request.get('ssl', False)
+        is_secure = settings.SECURE
         logger.debug('Is SSL? %s' % is_secure)
         connector = session.get('connector', None)
         logger.debug('Connector: %s' % connector)

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -447,6 +447,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " delete stale data using the cache session store backend, see "
           ":djangodoc:`Django cached session documentation <topics/http/"
           "sessions/#using-cached-sessions>` for more details.")],
+    "omero.web.secure":
+        ["SECURE",
+         "false",
+         parse_boolean,
+         ("Force all backend OMERO.server connections to use SSL.")],
     "omero.web.session_cookie_age":
         ["SESSION_COOKIE_AGE",
          86400,

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -61,13 +61,18 @@ class LoginForm(NonASCIIForm):
     password = forms.CharField(
         max_length=50,
         widget=forms.PasswordInput(attrs={'size': 22, 'autocomplete': 'off'}))
-    ssl = forms.BooleanField(
+    ssl_kwargs = dict(
         required=False,
         help_text='<img src="%swebgateway/img/nuvola_encrypted_grey16.png"'
         ' title="Real-time encrypted data transfer can be turned on by'
         ' checking the box, but it will slow down the data access. Turning'
         ' it off does not affect the connection to the server which is always'
         ' secure." alt="SSL"/>' % settings.STATIC_URL)
+    if settings.SECURE:
+        ssl_kwargs['initial'] = True
+        # Django 1.8 doesn't support ssl_kwargs['disabled']
+        ssl_kwargs['widget'] = forms.CheckboxInput(attrs={'disabled': 'yes'})
+    ssl = forms.BooleanField(**ssl_kwargs)
 
     def clean_username(self):
         if (self.cleaned_data['username'] == 'guest'):

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -28,7 +28,6 @@ try:
 except:
     pass
 
-from django.conf import settings
 from django import forms
 from django.forms.widgets import Textarea
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -53,7 +53,7 @@ class LoginForm(NonASCIIForm):
         self.fields['server'] = ServerModelChoiceField(
             Server, empty_label=None)
 
-        self.fields.keyOrder = ['server', 'username', 'password', 'ssl']
+        self.fields.keyOrder = ['server', 'username', 'password']
 
     username = forms.CharField(
         max_length=50, widget=forms.TextInput(attrs={
@@ -61,18 +61,6 @@ class LoginForm(NonASCIIForm):
     password = forms.CharField(
         max_length=50,
         widget=forms.PasswordInput(attrs={'size': 22, 'autocomplete': 'off'}))
-    ssl_kwargs = dict(
-        required=False,
-        help_text='<img src="%swebgateway/img/nuvola_encrypted_grey16.png"'
-        ' title="Real-time encrypted data transfer can be turned on by'
-        ' checking the box, but it will slow down the data access. Turning'
-        ' it off does not affect the connection to the server which is always'
-        ' secure." alt="SSL"/>' % settings.STATIC_URL)
-    if settings.SECURE:
-        ssl_kwargs['initial'] = True
-        # Django 1.8 doesn't support ssl_kwargs['disabled']
-        ssl_kwargs['widget'] = forms.CheckboxInput(attrs={'disabled': 'yes'})
-    ssl = forms.BooleanField(**ssl_kwargs)
 
     def clean_username(self):
         if (self.cleaned_data['username'] == 'guest'):

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -83,14 +83,6 @@
 					{% endcomment %}
 					
 			  		{{ form.server }}
-						
-				   <div id="ssl">
-					   <!--Padlock Image -->
-					   {{ form.ssl.help_text|safe }}{% if form.ssl.field.required %}*{% endif %}
-					   <!--Padlock Checkbox -->
-					   {{ form.ssl }}
-					   {{ form.ssl.errors }}
-				   </div>
 			   
 			   <!-- Form Error -->
 				{% if form.server.errors %}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2854,7 +2854,9 @@ class LoginView(View):
             username = form.cleaned_data['username']
             password = form.cleaned_data['password']
             server_id = form.cleaned_data['server']
-            is_secure = form.cleaned_data['ssl']
+            is_secure = settings.SECURE
+            if not is_secure:
+                is_secure = form.cleaned_data['ssl']
 
             connector = Connector(server_id, is_secure)
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2855,8 +2855,6 @@ class LoginView(View):
             password = form.cleaned_data['password']
             server_id = form.cleaned_data['server']
             is_secure = settings.SECURE
-            if not is_secure:
-                is_secure = form.cleaned_data['ssl']
 
             connector = Connector(server_id, is_secure)
 


### PR DESCRIPTION

This is the same as gh-5363 but rebased onto metadata53.

----

# What this PR does

- Removes the padlock checkbox from the OMERO.web login page.
- Adds a new property `omero.web.secure` that controls whether OMERO.web uses encrypted connections to OMERO.server, defaults to `False` (unencrypted) to keep the current default behaviour.

# Testing this PR

1. Setup a default OMERO.server, block port 4063 (e.g. using a firewall).
2. Setup OMERO.web on a different host, with `omero.web.server_list=[["omero-server-address", 4064, "omero"]]`
3. Attempt to login to OMERO.web. It should fail with an unhelpful error message- this is the existing behaviour (after creating a session it tries to use unencrypted port 4063 which is inaccessible).
4. Set `omero.web.secure=True` and restart OMERO.web
5. You should now be able to login

# Related reading

- https://trello.com/c/sc79fkLw/61-drop-lock-icon-in-web


                