### PR TITLE
Disable Owners and Members fields if not sufficient permissions

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -278,7 +278,7 @@ PERMISSION_CHOICES = (
 class GroupForm(NonASCIIForm):
 
     def __init__(self, name_check=False, group_is_current_or_system=False,
-                 can_modify_group=True, *args, **kwargs):
+                 can_modify_group=True, can_add_member=True, *args, **kwargs):
         super(GroupForm, self).__init__(*args, **kwargs)
         self.name_check = name_check
         try:
@@ -317,6 +317,11 @@ class GroupForm(NonASCIIForm):
         if not can_modify_group:
             for field in self.fields.values():
                 field.widget.attrs['disabled'] = True
+
+        # If we can't add members, disable owners and members fields
+        if not can_add_member:
+            self.fields['owners'].widget.attrs['disabled'] = True
+            self.fields['members'].widget.attrs['disabled'] = True
 
     name = forms.CharField(
         max_length=100,

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -93,7 +93,13 @@
                         "Follow the 'OMERO permissions' link below for full details.",
                         null, "WARNING", ['OK'], null, 180);
                 });
-
+                
+                if ('{{ can_add_member }}' == 'False') {
+                    $("label[for='id_owners']").hide();
+                    $("#id_owners_chosen").hide();
+                    $("label[for='id_members']").hide();
+                    $("#id_members_chosen").hide();
+                } 
         })
     </script>
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -93,13 +93,6 @@
                         "Follow the 'OMERO permissions' link below for full details.",
                         null, "WARNING", ['OK'], null, 180);
                 });
-                
-                if ('{{ can_add_member }}' == 'False') {
-                    $("label[for='id_owners']").hide();
-                    $("#id_owners_chosen").hide();
-                    $("label[for='id_members']").hide();
-                    $("#id_members_chosen").hide();
-                } 
         })
     </script>
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -93,6 +93,7 @@
                         "Follow the 'OMERO permissions' link below for full details.",
                         null, "WARNING", ['OK'], null, 180);
                 });
+
         })
     </script>
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -730,7 +730,7 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
             # group
             admins.append(conn.getUserId())
         return {'form': form, 'gid': gid, 'permissions': permissions,
-                'admins': admins, 'can_add_member': can_add_member}
+                'admins': admins, 'can_modify_group': can_modify_group}
 
     if action == 'new':
         can_modify_group = 'ModifyGroup' in conn.getCurrentAdminPrivileges()
@@ -739,8 +739,7 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
         form = GroupForm(initial={'experimenters': experimenters,
                                   'permissions': 0},
                          can_add_member=can_add_member)
-        context = {'form': form, 'can_modify_group': can_modify_group,
-                   'can_add_member': can_add_member}
+        context = {'form': form, 'can_modify_group': can_modify_group}
     elif action == 'create':
         if request.method != 'POST':
             return HttpResponseRedirect(reverse(viewname="wamanagegroupid",

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -702,6 +702,8 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
         memberIds = [m.id for m in group.getMembers()]
         permissions = getActualPermissions(group)
         can_modify_group = 'ModifyGroup' in conn.getCurrentAdminPrivileges()
+        can_add_member = 'ModifyGroupMembership' in \
+            conn.getCurrentAdminPrivileges()
         system_groups = [
             conn.getAdminService().getSecurityRoles().systemGroupId,
             conn.getAdminService().getSecurityRoles().userGroupId,
@@ -724,13 +726,17 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
             # group
             admins.append(conn.getUserId())
         return {'form': form, 'gid': gid, 'permissions': permissions,
-                'admins': admins, 'can_modify_group': can_modify_group}
+                'admins': admins, 'can_modify_group': can_modify_group,
+                'can_add_member': can_add_member}
 
     if action == 'new':
         can_modify_group = 'ModifyGroup' in conn.getCurrentAdminPrivileges()
+        can_add_member = 'ModifyGroupMembership' in \
+            conn.getCurrentAdminPrivileges()
         form = GroupForm(initial={'experimenters': experimenters,
                                   'permissions': 0})
-        context = {'form': form, 'can_modify_group': can_modify_group}
+        context = {'form': form, 'can_modify_group': can_modify_group,
+                   'can_add_member': can_add_member}
     elif action == 'create':
         if request.method != 'POST':
             return HttpResponseRedirect(reverse(viewname="wamanagegroupid",

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -681,8 +681,11 @@ def groups(request, conn=None, **kwargs):
 
     groups = conn.getObjects("ExperimenterGroup")
     can_modify_group = 'ModifyGroup' in conn.getCurrentAdminPrivileges()
+    can_add_member = 'ModifyGroupMembership' in \
+        conn.getCurrentAdminPrivileges()
 
-    context = {'groups': groups, 'can_modify_group': can_modify_group}
+    context = {'groups': groups, 'can_modify_group': can_modify_group,
+               'can_add_member': can_add_member}
     context['template'] = template
     return context
 
@@ -719,6 +722,7 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
             'members': memberIds,
             'experimenters': experimenters},
             can_modify_group=can_modify_group,
+            can_add_member=can_add_member,
             group_is_current_or_system=group_is_current_or_system)
         admins = [conn.getAdminService().getSecurityRoles().rootId]
         if long(gid) in system_groups:
@@ -726,15 +730,15 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
             # group
             admins.append(conn.getUserId())
         return {'form': form, 'gid': gid, 'permissions': permissions,
-                'admins': admins, 'can_modify_group': can_modify_group,
-                'can_add_member': can_add_member}
+                'admins': admins, 'can_add_member': can_add_member}
 
     if action == 'new':
         can_modify_group = 'ModifyGroup' in conn.getCurrentAdminPrivileges()
         can_add_member = 'ModifyGroupMembership' in \
             conn.getCurrentAdminPrivileges()
         form = GroupForm(initial={'experimenters': experimenters,
-                                  'permissions': 0})
+                                  'permissions': 0},
+                         can_add_member=can_add_member)
         context = {'form': form, 'can_modify_group': can_modify_group,
                    'can_add_member': can_add_member}
     elif action == 'create':

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1415,8 +1415,8 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         listOfOwners = list()
         for exp in owners:
             listOfOwners.append(exp._obj)
-
-        admin_serv.addGroupOwners(group, listOfOwners)
+        if listOfOwners:
+            admin_serv.addGroupOwners(group, listOfOwners)
         return gr_id
 
     def updateGroup(self, group, name, permissions, owners=list(),

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1455,34 +1455,42 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         add_exps = list()
         rm_exps = list()
 
-        # remove
-        for oex in old_owners:
-            flag = False
-            for nex in owners:
-                if nex._obj.id.val == oex.id.val:
-                    flag = True
-            if not flag:
-                rm_exps.append(oex)
-
-        # add
-        for nex in owners:
-            flag = False
+        can_mod = 'ModifyGroupMembership' in self.getCurrentAdminPrivileges()
+        if can_mod:
+            # remove
             for oex in old_owners:
-                if oex.id.val == nex._obj.id.val:
-                    flag = True
-            if not flag:
-                add_exps.append(nex._obj)
+                flag = False
+                for nex in owners:
+                    if nex._obj.id.val == oex.id.val:
+                        flag = True
+                if not flag:
+                    rm_exps.append(oex)
+
+            # add
+            for nex in owners:
+                flag = False
+                for oex in old_owners:
+                    if oex.id.val == nex._obj.id.val:
+                        flag = True
+                if not flag:
+                    add_exps.append(nex._obj)
 
         msgs = []
         admin_serv = self.getAdminService()
         # Should we update updateGroup so this would be atomic?
         admin_serv.updateGroup(up_gr)
+
+        if str(permissions) == str(up_gr.details.getPermissions()):
+            permissions = None
+
         if permissions is not None:
             err = self.updatePermissions(group, permissions)
             if err is not None:
                 msgs.append(err)
-        admin_serv.addGroupOwners(up_gr, add_exps)
-        admin_serv.removeGroupOwners(up_gr, rm_exps)
+        if add_exps:
+            admin_serv.addGroupOwners(up_gr, add_exps)
+        if rm_exps:
+            admin_serv.removeGroupOwners(up_gr, rm_exps)
         return msgs
 
     def updateMyAccount(self, experimenter, firstName, lastName, email,


### PR DESCRIPTION
# What this PR does

If the light admin has only create/edit group permission, creating a group will throw an error when webclient_gateway attempts to add a group owner and/or member (the user needs 'add users to group' permission for that). With this PR these fields are simply ~~hidden~~ disabled, when the user lacks the appropriate permisson.

# Testing this PR

Create a light admin user which only has 'Create and Edit Group' permission. Check that ~~there are no~~ Owners and Members fields are disabled. Create a group. 
Grant the 'Add Users to Groups' permission to the light admin user. Check that now ~~there are~~ the Owners and Members fields are enabled. Create a group.

# Related reading

https://trello.com/c/LUzfIhaU/46-crashes-in-webclient

# Remarks
- ~~Disabling the fields would be nicer than hiding them... Any Javascript experts here to give me a hint?~~
- ~~I think this PR is quite 'hacky', can't imagine @will-moore would be happy to merge this...~~
- Generally, "Create and Edit Groups" permission doesn't make much sense without the "Add Users to Group" permission, does it?


