### PR TITLE
Add login_required to open_with_options (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1681,6 +1681,7 @@ def projectDetail_json(request, pid, conn=None, **kwargs):
     return rv
 
 
+@login_required()
 @jsonp
 def open_with_options(request, **kwargs):
     """


### PR DESCRIPTION

This is the same as gh-5343 but rebased onto develop.

----

# What this PR does

See https://trello.com/c/gl7lsY2C/45-openwith-jsonp-without-loginrequired


                