### PR TITLE
batch original files query in repository DAO

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
+++ b/components/blitz/src/ome/services/blitz/repo/RepositoryDaoImpl.java
@@ -492,9 +492,15 @@ public class RepositoryDaoImpl implements RepositoryDao {
             if (CollectionUtils.isEmpty(ids)) {
                 return Collections.emptyList();
             }
-            Parameters p = new Parameters();
-            p.addIds(ids);
-            return q.findAllByQuery(LOAD_ORIGINAL_FILE+"f.id in (:ids)", p);
+            final List<ome.model.core.OriginalFile> files = new ArrayList<>(ids.size());
+            final String filesById = LOAD_ORIGINAL_FILE + "f.id in (:ids)";
+            for (final List<Long> idsBatch : Iterables.partition(ids, 1024)) {
+                final Parameters params = new Parameters().addIds(idsBatch);
+                for (final IObject file : q.findAllByQuery(filesById, params)) {
+                    files.add((ome.model.core.OriginalFile) file);
+                }
+            }
+            return files;
 
     }
 


### PR DESCRIPTION
# What this PR does

Batches the server's internal querying of open files by ID. May ease the use of `bin/omero admin cleanse` with ginormous directories if the query results can be passed via Ice.

# Testing this PR

Difficult: open to ideas! #5205 could be of help. `df -i` may reassure about inode exhaustion. There may be an efficient way to construct a single fileset (plate?) of very many tiny files.

# Related reading

http://lists.openmicroscopy.org.uk/pipermail/ome-users/2016-May/005987.html
http://trac.openmicroscopy.org/ome/ticket/13225