### PR TITLE
users with Chgrp privilege may move data to others' groups

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/chgrp.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chgrp.py
@@ -61,14 +61,9 @@ class ChgrpControl(GraphControl):
 
     def is_admin(self, client):
         # check if the user currently logged is an admin
-        svc = client.sf.getAdminService()
-        uid = self.ctx.get_event_context().userId
-        groups = svc.containedGroups(uid)
-        roles = svc.getSecurityRoles()
-        for g in groups:
-            if roles.systemGroupId == g.id.val:
-                return True
-        return False
+        from omero.model.enums import AdminPrivilegeChgrp
+        ec = self.ctx.get_event_context()
+        return AdminPrivilegeChgrp in ec.adminPrivileges
 
     def _process_request(self, req, args, client):
         # Retrieve group id


### PR DESCRIPTION
# What this PR does

Adjusts the CLI `bin/omero chgrp ...` to take account of the `Chgrp` administrative restriction in checking for moves outside the user's own groups.

# Testing this PR

Use webadmin to give or remove `Chgrp` privilege then try moving data via CLI. Note that it may take (literally) a minute for privilege changes to take effect.

1. Administrator with `Chgrp` privilege can move their and others' data to groups of which they are a member.
1. Administrator with `Chgrp` privilege can move their and others' data to groups of which they are not a member.
1. Administrator without `Chgrp` privilege can move only their data to groups of which they are a member.
1. Administrator without `Chgrp` privilege cannot move data to groups of which they are not a member.
1. Non-administrator can move only their data to groups of which they are a member.
1. Non-administrator cannot move data to groups of which they are not a member.

Wrongly violating the "of which they are a member" should have the CLI output a "Current user is not member of group" message without even attempting the move.

# Related reading

https://trello.com/c/VyOwZwyr/40-admin-only-chgrp-chown-in-clients
https://github.com/openmicroscopy/ome-help/pull/251