### PR TITLE
Fixed some light admin issues

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/DataBrowserAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/DataBrowserAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -141,6 +141,58 @@ public class DataBrowserAgent
 		if (b == null) return false;
 		return b.booleanValue();
 	}
+	
+	/**
+     * Returns <code>true</code> if the currently logged in user
+     * can edit users, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isEditUser()
+    {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_EDIT_USER);
+        if (b == null) return false;
+        return b.booleanValue();
+    }
+    
+	/**
+     * Returns <code>true</code> if the currently logged in user
+     * can edit groups, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isEditGroup()
+    {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_EDIT_GROUP);
+        if (b == null) return false;
+        return b.booleanValue();
+    }
+    
+    /**
+     * Returns <code>true</code> if the currently logged in user
+     * can add users to groups, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isAddToGroup()
+    {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_GROUP_ADD);
+        if (b == null) return false;
+        return b.booleanValue();
+    }
+    
+    /**
+     * Returns <code>true</code> if the currently logged in user
+     * can move object to/from groups, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isMoveGroup()
+    {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_MOVE_GROUP);
+        if (b == null) return false;
+        return b.booleanValue();
+    }
 	
 	/**
 	 * Returns the collection of groups the current user is the leader of.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -446,6 +446,20 @@ public class MetadataViewerAgent
             viewer.reloadROICount();
         }
         
+    }
+
+    /**
+     * Returns <code>true</code> if the currently logged in user is is allowed
+     * to edit groups, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isEditGroup() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_EDIT_GROUP);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -2395,6 +2395,22 @@ class EditorModel
 		}
 		return n;
 	}
+	
+    /**
+     * Returns the rating done by the current user.
+     * 
+     * @return See above
+     */
+    RatingAnnotationData getUserRatingData() {
+        if (!isMultiSelection()) {
+            Map<DataObject, RatingAnnotationData> map = getAllUserRatingAnnotation();
+            for (Entry<DataObject, RatingAnnotationData> e : map.entrySet()) {
+                if (e.getValue().getOwner().getId() == getLoggedInUserID())
+                    return e.getValue();
+            }
+        }
+        return null;
+    }
 	
 	/** 
 	 * Returns the average rating value.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/GroupProfile.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -100,7 +100,7 @@ class GroupProfile
     	ref = (GroupData) model.getRefObject();
     	namePane = new JTextField();
     	descriptionPane = new JTextField();
-    	final boolean mayChangePermissions = model.isAdministrator() || model.isGroupLeader(ref);
+    	final boolean mayChangePermissions = model.isGroupLeader(ref) || MetadataViewerAgent.isEditGroup();
     	//permission level
 
     	permissionsPane = new PermissionsPane(ref.getPermissions(),
@@ -113,7 +113,8 @@ class GroupProfile
     	permissionsPane.addPropertyChangeListener(this);
     	namePane.setText(ref.getName());
     	descriptionPane.setText(ref.getDescription());
-    	canEdit = mayChangePermissions && !model.isSystemGroup(ref.getId());
+    	canEdit = mayChangePermissions &&
+    	        !model.isSystemGroup(ref.getId());
     	namePane.setEditable(canEdit);
     	namePane.setEnabled(canEdit);
     	descriptionPane.setEditable(canEdit);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/RatingTaskPaneUI.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -183,9 +183,14 @@ public class RatingTaskPaneUI extends AnnotationTaskPaneUI implements
 
     @Override
     List<AnnotationData> getAnnotationsToSave() {
-        if (selectedValue != originalValue)
-            return Collections.<AnnotationData>singletonList(new RatingAnnotationData(selectedValue));
-        else
+        if (selectedValue != originalValue) {
+            RatingAnnotationData ra = model.getUserRatingData();
+            if (ra == null)
+                ra = new RatingAnnotationData(selectedValue);
+            else
+                ra.setRating(selectedValue);
+            return Collections.<AnnotationData> singletonList(ra);
+        } else
             return Collections.emptyList();
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -146,6 +146,62 @@ public class TreeViewerAgent
 		return b.booleanValue();
 	}
 	
+    /**
+     * Returns <code>true</code> if the currently logged in user is is allowed
+     * to move objects to/from groups, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isMoveGroup() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_MOVE_GROUP);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
+    }
+
+    /**
+     * Returns <code>true</code> if the currently logged in user is is allowed
+     * to edit groups, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isEditGroup() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_EDIT_GROUP);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
+    }
+    
+    /**
+     * Returns <code>true</code> if the currently logged in user is is allowed
+     * to to add users to groups, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isAddToGroup() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_GROUP_ADD);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
+    }
+
+    /**
+     * Returns <code>true</code> if the currently logged in user is is allowed
+     * to edit users, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isEditUser() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_EDIT_USER);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
+    }
+    
 	/**
 	 * Returns the context for an administrator.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/AddAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/AddAction.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -115,7 +115,7 @@ public class AddAction
                 if (array != null && array.length > 1) {
                     multipleNodesSelected = true;
                 }
-                setEnabled(!multipleNodesSelected);
+                setEnabled(!multipleNodesSelected && TreeViewerAgent.isAddToGroup());
             }
             putValue(Action.NAME, NAME_USER);
             putValue(Action.SHORT_DESCRIPTION,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/CreateTopContainerAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/actions/CreateTopContainerAction.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -218,7 +218,11 @@ public class CreateTopContainerAction
     {
         setEnabled(false);
         if (nodeType == GROUP) {
-            setEnabled(TreeViewerAgent.isAdministrator());
+            setEnabled(TreeViewerAgent.isEditGroup());
+            return;
+        }
+        if (nodeType == EXPERIMENTER) {
+            setEnabled(TreeViewerAgent.isEditUser());
             return;
         }
         if (model.getDisplayMode() == TreeViewer.EXPERIMENTER_DISPLAY
@@ -240,12 +244,12 @@ public class CreateTopContainerAction
                 if (ho instanceof ExperimenterData) {
                     long id = TreeViewerAgent.getUserDetails().getId();
                     ExperimenterData exp = (ExperimenterData) ho;
-                    setEnabled(exp.getId() == id);
+                    setEnabled(exp.getId() == id || TreeViewerAgent.isEditUser());
                     return;
                 }
                 if (ho instanceof GroupData) {
                     setEnabled(model.getDisplayMode() ==
-                            TreeViewer.GROUP_DISPLAY);
+                            TreeViewer.GROUP_DISPLAY && TreeViewerAgent.isEditGroup());
                     return;
                 }
                 setEnabled(model.canLink(ho));
@@ -260,7 +264,7 @@ public class CreateTopContainerAction
                 Object ho = selectedDisplay.getUserObject();
                 if (ho instanceof GroupData) {
                     TreeImageDisplay[] selected = browser.getSelectedDisplays();
-                    setEnabled(selected.length == 1);
+                    setEnabled(selected.length == 1 && TreeViewerAgent.isEditGroup());
                 } else setEnabled(false);
             }
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/AdminDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/AdminDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -341,7 +341,7 @@ implements ActionListener, PropertyChangeListener
             }
             body = new ExperimenterPane(true, groups, selected);
         } else if (GroupData.class.equals(type)) {
-            body = new GroupPane(TreeViewerAgent.isAdministrator());
+            body = new GroupPane(TreeViewerAgent.isAdministrator(), TreeViewerAgent.isAddToGroup());
         }
         body.addPropertyChangeListener(this);
         initComponents();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/GroupPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/GroupPane.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -68,25 +68,29 @@ class GroupPane
     /** Initializes the components.
      * @param admin
      *            Pass <code>true</code> to enable admin-only permission changes
+     * @param addUsers
+     *            Pass <code>true</code> to enable owner/members settings
      */
-    private void initComponents(boolean admin)
+    private void initComponents(boolean admin, boolean addUsers)
     {
     	permissions = new PermissionsPane(admin);
     	permissions.setBorder(
 				BorderFactory.createTitledBorder("Permissions"));
     	descriptionArea = new JTextField();
-    	expPane = new ExperimenterPane(false, null, null);
-    	expPane.setBorder(
-				BorderFactory.createTitledBorder("Owner"));
-    	expPane.addPropertyChangeListener(new PropertyChangeListener() {
-			
-			public void propertyChange(PropertyChangeEvent evt) {
-				if (AdminDialog.ENABLE_SAVE_PROPERTY.equals(
-						evt.getPropertyName()))
-				firePropertyChange(AdminDialog.ENABLE_SAVE_PROPERTY,
-						evt.getOldValue(), evt.getNewValue());
-			}
-		});
+
+        if (addUsers) {
+            expPane = new ExperimenterPane(false, null, null);
+            expPane.setBorder(BorderFactory.createTitledBorder("Owner"));
+            expPane.addPropertyChangeListener(new PropertyChangeListener() {
+
+                public void propertyChange(PropertyChangeEvent evt) {
+                    if (AdminDialog.ENABLE_SAVE_PROPERTY.equals(evt
+                            .getPropertyName()))
+                        firePropertyChange(AdminDialog.ENABLE_SAVE_PROPERTY,
+                                evt.getOldValue(), evt.getNewValue());
+                }
+            });
+        }
     }
     
     /**
@@ -152,8 +156,10 @@ class GroupPane
         add(buildContentPanel(), c);
         c.gridy++;
         add(permissions, c);
-        c.gridy++;
-        add(expPane, c);
+        if (expPane != null) {
+            c.gridy++;
+            add(expPane, c);
+        }
     }
     
     /**
@@ -161,12 +167,14 @@ class GroupPane
      * 
      * @param admin
      *            Pass <code>true</code> to enable admin-only permission changes
+     * @param addUsers
+     *            Pass <code>true</code> to enable owner/members settings
      */
-	GroupPane(boolean admin)
-	{
-		initComponents(admin);
-		buildGUI();
-	}
+    GroupPane(boolean admin, boolean addUsers) {
+        initComponents(admin, addUsers);
+        buildGUI();
+    }
+	
 	/**
 	 * Returns <code>true</code> if the login name has been populated,
 	 * <code>false</code> otherwise.
@@ -193,7 +201,7 @@ class GroupPane
 		data.setDescription(descriptionArea.getText().trim());
 		Map<ExperimenterData, UserCredentials> 
 		m = new HashMap<ExperimenterData, UserCredentials>();
-		if (expPane.hasLoginCredentials())
+		if (expPane != null && expPane.hasLoginCredentials())
 			m = expPane.getObjectToSave();
 		AdminObject object = new AdminObject(data, m, AdminObject.CREATE_GROUP);
 		object.setPermissions(permissions.getPermissions());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerComponent.java
@@ -1972,7 +1972,7 @@ class TreeViewerComponent
 	 */
 	public boolean canChgrp(Object ho)
 	{
-		if (TreeViewerAgent.isAdministrator()) return true;
+		if (TreeViewerAgent.isMoveGroup()) return true;
 		long id = model.getUserDetails().getId();
 		boolean b = false;
 		if (ho instanceof TreeImageTimeSet) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -762,6 +762,9 @@ class TreeViewerControl
 	 */
 	List<MoveToAction> getMoveAction()
 	{
+	    if (!TreeViewerAgent.isMoveGroup())
+	        return null;
+	        
 		//First check that we can move the data.
 		Browser browser = model.getSelectedBrowser();
 		List selection = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/TreeViewerControl.java
@@ -762,9 +762,6 @@ class TreeViewerControl
 	 */
 	List<MoveToAction> getMoveAction()
 	{
-	    if (!TreeViewerAgent.isMoveGroup())
-	        return null;
-	        
 		//First check that we can move the data.
 		Browser browser = model.getSelectedBrowser();
 		List selection = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/util/ui/PermissionsPane.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -504,7 +504,7 @@ public class PermissionsPane
 		if (readOnlyGroupBox != null) readOnlyGroupBox.setEnabled(enabled);
 		if (readOnlyPublicBox != null) readOnlyPublicBox.setEnabled(enabled);
 		if (readWriteGroupBox != null)
-			readWriteGroupBox.setEnabled(admin);
+			readWriteGroupBox.setEnabled(enabled);
 		if (readAnnotateGroupBox != null)
 			readAnnotateGroupBox.setEnabled(enabled);
 		publicBox.addActionListener(this);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.LookupNames
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -169,6 +169,18 @@ public class LookupNames
 
     /** Field indicating if the user is an administrator. */
     public static final String USER_ADMINISTRATOR = "/users/administrator";
+    
+    /** Field indicating if the user can edit users. */
+    public static final String PRIV_EDIT_USER = "/users/edit";
+    
+    /** Field indicating if the user can edit groups. */
+    public static final String PRIV_EDIT_GROUP = "/groups/edit";
+    
+    /** Field indicating if the user move objects to/from groups. */
+    public static final String PRIV_MOVE_GROUP = "/groups/move";
+    
+    /** Field indicating if the user add group members. */
+    public static final String PRIV_GROUP_ADD = "/groups/add";
 
     /** Field to indicate if the connection is fast or not. */
     public static final String IMAGE_QUALITY_LEVEL = "/connection/speed";

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -634,10 +634,26 @@ class OmeroMetadataServiceImpl
 			}
 		}
 		else if (annotation instanceof RatingAnnotationData) {
-			clearAnnotation(ctx, data.getClass(), data.getId(),
-					RatingAnnotationData.class);
-			link = ModelMapper.linkAnnotation(ho, an);
-		} else {
+		    RatingAnnotationData ra = (RatingAnnotationData) annotation;
+            link = findAnnotationLink(ctx, ho.getClass(),
+                    ho.getId().getValue(), ra.getId(), expIds);
+            if (link == null)
+                link = ModelMapper.linkAnnotation(ho, an);
+            else {
+                updateAnnotationData(ctx, ra);
+                exist = true;
+            }
+		} else if (annotation instanceof LongAnnotationData) {
+		    LongAnnotationData ra = (LongAnnotationData) annotation;
+            link = findAnnotationLink(ctx, ho.getClass(),
+                    ho.getId().getValue(), ra.getId(), expIds);
+            if (link == null)
+                link = ModelMapper.linkAnnotation(ho, an);
+            else {
+                updateAnnotationData(ctx, ra);
+                exist = true;
+            }
+        } else {
 			link = ModelMapper.linkAnnotation(ho, an);
 		}
 		if (link != null && !exist) 
@@ -712,7 +728,16 @@ class OmeroMetadataServiceImpl
 			ho.setDescription(omero.rtypes.rstring(tag.getDescription()));
 			IObject object = gateway.updateObject(ctx, ho, new Parameters());
 			return PojoMapper.asDataObject(object);
-		} else if (ann instanceof LongAnnotationData && ann.isDirty()) {
+		} else if (ann instanceof RatingAnnotationData && ann.isDirty()) {
+		    RatingAnnotationData tag = (RatingAnnotationData) ann;
+            id = tag.getId();
+            ioType = PojoMapper.getModelType(LongAnnotationData.class).getName();
+            LongAnnotation ho = (LongAnnotation) gateway.findIObject(ctx,
+                    ioType, id);
+            ho.setLongValue(omero.rtypes.rlong(tag.getRating()));
+            IObject object = gateway.updateObject(ctx, ho, new Parameters());
+            return PojoMapper.asDataObject(object);
+        } else if (ann instanceof LongAnnotationData && ann.isDirty()) {
 			LongAnnotationData tag = (LongAnnotationData) ann;
 			id = tag.getId();
 			ioType = PojoMapper.getModelType(LongAnnotationData.class).getName();


### PR DESCRIPTION
# What this PR does

Fixes some issues related to light admins, i. e. menus enabled or UI components available, although the user doesn't have the necessary permissions.

# Testing this PR

Check the following points:

- User without 'Create groups' permission shouldn't be able to create groups
- User with 'Create groups' permission but without 'Add group members' permission shouldn't be able to set an owner of a group while creating the group, nor edit the group membership of existing groups
- User without 'Create user' permission should not be able create or edit user
- User without 'Change group' permission should not be able to move another user's data to another group. Also check that a normal user still can move its own data (see @pwalczysko  comment).
- User with "Write" permission should be able to rate (and modify his rating) on other user's data in read-only group

Test only the menus in the left hand side treeviewer (ignore the right hand side metadata panel, it's quite buggy when a User or Group item is selected anyway).

# Related reading

https://trello.com/c/0K25vyHa/67-light-crashes-in-insight

Note: ~~Not ready yet, there's still one point open on the checklist (Ratings), which I want to fix within this PR.~~ Done (last commit)
