### PR TITLE
Search GET only take 2 (partial rebase 5338)

### DIFF
--- a/components/tests/ui/testcases/web/annotate_test.txt
+++ b/components/tests/ui/testcases/web/annotate_test.txt
@@ -287,7 +287,7 @@ Test Search Results File Annotations
 
     Input Text  id=id_search_query              ${fileNameTwo}
     Submit Form
-    Location Should Be                          ${SEARCH URL}
+    Location Should Be                          ${SEARCH URL}?search_query=${fileNameTwo}
 
     Wait Until Page Contains Element            xpath=//img[contains(@alt, 'plate')]
     Click Element                               xpath=//img[contains(@alt, 'plate')]

--- a/components/tests/ui/testcases/web/forms_test.txt
+++ b/components/tests/ui/testcases/web/forms_test.txt
@@ -183,7 +183,7 @@ Test Search
     Submit Form                             id=search
 
     # We don't care about results, just check we get *some* results in dataTable
-    Location Should Be                      ${WELCOME URL}search/
+    Location Should Be                      ${WELCOME URL}search/?search_query=test
     Wait Until Page Contains Element        dataTable       ${WAIT}
     # Repeat search
     Submit Form                             searching_form

--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -165,7 +165,7 @@ Test Default Search Check
     [Documentation]     login,search and Check that you are taken to the search ‘page’/UI with your search query entered into the search field.
     
     Omero Default Search
-    Location Should Be                  ${SEARCH URL}
+    Location Should Be                  ${SEARCH URL}?search_query=${SEARCH_QUERY}
     Page Should Contain Textfield       name=query
     Textfield Value Should be           name=query      ${SEARCH_QUERY}
     Wait Until Page Contains Element    id=dataTable    ${WAIT}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/search_field.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/search_field.html
@@ -20,7 +20,7 @@
 {% endcomment %}
 
 
-<form id="search" action="{% url 'load_template' 'search' %}" method="post" title="Search OMERO">{% csrf_token %}
+<form id="search" action="{% url 'load_template' 'search' %}" title="Search OMERO">
 
     <div id="top_search_field">
         <label class="inline_label" for="id_search_query">Search:</label>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -220,7 +220,7 @@
 	
 	<div class="left_panel_inner">
 	    
-		<form id="searching_form" class="standard_form" action="{% url 'load_searching' 'form' %}">{% csrf_token %}
+		<form id="searching_form" class="standard_form" action="{% url 'load_searching' 'form' %}">
 					
 					<h2>{% trans "General Search" %}</h2>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -371,7 +371,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
 
     # search support
     init = {}
-    global_search_form = GlobalSearchForm(data=request.POST.copy())
+    global_search_form = GlobalSearchForm(data=request.GET.copy())
     if menu == "search":
         if global_search_form.is_valid():
             init['query'] = global_search_form.cleaned_data['search_query']
@@ -1373,7 +1373,7 @@ def load_searching(request, form=None, conn=None, **kwargs):
 
     foundById = []
     # form = 'form' if we are searching. Get query from request...
-    r = request.GET or request.POST
+    r = request.GET
     if form is not None:
         query_search = r.get('query').replace("+", " ")
         template = "webclient/search/search_details.html"


### PR DESCRIPTION
# What this PR does

This is an attempt to fix some CSRF/POST issues with search on the IDR by partially rebasing #5338, excluding the merge commit.

https://github.com/openmicroscopy/openmicroscopy/pull/4900/commits/320efe9d32ae3e37fbb3e85b03f6eed4c6b2c191 made search use `GET` on metadata52. This was removed in https://github.com/openmicroscopy/openmicroscopy/commit/2845d589675b365ab22654f1316756da207d557c#diff-e226bce909b5b71ca51f5a26c7db1823L398 presumably when metadata53 was re-branched.

# Testing this PR

1. Click on a mapr tab.
2. Search for something in the top-right OMERO.web search box
3. It should not crash