### PR TITLE
Webui field display

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2183,10 +2183,11 @@ div.paging input.button_pagination {
     position: relative;
 }
 #spw table td.well {
-    background: #eee;
+    background: #fff;
 }
 #spw table td.placeholder {
     vertical-align: top;
+    background: #fff;
 }
 
 #spw table td.ui-selecting { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -848,6 +848,7 @@
 
     <!-- Panel hidden unless needed for showing spatial birds eye view of Wells - see ome.spwgridview.js -->
     <div id="left_panel_bottom" class="left_panel_inner" style="top: auto; height: 0; border-top: solid 1px hsl(210,10%,85%);">
+        <label style="margin-top: 4px; margin-left: 4px;">Field positions in well</label>
         <a id="hide_well_birds_eye" href="#" class="action" style="position: absolute; right: 3px; top: 0">X</a>
         <div id="well_birds_eye_container">
             <div id="well_birds_eye" class="" style="top: 4px; left: -6px; position: relative; margin:auto; border-right: none; overflow: visible;"></div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -334,10 +334,15 @@
     <div class="verticalDragHandle"></div>
 </div>
 <div id="wellImagesContainer" class="wellImages fillSpace" style="bottom: 0px; height: 150px">
-    <div class='fillSpace toolbarBg' style='top: 0; height: 26px; border-bottom: solid 1px #ddd; padding-left:10px'>
-        <span>Wrap</span>
-        <input type="number" id="imagesPerRow" min="0" style="margin: 2px; width: 30px;"/>
-        <span>images per row</span>
+    <div class='fillSpace toolbarBg' style='top: 0; height: 30px; border-bottom: solid 1px #ddd; padding-left:10px;'>
+        <div style="float:left;">
+            <span>Wrap</span>
+            <input type="number" id="imagesPerRow" min="0" style="margin: 2px; width: 30px;"/>
+            <span>images per row</span>
+        </div>
+        <div style='margin-top: 10px; margin-left: auto; margin-right: auto; transform: translate(-80px, 0px); text-align: center;'>
+            <span>Images from each field</span>
+        </div>
     </div>
     <!-- Scrollable container for wellImages -->
     <div id="wellImages" class='fillSpace' style='top: 26px; bottom: 25px'>


### PR DESCRIPTION
# What this PR does

Fixes some issues with the field display

- Lower left box of field positions: Add label 'Field positions in well'
- Lower centre panel showing the images from each field: Add label 'Images from each field'
- "The plate view in the centre panel for some screens looks quite messy": Set the background of the cell displaying the well to white to match the placeholder (empty) well color.

# Testing this PR

Check the points mentioned above.


# Related reading

https://trello.com/c/MvTUcbkj/18-webui-display-of-fields

Note: I can't replicate first on the card, would need an example plate showing that behaviour.
