### PR TITLE
Add three new roles integration tests

### DIFF
--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -22,15 +22,12 @@ package integration;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import omero.RLong;
 import omero.RString;
-import omero.RType;
 import omero.SecurityViolation;
 import omero.ServerError;
 import omero.api.IRenderingSettingsPrx;
@@ -42,7 +39,6 @@ import omero.gateway.util.Requests;
 import omero.gateway.util.Requests.Delete2Builder;
 import omero.model.AdminPrivilege;
 import omero.model.AdminPrivilegeI;
-import omero.model.Annotation;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
@@ -51,16 +47,13 @@ import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
 import omero.model.ExperimenterI;
 import omero.model.FileAnnotation;
-import omero.model.FileAnnotationI;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
-import omero.model.ImageAnnotationLinkI;
 import omero.model.ImageI;
 import omero.model.NamedValue;
 import omero.model.OriginalFile;
 import omero.model.OriginalFileI;
-import omero.model.Permissions;
 import omero.model.PermissionsI;
 import omero.model.Pixels;
 import omero.model.Project;
@@ -70,7 +63,6 @@ import omero.model.RectangleI;
 import omero.model.RenderingDef;
 import omero.model.Roi;
 import omero.model.RoiI;
-import omero.model.Session;
 import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
 import omero.model.enums.AdminPrivilegeChgrp;
@@ -86,16 +78,13 @@ import omero.model.enums.AdminPrivilegeWriteManagedRepo;
 import omero.model.enums.AdminPrivilegeWriteOwned;
 import omero.model.enums.AdminPrivilegeWriteScriptRepo;
 import omero.sys.EventContext;
-import omero.sys.Parameters;
 import omero.sys.ParametersI;
-import omero.sys.Principal;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Tests the concrete workflows of the light admins

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -391,13 +391,8 @@ public class LightAdminRolesTest extends RolesTests {
       normalUsergroup = addUsers(normalUsergroup, ImmutableList.of(lightAdmin.userId, otherUser.userId), false);
       /* normalUser creates a Dataset and Project.*/
       loginUser(normalUser);
-      client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
-      Project proj = mmFactory.simpleProject();
-      Dataset dat = mmFactory.simpleDataset();
-      Project sentProj = null;
-      Dataset sentDat = null;
-      sentProj = (Project) iUpdate.saveAndReturnObject(proj);
-      sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+      Project sentProj = (Project) iUpdate.saveAndReturnObject(mmFactory.simpleProject());
+      Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset());
       /* normalUser imports an image
        * and targets it into the created Dataset.*/
       List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
@@ -1000,7 +995,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "WriteOwned and IsAdmin cases")
+    @Test(dataProvider = "WriteOwned and isAdmin cases")
     public void testLinkMemberOfGroupNoSudo(boolean permWriteOwned, boolean isAdmin,
             String groupPermissions) throws Exception {
         /* WriteOwned permission is necessary and sufficient for lightAdmin to link
@@ -2224,10 +2219,10 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * @return WriteOwned and Chown test cases for
+     * @return WriteOwned and isAdmin test cases for
      * testLinkNoSudo and testROIAndRenderingSettingsNoSudo
      */
-    @DataProvider(name = "WriteOwned and IsAdmin cases")
+    @DataProvider(name = "WriteOwned and isAdmin cases")
     public Object[][] provideWriteOwnedAndIsAdmin() {
         int index = 0;
         final int PERM_WRITEOWNED = index++;

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -437,9 +437,9 @@ public class LightAdminRolesTest extends RolesTests {
        * Also check that the canDelete boolean
        * on the object retrieved by the lightAdmin matches the deletePassing
        * boolean.*/
-      //Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
+      Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
       doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
-      //Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
+      Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
       doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
       Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
       doChange(client, factory, Requests.delete().target(image).build(), deletePassing);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -377,11 +377,10 @@ public class LightAdminRolesTest extends RolesTests {
     * user. Behaviors of the system are explored when lightAdmin
     * is member of the group and also comparing test is made when otherUser
     * (non-admin) is attempting the delete.
-    * @param isSudoing if to test a success of workflows where Sudoed in
+    * @param isAdmin if to test a success of workflows when light admin
     * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
     * @param groupPermissions to test the effect of group permission level
     * @throws Exception unexpected
-    * @see <a href="https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit">graphical explanation</a>
     */
   @Test(dataProvider = "isSudoing and Delete privileges cases")
   public void testDeleteGroupMemeberNoSudo(boolean isAdmin, boolean permDeleteOwned,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1313,12 +1313,11 @@ public class LightAdminRolesTest extends RolesTests {
 
     /**
      * Light admin (lightAdmin) tries to delete ROI (belonging to normalUser)
-     * from image of normalUser.
+     * The ROI is on image of normalUser.
      * lightAdmin does not use Sudo in this test.
      * @param isPrivileged if to test a user who has the <tt>DeleteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit">graphical explanation</a>
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testROIDelete(boolean isPrivileged, String groupPermissions) throws Exception {
@@ -1352,6 +1351,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         assertExists(sentImage);
     }
+
     /**
      * Light admin (lightAdmin) tries to put ROI and Rendering Settings on an
      * image of normalUser.

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -327,9 +327,8 @@ public class LightAdminRolesTest extends RolesTests {
          * during writing of this test. The order of the below delete() commands
          * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
          * tested in this way.
-         * Also check that the canDelete boolean
-         * on the object retrieved by the lightAdmin matches the deletePassing
-         * boolean.*/
+         * Also check that the canDelete boolean on the object retrieved
+         * by the lightAdmin matches the deletePassing boolean.*/
         Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
         doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
         Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
@@ -1002,7 +1001,8 @@ public class LightAdminRolesTest extends RolesTests {
          * others objects to their objects. Exceptions are Private group, where such linking will
          * fail in all cases and Read-Write group where linking will succeed even
          * for otherUser (otherUser and lightAdmin are both members of the group).*/
-        boolean isExpectLinkingSuccessAdmin = (permWriteOwned && !groupPermissions.equals("rw----") || groupPermissions.equals("rwrw--"));
+        boolean isExpectLinkingSuccessAdmin =
+                (permWriteOwned && !groupPermissions.equals("rw----") || groupPermissions.equals("rwrw--"));
         boolean isExpectLinkingSuccessUser = groupPermissions.equals("rwrw--");
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         final EventContext otherUser = newUserAndGroup(groupPermissions);
@@ -1064,23 +1064,23 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
-        /**
-         * Light admin (lightAdmin) imports data for others (normalUser) without using Sudo.
-         * lightAdmin first creates a Dataset and imports an Image into it in lightAdmin's group
-         * (normalUser is not member of lightAdmin's group).
-         * Then, lightAdmin tries to move the Dataset into normalUser's group.
-         * Then, lightAdmin tries to chown the Dataset to normalUser.
-         * For this test, combinations of <tt>Chown</tt>, <tt>Chgrp</tt>,
-         * privileges of lightAdmin are explored.
-         * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
-         * @param permChown if to test a user who has the <tt>Chown</tt> privilege
-         * @param groupPermissions to test the effect of group permission level
-         * @throws Exception unexpected
-         * @see <a href="https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit">graphical explanation</a>
-         */
-        @Test(dataProvider = "Chgrp and Chown privileges cases")
-        public void testImporterAsNoSudoChgrpChownWorkflow(boolean permChgrp, boolean permChown,
-                String groupPermissions) throws Exception {
+    /**
+     * Light admin (lightAdmin) imports data for others (normalUser) without using Sudo.
+     * lightAdmin first creates a Dataset and imports an Image into it in lightAdmin's group
+     * (normalUser is not member of lightAdmin's group).
+     * Then, lightAdmin tries to move the Dataset into normalUser's group.
+     * Then, lightAdmin tries to chown the Dataset to normalUser.
+     * For this test, combinations of <tt>Chown</tt>, <tt>Chgrp</tt>,
+     * privileges of lightAdmin are explored.
+     * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
+     * @param permChown if to test a user who has the <tt>Chown</tt> privilege
+     * @param groupPermissions to test the effect of group permission level
+     * @throws Exception unexpected
+     * @see <a href="https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit">graphical explanation</a>
+     */
+    @Test(dataProvider = "Chgrp and Chown privileges cases")
+    public void testImporterAsNoSudoChgrpChownWorkflow(boolean permChgrp, boolean permChown,
+            String groupPermissions) throws Exception {
         /* Importing into the group of the lightAdmin and
          * subsequent moving the data into the group of normalUser and chowning
          * them to the normalUser succeeds if Chgrp and Chown is possible,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -298,12 +298,8 @@ public class LightAdminRolesTest extends RolesTests {
         sudo(new ExperimenterI(normalUser.userId, false));
         /* Create a Dataset and Project being sudoed as normalUser.*/
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
-        Project proj = mmFactory.simpleProject();
-        Dataset dat = mmFactory.simpleDataset();
-        Project sentProj = null;
-        Dataset sentDat = null;
-        sentProj = (Project) iUpdate.saveAndReturnObject(proj);
-        sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+        Project sentProj = (Project) iUpdate.saveAndReturnObject(mmFactory.simpleProject());
+        Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset());
         /* Import an image for the normalUser into the normalUser's default group
          * and target it into the created Dataset.*/
         List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1011,7 +1011,6 @@ public class LightAdminRolesTest extends RolesTests {
      * @param isAdmin if to test a lightAdmin
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and IsAdmin cases")
     public void testLinkMemberOfGroupNoSudo(boolean permWriteOwned, boolean isAdmin,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1013,7 +1013,6 @@ public class LightAdminRolesTest extends RolesTests {
         normalUsergroup = addUsers(normalUsergroup, ImmutableList.of(lightAdmin.userId, otherUser.userId), false);
         /* Create Dataset and Project as normalUser in normalUser's group.*/
         loginUser(normalUser);
-        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         Dataset dat = mmFactory.simpleDataset();
         Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
         Project proj = mmFactory.simpleProject();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1019,7 +1019,7 @@ public class LightAdminRolesTest extends RolesTests {
         Project proj = mmFactory.simpleProject();
         Project sentProj = (Project) iUpdate.saveAndReturnObject(proj);
         /* Create Image and Dataset as lightAdmin or otherUser in normalUser's group.*/
-        if(isAdmin) {
+        if (isAdmin) {
             loginUser(lightAdmin);
         } else {
             loginUser(otherUser);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -385,8 +385,7 @@ public class LightAdminRolesTest extends RolesTests {
       /* Set up the light admin's permissions for this test.*/
       List<String> permissions = new ArrayList<String>();
       if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
-      final EventContext lightAdmin;
-      lightAdmin = loginNewAdmin(true, permissions);
+      final EventContext lightAdmin = loginNewAdmin(true, permissions);
       /* root adds lightAdmin to normalUser's group.*/
       logRootIntoGroup(normalUser);
       normalUsergroup = addUsers(normalUsergroup, ImmutableList.of(lightAdmin.userId, otherUser.userId), false);
@@ -1016,8 +1015,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Set up the light admin's permissions for this test.*/
         List<String> permissions = new ArrayList<String>();
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        final EventContext lightAdmin = loginNewAdmin(true, permissions);
         /* root adds lightAdmin to normalUser's group.*/
         logRootIntoGroup(normalUser);
         normalUsergroup = addUsers(normalUsergroup, ImmutableList.of(lightAdmin.userId, otherUser.userId), false);
@@ -1327,8 +1325,7 @@ public class LightAdminRolesTest extends RolesTests {
         assertOwnedBy(sentImage, normalUser);
         assertOwnedBy(roi, normalUser);
         /* lightAdmin logs in and tries to delete the ROI.*/
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        final EventContext lightAdmin = loginNewAdmin(true, permissions);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         doChange(client, factory, Requests.delete().target(roi).build(), isExpectSuccessDeleteROI);
         /* Check the ROI was deleted, whereas the image exists.*/

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -281,175 +281,175 @@ public class LightAdminRolesTest extends RolesTests {
      * @throws Exception unexpected
      * @see <a href="https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit">graphical explanation</a>
      */
-   @Test(dataProvider = "isSudoing and Delete privileges cases")
-   public void testDelete(boolean isSudoing, boolean permDeleteOwned,
-           String groupPermissions) throws Exception {
-       /* Only DeleteOwned permission is needed for deletion of links, Dataset
-        * and image (with original file) when not sudoing. When sudoing, no other
-        * permission is needed.*/
-       boolean deletePassing = permDeleteOwned || isSudoing;
-       final EventContext normalUser = newUserAndGroup(groupPermissions);
-       /* Set up the light admin's permissions for this test */
-       List<String> permissions = new ArrayList<String>();
-       permissions.add(AdminPrivilegeSudo.value);
-       if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
-       final EventContext lightAdmin;
-       lightAdmin = loginNewAdmin(true, permissions);
-       sudo(new ExperimenterI(normalUser.userId, false));
-       /* Create a Dataset and Project being sudoed as normalUser.*/
-       client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
-       Project proj = mmFactory.simpleProject();
-       Dataset dat = mmFactory.simpleDataset();
-       Project sentProj = null;
-       Dataset sentDat = null;
-       sentProj = (Project) iUpdate.saveAndReturnObject(proj);
-       sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
-       /* Import an image for the normalUser into the normalUser's default group
-        * and target it into the created Dataset.*/
-       List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
-       OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
-       Image image = (Image) originalFileAndImage.get(1);
-       assertOwnedBy(image, normalUser);
-       /* Link the Project and the Dataset.*/
-       ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
-       IObject datasetImageLink = iQuery.findByQuery(
-               "FROM DatasetImageLink WHERE child.id = :id",
-               new ParametersI().addId(image.getId()));
-       /* Take care of post-import workflows which do not use sudo.*/
-       if (!isSudoing) {
-           loginUser(lightAdmin);
-           client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
-       }
-       /* Check that lightAdmin can delete the objects
-        * created on behalf of normalUser only if lightAdmin has sufficient permissions.
-        * Note that deletion of the Project
-        * would delete the whole hierarchy, which was successfully tested
-        * during writing of this test. The order of the below delete() commands
-        * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
-        * tested in this way.
-        * Also check that the canDelete boolean
-        * on the object retrieved by the lightAdmin matches the deletePassing
-        * boolean.*/
-       Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
-       doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
-       Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
-       doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
-       Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
-       doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
-       Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
-       doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
-       Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
-       doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
+    @Test(dataProvider = "isSudoing and Delete privileges cases")
+    public void testDelete(boolean isSudoing, boolean permDeleteOwned,
+            String groupPermissions) throws Exception {
+        /* Only DeleteOwned permission is needed for deletion of links, Dataset
+         * and image (with original file) when not sudoing. When sudoing, no other
+         * permission is needed.*/
+        boolean deletePassing = permDeleteOwned || isSudoing;
+        final EventContext normalUser = newUserAndGroup(groupPermissions);
+        /* Set up the light admin's permissions for this test */
+        List<String> permissions = new ArrayList<String>();
+        permissions.add(AdminPrivilegeSudo.value);
+        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
+        final EventContext lightAdmin;
+        lightAdmin = loginNewAdmin(true, permissions);
+        sudo(new ExperimenterI(normalUser.userId, false));
+        /* Create a Dataset and Project being sudoed as normalUser.*/
+        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
+        Project proj = mmFactory.simpleProject();
+        Dataset dat = mmFactory.simpleDataset();
+        Project sentProj = null;
+        Dataset sentDat = null;
+        sentProj = (Project) iUpdate.saveAndReturnObject(proj);
+        sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+        /* Import an image for the normalUser into the normalUser's default group
+         * and target it into the created Dataset.*/
+        List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
+        OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
+        Image image = (Image) originalFileAndImage.get(1);
+        assertOwnedBy(image, normalUser);
+        /* Link the Project and the Dataset.*/
+        ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
+        IObject datasetImageLink = iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE child.id = :id",
+                new ParametersI().addId(image.getId()));
+        /* Take care of post-import workflows which do not use sudo.*/
+        if (!isSudoing) {
+            loginUser(lightAdmin);
+            client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
+        }
+        /* Check that lightAdmin can delete the objects
+         * created on behalf of normalUser only if lightAdmin has sufficient permissions.
+         * Note that deletion of the Project
+         * would delete the whole hierarchy, which was successfully tested
+         * during writing of this test. The order of the below delete() commands
+         * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
+         * tested in this way.
+         * Also check that the canDelete boolean
+         * on the object retrieved by the lightAdmin matches the deletePassing
+         * boolean.*/
+        Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
 
-       /* Check the existence/non-existence of the objects as appropriate.*/
-       if (deletePassing) {
-           assertDoesNotExist(originalFile);
-           assertDoesNotExist(image);
-           assertDoesNotExist(sentDat);
-           assertDoesNotExist(sentProj);
-           assertDoesNotExist(datasetImageLink);
-           assertDoesNotExist(projectDatasetLink);
-       } else {
-           assertExists(originalFile);
-           assertExists(image);
-           assertExists(sentDat);
-           assertExists(sentProj);
-           assertExists(datasetImageLink);
-           assertExists(projectDatasetLink);
-       }
-   }
+        /* Check the existence/non-existence of the objects as appropriate.*/
+        if (deletePassing) {
+            assertDoesNotExist(originalFile);
+            assertDoesNotExist(image);
+            assertDoesNotExist(sentDat);
+            assertDoesNotExist(sentProj);
+            assertDoesNotExist(datasetImageLink);
+            assertDoesNotExist(projectDatasetLink);
+        } else {
+            assertExists(originalFile);
+            assertExists(image);
+            assertExists(sentDat);
+            assertExists(sentProj);
+            assertExists(datasetImageLink);
+            assertExists(projectDatasetLink);
+        }
+    }
 
 
-   /**
-    * Test whether a light admin (lightAdmin) can delete image, Project and Dataset
-    * and their respective links belonging to another
-    * user (normalUser).
-    * Note that for this test, lightAdmin is member of normalUser's group.
-    * lightAdmin's privileges regarding deletion of others' data are not elevated by
-    * membership in the group over the privileges of normal member of group (otherUser).
-    * @param isAdmin if to test a success of workflows when light admin
-    * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
-    * @param groupPermissions to test the effect of group permission level
-    * @throws Exception unexpected
-    */
-  @Test(dataProvider = "isAdmin and Delete cases")
-  public void testDeleteGroupMemberNoSudo(boolean isAdmin, boolean permDeleteOwned,
-          String groupPermissions) throws Exception {
-      /* Only DeleteOwned permission is needed for deletion of links, Dataset
-       * and image (with original file) when isAdmin. When not isAdmin, only in
-       * read-write group deletion of others data is possible.*/
-      boolean deletePassing = (permDeleteOwned && isAdmin) || groupPermissions.equals("rwrw--");
-      final EventContext normalUser = newUserAndGroup(groupPermissions);
-      final EventContext otherUser = newUserAndGroup(groupPermissions);
-      ExperimenterGroup normalUsergroup = new ExperimenterGroupI(normalUser.groupId, false);
-      /* Set up the light admin's permissions for this test.*/
-      List<String> permissions = new ArrayList<String>();
-      if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
-      final EventContext lightAdmin = loginNewAdmin(true, permissions);
-      /* root adds lightAdmin to normalUser's group.*/
-      logRootIntoGroup(normalUser);
-      normalUsergroup = addUsers(normalUsergroup, ImmutableList.of(lightAdmin.userId, otherUser.userId), false);
-      /* normalUser creates a Dataset and Project.*/
-      loginUser(normalUser);
-      Project sentProj = (Project) iUpdate.saveAndReturnObject(mmFactory.simpleProject());
-      Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset());
-      /* normalUser imports an image
-       * and targets it into the created Dataset.*/
-      List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
-      OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
-      Image image = (Image) originalFileAndImage.get(1);
-      assertOwnedBy(image, normalUser);
-      /* normalUser links the Project and the Dataset.*/
-      ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
-      IObject datasetImageLink = iQuery.findByQuery(
-              "FROM DatasetImageLink WHERE child.id = :id",
-              new ParametersI().addId(image.getId()));
-      /* Post-import workflows are done either by lightAdmin or by otherUser.*/
-      if(isAdmin) {
-          loginUser(lightAdmin);
-      } else {
-          loginUser(otherUser);
-      }
-      client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
-      /* Check that lightAdmin or otherUser can delete the objects
-       * of normalUser only if lightAdmin has sufficient permissions or it is read-write group.
-       * Note that deletion of the Project
-       * would delete the whole hierarchy, which was successfully tested
-       * during writing of this test. The order of the below delete() commands
-       * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
-       * tested in this way.
-       * Also check that the canDelete boolean
-       * on the object retrieved by the lightAdmin or otherUser matches the deletePassing
-       * boolean.*/
-      Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
-      doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
-      Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
-      doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
-      Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
-      doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
-      Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
-      doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
-      Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
-      doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
+    /**
+     * Test whether a light admin (lightAdmin) can delete image, Project and Dataset
+     * and their respective links belonging to another
+     * user (normalUser).
+     * Note that for this test, lightAdmin is member of normalUser's group.
+     * lightAdmin's privileges regarding deletion of others' data are not elevated by
+     * membership in the group over the privileges of normal member of group (otherUser).
+     * @param isAdmin if to test a success of workflows when light admin
+     * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
+     * @param groupPermissions to test the effect of group permission level
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "isAdmin and Delete cases")
+    public void testDeleteGroupMemberNoSudo(boolean isAdmin, boolean permDeleteOwned,
+            String groupPermissions) throws Exception {
+        /* Only DeleteOwned permission is needed for deletion of links, Dataset
+         * and image (with original file) when isAdmin. When not isAdmin, only in
+         * read-write group deletion of others data is possible.*/
+        boolean deletePassing = (permDeleteOwned && isAdmin) || groupPermissions.equals("rwrw--");
+        final EventContext normalUser = newUserAndGroup(groupPermissions);
+        final EventContext otherUser = newUserAndGroup(groupPermissions);
+        ExperimenterGroup normalUsergroup = new ExperimenterGroupI(normalUser.groupId, false);
+        /* Set up the light admin's permissions for this test.*/
+        List<String> permissions = new ArrayList<String>();
+        if (permDeleteOwned) permissions.add(AdminPrivilegeDeleteOwned.value);
+        final EventContext lightAdmin = loginNewAdmin(true, permissions);
+        /* root adds lightAdmin to normalUser's group.*/
+        logRootIntoGroup(normalUser);
+        normalUsergroup = addUsers(normalUsergroup, ImmutableList.of(lightAdmin.userId, otherUser.userId), false);
+        /* normalUser creates a Dataset and Project.*/
+        loginUser(normalUser);
+        Project sentProj = (Project) iUpdate.saveAndReturnObject(mmFactory.simpleProject());
+        Dataset sentDat = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset());
+        /* normalUser imports an image
+         * and targets it into the created Dataset.*/
+        List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
+        OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
+        Image image = (Image) originalFileAndImage.get(1);
+        assertOwnedBy(image, normalUser);
+        /* normalUser links the Project and the Dataset.*/
+        ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
+        IObject datasetImageLink = iQuery.findByQuery(
+                "FROM DatasetImageLink WHERE child.id = :id",
+                new ParametersI().addId(image.getId()));
+        /* Post-import workflows are done either by lightAdmin or by otherUser.*/
+        if (isAdmin) {
+            loginUser(lightAdmin);
+        } else {
+            loginUser(otherUser);
+        }
+        client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
+        /* Check that lightAdmin or otherUser can delete the objects
+         * of normalUser only if lightAdmin has sufficient permissions or it is read-write group.
+         * Note that deletion of the Project
+         * would delete the whole hierarchy, which was successfully tested
+         * during writing of this test. The order of the below delete() commands
+         * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
+         * tested in this way.
+         * Also check that the canDelete boolean on the object retrieved by the lightAdmin
+         * or otherUser matches the deletePassing boolean.*/
+        Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
+        Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
+        doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
 
-      /* Check the existence/non-existence of the objects as appropriate.*/
-      logRootIntoGroup(normalUser);
-      if (deletePassing) {
-          assertDoesNotExist(originalFile);
-          assertDoesNotExist(image);
-          assertDoesNotExist(sentDat);
-          assertDoesNotExist(sentProj);
-          assertDoesNotExist(datasetImageLink);
-          assertDoesNotExist(projectDatasetLink);
-      } else {
-          assertExists(originalFile);
-          assertExists(image);
-          assertExists(sentDat);
-          assertExists(sentProj);
-          assertExists(datasetImageLink);
-          assertExists(projectDatasetLink);
-      }
-  }
+        /* Check the existence/non-existence of the objects as appropriate.*/
+        logRootIntoGroup(normalUser);
+        if (deletePassing) {
+            assertDoesNotExist(originalFile);
+            assertDoesNotExist(image);
+            assertDoesNotExist(sentDat);
+            assertDoesNotExist(sentProj);
+            assertDoesNotExist(datasetImageLink);
+            assertDoesNotExist(projectDatasetLink);
+        } else {
+            assertExists(originalFile);
+            assertExists(image);
+            assertExists(sentDat);
+            assertExists(sentProj);
+            assertExists(datasetImageLink);
+            assertExists(projectDatasetLink);
+        }
+    }
+
     /**
      * Test that a light admin can edit the name of a project
      * on behalf of another user either using <tt>Sudo</tt> privilege

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2023,7 +2023,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * @return test cases for testDelete
+     * @return test cases for {@link #testDeleteGroupMemberNoSudo}
      */
     @DataProvider(name = "isAdmin and Delete cases")
     public Object[][] provideIsAdminDeleteOwned() {
@@ -2201,7 +2201,7 @@ public class LightAdminRolesTest extends RolesTests {
 
     /**
      * @return WriteOwned and isAdmin test cases for
-     * testLinkNoSudo and testROIAndRenderingSettingsNoSudo
+     * {@link #testLinkMemberOfGroupNoSudo}
      */
     @DataProvider(name = "WriteOwned and isAdmin cases")
     public Object[][] provideWriteOwnedAndIsAdmin() {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1000,6 +1000,7 @@ public class LightAdminRolesTest extends RolesTests {
         boolean isExpectLinkingSuccessAdmin =
                 (permWriteOwned && !groupPermissions.equals("rw----") || groupPermissions.equals("rwrw--"));
         boolean isExpectLinkingSuccessUser = groupPermissions.equals("rwrw--");
+        final boolean isExpectLinkingSuccess = isAdmin ? isExpectLinkingSuccessAdmin : isExpectLinkingSuccessUser;
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         final EventContext otherUser = newUserAndGroup(groupPermissions);
         ExperimenterGroup normalUsergroup = new ExperimenterGroupI(normalUser.groupId, false);
@@ -1032,31 +1033,15 @@ public class LightAdminRolesTest extends RolesTests {
          * is true (for own image) and for other people's objects (sentProj, sentDat) the canLink
          * are matching the expected behavior (see booleans isExpectLinkingSuccess... definitions).*/
         Assert.assertTrue(getCurrentPermissions(sentOwnImage).canLink());
-        if (isAdmin) {
-            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccessAdmin);
-        } else {
-            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccessUser);
-        }
+        Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccess);
         /* lightAdmin or otherUser try to create links between their own image and normalUser's Dataset
          * and between their own Dataset and normalUser's Project.*/
-        DatasetImageLink linkOfDatasetImage = new DatasetImageLinkI();
-        ProjectDatasetLink linkOfProjectDataset = new ProjectDatasetLinkI();
-        if (isAdmin) {
-            try {
-                linkOfDatasetImage = linkParentToChild(sentDat, sentOwnImage);
-                linkOfProjectDataset = linkParentToChild(sentProj, sentOwnDat);
-                Assert.assertTrue(isExpectLinkingSuccessAdmin);
-            } catch (ServerError se) {
-                Assert.assertFalse(isExpectLinkingSuccessAdmin, se.toString());
-            }
-        } else {
-            try {
-                linkOfDatasetImage = linkParentToChild(sentDat, sentOwnImage);
-                linkOfProjectDataset = linkParentToChild(sentProj, sentOwnDat);
-                Assert.assertTrue(isExpectLinkingSuccessUser);
-            } catch (ServerError se) {
-                Assert.assertFalse(isExpectLinkingSuccessUser, se.toString());
-            }
+        try {
+            DatasetImageLink linkOfDatasetImage = linkParentToChild(sentDat, sentOwnImage);
+            ProjectDatasetLink linkOfProjectDataset = linkParentToChild(sentProj, sentOwnDat);
+            Assert.assertTrue(isExpectLinkingSuccess);
+        } catch (ServerError se) {
+            Assert.assertFalse(isExpectLinkingSuccess, se.toString());
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -99,7 +99,9 @@ public class RolesTests extends AbstractServerImportTest {
             } else {
                 objectRetrieved = iQuery.get(objectClass, objectId, ALL_GROUPS_CONTEXT);
             }
-
+            if (objectRetrieved == null) {
+                return NO_PERMISSIONS;
+            }
             return objectRetrieved.getDetails().getPermissions();
         } catch (SecurityViolation sv) {
             return NO_PERMISSIONS;


### PR DESCRIPTION
# What this PR does

  - Two new tests dealing with eventuality of lightAdmin being a member of the group in which the data they are operating on are, testLinkMemberOfGroupNoSudo and testDeleteMemberOfGroup 
  - One new test dealing with deletion of others' ROIs by lightAdmin ("classical" situation here, lightAdmin is not a member of the group)


Happy to be told that this is too much of new tests, but then again, the testLinkMemberOfGroupNoSudo exposed a bug fixed by https://github.com/openmicroscopy/openmicroscopy/pull/5362 and the testDeleteMemberOfGroup is patching a hole in our Delete coverage.



# Testing this PR
Check the code and CI must pass.

--depends-on https://github.com/openmicroscopy/openmicroscopy/pull/5362

cc @mtbc @joshmoore 