### PR TITLE
provide Java Gateway methods for handling OMERO enumeration values

### DIFF
--- a/components/blitz/test/omero/gateway/util/UtilsTest.java
+++ b/components/blitz/test/omero/gateway/util/UtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.gateway.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import omero.model.AdminPrivilege;
+import omero.model.AdminPrivilegeI;
+import omero.model.ChecksumAlgorithm;
+import omero.model.ChecksumAlgorithmI;
+import omero.model.Image;
+import omero.model.ImageI;
+import omero.model.enums.AdminPrivilegeChgrp;
+import omero.model.enums.AdminPrivilegeChown;
+import omero.model.enums.ChecksumAlgorithmCRC32;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Unit tests for converting between OMERO model enumerations and their string values.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.4.0
+ */
+@Test(groups = "unit")
+public class UtilsTest {
+    /**
+     * Test converting enumeration instances to their corresponding string values.
+     * @throws ReflectiveOperationException unexpected
+     */
+    @Test
+    public void testConvertFrom() throws ReflectiveOperationException {
+        final AdminPrivilege chmodInstance = new AdminPrivilegeI();
+        chmodInstance.setValue(omero.rtypes.rstring(AdminPrivilegeChgrp.value));
+        final ChecksumAlgorithm crcInstance = new ChecksumAlgorithmI();
+        crcInstance.setValue(omero.rtypes.rstring(ChecksumAlgorithmCRC32.value));
+        final List<String> values = Utils.fromEnum(ImmutableSet.of(chmodInstance, crcInstance));
+        Assert.assertEquals(values.size(), 2);
+        Assert.assertEquals(values.get(0), AdminPrivilegeChgrp.value);
+        Assert.assertEquals(values.get(1), ChecksumAlgorithmCRC32.value);
+    }
+
+    /**
+     * Test converting string values to their corresponding enumeration instances.
+     * @throws ReflectiveOperationException unexpected
+     */
+    @Test
+    public void testConvertTo() throws ReflectiveOperationException {
+        final Collection<String> privilegeNames = ImmutableSet.of(AdminPrivilegeChgrp.value, AdminPrivilegeChown.value);
+        final List<AdminPrivilege> privileges = Utils.toEnum(AdminPrivilege.class, AdminPrivilegeI.class, privilegeNames);
+        Assert.assertEquals(privileges.size(), 2);
+        Assert.assertEquals(privileges.get(0).getValue().getValue(), AdminPrivilegeChgrp.value);
+        Assert.assertEquals(privileges.get(1).getValue().getValue(), AdminPrivilegeChown.value);
+    }
+
+    /**
+     * Test exception in converting from non-enumeration instances.
+     * @throws ReflectiveOperationException unexpected
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConvertFromBadClass() throws ReflectiveOperationException {
+        Utils.fromEnum(Collections.singleton(new ImageI()));
+    }
+
+    /**
+     * Test exception in converting to non-enumeration instances.
+     * @throws ReflectiveOperationException unexpected
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConvertToBadClass() throws ReflectiveOperationException {
+        Utils.toEnum(Image.class, ImageI.class, Collections.singleton("image"));
+    }
+}

--- a/components/blitz/test/unit.testng.xml
+++ b/components/blitz/test/unit.testng.xml
@@ -24,6 +24,7 @@
       <package name="omero.cmd.graphs.*"/>
       <package name="omero.model.*"/>
       <package name="omero.gateway.model.*"/>
+      <package name="omero.gateway.util.*"/>
       <package name="omero.util.*"/>
     </packages>
   </test>

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -37,6 +37,7 @@ import omero.api.ServiceFactoryPrx;
 import omero.cmd.Chown2;
 import omero.gateway.util.Requests;
 import omero.gateway.util.Requests.Delete2Builder;
+import omero.gateway.util.Utils;
 import omero.model.AdminPrivilege;
 import omero.model.AdminPrivilegeI;
 import omero.model.Dataset;
@@ -119,13 +120,8 @@ public class LightAdminRolesTest extends RolesTests {
         final ServiceFactoryPrx rootSession = root.getSession();
         Experimenter user = new ExperimenterI(ctx.userId, false);
         user = (Experimenter) rootSession.getQueryService().get("Experimenter", ctx.userId);
-        final List<AdminPrivilege> privileges = new ArrayList<>();
-        rootSession.getAdminService().setAdminPrivileges(user, privileges);
-        for (final String permission : permissions) {
-            final AdminPrivilege privilege = new AdminPrivilegeI();
-            privilege.setValue(omero.rtypes.rstring(permission));
-            privileges.add(privilege);
-        }
+        final List<AdminPrivilege> privileges = Utils.toEnum(AdminPrivilege.class, AdminPrivilegeI.class, permissions);
+        rootSession.getAdminService().setAdminPrivileges(user, Collections.<AdminPrivilege>emptyList());
         rootSession.getAdminService().setAdminPrivileges(user, privileges);
         /* avoid old session as privileges are briefly cached */
         loginUser(ctx);


### PR DESCRIPTION
# What this PR does

Adds to an existing Java Gateway utilities class some methods for converting between lists of OMERO enumerations and their string values.

# Testing this PR

CI suffices.

# Related reading

https://trello.com/c/FjayBnvM/39-gateway-support-for-roles