### PR TITLE
Increase OMEROweb log-size to 500MB

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -85,6 +85,8 @@ FULL_REQUEST_LOGFORMAT = (
     ' HTTP %(status_code)d %(request)s')
 
 LOGGING_CLASS = 'omero_ext.cloghandler.ConcurrentRotatingFileHandler'
+LOGSIZE = 500000000
+
 
 LOGGING = {
     'version': 1,
@@ -111,7 +113,7 @@ LOGGING = {
             'class': LOGGING_CLASS,
             'filename': os.path.join(
                 LOGDIR, 'OMEROweb.log').replace('\\', '/'),
-            'maxBytes': 1024*1024*5,  # 5 MB
+            'maxBytes': LOGSIZE,
             'backupCount': 10,
             'formatter': 'standard',
         },
@@ -120,7 +122,7 @@ LOGGING = {
             'class': LOGGING_CLASS,
             'filename': os.path.join(
                 LOGDIR, 'OMEROweb.log').replace('\\', '/'),
-            'maxBytes': 1024*1024*5,  # 5 MB
+            'maxBytes': LOGSIZE,
             'backupCount': 10,
             'filters': ['require_debug_false'],
             'formatter': 'full_request',


### PR DESCRIPTION
# What this PR does

OMERO.web logs are currently rotated at 5MB, in contrast to the Java servers such as Blitz which are rotated at 500MB. This PR sets it to 500MB, matching the `LOGSIZE` set for the Python servers https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.0-m2/components/tools/OmeroPy/src/omero/util/__init__.py#L33

# Testing this PR

Install OMERO.web. Interact with the webclient until `OMEROweb.log` is larger than 5MB. Setting `omero.web.debug=false` will help fill the logs up.

This PR is required for debugging issues on the IDR regarding large numbers of queries/sessions.