### PR TITLE
Generate Nginx includes for advanced configuration (e.g. SSL) (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -97,8 +97,10 @@ def assert_config_argtype(func):
                 mismatch = True
             if settings.APPLICATION_SERVER in (settings.WSGITCP,):
                 if argtype not in (
-                        "nginx", "nginx-development",
-                        "nginx-location", "nginx-upstream"):
+                    "nginx",
+                    "nginx-development",
+                    "nginx-location",
+                ):
                     mismatch = True
             if (settings.APPLICATION_SERVER in (settings.WSGI,) and
                     argtype not in ("apache22", "apache24", "apache")):
@@ -118,9 +120,13 @@ class WebControl(BaseControl):
 
     # DEPRECATED: apache
     config_choices = (
-        "nginx", "nginx-development",
-        "nginx-location", "nginx-upstream",
-        "apache22", "apache24", "apache")
+        "nginx",
+        "nginx-development",
+        "nginx-location",
+        "apache22",
+        "apache24",
+        "apache",
+    )
 
     def _configure(self, parser):
         sub = parser.sub()
@@ -163,7 +169,6 @@ class WebControl(BaseControl):
             "  nginx: Nginx system configuration for inclusion\n"
             "  nginx-development: Standalone user-run Nginx server\n"
             "  nginx-location: Minimal location blocks (experts only)\n"
-            "  nginx-upstream: Minimal upstream block (experts only)\n"
             "  apache22: Apache 2.2 with mod_wsgi\n"
             "  apache24: Apache 2.4+ with mod_wsgi\n")
         config.add_argument("type", choices=self.config_choices)

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -96,7 +96,9 @@ def assert_config_argtype(func):
             if settings.APPLICATION_SERVER in ("development",):
                 mismatch = True
             if settings.APPLICATION_SERVER in (settings.WSGITCP,):
-                if argtype not in ("nginx", "nginx-development",):
+                if argtype not in (
+                        "nginx", "nginx-development",
+                        "nginx-location", "nginx-upstream"):
                     mismatch = True
             if (settings.APPLICATION_SERVER in (settings.WSGI,) and
                     argtype not in ("apache22", "apache24", "apache")):
@@ -116,7 +118,9 @@ class WebControl(BaseControl):
 
     # DEPRECATED: apache
     config_choices = (
-        "nginx", "nginx-development", "apache22", "apache24", "apache")
+        "nginx", "nginx-development",
+        "nginx-location", "nginx-upstream",
+        "apache22", "apache24", "apache")
 
     def _configure(self, parser):
         sub = parser.sub()
@@ -158,6 +162,8 @@ class WebControl(BaseControl):
             "Output a config template for web server\n"
             "  nginx: Nginx system configuration for inclusion\n"
             "  nginx-development: Standalone user-run Nginx server\n"
+            "  nginx-location: Minimal location blocks (experts only)\n"
+            "  nginx-upstream: Minimal upstream block (experts only)\n"
             "  apache22: Apache 2.2 with mod_wsgi\n"
             "  apache24: Apache 2.4+ with mod_wsgi\n")
         config.add_argument("type", choices=self.config_choices)

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location-withoptions.conf
@@ -1,0 +1,32 @@
+#sendfile on;
+#client_max_body_size ;
+
+# maintenance page serve from here
+location @maintenance_test {
+    root /home/omero/OMERO.server/etc/templates/error;
+    try_files $uri /maintainance.html =502;
+}
+
+# weblitz django apps serve media from here
+location /test-static {
+    alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+}
+
+location @proxy_to_app_test {
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_buffering off;
+
+    proxy_pass http://0.0.0.0:12345;
+}
+
+location /test {
+
+    error_page 502 @maintenance_test;
+    # checks for static file, if not found proxy to app
+    try_files $uri @proxy_to_app_test;
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location-withoptions.conf
@@ -1,5 +1,7 @@
+# You are strongly recommended to include the following in your enclosing
+# server configuration:
 #sendfile on;
-#client_max_body_size ;
+#client_max_body_size 0;
 
 # maintenance page serve from here
 location @maintenance_test {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location-withoptions.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location-withoptions.conf
@@ -1,7 +1,18 @@
-# You are strongly recommended to include the following in your enclosing
-# server configuration:
-#sendfile on;
-#client_max_body_size 0;
+# These location blocks should be included in your server configuration
+# For example:
+#
+##server {
+##    listen 80;
+##    server_name $hostname;
+##
+##    # SSL configuration ...
+##
+##    sendfile on;
+##    client_max_body_size 0;
+##
+##    # Include generated file from omero web config nginx-location:
+##    include /opt/omero/web/omero-web-location.include;
+##}
 
 # maintenance page serve from here
 location @maintenance_test {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location.conf
@@ -1,5 +1,7 @@
+# You are strongly recommended to include the following in your enclosing
+# server configuration:
 #sendfile on;
-#client_max_body_size ;
+#client_max_body_size 0;
 
 # maintenance page serve from here
 location @maintenance {

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location.conf
@@ -1,0 +1,32 @@
+#sendfile on;
+#client_max_body_size ;
+
+# maintenance page serve from here
+location @maintenance {
+    root /home/omero/OMERO.server/etc/templates/error;
+    try_files $uri /maintainance.html =502;
+}
+
+# weblitz django apps serve media from here
+location /static {
+    alias /home/omero/OMERO.server/lib/python/omeroweb/static;
+}
+
+location @proxy_to_app {
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_buffering off;
+
+    proxy_pass http://127.0.0.1:4080;
+}
+
+location / {
+
+    error_page 502 @maintenance;
+    # checks for static file, if not found proxy to app
+    try_files $uri @proxy_to_app;
+}
+
+

--- a/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location.conf
+++ b/components/tools/OmeroPy/test/unit/clitest/reference_templates/nginx-location.conf
@@ -1,7 +1,18 @@
-# You are strongly recommended to include the following in your enclosing
-# server configuration:
-#sendfile on;
-#client_max_body_size 0;
+# These location blocks should be included in your server configuration
+# For example:
+#
+##server {
+##    listen 80;
+##    server_name $hostname;
+##
+##    # SSL configuration ...
+##
+##    sendfile on;
+##    client_max_body_size 0;
+##
+##    # Include generated file from omero web config nginx-location:
+##    include /opt/omero/web/omero-web-location.include;
+##}
 
 # maintenance page serve from here
 location @maintenance {

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -598,3 +598,35 @@ class TestWeb(object):
         d = self.compare_with_reference(
             server_type[0] + '-withoptions.conf', o)
         assert not d, 'Files are different:\n' + d
+
+    def testNginxLocationComment(self):
+        """
+        Check the example comment in nginx-location matches the recommended
+        nginx configuration
+        """
+
+        def clean(refname):
+            fn = path(__file__).dirname() / 'reference_templates' / refname
+            out = []
+            with open(fn) as f:
+                for line in f:
+                    if re.match('##\s*\w', line):
+                        out.append(line[2:].strip())
+                    elif re.match('[^#]\s*\w', line):
+                        out.append(line.strip())
+            return out
+
+        diffs = list(unified_diff(
+            clean('nginx.conf'), clean('nginx-location.conf'), n=0))
+        assert diffs == [
+            '--- \n',
+            '+++ \n',
+            '@@ -1,2 +0,0 @@\n',
+            '-upstream omeroweb {',
+            '-server 127.0.0.1:4080 fail_timeout=0;',
+            '@@ -7,0 +6 @@\n',
+            '+include /opt/omero/web/omero-web-location.include;',
+            '@@ -19 +18 @@\n',
+            '-proxy_pass http://omeroweb;',
+            '+proxy_pass http://127.0.0.1:4080;'
+        ]

--- a/components/tools/OmeroPy/test/unit/clitest/test_web.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_web.py
@@ -541,6 +541,7 @@ class TestWeb(object):
     @pytest.mark.parametrize('server_type', [
         ["nginx", 'wsgi-tcp'],
         ["nginx-development", 'wsgi-tcp'],
+        ["nginx-location", 'wsgi-tcp'],
         ["apache22", 'wsgi'],
         ["apache24", 'wsgi']])
     @pytest.mark.parametrize('static_root', [
@@ -566,6 +567,9 @@ class TestWeb(object):
          '--servername', 'omeroweb.host',
          '--max-body-size', '2m', 'wsgi-tcp'],
         ['nginx-development', '--http', '1234',
+         '--servername', 'omeroweb.host',
+         '--max-body-size', '2m', 'wsgi-tcp'],
+        ['nginx-location', '--http', '1234',
          '--servername', 'omeroweb.host',
          '--max-body-size', '2m', 'wsgi-tcp'],
         ['apache22', '--http', '1234', 'wsgi'],

--- a/etc/templates/web/nginx-location.conf.template
+++ b/etc/templates/web/nginx-location.conf.template
@@ -19,7 +19,7 @@ location @proxy_to_app%(PREFIX_NAME)s {
     proxy_redirect off;
     proxy_buffering off;
 
-    proxy_pass http://%(FASTCGI_EXTERNAL)s fail_timeout=0;
+    proxy_pass http://%(FASTCGI_EXTERNAL)s;
 }
 
 location %(FORCE_SCRIPT_NAME)s {

--- a/etc/templates/web/nginx-location.conf.template
+++ b/etc/templates/web/nginx-location.conf.template
@@ -1,5 +1,7 @@
+# You are strongly recommended to include the following in your enclosing
+# server configuration:
 #sendfile on;
-#client_max_body_size ;
+#client_max_body_size 0;
 
 # maintenance page serve from here
 location @maintenance%(PREFIX_NAME)s {

--- a/etc/templates/web/nginx-location.conf.template
+++ b/etc/templates/web/nginx-location.conf.template
@@ -1,7 +1,18 @@
-# You are strongly recommended to include the following in your enclosing
-# server configuration:
-#sendfile on;
-#client_max_body_size 0;
+# These location blocks should be included in your server configuration
+# For example:
+#
+##server {
+##    listen 80;
+##    server_name $hostname;
+##
+##    # SSL configuration ...
+##
+##    sendfile on;
+##    client_max_body_size 0;
+##
+##    # Include generated file from omero web config nginx-location:
+##    include /opt/omero/web/omero-web-location.include;
+##}
 
 # maintenance page serve from here
 location @maintenance%(PREFIX_NAME)s {

--- a/etc/templates/web/nginx-location.conf.template
+++ b/etc/templates/web/nginx-location.conf.template
@@ -1,0 +1,30 @@
+#sendfile on;
+#client_max_body_size ;
+
+# maintenance page serve from here
+location @maintenance%(PREFIX_NAME)s {
+    root %(ROOT)s/etc/templates/error;
+    try_files $uri /maintainance.html =502;
+}
+
+# weblitz django apps serve media from here
+location %(STATIC_URL)s {
+    alias %(STATIC_ROOT)s;
+}
+
+location @proxy_to_app%(PREFIX_NAME)s {
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_buffering off;
+
+    proxy_pass http://%(FASTCGI_EXTERNAL)s fail_timeout=0;
+}
+
+location %(FORCE_SCRIPT_NAME)s {
+
+    error_page 502 @maintenance%(PREFIX_NAME)s;
+    # checks for static file, if not found proxy to app
+    try_files $uri @proxy_to_app%(PREFIX_NAME)s;
+}

--- a/etc/templates/web/nginx-upstream.conf.template
+++ b/etc/templates/web/nginx-upstream.conf.template
@@ -1,0 +1,3 @@
+upstream omeroweb%(PREFIX_NAME)s {
+    server %(FASTCGI_EXTERNAL)s fail_timeout=0;
+}

--- a/etc/templates/web/nginx-upstream.conf.template
+++ b/etc/templates/web/nginx-upstream.conf.template
@@ -1,3 +1,0 @@
-upstream omeroweb%(PREFIX_NAME)s {
-    server %(FASTCGI_EXTERNAL)s fail_timeout=0;
-}


### PR DESCRIPTION

This is the same as gh-5381 but rebased onto metadata53.

----

# What this PR does

This creates a minimal nginx configuration file that can be included in a fixed file created by a sysadmin. This allows custom nginx options to be defined once (e.g. SSL options), instead of having to modify the generated web config after every upgrade, and means any Nginx server options can be used.

# Testing this PR

1. Install a production OMERO.web in the standard way
2. Install Nginx.
3. Create a omero-web nginx wrapper file with an `include` statement for the generated omero-web config. This file is exclusively managed by the sysadmin e.g. `/etc/nginx/conf.d/omero-web-wrapper.conf`:
```
server {
    listen 80;
    server_name $hostname;

    # SSL configuration ...

    sendfile on;
    client_max_body_size 0;

    # Include generated file from omero web config nginx-location:
    include /opt/omero/web/omero-web-location.include;
}
```
4. Generate the minimal omero-web configuration in the location specified by your `include` statement. The expectation is that this would be routinely regenerated on every OMERO.web upgrade. e.g.
```
omero web config nginx-location > /opt/omero/web/omero-web-location.include
```
5. Start nginx
6. Start OMERO.web: `omero web start`
7. OMERO.web should work as normal

# Related reading
- https://trello.com/c/igcRoPcu/11-configure-ssl-via-bin-omero-web-nginx

# Notes
- `omero web config nginx-location` generates the `location` blocks only, other server options are now left for the sysadmin to manage e.g. `sendfile on;`, `client_max_body_size 0;`.
- I've removed the separate `upstream` block since there was only one server which means it's redundant, and it would be impossible to auto-generate a load-balanced upstream configuration since you'd need to know the addresses of all OMERO.web backends.

                