### PR TITLE
adjust OMERO_STARTUP_WAIT delay from 10000 to 80000

### DIFF
--- a/components/blitz/src/ome/services/blitz/Entry.java
+++ b/components/blitz/src/ome/services/blitz/Entry.java
@@ -52,7 +52,7 @@ public class Entry {
     volatile Ice.Communicator ic = null;
 
     private static void waitOnStartup() {
-        int ms = 10000; // 10 seconds by default
+        int ms = 80000; // 80 seconds by default
         try {
             String prop = System.getenv("OMERO_STARTUP_WAIT");
             ms = Integer.valueOf(prop);

--- a/components/tools/OmeroPy/src/omero/util/__init__.py
+++ b/components/tools/OmeroPy/src/omero/util/__init__.py
@@ -444,9 +444,9 @@ class Server(Ice.Application):
         self.dependencies = dependencies
 
     def waitOnStartup(self):
-        ms = 10000  # 10 seconds by default
+        ms = 80000  # 80 seconds by default
         try:
-            i = os.environ.get("OMERO_STARTUP_WAIT", "10000")
+            i = os.environ.get("OMERO_STARTUP_WAIT", "80000")
             ms = int(i)
         except:
             self.logger.debug(exc_info=1)


### PR DESCRIPTION
# What this PR does

Sets `OMERO_STARTUP_WAIT` to 80 seconds.

# Testing this PR

Tables tests may again pass.

# Related reading

https://trello.com/c/wPBnTfPU/58-flaky-tests