### PR TITLE
adjust some CLI admin checking to respect restrictions

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -617,7 +617,8 @@ def admin_only(*fargs):
             if not ec.isAdmin:
                 self.error_admin_only(fatal=True)
             elif not need_privs <= have_privs:
-                self.error_admin_only_privs(need_privs - have_privs, fatal=True)
+                self.error_admin_only_privs(need_privs - have_privs,
+                                            fatal=True)
             return func(*args, **kwargs)
         return _check_admin
     return _admin_only

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -34,6 +34,8 @@ from omero.cli import NonZeroReturnCode
 from omero.cli import VERSION
 from omero.cli import UserGroupControl
 
+from omero.model.enums import AdminPrivilegeReadSession
+
 from omero.plugins.prefs import \
     WriteableConfigControl, with_config, with_rw_config
 from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
@@ -1789,7 +1791,7 @@ OMERO Diagnostics %s
             " regenerated. Use the omero.ports.xxx configuration properties"
             " instead.")
 
-    @admin_only()
+    @admin_only(AdminPrivilegeReadSession)
     def cleanse(self, args):
         self.check_access()
         from omero.util.cleanse import cleanse

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -957,7 +957,7 @@ present, the user will enter a console""")
         else:
             self.ctx.call(command)
 
-    @admin_only
+    @admin_only()
     @with_config
     def fixpyramids(self, args, config):
         self.check_access()
@@ -1789,7 +1789,7 @@ OMERO Diagnostics %s
             " regenerated. Use the omero.ports.xxx configuration properties"
             " instead.")
 
-    @admin_only
+    @admin_only()
     def cleanse(self, args):
         self.check_access()
         from omero.util.cleanse import cleanse

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -39,7 +39,10 @@ from omero.cli import CmdControl
 from omero.cli import CLI
 from omero.cli import ProxyStringType
 from omero.gateway import BlitzGateway
-
+from omero.model.enums import (
+    AdminPrivilegeChown,
+    AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
+    AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo)
 from omero.rtypes import rstring
 from omero.rtypes import unwrap
 from omero.sys import Principal
@@ -457,7 +460,7 @@ Examples:
             tb.row(idx, *tuple(values))
         self.ctx.out(str(tb.build()))
 
-    @admin_only()
+    @admin_only(AdminPrivilegeWriteManagedRepo, AdminPrivilegeChown)
     def mkdir(self, args):
         """Make a new directory (admin-only)
 
@@ -483,7 +486,8 @@ omero.fs.repo.path are all set to be owned by the root user.
         mrepo.makeDir(args.new_dir, args.parents)
 
     @windows_warning
-    @admin_only()
+    @admin_only(AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
+                AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo)
     def rename(self, args):
         """Moves an existing fileset to a new location (admin-only)
 

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -457,7 +457,7 @@ Examples:
             tb.row(idx, *tuple(values))
         self.ctx.out(str(tb.build()))
 
-    @admin_only
+    @admin_only()
     def mkdir(self, args):
         """Make a new directory (admin-only)
 
@@ -483,7 +483,7 @@ omero.fs.repo.path are all set to be owned by the root user.
         mrepo.makeDir(args.new_dir, args.parents)
 
     @windows_warning
-    @admin_only
+    @admin_only()
     def rename(self, args):
         """Moves an existing fileset to a new location (admin-only)
 
@@ -782,7 +782,7 @@ Examples:
                 117,
                 "Log file not accessible for Fileset:%s" % args.fileset.id.val)
 
-    @admin_only
+    @admin_only()
     def set_repo(self, args):
         """Change configuration properties for single repositories
         """

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -11,6 +11,7 @@
 import sys
 
 from omero.cli import UserGroupControl, CLI, ExceptionHandler, admin_only
+from omero.model.enums import AdminPrivilegeModifyGroup
 
 HELP = """Group administration methods"""
 defaultperms = {
@@ -133,7 +134,7 @@ server-permissions.html
         except ValueError, ve:
             self.ctx.die(505, str(ve))
 
-    @admin_only()
+    @admin_only(AdminPrivilegeModifyGroup)
     def add(self, args):
 
         import omero

--- a/components/tools/OmeroPy/src/omero/plugins/group.py
+++ b/components/tools/OmeroPy/src/omero/plugins/group.py
@@ -133,7 +133,7 @@ server-permissions.html
         except ValueError, ve:
             self.ctx.die(505, str(ve))
 
-    @admin_only
+    @admin_only()
     def add(self, args):
 
         import omero

--- a/components/tools/OmeroPy/src/omero/plugins/ldap.py
+++ b/components/tools/OmeroPy/src/omero/plugins/ldap.py
@@ -92,7 +92,7 @@ to users.""")
         for x in (active, list, getdn, setdn, discover, create):
             x.add_login_arguments()
 
-    @admin_only
+    @admin_only()
     def active(self, args):
         c = self.ctx.conn(args)
         ildap = c.sf.getLdapService()
@@ -102,7 +102,7 @@ to users.""")
         else:
             self.ctx.die(1, "No")
 
-    @admin_only
+    @admin_only()
     def list(self, args):
         c = self.ctx.conn(args)
         iadmin = c.sf.getAdminService()
@@ -129,7 +129,7 @@ to users.""")
                 count += 1
         self.ctx.out(str(tb.build()))
 
-    @admin_only
+    @admin_only()
     def getdn(self, args):
         c = self.ctx.conn(args)
         iadmin = c.sf.getAdminService()
@@ -163,7 +163,7 @@ to users.""")
         if dn is not None and dn.strip():
             self.ctx.out(dn)
 
-    @admin_only
+    @admin_only()
     def setdn(self, args):
         c = self.ctx.conn(args)
         iupdate = c.sf.getUpdateService()
@@ -188,7 +188,7 @@ to users.""")
                               in ("yes", "true", "t", "1")))
             iupdate.saveObject(obj)
 
-    @admin_only
+    @admin_only()
     def discover(self, args):
         c = self.ctx.conn(args)
         ildap = c.sf.getLdapService()
@@ -223,7 +223,7 @@ to users.""")
                                      % (e.getId().getValue(),
                                         e.getOmeName().getValue()))
 
-    @admin_only
+    @admin_only()
     def create(self, args):
         c = self.ctx.conn(args)
         ildap = c.sf.getLdapService()

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -11,6 +11,8 @@
 import sys
 
 from omero.cli import UserGroupControl, CLI, ExceptionHandler, admin_only
+from omero.model.enums import (AdminPrivilegeModifyGroupMembership,
+                               AdminPrivilegeModifyUser)
 from omero.rtypes import unwrap as _
 
 HELP = "Support for adding and managing users"
@@ -214,7 +216,7 @@ class UserControl(UserGroupControl):
         groups = admin.containedGroups(uids[0])
         self.output_groups_list(groups, args)
 
-    @admin_only()
+    @admin_only(AdminPrivilegeModifyUser, AdminPrivilegeModifyGroupMembership)
     def add(self, args):
         email = args.email
         login = args.username

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -214,7 +214,7 @@ class UserControl(UserGroupControl):
         groups = admin.containedGroups(uids[0])
         self.output_groups_list(groups, args)
 
-    @admin_only
+    @admin_only()
     def add(self, args):
         email = args.email
         login = args.username


### PR DESCRIPTION
# What this PR does

OMERO.cli has various subcommands that check if the user is an administrator. This PR modifies some of those to check specifically that the user has certain light admin privileges. It does not add checks to subcommands that did not already have administrator checks.

# Testing this PR

Subcommands that used to report "SecurityViolation: Admins only!" will now, in cases where a certain light admin privilege is always required for that subcommand and the light admin does not have it, report a different "SecurityViolation" message that lists the missing privilege(s). Affected subcommands are:

* `bin/omero fs mkdir` which now requires `WriteManagedRepo` and `Chown`
* `bin/omero fs rename` which now requires `WriteOwned`, `WriteManagedRepo`, `DeleteOwned`, `DeleteManagedRepo`
* `bin/omero group add` which now requires `ModifyGroup`
* `bin/omero user add` which now requires `ModifyUser` and `ModifyGroupMembership`
* `bin/omero ldap create` which now requires `ModifyUser` and `ModifyGroupMembership`
* `bin/omero ldap setdn` which now requires `ModifyUser` or `ModifyGroup` depending on the arguments.

Web admin allows adjusting privileges but for fine-grained tests one may need to consult our sysadmin CLI docs for 5.4. Further, note that the server may take up to a minute to apply privilege changes to existing sessions.

# Related reading

https://trello.com/c/VyOwZwyr/40-admin-only-chgrp-chown-in-clients