### PR TITLE
revert workaround for IcePy communicator leak

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -1006,7 +1006,6 @@ class BaseClient(object):
                 # * Ice.DNSException
             finally:
                 oldIc.destroy()
-                del oldIc._impl  # WORKAROUND ticket:2007
 
         finally:
             self.__lock.release()


### PR DESCRIPTION
# What this PR does

Removes a prior workaround for Ice leaking Communicator objects which may now be fixed in Ice 3.6 which OMERO 5.4 requires. These days we are seeing "communicator not destroyed" errors from OMERO.cli that may be caused by the workaround.

# Testing this PR

Review the related reading to see if either the original problem or the worrying messages occur.

# Related reading

https://forums.zeroc.com/discussion/4969/python-seems-to-leak-communicator-objects
https://trello.com/c/DPv5q2Ec/77-command-line-intermittent-error