### PR TITLE
all admins no longer have full power over data in "system" group

### DIFF
--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -278,8 +278,7 @@ public class BasicACLVoter implements ACLVoter {
         Assert.notNull(iObject);
         Class<?> cls = iObject.getClass();
 
-        boolean sysType = sysTypes.isSystemType(cls)
-            || sysTypes.isInSystemGroup(iObject.getDetails());
+        boolean sysType = sysTypes.isSystemType(cls);
 
         // Note: removed restriction from #1769 that admins can only
         // create objects belonging to the current user. Instead,
@@ -321,8 +320,7 @@ public class BasicACLVoter implements ACLVoter {
             throws SecurityViolation {
         Assert.notNull(iObject);
 
-        boolean sysType = sysTypes.isSystemType(iObject.getClass()) ||
-            sysTypes.isInSystemGroup(iObject.getDetails());
+        boolean sysType = sysTypes.isSystemType(iObject.getClass());
 
         if (sysType) {
             throw new SecurityViolation(iObject + " is a System-type, and may be created only through privileged APIs.");
@@ -350,8 +348,7 @@ public class BasicACLVoter implements ACLVoter {
     public void throwUpdateViolation(IObject iObject) throws SecurityViolation {
         Assert.notNull(iObject);
 
-        boolean sysType = sysTypes.isSystemType(iObject.getClass()) ||
-            sysTypes.isInSystemGroup(iObject.getDetails());
+        boolean sysType = sysTypes.isSystemType(iObject.getClass());
 
         if (!sysType && currentUser.isGraphCritical(iObject.getDetails())) { // ticket:1769
             throw new GroupSecurityViolation(iObject +"-modification violates " +
@@ -431,8 +428,7 @@ public class BasicACLVoter implements ACLVoter {
             throw new InternalException("trustedDetails are null!");
         }
 
-        final boolean sysType = sysTypes.isSystemType(iObject.getClass()) ||
-            sysTypes.isInSystemGroup(d);
+        final boolean sysType = sysTypes.isSystemType(iObject.getClass());
         final boolean sysTypeOrUsrGroup = sysType ||
             sysTypes.isInUserGroup(d);
 

--- a/components/server/src/ome/security/basic/CurrentDetails.java
+++ b/components/server/src/ome/security/basic/CurrentDetails.java
@@ -272,7 +272,7 @@ public class CurrentDetails implements PrincipalHolder {
             return false;
         }
 
-        final boolean isSysType =  sysTypes.isSystemType(object.getClass()) || sysTypes.isInSystemGroup(object.getDetails());
+        final boolean isSysType =  sysTypes.isSystemType(object.getClass());
         final Set<AdminPrivilege> privileges = ec.getCurrentAdminPrivileges();
 
         if (isSysType) {

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -692,8 +692,7 @@ public class OmeroInterceptor implements Interceptor {
 
         // Light administrator privileges
         final boolean isPrivilegedCreator;
-        final boolean sysType = sysTypes.isSystemType(obj.getClass())
-                || sysTypes.isInSystemGroup(obj.getDetails());
+        final boolean sysType = sysTypes.isSystemType(obj.getClass());
         final Set<AdminPrivilege> privileges = bec.getCurrentAdminPrivileges();
 
         if (!bec.isCurrentUserAdmin()) {
@@ -803,16 +802,13 @@ public class OmeroInterceptor implements Interceptor {
             Permissions groupPerms = currentUser.getCurrentEventContext()
                 .getCurrentGroupPermissions();
 
-            boolean isInSysGrp = sysTypes.isInSystemGroup(newDetails);
             boolean isInUsrGrp = sysTypes.isInUserGroup(newDetails);
             if (groupPerms.identical(source.getPermissions())) {
                 // ok. weird that they're set. probably an instance
                 // of a managed object being passed in as with
                 // ticket:2055
             } else if (!sysTypes.isSystemType(obj.getClass())) {
-                if (isInSysGrp) {
-                    // allow admin to do what they want. is this right?
-                } else if (isInUsrGrp) {
+                if (isInUsrGrp) {
                     // similarly, allow whatever in user group for the moment.
                 } else {
                     throw new PermissionMismatchGroupSecurityViolation(

--- a/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
@@ -1,25 +1,30 @@
 /*
- *   Copyright 2006-2015 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package integration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import omero.api.IAdminPrx;
 import omero.api.IRenderingSettingsPrx;
 import omero.cmd.Delete2;
 import omero.cmd.DoAll;
 import omero.cmd.Request;
 import omero.constants.metadata.NSINSIGHTRATING;
 import omero.gateway.util.Requests;
+import omero.model.AdminPrivilege;
 import omero.model.Annotation;
 import omero.model.CommentAnnotation;
 import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
 import omero.model.DatasetImageLink;
 import omero.model.DatasetImageLinkI;
+import omero.model.ExperimenterGroupI;
+import omero.model.ExperimenterI;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
@@ -1083,4 +1088,38 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
         assertDoesNotExist(img);
     }
 
+    /**
+     * Test that restricted administrators cannot always delete others' data from the <tt>system</tt> group.
+     * @param isRootOwner is the data owner <tt>root</tt>?
+     * @param isRootDeleting is the data deleter <tt>root</tt>?
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "test cases using two Boolean arguments")
+    public void testDeleteSystemImage(boolean isRootOwner, boolean isRootDeleting) throws Exception {
+        final boolean isExpectSuccess = isRootDeleting || !isRootOwner;
+        final EventContext lightAdmin;
+        if (isRootOwner && isRootDeleting) {
+            lightAdmin = null;
+        } else {
+            final IAdminPrx iAdminRoot = root.getSession().getAdminService();
+            lightAdmin = newUserInGroup(new ExperimenterGroupI(roles.systemGroupId, false), false);
+            iAdminRoot.setAdminPrivileges(new ExperimenterI(lightAdmin.userId, false), Collections.<AdminPrivilege>emptyList());
+        }
+        if (isRootOwner) {
+            logRootIntoGroup(roles.systemGroupId);
+        } else {
+            loginUser(lightAdmin);
+        }
+        Image image = (Image) iUpdate.saveAndReturnObject(mmFactory.simpleImage()).proxy();
+        if (isRootOwner != isRootDeleting) {
+            if (isRootDeleting) {
+                logRootIntoGroup(roles.systemGroupId);
+            } else {
+                loginUser(lightAdmin);
+            }
+        }
+        image = (Image) iQuery.get("Image", image.getId().getValue());
+        Assert.assertEquals(image.getDetails().getPermissions().canDelete(), isExpectSuccess);
+        doChange(client, factory, Requests.delete().target(image).build(), isExpectSuccess);
+    }
 }


### PR DESCRIPTION
# What this PR does

This PR brings `system` group behavior more in line with normal groups. Previously any admin, including wholly restricted light admins, could delete any user's data in the `system` group.

# Testing this PR

Check https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/DeleteServicePermissionsTest/ and try some manual testing.

# Related reading

https://trello.com/c/zVJCwsVA/69-light-admins-power-over-the-system-group