### PR TITLE
increase timeout for integration test cleanup in teardown

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2165,7 +2165,7 @@ public class AbstractServerTest extends AbstractTest {
      * @throws Exception
      */
     protected Response doChange(Request change) throws Exception {
-        return doChange(client, factory, change, true, null);
+        return doChange(client, factory, change, true);
     }
 
     /**
@@ -2177,12 +2177,12 @@ public class AbstractServerTest extends AbstractTest {
      * @throws Exception
      */
     protected Response doChange(Request change, long groupID) throws Exception {
-        return doChange(client, factory, change, true, groupID);
+        return doChange(client, factory, change, true, groupID, null);
     }
 
     protected Response doChange(omero.client c, ServiceFactoryPrx f,
             Request change, boolean pass) throws Exception {
-        return doChange(c, f, change, pass, null);
+        return doChange(c, f, change, pass, null, null);
     }
 
     protected Response doAllChanges(omero.client c, ServiceFactoryPrx f,
@@ -2203,7 +2203,7 @@ public class AbstractServerTest extends AbstractTest {
      * @throws Exception
      */
     protected Response doChange(omero.client c, ServiceFactoryPrx f,
-            Request change, boolean pass, Long groupID) throws Exception {
+            Request change, boolean pass, Long groupID, Integer scalingFactorAdjustment) throws Exception {
         final Map<String, String> callContext = new HashMap<String, String>();
         if (groupID != null) {
             callContext.put("omero.group", "" + groupID);
@@ -2211,7 +2211,11 @@ public class AbstractServerTest extends AbstractTest {
         final HandlePrx prx = f.submit(change, callContext);
         // assertFalse(prx.getStatus().flags.contains(State.FAILURE));
         CmdCallbackI cb = new CmdCallbackI(c, prx);
-        cb.loop(20, scalingFactor);
+        long useScalingFactor = scalingFactor;
+        if (scalingFactorAdjustment != null) {
+            useScalingFactor *= scalingFactorAdjustment;
+        }
+        cb.loop(20, useScalingFactor);
         return assertCmd(cb, pass);
     }
 

--- a/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServicePermissionsTest.java
@@ -112,7 +112,7 @@ public class DeleteServicePermissionsTest extends AbstractServerTest {
 
         DoAll all = new DoAll();
         all.requests = commands;
-        doChange(client, factory, all, false, null);
+        doChange(client, factory, all, false);
 
         // Now log the original user back in
         disconnect();

--- a/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/DeleteServiceTest.java
@@ -3070,7 +3070,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         iUpdate.saveAndReturnArray(lcs);
         Delete2 dc = Requests.delete().target(img1, img2).build();
         // Now delete the image.
-        doChange(client, factory, dc, true, null);
+        doChange(client, factory, dc, true);
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
         ids.add(img2.getId().getValue());
@@ -3225,7 +3225,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
         iUpdate.saveAndReturnArray(lcs);
         Delete2 dc = Requests.delete().target(img1, img2).build();
-        doChange(client, factory, dc, true, null);
+        doChange(client, factory, dc, true);
         // Now delete the image.
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
@@ -3344,7 +3344,7 @@ public class DeleteServiceTest extends AbstractServerTest {
         }
         iUpdate.saveAndReturnArray(l);
         Delete2 dc = Requests.delete().target(img1, img2).build();
-        doChange(client, factory, dc, true, null);
+        doChange(client, factory, dc, true);
         List<Long> ids = new ArrayList<Long>();
         ids.add(img1.getId().getValue());
         ids.add(img2.getId().getValue());
@@ -3441,7 +3441,7 @@ public class DeleteServiceTest extends AbstractServerTest {
                 Collections.singletonList(img1.getId().getValue()),
                 Dataset.class.getSimpleName(),
                 Collections.singletonList(d.getId().getValue()));
-        doChange(client, factory, dc, true, null);
+        doChange(client, factory, dc, true);
         ParametersI param = new ParametersI();
         param.addId(img1.getId().getValue());
 

--- a/components/tools/OmeroJava/test/integration/DiskUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/DiskUsageTest.java
@@ -623,6 +623,6 @@ public class DiskUsageTest extends AbstractServerTest {
     @Test
     public void testBadClassName() throws Exception {
         final DiskUsage2 request = Requests.diskUsage().target("NoClass").id(1L).build();
-        doChange(client, factory, request, false, null);
+        doChange(client, factory, request, false);
     }
 }

--- a/components/tools/OmeroJava/test/integration/DuplicationTest.java
+++ b/components/tools/OmeroJava/test/integration/DuplicationTest.java
@@ -171,7 +171,7 @@ public class DuplicationTest extends AbstractServerTest {
     @AfterClass
     public void deleteTestImages() throws Exception {
         final Delete2 delete = Requests.delete().target("Image").id(testImages).build();
-        doChange(root, root.getSession(), delete, true);
+        doChange(root, root.getSession(), delete, true, null, 2);
         clearTestImages();
     }
 

--- a/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chmod/PermissionsTest.java
@@ -111,7 +111,7 @@ public class PermissionsTest extends AbstractServerTest {
     @AfterClass
     public void deleteTestImages() throws Exception {
         final Delete2 delete = Requests.delete().target("Image").id(testImages).build();
-        doChange(root, root.getSession(), delete, true);
+        doChange(root, root.getSession(), delete, true, null, 2);
         clearTestImages();
     }
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -122,7 +122,7 @@ public class PermissionsTest extends AbstractServerTest {
     @AfterClass
     public void deleteTestImages() throws Exception {
         final Delete2 delete = Requests.delete().target("Image").id(testImages).build();
-        doChange(root, root.getSession(), delete, true);
+        doChange(root, root.getSession(), delete, true, null, 2);
         clearTestImages();
     }
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -20,7 +20,6 @@
 package integration.chown;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -57,7 +56,6 @@ import omero.model.FolderImageLinkI;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
-import omero.model.ImageAnnotationLinkI;
 import omero.model.Instrument;
 import omero.model.MapAnnotation;
 import omero.model.MapAnnotationI;


### PR DESCRIPTION
# What this PR does

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/636/testngreports/integration.chown/PermissionsTest/deleteTestImages/ threw `omero.LockTimeout`. I don't know if a configuration method failing caused that job run's many other test skips but, just in case it did, this PR increases patience with `deleteTestImages()`.

# Testing this PR

CI suffices.