### PR TITLE
Fix training print encode error

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1285,7 +1285,7 @@ class BlitzObjectWrapper (object):
                     rv = getattr(self._obj, attrName)
                     if hasattr(rv, 'val'):
                         if isinstance(rv.val, StringType):
-                            return rv.val.decode('utf8')
+                            return rv.val
                         # E.g. pixels.getPhysicalSizeX()
                         if hasattr(rv, "_unit"):
                             return rv
@@ -1305,8 +1305,7 @@ class BlitzObjectWrapper (object):
                 # If this is a _unit, then we ignore val
                 # since it's not an rtype to unwrap.
                 if not hasattr(rv, "_unit"):
-                    return (isinstance(rv.val, StringType) and
-                            rv.val.decode('utf8') or rv.val)
+                    return rv.val
             return rv
         raise AttributeError(
             "'%s' object has no attribute '%s'"

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1285,7 +1285,7 @@ class BlitzObjectWrapper (object):
                     rv = getattr(self._obj, attrName)
                     if hasattr(rv, 'val'):
                         if isinstance(rv.val, StringType):
-                            return rv.val
+                            return rv.val.decode('utf8')
                         # E.g. pixels.getPhysicalSizeX()
                         if hasattr(rv, "_unit"):
                             return rv
@@ -1305,7 +1305,8 @@ class BlitzObjectWrapper (object):
                 # If this is a _unit, then we ignore val
                 # since it's not an rtype to unwrap.
                 if not hasattr(rv, "_unit"):
-                    return rv.val
+                    return (isinstance(rv.val, StringType) and
+                            rv.val.decode('utf8') or rv.val)
             return rv
         raise AttributeError(
             "'%s' object has no attribute '%s'"

--- a/examples/Training/python/Connect_To_OMERO.py
+++ b/examples/Training/python/Connect_To_OMERO.py
@@ -84,13 +84,8 @@ if __name__ == '__main__':
     # New in OMERO 5
     print "Admins:"
     for exp in conn.getAdministrators():
-        fullName = exp.getFullName()
-        print "fullName", type(fullName)
-        print "Full Name...", fullName
-        print "str", str(fullName)
-        print "Full Name: %s" % fullName
         print "   ID: %s %s Name: %s" % (
-            exp.getId(), exp.getOmeName(), fullName)
+            exp.getId(), exp.getOmeName(), exp.getFullName())
 
     # The 'context' of our current session
     ctx = conn.getEventContext()

--- a/examples/Training/python/Connect_To_OMERO.py
+++ b/examples/Training/python/Connect_To_OMERO.py
@@ -84,8 +84,13 @@ if __name__ == '__main__':
     # New in OMERO 5
     print "Admins:"
     for exp in conn.getAdministrators():
+        fullName = exp.getFullName()
+        print "fullName", type(fullName)
+        print "Full Name...", fullName
+        print "str", str(fullName)
+        print "Full Name: %s" % fullName
         print "   ID: %s %s Name: %s" % (
-            exp.getId(), exp.getOmeName(), exp.getFullName())
+            exp.getId(), exp.getOmeName(), fullName)
 
     # The 'context' of our current session
     ctx = conn.getEventContext()

--- a/examples/Training/python/Connect_To_OMERO.py
+++ b/examples/Training/python/Connect_To_OMERO.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
     print "Member of:"
     for g in conn.getGroupsMemberOf():
-        print "   ID:", g.getName(), " Name:", g.getId()
+        print "   ID:", g.getId(), " Name:", g.getName()
     group = conn.getGroupFromContext()
     print "Current group: ", group.getName()
 
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
     print "Owner of:"
     for g in conn.listOwnedGroups():
-        print "   ID: ", g.getName(), " Name:", g.getId()
+        print "   ID: ", g.getId(), " Name:", g.getName()
 
     # New in OMERO 5
     print "Admins:"

--- a/examples/Training/python/Connect_To_OMERO.py
+++ b/examples/Training/python/Connect_To_OMERO.py
@@ -70,11 +70,11 @@ if __name__ == '__main__':
     owners, members = group.groupSummary()
     print "   Group owners:"
     for o in owners:
-        print "     ID: %s %s Name: %s" % (
+        print "     ID: %s UserName: %s Name: %s" % (
             o.getId(), o.getOmeName(), o.getFullName())
     print "   Group members:"
     for m in members:
-        print "     ID: %s %s Name: %s" % (
+        print "     ID: %s UserName: %s Name: %s" % (
             m.getId(), m.getOmeName(), m.getFullName())
 
     print "Owner of:"
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     # New in OMERO 5
     print "Admins:"
     for exp in conn.getAdministrators():
-        print "   ID: %s %s Name: %s" % (
+        print "   ID: %s UserName: %s Name: %s" % (
             exp.getId(), exp.getOmeName(), exp.getFullName())
 
     # The 'context' of our current session

--- a/examples/Training/python/Parse_OMERO_Properties.py
+++ b/examples/Training/python/Parse_OMERO_Properties.py
@@ -12,10 +12,15 @@ FOR TRAINING PURPOSES ONLY!
 """
 
 import omero
+import sys
+import codecs
 
 client = omero.client()
 
 omeroProperties = client.getProperties().getPropertiesForPrefix('omero')
+
+# Handle printing of unicode
+sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
 # Configuration
 # =================================================================

--- a/examples/Training/python/Parse_OMERO_Properties.py
+++ b/examples/Training/python/Parse_OMERO_Properties.py
@@ -17,12 +17,6 @@ client = omero.client()
 
 omeroProperties = client.getProperties().getPropertiesForPrefix('omero')
 
-# Set encoding so that print statements or str(unicode) don't fail
-# in testing. See https://github.com/openmicroscopy/openmicroscopy/pull/5400
-import sys
-reload(sys)
-sys.setdefaultencoding('utf-8')
-
 # Configuration
 # =================================================================
 # These values will be imported by all the other training scripts.

--- a/examples/Training/python/Parse_OMERO_Properties.py
+++ b/examples/Training/python/Parse_OMERO_Properties.py
@@ -17,6 +17,12 @@ client = omero.client()
 
 omeroProperties = client.getProperties().getPropertiesForPrefix('omero')
 
+# Set encoding so that print statements or str(unicode) don't fail
+# in testing. See https://github.com/openmicroscopy/openmicroscopy/pull/5400
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 # Configuration
 # =================================================================
 # These values will be imported by all the other training scripts.


### PR DESCRIPTION
# What this PR does

Fixes failing Training examples test at
https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-training/690/console

This was failing because the BlitzGateway BlitzObjectWrapper ```__getattr__``` which handles access to underlying ```omero.model``` objects decodes strings to unicode. If you then try to cast this to a string (for example to print to console) then we get a UnicodeEncodeError.
Test started failing because "Köhler" was set as a user name in a previous test added at
https://github.com/openmicroscopy/openmicroscopy/pull/5397/files#diff-d91232ef1e245a87e311c4a79a2a5f77R1692

For example:
```
>>> from omero.gateway import BlitzGateway
>>> conn = BlitzGateway(client_obj=client)
>>> exp = conn.getUser()

# This uses __getattr__ to return function that unwraps rstring and decodes to unicode
>>> exp.getLastName()
    u'K\xf6hler'

# Here we call getLastName on the simply unwrap the rstring to return a string
>>> exp._obj.getLastName().getValue()
    'K\xc3\xb6hler'
```

This PR removes the decoding to unicode in ```__getattr__``` so that e.g. ```BlitzGatewayObject.getLastName()``` returns a string.

This also makes the BlitzGatewayObject more consistent since previously, ```experimeterWrapper.getName()``` returns unicode but ```imageWrapper.getName()``` returns a string.

```
>>> exp.getName()
    u'will'
>>> i = conn.getObject("Image", 9551)
>>> i.getName()
    '438_01_R3D_D3D\xc3\xb6.dv'
```

# Testing this PR

 - Check that test above is now passing.
 - Test ``` bin/omero shell --login ``` examples above to see that we always get a String for ```exp.getName(), exp.getLastName()``` etc.
 - Test display of unicode characters in webclient. E.g. use "Köhler" as a user name, image name, tag name etc and check that this is displayed correctly everywhere.

# Related reading

TODO: Add to release notes - potentially breaking API change for Blitz Gateway in 5.4.0.

cc @chris-allan, @knabar, @joshmoore Any idea why this we used ```rv.val.decode('utf8')``` originally?
