### PR TITLE
allow creation of light admins with passwords

### DIFF
--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -324,7 +324,24 @@ module omero {
                  * @return id of the newly created
                  *         {@link omero.model.Experimenter}
                  */
-                long createLightSystemUser(omero::model::Experimenter experimenter, AdminPrivilegeList privileges) throws ServerError;
+                long createRestrictedSystemUser(omero::model::Experimenter experimenter, AdminPrivilegeList privileges) throws ServerError;
+
+                /**
+                 * Creates and returns a new system user. This user will be
+                 * created with the <i>System</i> (administration) group as
+                 * default and will also be in the <i>user</i> group. Their
+                 * light administrator privileges and password will be set
+                 * as given.
+                 *
+                 * @param experimenter a new {@link omero.model.Experimenter}
+                 *        instance
+                 * @param privileges the privileges to set for the user
+                 * @param password Not-null. Must pass validation in the
+                 *        security sub-system.
+                 * @return id of the newly created
+                 *         {@link omero.model.Experimenter}
+                 */
+                long createRestrictedSystemUserWithPassword(omero::model::Experimenter experimenter, AdminPrivilegeList privileges, omero::RString password) throws ServerError;
 
                 /**
                  * Creates and returns a new user in the given groups.

--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -312,6 +312,8 @@ module omero {
                  */
                 long createSystemUser(omero::model::Experimenter experimenter) throws ServerError;
 
+                long createLightSystemUser(omero::model::Experimenter experimenter, AdminPrivilegeList privileges) throws ServerError;
+
                 /**
                  * Creates and returns a new system user. This user will be
                  * created with the <i>System</i> (administration) group as

--- a/components/blitz/src/ome/services/blitz/impl/AdminI.java
+++ b/components/blitz/src/ome/services/blitz/impl/AdminI.java
@@ -30,6 +30,7 @@ import omero.api.AMD_IAdmin_containedGroups;
 import omero.api.AMD_IAdmin_createExperimenter;
 import omero.api.AMD_IAdmin_createExperimenterWithPassword;
 import omero.api.AMD_IAdmin_createGroup;
+import omero.api.AMD_IAdmin_createLightSystemUser;
 import omero.api.AMD_IAdmin_createRestrictedSystemUser;
 import omero.api.AMD_IAdmin_createRestrictedSystemUserWithPassword;
 import omero.api.AMD_IAdmin_createSystemUser;
@@ -194,6 +195,13 @@ public class AdminI extends AbstractAmdServant implements _IAdminOperations {
     public void createSystemUser_async(AMD_IAdmin_createSystemUser __cb,
             Experimenter experimenter, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, experimenter);
+    }
+
+    @Override
+    public void createLightSystemUser_async(AMD_IAdmin_createLightSystemUser __cb,
+            Experimenter experimenter, List<AdminPrivilege> privileges,
+            Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, experimenter, privileges);
     }
 
     @Override

--- a/components/blitz/src/ome/services/blitz/impl/AdminI.java
+++ b/components/blitz/src/ome/services/blitz/impl/AdminI.java
@@ -30,7 +30,8 @@ import omero.api.AMD_IAdmin_containedGroups;
 import omero.api.AMD_IAdmin_createExperimenter;
 import omero.api.AMD_IAdmin_createExperimenterWithPassword;
 import omero.api.AMD_IAdmin_createGroup;
-import omero.api.AMD_IAdmin_createLightSystemUser;
+import omero.api.AMD_IAdmin_createRestrictedSystemUser;
+import omero.api.AMD_IAdmin_createRestrictedSystemUserWithPassword;
 import omero.api.AMD_IAdmin_createSystemUser;
 import omero.api.AMD_IAdmin_createUser;
 import omero.api.AMD_IAdmin_deleteExperimenter;
@@ -196,10 +197,17 @@ public class AdminI extends AbstractAmdServant implements _IAdminOperations {
     }
 
     @Override
-    public void createLightSystemUser_async(AMD_IAdmin_createLightSystemUser __cb,
+    public void createRestrictedSystemUser_async(AMD_IAdmin_createRestrictedSystemUser __cb,
             Experimenter experimenter, List<AdminPrivilege> privileges,
             Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, experimenter, privileges);
+    }
+
+    @Override
+    public void createRestrictedSystemUserWithPassword_async(AMD_IAdmin_createRestrictedSystemUserWithPassword __cb,
+            Experimenter experimenter, List<AdminPrivilege> privileges,
+            RString password, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, experimenter, privileges, password);
     }
 
     public void createUser_async(AMD_IAdmin_createUser __cb,

--- a/components/common/src/ome/api/IAdmin.java
+++ b/components/common/src/ome/api/IAdmin.java
@@ -316,8 +316,22 @@ public interface IAdmin extends ServiceInterface {
      * @param privileges the privileges to set for the user
      * @return id of the newly created {@link Experimenter}
      */
-    long createLightSystemUser(@NotNull Experimenter newSystemUser,
+    long createRestrictedSystemUser(@NotNull Experimenter newSystemUser,
             @NotNull @Validate(AdminPrivilege.class) List<AdminPrivilege> privileges);
+
+    /**
+     * Create and return a new system user. This user will be created with the
+     * "System" (administration) group as default and will also be in the "user"
+     * group.
+     *
+     * @param newSystemUser a new {@link Experimenter} instance
+     * @param privileges the privileges to set for the user
+     * @param password the password to set for the user
+     * @return id of the newly created {@link Experimenter}
+     */
+    long createRestrictedSystemUserWithPassword(@NotNull Experimenter newSystemUser,
+            @NotNull @Validate(AdminPrivilege.class) List<AdminPrivilege> privileges,
+            @Hidden String password);
 
     /**
      * create and return a new user in the given groups.

--- a/components/common/src/ome/api/IAdmin.java
+++ b/components/common/src/ome/api/IAdmin.java
@@ -307,6 +307,9 @@ public interface IAdmin extends ServiceInterface {
     long createSystemUser(@NotNull
     Experimenter newSystemUser);
 
+    long createLightSystemUser(@NotNull Experimenter newSystemUser,
+            @NotNull @Validate(AdminPrivilege.class) List<AdminPrivilege> privileges);
+
     /**
      * Create and return a new system user. This user will be created with the
      * "System" (administration) group as default and will also be in the "user"

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -670,6 +670,13 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
     @Override
     @RolesAllowed("system")
     @Transactional(readOnly = false)
+    public long createLightSystemUser(Experimenter newSystemUser, List<AdminPrivilege> privileges) {
+        return createRestrictedSystemUser(newSystemUser, privileges);
+    }
+
+    @Override
+    @RolesAllowed("system")
+    @Transactional(readOnly = false)
     public long createRestrictedSystemUser(Experimenter newSystemUser, List<AdminPrivilege> privileges) {
         newSystemUser.setConfig(getRestrictedSystemUserConfig(privileges));
         return createSystemUser(newSystemUser);

--- a/components/tools/OmeroJava/test/integration/AdminServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/AdminServiceTest.java
@@ -21,7 +21,10 @@ import omero.api.IAdminPrx;
 import omero.api.IQueryPrx;
 import omero.api.ServiceFactoryPrx;
 import omero.cmd.Request;
+import omero.gateway.Gateway;
+import omero.gateway.LoginCredentials;
 import omero.gateway.util.Requests;
+import omero.log.SimpleLogger;
 import omero.model.AdminPrivilege;
 import omero.model.AdminPrivilegeI;
 import omero.model.Experimenter;
@@ -48,6 +51,7 @@ import com.google.common.collect.Sets;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.GroupData;
 
@@ -1920,12 +1924,10 @@ public class AdminServiceTest extends AbstractServerTest {
     }
 
     /**
-     * Test creating a light administrator.
-     * @throws ServerError unexpected
+     * @return a proper non-empty subset of the available light administrator privileges
+     * @throws ServerError if the list of all light administrator privileges could not be obtained from the server
      */
-    @Test
-    public void testCreateLightSystemUser() throws ServerError {
-        final IAdminPrx svc = root.getSession().getAdminService();
+    private List<AdminPrivilege> getAdminPrivilegeSubset() throws ServerError {
         boolean useNext = false;
         final List<AdminPrivilege> expectedPrivileges = new ArrayList<>();
         boolean addedSome = false;
@@ -1941,13 +1943,24 @@ public class AdminServiceTest extends AbstractServerTest {
         }
         Assert.assertTrue(addedSome);
         Assert.assertTrue(skippedSome);
+        return expectedPrivileges;
+    }
+
+    /**
+     * Test creating a light administrator.
+     * @throws ServerError unexpected
+     */
+    @Test
+    public void testCreateRestrictedSystemUser() throws ServerError {
+        final IAdminPrx svc = root.getSession().getAdminService();
+        final List<AdminPrivilege> expectedPrivileges = getAdminPrivilegeSubset();
         final Set<String> expectedPrivilegeNames = new HashSet<>();
         for (final AdminPrivilege privilege : expectedPrivileges) {
             expectedPrivilegeNames.add(privilege.getValue().getValue());
         }
         final String lightAdminName = UUID.randomUUID().toString();
         Experimenter lightAdmin = createExperimenterI(lightAdminName, "test", "user");
-        final long lightAdminId = svc.createLightSystemUser(lightAdmin, expectedPrivileges);
+        final long lightAdminId = svc.createRestrictedSystemUser(lightAdmin, expectedPrivileges);
         final List<AdminPrivilege> actualPrivileges = svc.getAdminPrivileges(new ExperimenterI(lightAdminId, false));
         final Set<String> actualPrivilegeNames = new HashSet<>();
         for (final AdminPrivilege privilege : actualPrivileges) {
@@ -1961,6 +1974,53 @@ public class AdminServiceTest extends AbstractServerTest {
             }
         }
         Assert.fail("new light system user must be member of system group");
+    }
+
+    /**
+     * Test creating a light administrator with a password.
+     * @throws ServerError unexpected
+     * @throws DSOutOfServiceException if login as the new light administrator failed
+     */
+    @Test
+    public void testCreateRestrictedSystemUserWithPassword() throws ServerError, DSOutOfServiceException {
+        final IAdminPrx svc = root.getSession().getAdminService();
+        final List<AdminPrivilege> expectedPrivileges = getAdminPrivilegeSubset();
+        final Set<String> expectedPrivilegeNames = new HashSet<>();
+        for (final AdminPrivilege privilege : expectedPrivileges) {
+            expectedPrivilegeNames.add(privilege.getValue().getValue());
+        }
+        final String lightAdminName = UUID.randomUUID().toString();
+        final String lightAdminPassword = UUID.randomUUID().toString();
+        Experimenter lightAdmin = createExperimenterI(lightAdminName, "test", "user");
+        final long lightAdminId = svc.createRestrictedSystemUserWithPassword(lightAdmin, expectedPrivileges,
+                omero.rtypes.rstring(lightAdminPassword));
+        final List<AdminPrivilege> actualPrivileges = svc.getAdminPrivileges(new ExperimenterI(lightAdminId, false));
+        final Set<String> actualPrivilegeNames = new HashSet<>();
+        for (final AdminPrivilege privilege : actualPrivileges) {
+            actualPrivilegeNames.add(privilege.getValue().getValue());
+        }
+        Assert.assertEquals(actualPrivilegeNames, expectedPrivilegeNames);
+        lightAdmin = svc.lookupExperimenter(lightAdminName);
+        boolean isInSystemGroup = false;
+        for (final GroupExperimenterMap group : lightAdmin.copyGroupExperimenterMap()) {
+            if (group.getParent().getId().getValue() == roles.systemGroupId) {
+                isInSystemGroup = true;
+                break;
+            }
+        }
+        Assert.assertTrue(isInSystemGroup, "new light system user must be member of system group");
+        final LoginCredentials credentials = new LoginCredentials();
+        credentials.getServer().setHostname(client.getProperty("omero.host"));
+        credentials.getServer().setPort(Integer.parseInt(client.getProperty("omero.port")));
+        credentials.getUser().setUsername(lightAdminName);
+        credentials.getUser().setPassword(lightAdminPassword);
+        final Gateway gateway = new Gateway(new SimpleLogger());
+        try {
+            final ExperimenterData lightAdminData = gateway.connect(credentials);
+            Assert.assertEquals(lightAdminData.getId(), lightAdmin.getId().getValue());
+        } finally {
+            gateway.disconnect();
+        }
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -2762,7 +2762,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
 
     /**
      * Test that administrators may give users only privileges that they themselves have.
-     * Attempts editng privileges via {@link omero.api.IUpdatePrx}.
+     * Attempts editing privileges via {@link omero.api.IUpdatePrx}.
      * @param isHasSudo if the administrator has the <tt>Sudo</tt> privilege
      * @param isGrantsSudo if the target user should be given the <tt>Sudo</tt> privilege
      * @param isEditsAdmin if the target user should be an administrator
@@ -2776,7 +2776,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         Experimenter newUser = createExperimenterI(UUID.randomUUID().toString(), getClass().getSimpleName(), "Test");
         final long newUserId;
         if (isEditsAdmin) {
-            newUserId = iAdmin.createLightSystemUser(newUser, Collections.<AdminPrivilege>emptyList());
+            newUserId = iAdmin.createRestrictedSystemUser(newUser, Collections.<AdminPrivilege>emptyList());
         } else {
             final String groupName = newUserAndGroup("rwr---", false).groupName;
             loginUser(actor);


### PR DESCRIPTION
# What this PR does

Adjusts the admin service API:
* Makes `createLightSystemUser` a shim around new `createRestrictedSystemUser`.
* Provides new `createRestrictedSystemUserWithPassword`.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/AdminServiceTest/ until @will-moore's webadmin interface can utilize the new methods.

# Related reading

#5394
https://trello.com/c/KPI5h2y3/90-admin-service-has-light-admins

# Notes

Once this PR is merged and the code of @pwalczysko and @will-moore no longer uses `createLightSystemUser` then https://github.com/mtbc/openmicroscopy/commit/311e5ead6870c070cc1c92263ebe1d2343475e4a can be reverted.