### PR TITLE
Cleanup locks if plpgsql ome_nextval fails

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -139,9 +139,18 @@ BEGIN
           INSERT INTO _lock_ids (id, name) VALUES (Lid, seq);
       END IF;
 
-      PERFORM pg_advisory_xact_lock(1, Lid);
-      PERFORM nextval(seq) FROM generate_series(1, increment);
-      SELECT currval(seq) INTO nv;
+      PERFORM pg_advisory_lock(1, Lid);
+
+      BEGIN
+          PERFORM nextval(seq) FROM generate_series(1, increment);
+          SELECT currval(seq) INTO nv;
+      EXCEPTION
+          WHEN OTHERS THEN
+              PERFORM pg_advisory_unlock(1, Lid);
+          RAISE;
+      END;
+
+      PERFORM pg_advisory_unlock(1, Lid);
 
       RETURN nv;
 

--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -139,20 +139,9 @@ BEGIN
           INSERT INTO _lock_ids (id, name) VALUES (Lid, seq);
       END IF;
 
-      BEGIN
-        PERFORM pg_advisory_lock(1, Lid);
-      EXCEPTION
-        WHEN undefined_function THEN
-          RAISE DEBUG ''No function pg_advisory_lock'';
-      END;
+      PERFORM pg_advisory_xact_lock(1, Lid);
       PERFORM nextval(seq) FROM generate_series(1, increment);
       SELECT currval(seq) INTO nv;
-      BEGIN
-        PERFORM pg_advisory_unlock(1, Lid);
-      EXCEPTION
-        WHEN undefined_function THEN
-          RAISE DEBUG ''No function pg_advisory_unlock'';
-      END;
 
       RETURN nv;
 

--- a/sql/psql/patches/psql-footer.sql
+++ b/sql/psql/patches/psql-footer.sql
@@ -1,0 +1,34 @@
+--
+-- Copyright 2006-2016 University of Dundee. All rights reserved.
+-- Use is subject to license terms supplied in LICENSE.txt
+--
+
+CREATE OR REPLACE FUNCTION ome_nextval(seq VARCHAR, increment int4) RETURNS INT8 AS '
+DECLARE
+      Lid  int4;
+      nv   int8;
+BEGIN
+      SELECT id INTO Lid FROM _lock_ids WHERE name = seq;
+      IF Lid IS NULL THEN
+          SELECT INTO Lid nextval(''_lock_seq'');
+          INSERT INTO _lock_ids (id, name) VALUES (Lid, seq);
+      END IF;
+
+      BEGIN
+        PERFORM pg_advisory_lock(1, Lid);
+      EXCEPTION
+        WHEN undefined_function THEN
+          RAISE DEBUG ''No function pg_advisory_lock'';
+      END;
+      PERFORM nextval(seq) FROM generate_series(1, increment);
+      SELECT currval(seq) INTO nv;
+      BEGIN
+        PERFORM pg_advisory_unlock(1, Lid);
+      EXCEPTION
+        WHEN undefined_function THEN
+          RAISE DEBUG ''No function pg_advisory_unlock'';
+      END;
+
+      RETURN nv;
+
+END;' LANGUAGE plpgsql;

--- a/sql/psql/patches/psql-footer.sql
+++ b/sql/psql/patches/psql-footer.sql
@@ -17,9 +17,18 @@ BEGIN
           INSERT INTO _lock_ids (id, name) VALUES (Lid, seq);
       END IF;
 
-      PERFORM pg_advisory_xact_lock(1, Lid);
-      PERFORM nextval(seq) FROM generate_series(1, increment);
-      SELECT currval(seq) INTO nv;
+      PERFORM pg_advisory_lock(1, Lid);
+
+      BEGIN
+          PERFORM nextval(seq) FROM generate_series(1, increment);
+          SELECT currval(seq) INTO nv;
+      EXCEPTION
+          WHEN OTHERS THEN
+              PERFORM pg_advisory_unlock(1, Lid);
+          RAISE;
+      END;
+
+      PERFORM pg_advisory_unlock(1, Lid);
 
       RETURN nv;
 

--- a/sql/psql/patches/psql-footer.sql
+++ b/sql/psql/patches/psql-footer.sql
@@ -1,6 +1,9 @@
 --
--- Copyright 2006-2016 University of Dundee. All rights reserved.
--- Use is subject to license terms supplied in LICENSE.txt
+-- This is a manual patch for ome_nextval($1, $2)
+-- to prevent deadlocks if nextval(seq) fails in
+-- https://github.com/openmicroscopy/openmicroscopy/blob/v5.3.3/sql/psql/OMERO5.3__0/psql-footer.sql#L795
+-- pg_advisory_xact_lock should automatically release the lock at the end of
+-- the transaction
 --
 
 CREATE OR REPLACE FUNCTION ome_nextval(seq VARCHAR, increment int4) RETURNS INT8 AS '
@@ -14,20 +17,9 @@ BEGIN
           INSERT INTO _lock_ids (id, name) VALUES (Lid, seq);
       END IF;
 
-      BEGIN
-        PERFORM pg_advisory_lock(1, Lid);
-      EXCEPTION
-        WHEN undefined_function THEN
-          RAISE DEBUG ''No function pg_advisory_lock'';
-      END;
+      PERFORM pg_advisory_xact_lock(1, Lid);
       PERFORM nextval(seq) FROM generate_series(1, increment);
       SELECT currval(seq) INTO nv;
-      BEGIN
-        PERFORM pg_advisory_unlock(1, Lid);
-      EXCEPTION
-        WHEN undefined_function THEN
-          RAISE DEBUG ''No function pg_advisory_unlock'';
-      END;
 
       RETURN nv;
 


### PR DESCRIPTION
# What this PR does

`ome_nextval` calls:
1. `pg_advisory_lock(1, Lid)` before calling
2. `nextval(seq)`
3. `pg_advisory_unlock(1, Lid)`

If the call to `nextval(seq)` fails `pg_advisory_unlock` is never called, leading to a potential deadlock. This PR replaces `pg_advisory_lock`/`pg_advisory_unlock` with a single call to `pg_advisory_xact_lock` which automatically unlocks at the end of the transaction.

In addition this removes the `BEGIN`-`EXCEPTION`-`END` wrapper since the [lock functions exist in PostgreSQL 9.1](https://www.postgresql.org/docs/9.1/static/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS) which is less than the minimum OMERO requirement.

This also includes an SQL file for manually testing the IDR.

# Testing this PR

See https://trello.com/c/1DGiYzfM/61-plpgsql-omenextval-may-deadlock-with-a-readonly-user

It's not reliably reproducible