### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk: oraclejdk8
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
+sudo: required
 
 # http://docs.travis-ci.com/user/caching/#Arbitrary-directories
 cache:
@@ -19,11 +19,11 @@ matrix:
 addons:
   apt_packages:
     - git
-    - zeroc-ice35
-    - python-imaging
-    - python-numpy
-    - python-tables
-    - python-yaml
+    #- zeroc-ice35
+    #- python-imaging
+    #- python-numpy
+    #- python-tables
+    #- python-yaml
     - cmake
     - libgtest-dev
 
@@ -32,6 +32,8 @@ env:
     - BUILD="build-java"
 
 before_install:
+    - echo $PATH
+    - sudo apt-get install -y zeroc-ice35 python-imaging python-numpy python-tables python-yaml
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi
     - export PATH=$PATH:$HOME/.local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ before_install:
     - echo $PATH
     - export PATH=/usr/bin/:$PATH
     - sudo apt-get install -y zeroc-ice35 python-imaging python-numpy python-tables python-yaml
+    #- sudo apt-get purge python-numpy  libhdf5-serial-dev 
+    - pip install -U numexpr # table test failure otherwise
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi
     - export PATH=$PATH:$HOME/.local/bin
@@ -43,6 +45,7 @@ before_install:
 # retries the build due to:
 # https://github.com/travis-ci/travis-ci/issues/2507
 install:
+    - pip install --user numpy
     - if [[ $BUILD == 'build-python' ]]; then travis_retry ./components/tools/travis-build py-build; fi
     - if [[ $BUILD == 'build-java' ]]; then travis_retry ./components/tools/travis-build java-build; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-
+dist: trusty
 jdk: oraclejdk8
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-dist: precise
+
 jdk: oraclejdk8
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,15 @@ env:
     - BUILD="build-java"
 
 before_install:
+    # The installation of the python dependencies must be done in that level for now
+    # otherwise they are not available in the containers,
+    # see https://github.com/travis-ci/travis-ci/issues/8048
+    # Changing the value for sudo will also need to be reviewed at the same time
+    # This will need to be reviewed when the issue above is fixed
     - export PATH=/usr/bin/:$PATH
     - sudo apt-get install -y zeroc-ice35 python-imaging python-numpy python-tables python-yaml
-    - pip install -U numexpr # table test failure otherwise
+    # upgrade numexpr to fix table test failures
+    - pip install -U numexpr
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi
     - export PATH=$PATH:$HOME/.local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ matrix:
 addons:
   apt_packages:
     - git
-    #- zeroc-ice35
-    #- python-imaging
-    #- python-numpy
-    #- python-tables
-    #- python-yaml
     - cmake
     - libgtest-dev
 
@@ -31,10 +26,8 @@ env:
     - BUILD="build-java"
 
 before_install:
-    - echo $PATH
     - export PATH=/usr/bin/:$PATH
     - sudo apt-get install -y zeroc-ice35 python-imaging python-numpy python-tables python-yaml
-    #- sudo apt-get purge python-numpy  libhdf5-serial-dev 
     - pip install -U numexpr # table test failure otherwise
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi
@@ -45,7 +38,6 @@ before_install:
 # retries the build due to:
 # https://github.com/travis-ci/travis-ci/issues/2507
 install:
-    - pip install --user numpy
     - if [[ $BUILD == 'build-python' ]]; then travis_retry ./components/tools/travis-build py-build; fi
     - if [[ $BUILD == 'build-java' ]]; then travis_retry ./components/tools/travis-build java-build; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-
 jdk: oraclejdk8
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on
@@ -33,6 +32,7 @@ env:
 
 before_install:
     - echo $PATH
+    - export PATH=/usr/bin/:$PATH
     - sudo apt-get install -y zeroc-ice35 python-imaging python-numpy python-tables python-yaml
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 addons:
   apt_packages:
     - git
-    - zeroc-ice34
+    - zeroc-ice35
     - python-imaging
     - python-numpy
     - python-tables

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
 
 before_install:
     - pip install --user pytest
-    - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all.txt; fi
+    - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi
     - export PATH=$PATH:$HOME/.local/bin
     - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest==2.7.3; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -19,31 +19,8 @@ clean()
     ant clean
 }
 
-get_ice()
-{
-  if [ "$TRAVIS" = "true" ]; then
-    NAME=ice
-    fold start install
-    ice=Ice-3.5.1-b1-ubuntu1204-amd64.tar.xz
-    if [ ! -f "download/$ice" ]; then
-      mkdir -p download
-      cd download
-      wget "http://downloads.openmicroscopy.org/ice/experimental/$ice"
-      cd ..
-    fi
-    tar -xvf "download/$ice"
-    ICE_HOME="$(pwd)/Ice-3.5.1-b1-ubuntu1204-amd64"
-    export SLICEPATH="${ICE_HOME}/slice"
-    export PATH="${ICE_HOME}/bin:$PATH"
-    export LD_LIBRARY_PATH="${ICE_HOME}/lib:$LD_LIBRARY_PATH"
-    export PYTHONPATH="${ICE_HOME}/python:$PYTHONPATH"
-    fold end install
-  fi
-}
-
 java_build()
 {
-    get_ice
     NAME=java_build
     fold start default
         TEST="-p" ant build-default -Dpackage-extra=false
@@ -55,7 +32,6 @@ java_build()
 
 java_test()
 {
-    get_ice
     NAME=java_test
     for dir in dsl model common rendering server blitz tools/OmeroJava
     do
@@ -88,7 +64,6 @@ py_flake8()
 
 py_build()
 {
-    get_ice
     NAME=py_build
     fold start default
         ant build-default -Dpackage-extra=false
@@ -97,7 +72,6 @@ py_build()
 
 py_test()
 {
-    get_ice
     NAME=py_test
     for dir in OmeroPy OmeroFS OmeroWeb
     do
@@ -127,7 +101,6 @@ py_test()
 
 build_cpp()
 {
-    get_ice
     (
         cd components/tools/OmeroCpp
         mkdir build
@@ -148,7 +121,6 @@ build_cpp()
 
 if [ $# -eq 0 ]
 then
-    get_ice
     clean
     java_build
     py_build

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -23,7 +23,7 @@ java_build()
 {
     NAME=java_build
     fold start default
-        TEST="-p" ./build.py build-default -Dpackage-extra=false
+        TEST="-p" ant build-default -Dpackage-extra=false
     fold end default
     fold start tests
         TEST="-p" ant test-compile
@@ -66,7 +66,7 @@ py_build()
 {
     NAME=py_build
     fold start default
-        ./build.py build-default -Dpackage-extra=false
+        ant build-default -Dpackage-extra=false
     fold end default
 }
 

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -23,7 +23,7 @@ java_build()
 {
     NAME=java_build
     fold start default
-        TEST="-p" ant build-default -Dpackage-extra=false
+        TEST="-p" ./build.py build-default -Dpackage-extra=false
     fold end default
     fold start tests
         TEST="-p" ant test-compile
@@ -66,7 +66,7 @@ py_build()
 {
     NAME=py_build
     fold start default
-        ant build-default -Dpackage-extra=false
+        ./build.py build-default -Dpackage-extra=false
     fold end default
 }
 


### PR DESCRIPTION
# What this PR does

Use trusty to build 
This is necessary to build with newer version of pytables
and newer version of ice

 * building using ``ant`` fails all the time, need to use ``./build.py``.
 * installation of python dependencies needs to be explicitly done via
``sudo apt-get`` during ``before_install:`` otherwise the dependencies will not be available to the container. This means that the python tests will fail with for example ``No module Ice``. Change ``sudo`` option to ``required``. I did not notice an increase in the build time with that change.  See https://github.com/travis-ci/travis-ci/issues/8048
 * update ``numexpr`` via pip to avoid some table test failure  e.g.
``test/unit/tablestest/test_servants.py:349:`` will fail with ``ValueError: Using `oa_ndim == 0` when `op_axes` is NULL. Use `oa_ndim == -1` or the MultiNew iterator for NumPy <1.8 compatibility``



# Testing this PR
Check that travis is green

See https://trello.com/c/gVsUkLH8/100-travis-upgrade