### PR TITLE
projectPixels: t range overshoots (unless full range is selected)

### DIFF
--- a/components/server/src/ome/services/projection/ProjectionBean.java
+++ b/components/server/src/ome/services/projection/ProjectionBean.java
@@ -270,7 +270,7 @@ public class ProjectionBean extends AbstractLevel2Service implements IProjection
                                             "Unknown algorithm: " + algorithm);
                                 }
                             }
-                            destinationBuffer.setPlane(buf, 0, newC, t);
+                            destinationBuffer.setPlane(buf, 0, newC, t-tStart);
                         }
                         catch (IOException e)
                         {

--- a/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ProjectionServiceTest.java
@@ -235,6 +235,19 @@ public class ProjectionServiceTest extends AbstractServerTest
     }
 
     /**
+     * Test the projection with a restricted but valid timepoint range.
+     *
+     * @throws Exception Thrown if an error occurred.
+     */
+    @Test
+    public void testTimepointIntervalNotFullRange() throws Exception {
+        Pixels pixels = importImage();
+        List<Integer> channels = Arrays.asList(0);
+        projectImage(pixels, 2, 4, 1, 3, 1,
+                ProjectionType.MAXIMUMINTENSITY, null, channels);
+    }
+    
+    /**
      * Test the projection with an invalid timepoint range.
      *
      * @throws Exception Thrown if an error occurred.


### PR DESCRIPTION
Piggy-backing on the method projectPixels (ProjectionService) to save a projection as a new image (for iviewer) I noticed that I got errors when setting the range of Ts not to the full range or 0:0.

Cross-checking with insight,I got the same error: 

`
ServerExceptionClass = "ome.conditions.ValidationException"
    message = "C=0 or T=22 out of range for Pixels Id 104: T '22' greater than sizeT '22'."
`

This can be reproduced with images that have more than 1 T and Z. Change the T range in the projection dialog to something that is not the entire range and you should get the error.