### PR TITLE
Allow child-options to be set when deleting MapAnnotations

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1625,14 +1625,16 @@ class DeleteMapAnnotationContext(_QueryContext):
         for objtype, maids in self.mapannids.iteritems():
             for batch in self._batch(maids, sz=batch_size):
                 self._write_to_omero_batch(
-                    {"%sAnnotationLink" % objtype: batch},
-                    childoptions, loops, ms)
+                    {"%sAnnotationLink" % objtype: batch}, loops, ms)
         for batch in self._batch(self.fileannids, sz=batch_size):
             self._write_to_omero_batch(
-                {"FileAnnotation": batch}, childoptions, loops, ms)
+                {"FileAnnotation": batch}, loops, ms)
 
     def _write_to_omero_batch(
-            self, to_delete, childoptions, loops=10, ms=500):
+            self, to_delete, loops=10, ms=500):
+        # options[childoptions] must be a list of dicts
+        childoptions = [ChildOption(**kw)for kw in
+                        self.options.get('childoptions', [])]
         delCmd = omero.cmd.Delete2(
             targetObjects=to_delete, childOptions=childoptions)
         try:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -1618,10 +1618,6 @@ class DeleteMapAnnotationContext(_QueryContext):
                       [NSBULKANNOTATIONSCONFIG], self.fileannids)
 
     def write_to_omero(self, batch_size=1000, loops=10, ms=500):
-        # options[childoptions] must be a list of dicts
-        childoptions = [ChildOption(**kw)for kw in
-                        self.options.get('childoptions', [])]
-
         for objtype, maids in self.mapannids.iteritems():
             for batch in self._batch(maids, sz=batch_size):
                 self._write_to_omero_batch(
@@ -1633,10 +1629,14 @@ class DeleteMapAnnotationContext(_QueryContext):
     def _write_to_omero_batch(
             self, to_delete, loops=10, ms=500):
         # options[childoptions] must be a list of dicts
+        # options[typestoignore] must be a list of strings
         childoptions = [ChildOption(**kw)for kw in
                         self.options.get('childoptions', [])]
+        typestoignore = self.options.get('typestoignore', [])
         delCmd = omero.cmd.Delete2(
-            targetObjects=to_delete, childOptions=childoptions)
+            targetObjects=to_delete,
+            childOptions=childoptions,
+            typesToIgnore=typestoignore)
         try:
             callback = self.client.submit(
                 delCmd, loops=loops, ms=ms, failontimeout=True)


### PR DESCRIPTION
# What this PR does

Allows child-options to be passed to the `Delete2` command, as suggested by @mtbc to workaround the performance issues described in https://trello.com/c/kRPgBR36/57-linked-annotation-deletion-is-very-slow-due-to-53-graph-deletion-rules#comment-597c44d077236b6fb2e8fc40

# Testing this PR

Child options in can be passed using `--localcfg`. For example:

    omero metadata populate --context deletemap 
        --localcfg '{"ns":"openmicroscopy.org/omero/bulk_annotations",
        "childoptions":[{"excludeType":["Annotation"]}]}'
        Well:125 --report

will delete `WellAnnotationLink`s to `MapAnnotation`s in namespace `openmicroscopy.org/omero/bulk_annotations` for `Well:125`, but will never delete the `MapAnnotation` even if it is orphaned since this introduces a significant performance degradation.

## Updated 20170823

--depends-on #5464

This should be a faster version of the above: `--localcfg '{"ns":"openmicroscopy.org/omero/bulk_annotations", "typestoignore":["Annotation"]}'`