### PR TITLE
Revert "enable delete policy rules for orphaned non-shared annotations"

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-delete-rules.xml
@@ -193,8 +193,10 @@
 
         <!-- If a basic or comment annotation is unlinked then consider it for deletion regardless of permissions. -->
 
+        <!-- omitted at present because it causes errors in the web client
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:BasicAnnotation[E]{i}" p:changes="A:{r}"/>
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:CommentAnnotation[E]{i}" p:changes="A:{r}"/>
+          -->
 
         <!--
              If an annotated object is deleted then consider its basic or comment annotations for deletion regardless of
@@ -218,9 +220,11 @@
 
         <!-- If a list, map, or XML annotation is unlinked then consider it for deletion. -->
 
+        <!-- omitted at present because it causes errors in the web client
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:ListAnnotation[E]{i}/d" p:changes="A:{r}"/>
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:MapAnnotation[E]{i}/d" p:changes="A:{r}"/>
         <bean parent="graphPolicyRule" p:matches="IAnnotationLink[D].child = A:XmlAnnotation[E]{i}/d"  p:changes="A:{r}"/>
+          -->
 
         <!-- If an annotated object is deleted then consider its list, map, or XML annotations for deletion. -->
 


### PR DESCRIPTION
This reverts commit ea298a5a8a2f35860105da91b66843169b30ce46.

https://github.com/openmicroscopy/openmicroscopy/pull/4585/ led to severe performance problems on the metadata53 branch when deleting. This reverts the commit believed to be responsible for the deletion performance.

This PR only reverts one commit from #4585. Integration tests are now expected to fail, including `test/integration/metadata/test_populate.py::TestPopulateMetadata`

# Related reading

- https://trello.com/c/kRPgBR36/57-linked-annotation-deletion-is-very-slow-due-to-53-graph-deletion-rules
- https://github.com/openmicroscopy/openmicroscopy/pull/5414 didn't seem to help