### PR TITLE
state_copy_paste

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -988,6 +988,7 @@ $(function() {
                                 var inst = $.jstree.reference('#dataTree');
                                 OME.copyRenderingSettings(WEBCLIENT.URLS.copy_image_rdef_json,
                                     inst.get_selected(true));
+                                WEBCLIENT.HAS_RDEF = true;
                             }
                         },
                         "paste_rdef": {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1186,8 +1186,13 @@ $(function() {
                         node.type === 'acquisition' ||
                         node.type === 'image') {
 
+                        if (WEBCLIENT.HAS_RDEF) {
+                            // If the user has not got an object to copy, don't show the
+                            // paste option as a valid item
+                            config['renderingsettings']["submenu"]['paste_rdef']['_disabled'] = false;
+                        }
+
                         config['renderingsettings']['_disabled'] = false;
-                        config['renderingsettings']["submenu"]['paste_rdef']['_disabled'] = false;
                         config['renderingsettings']["submenu"]['reset_rdef']['_disabled'] = false;
                         config['renderingsettings']["submenu"]['owner_rdef']['_disabled'] = false;
                     }

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -208,6 +208,10 @@
             var PAGE_SIZE = {{ page_size }};
         {% endif %}
 
+        WEBCLIENT.HAS_RDEF = false;
+        $.getJSON("{% url 'webgateway.views.get_image_rdef_json' %}", function(data){
+            WEBCLIENT.HAS_RDEF = !!(data && data.rdef);
+        });
 
         // ** "Open With" config used by E.g. ome.tree.js **
         // Loaded scripts can call OME.setOpenWithEnabledHandler and/or

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -32,6 +32,11 @@
         var jqxhr = $.getJSON(viewport.viewport_server + "/copyImgRDef/?" + rdefQry);
         jqxhr.complete(function() {
             $("#rdef-paste-btn").removeAttr('disabled').removeClass("button-disabled");
+
+            // Optional : only present on webclient app
+            if (WEBCLIENT) {
+                WEBCLIENT.HAS_RDEF = true;
+            }
         });
     };
 


### PR DESCRIPTION
Added a simple boolean property to WEBCLIENT object (in base_container.html) which acts as a flag to enable / disable the paste option in the 'rendersettings' context menu.

### Testing this PR

Please ensure you have logged out and logged in before testing

1. Right click on image in left tree and check if "Rendering Settings" > "Paste and save" is disabled

2. Copy an image from the left hand tree and you should be able to select another image to paste on ( "Paste and save"  no longer disabled)

3 . Click to copy an image from the right hand "Preview" tab. Click on an image on the left tree and the option to  "Paste and save" should be available.

Trello card:
https://trello.com/c/GEekfV57/71-rnd-settings
