### PR TITLE
Link graphical test explanations to ppts in downloads (not gdocs)

### DIFF
--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -182,7 +182,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testImporterAsSudoCreateImport.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testImporterAsSudoCreateImport.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testImporterAsSudoCreateImport(boolean isSudoing, boolean permWriteOwned,
@@ -277,7 +277,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testDelete.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testDelete.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Delete privileges cases")
     public void testDelete(boolean isSudoing, boolean permDeleteOwned,
@@ -510,7 +510,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testEdit.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testEdit.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testEdit(boolean isSudoing, boolean permWriteOwned,
@@ -581,7 +581,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChgrp.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChgrp.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrp(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -661,7 +661,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChgrpNonMember.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChgrpNonMember.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrpNonMember(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -748,7 +748,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChown.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChown.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chown privileges cases")
     public void testChown(boolean isSudoing, boolean permChown, String groupPermissions)
@@ -840,7 +840,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testImporterAsNoSudoChownOnlyWorkflow.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testImporterAsNoSudoChownOnlyWorkflow.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
     public void testImporterAsNoSudoChownOnlyWorkflow(boolean permWriteOwned, boolean permWriteFile,
@@ -948,7 +948,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testLinkNoSudo.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testLinkNoSudo.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testLinkNoSudo(boolean permWriteOwned, boolean permChown,
@@ -1113,7 +1113,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1zqDRwYDm3wA_xE79M6qR56U8giFbLFDywH3slj0wURA/edit">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testImporterAsNoSudoChgrpChownWorkflow.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "Chgrp and Chown privileges cases")
     public void testImporterAsNoSudoChgrpChownWorkflow(boolean permChgrp, boolean permChown,
@@ -1236,7 +1236,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param isPrivileged if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUserLightAdmin.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUserLightAdmin.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testChownAllBelongingToUser(boolean isPrivileged, String groupPermissions) throws Exception {
@@ -1379,7 +1379,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testROIAndRenderingSettingsNoSudo.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testROIAndRenderingSettingsNoSudo.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testROIAndRenderingSettingsNoSudo(boolean permWriteOwned, boolean permChown,
@@ -1503,7 +1503,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testFileAttachmentNoSudo.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testFileAttachmentNoSudo.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "fileAttachment privileges cases")
     public void testFileAttachmentNoSudo(boolean permChown, boolean permWriteOwned,

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -182,7 +182,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1JX6b9pkPtG-3hZIGSp2bu4WVvNKn6GHqIKdfbbJkiw8/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testImporterAsSudoCreateImport.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testImporterAsSudoCreateImport(boolean isSudoing, boolean permWriteOwned,
@@ -277,7 +277,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permDeleteOwned if to test a user who has the <tt>DeleteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1SRWiFJs7oIYJCSg8XpfeW0QyOPwbrSnAbXL_FaKF0I4/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testDelete.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Delete privileges cases")
     public void testDelete(boolean isSudoing, boolean permDeleteOwned,
@@ -510,7 +510,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteOwned if to test a user who has the <tt>WriteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/18u5hRD_oFKjGlGQ7x55oUowrmdjS4HXkXKfJSlpbiVY/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testEdit.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and WriteOwned privileges cases")
     public void testEdit(boolean isSudoing, boolean permWriteOwned,
@@ -581,7 +581,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1BUSzGp89en0Y7-5i7DkQbtVM-AgyfCJVa7rLhnMeO5A/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChgrp.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrp(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -661,7 +661,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChgrp if to test a user who has the <tt>Chgrp</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1c3TGh4bD5_djKO_-lJs5LoBjL0koYsko7QkyEuu-nXY/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChgrpNonMember.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chgrp privileges cases")
     public void testChgrpNonMember(boolean isSudoing, boolean permChgrp, String groupPermissions)
@@ -748,7 +748,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1r4qlG9JKLfTgS8s5xWM8SDJJ25t4RwSWuiy6BfFfO_o/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChown.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isSudoing and Chown privileges cases")
     public void testChown(boolean isSudoing, boolean permChown, String groupPermissions)
@@ -840,7 +840,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1w_W6g69CV5Uy_rUom2K9O86w2Q2CGkl3rzNj-ZQzSt0/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testImporterAsNoSudoChownOnlyWorkflow.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned, WriteFile, WriteManagedRepo and Chown privileges cases")
     public void testImporterAsNoSudoChownOnlyWorkflow(boolean permWriteOwned, boolean permWriteFile,
@@ -948,7 +948,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1uetvPv-tsnHdRqkVvMx2xpHvVXYyUL2HTob8LUC6Mds/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testLinkNoSudo.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testLinkNoSudo(boolean permWriteOwned, boolean permChown,
@@ -1236,7 +1236,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param isPrivileged if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1zbIu5gYPObbVkBSxdD4sMmPFMGgspbtYQEnJ9k8vfCs/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUserLightAdmin.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "isPrivileged cases")
     public void testChownAllBelongingToUser(boolean isPrivileged, String groupPermissions) throws Exception {
@@ -1379,7 +1379,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permChown if to test a user who has the <tt>Chown</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1ukEZmh0c6NCNKUE1dFqaYjN6Sd5xxCuOYkSuMdpiqvE/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testROIAndRenderingSettingsNoSudo.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "WriteOwned and Chown privileges cases")
     public void testROIAndRenderingSettingsNoSudo(boolean permWriteOwned, boolean permChown,
@@ -1503,7 +1503,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param permWriteFile if to test a user who has the <tt>WriteFile</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-     * @see <a href="https://docs.google.com/presentation/d/1jfdsPSvqJvBlN18vIFrRsNqh13eAlF5Gjh3G_MiGGAE/edit">graphical explanation</a>
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testFileAttachmentNoSudo.pptx">graphical explanation</a>
      */
     @Test(dataProvider = "fileAttachment privileges cases")
     public void testFileAttachmentNoSudo(boolean permChown, boolean permWriteOwned,

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -435,7 +435,7 @@ public class PermissionsTest extends AbstractServerTest {
      * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
      * @param isExpectSuccessOneTargetUser if the one-user chown is expected to succeed
      * @param isExpectSuccessTwoTargetUsers if the two-users chown is expected to succeed
-     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUser.pptx">graphical explanation</a>
+     * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUser.pptx">graphical explanation</a>
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown targetUser test cases")

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -435,6 +435,7 @@ public class PermissionsTest extends AbstractServerTest {
      * @param isRecipientInGroup if the user receiving data by means of the {@link Chown2} request is a member of the data's group
      * @param isExpectSuccessOneTargetUser if the one-user chown is expected to succeed
      * @param isExpectSuccessTwoTargetUsers if the two-users chown is expected to succeed
+     * @see <a href="http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUser.pptx">graphical explanation</a>
      * @throws Exception unexpected
      */
     @Test(dataProvider = "chown targetUser test cases")


### PR DESCRIPTION
# What this PR does

As we have the ``http://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/`` folder now, this PR links the graphical explanations (as ppts) inside that folder to the tests themselves. T


# Testing this PR

To test, build in Eclipse the Javadoc. (Be sure to open the page with the tests, either ``integration/LightAdminRolesTest.java`` or ``/integration/Chown/PermissionsTest.java``. Then 
Project > Generate Javadoc. The console output will lead you to where the index.html was built locally for you by Eclipse. Find the tests in that html in the browser and check that the click to "graphical explanation" will download the appropriate ppt to this test.

2. actions to perform

3. expected observations


# Related reading
https://trello.com/c/fdiVZar7/42-add-to-javadoc-the-link-to-test-explanations

@jburel @joshmoore @mtbc 
