### PR TITLE
public_get_only (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -238,6 +238,8 @@ class login_required(object):
                             'disabling OMERO.webpublic.')
                 settings.PUBLIC_ENABLED = False
                 return False
+            if settings.PUBLIC_GET_ONLY and (request.method != 'GET'):
+                return False
             if self.allowPublic is None:
                 return settings.PUBLIC_URL_FILTER.search(request.path) \
                     is not None

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -42,15 +42,8 @@ import string
 
 from omero_ext import portalocker
 from omero.install.python_warning import py27_only, PYTHON_WARNING
-
-# Load custom settings from etc/grid/config.xml
-# Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
 from omero.util.concurrency import get_event
-
-# Load server list and freeze
 from utils import sort_properties_to_tuple
-
-# Load server list and freeze
 from connector import Server
 
 logger = logging.getLogger(__name__)
@@ -1265,10 +1258,13 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
+# Load custom settings from etc/grid/config.xml
+# Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
 MIDDLEWARE_CLASSES = sort_properties_to_tuple(MIDDLEWARE_CLASSES_LIST)  # noqa
 
 
+# Load server list and freeze
 def load_server_list():
     for s in SERVER_LIST:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
         server = (len(s) > 2) and unicode(s[2]) or None

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -514,8 +514,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " navigate. The idea is that you can create the public pages"
           " yourself (see OMERO.web framework since we do not provide public"
           " pages.")],
-    "omero.web.public.get_only" :
-        ["PUBLIC_GET_ONLY", "true", parse_boolean, "Restrict public users to GET requests only"],
+    "omero.web.public.get_only":
+        ["PUBLIC_GET_ONLY",
+         "true",
+         parse_boolean,
+         "Restrict public users to GET requests only"],
     "omero.web.public.server_id":
         ["PUBLIC_SERVER_ID", 1, int, "Server to authenticate against."],
     "omero.web.public.user":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -514,6 +514,8 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " navigate. The idea is that you can create the public pages"
           " yourself (see OMERO.web framework since we do not provide public"
           " pages.")],
+    "omero.web.public.get_only" :
+        ["PUBLIC_GET_ONLY", "true", parse_boolean, "Restrict public users to GET requests only"],
     "omero.web.public.server_id":
         ["PUBLIC_SERVER_ID", 1, int, "Server to authenticate against."],
     "omero.web.public.user":

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -43,6 +43,16 @@ import string
 from omero_ext import portalocker
 from omero.install.python_warning import py27_only, PYTHON_WARNING
 
+# Load custom settings from etc/grid/config.xml
+# Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
+from omero.util.concurrency import get_event
+
+# Load server list and freeze
+from utils import sort_properties_to_tuple
+
+# Load server list and freeze
+from connector import Server
+
 logger = logging.getLogger(__name__)
 
 if not py27_only():
@@ -161,9 +171,6 @@ LOGGING = {
 }
 
 
-# Load custom settings from etc/grid/config.xml
-# Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
-from omero.util.concurrency import get_event
 CONFIG_XML = os.path.join(OMERO_HOME, 'etc', 'grid', 'config.xml')
 count = 10
 event = get_event("websettings")
@@ -1258,15 +1265,8 @@ MANAGERS = ADMINS  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
 # omeroweb.connector.Connector object
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
-
-# Load server list and freeze
-from utils import sort_properties_to_tuple
-
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
 MIDDLEWARE_CLASSES = sort_properties_to_tuple(MIDDLEWARE_CLASSES_LIST)  # noqa
-
-# Load server list and freeze
-from connector import Server
 
 
 def load_server_list():


### PR DESCRIPTION

This is the same as gh-5406 but rebased onto metadata53.

----

Added config setting in to restrict public users from performing anything but GET requests

`omero.web.public.get_only true (default)`

### Testing this PR

1. Checkout this branch and clean build OMERO
2. Create a public group
3. Create a user with read only rights
4. Set the following: 
```
$ omero config set omero.web.public.enabled true
$ omero config set omero.web.public.get_only true 
$ omero config set omero.web.public.user '<user with read only rights>'
$ omero config set omero.web.public.password '<password (optional) for user with read only rights>'
```
5. Navigate to omero webclient and the user should be logged in as a public user
6. Attempt to perform an action which will trigger a HTTP POST request, such as creating a new project

Trello card:
https://trello.com/c/cWcsQClq/2-public-url-filter-vv-post-urls


                