### PR TITLE
Allow the local Maven repository to be overriden 

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -16,7 +16,8 @@
   <properties file="${ivy.settings.dir}/build.properties"/>
   <properties file="${ivy.settings.dir}/local.properties"/>
   <properties file="${ivy.settings.dir}/../target/omero.version"/>
-  <property name="local-maven2-dir" value="${user.home}/.m2/repository/"/>
+  <property name="local-maven2-dir" value="${user.home}/.m2/repository/"
+      override="false"/>
 
   <settings defaultResolver="${omero.resolver}"/>
 

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -16,7 +16,9 @@
   <properties file="${ivy.settings.dir}/build.properties"/>
   <properties file="${ivy.settings.dir}/local.properties"/>
   <properties file="${ivy.settings.dir}/../target/omero.version"/>
-  <property name="maven.repo.local" value="${user.home}/.m2/repository/"
+  <property name="local-maven2-dir" value="${user.home}/.m2/repository/"
+      override="false"/> <!-- deprecated - use maven.repo.local instead -->
+  <property name="maven.repo.local" value="${local-maven2-dir}"
       override="false"/>
 
   <settings defaultResolver="${omero.resolver}"/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -16,7 +16,7 @@
   <properties file="${ivy.settings.dir}/build.properties"/>
   <properties file="${ivy.settings.dir}/local.properties"/>
   <properties file="${ivy.settings.dir}/../target/omero.version"/>
-  <property name="local-maven2-dir" value="${user.home}/.m2/repository/"
+  <property name="maven.repo.local" value="${user.home}/.m2/repository/"
       override="false"/>
 
   <settings defaultResolver="${omero.resolver}"/>
@@ -29,7 +29,7 @@
            while maven is for any stable, unchanging jar that is being
            downloaded -->
       <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"/>
-      <cache name="maven" basedir="${local-maven2-dir}"
+      <cache name="maven" basedir="${maven.repo.local}"
         artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"
         ivyPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].xml"
         lockStrategy="artifact-lock"
@@ -56,10 +56,10 @@
           checkmodified="true" changingMatcher="regexp"
           changingPattern=".*SNAPSHOT.*"
           cache="local" descriptor="required">
-        <artifact pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
-        <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[artifact]-[revision].xml"/>
+        <artifact pattern="${maven.repo.local}/[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"/>
+        <ivy pattern="${maven.repo.local}/[orgPath]/[module]/[revision]/[artifact]-[revision].xml"/>
         <!-- Ivy pattern for artifacts installed locally via Maven -->
-        <ivy pattern="${local-maven2-dir}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
+        <ivy pattern="${maven.repo.local}/[orgPath]/[module]/[revision]/[module]-[revision].pom"/>
       </filesystem>
 
       <!-- Remote downloads; cached to '~/.m2/repository' -->


### PR DESCRIPTION
## What this PR does

This PR primarily adds the ability to control the parameter defining the local Maven repository used for retrieving and storing the JARs during the build of the Java components. An [Ivy property](http://ant.apache.org/ivy/history/latest-milestone/settings/property.html) had been previously defined but was not externally settable without modifying `etc/ivysettings.xml`.

7220b43 sets the `override` attribute to `true` so that the `local-maven2-dir` property can be overriden in command-line or via `etc/local.properties`. 4dd2745 and 9053637 additionally deprecate this property and introduce a new property, `maven.repo.local` in agreement with the Maven naming scheme, allowing to control the local Maven repository.

## Testing this PR

### Without this PR

Prior to testing, rename your local Maven repository as `~/.m2.bak`. Without this PR, any of the command below should lead to the Java artifacts retrieved under the default `~/.m2/repository`.

- `./build.py -Dlocal-maven2-dir=/tmp/.m2/repository build-dev`
- `echo "local-maven2-dir=/tmp/.m2/repository2" > etc/local.properties && ./build.py build-dev`

### With this PR:

Run all or part of the following commands:

- `./build.py -Dlocal-maven2-dir=/tmp/.m2/repository1 build-dev`
- `./build.py -Dmaven.repo.local=/tmp/.m2/repository2 build-dev`
- `echo "local-maven2-dir=/tmp/.m2/repository3" > etc/local.properties && ./build.py build-dev`
- `echo "maven.repo.local=/tmp/.m2/repository4" > etc/local.properties && ./build.py build-dev`

In all cases above, the Java artifacts should be stored in the correct temporary location.

## Related reading

Under some conditions, non-defaut Maven repository needs to be specified for building OMERO. See https://github.com/ome/homebrew-alt/pull/136 for a use case.