### PR TITLE
fix script upload check for light admins

### DIFF
--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -2054,7 +2054,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
     /**
      * Test that users may write official scripts only if they are a member of the <tt>system</tt> group and
      * have the <tt>WriteScriptRepo</tt> privilege.
-     * Attempts creation of a file in another user's group via {@link omero.api.IScriptPrx#uploadOfficialScript(String, String)}.
+     * Attempts creation of a file in the <q>user</q> group via {@link omero.api.IScriptPrx#uploadOfficialScript(String, String)}.
      * @param isAdmin if to test a member of the <tt>system</tt> group
      * @param isRestricted if to test a user who does <em>not</em> have the <tt>WriteScriptRepo</tt> privilege
      * @param isSudo if to test attempt to subvert privilege by sudo to an unrestricted member of the <tt>system</tt> group
@@ -2072,10 +2072,9 @@ public class LightAdminPrivilegesTest extends RolesTests {
         rfs.setFileId(scriptFile.getId().getValue());
         final String actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        /* try uploading the script as a new script in the normal user's group */
+        /* try uploading the script as a new script */
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
-        client.getImplicitContext().put(Login.OMERO_GROUP, Long.toString(normalUser.groupId));
         iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         long testScriptId = -1;


### PR DESCRIPTION
# What this PR does

@pwalczysko noticed that light admins can upload official scripts *without* `WriteScriptRepo` privilege. This PR fixes the issue and adjusts the existing integration testing to detect regressions.

# Testing this PR

Check that `WriteScriptRepo` privilege is required for writing official scripts.

# Related reading

https://trello.com/c/7xa7ggwp/111-bug-every-light-admin-can-upload-script