### PR TITLE
enhance setting canChgrp, canChown permissions bits

### DIFF
--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -610,20 +610,16 @@ public class BasicACLVoter implements ACLVoter {
      * @return the permissions integer, possibly adjusted
      */
     private int addChgrpChownRestrictionBits(Class<? extends IObject> objectClass, Details details, int allow) {
-        if (details.getOwner() == null || details.getGroup() == null) {
-            /* probably a system type, either way we cannot judge on this basis */
-            return allow;
-        }
         final EventContext ec = currentUser.getCurrentEventContext();
         final Set<AdminPrivilege> privileges = ec.getCurrentAdminPrivileges();
         final boolean isChgrpPrivilege = privileges.contains(adminPrivileges.getPrivilege(AdminPrivilege.VALUE_CHGRP));
         final boolean isChownPrivilege = privileges.contains(adminPrivileges.getPrivilege(AdminPrivilege.VALUE_CHOWN));
         final int chgrpBit = 1 << Permissions.CHGRPRESTRICTION;
         final int chownBit = 1 << Permissions.CHOWNRESTRICTION;
-        if (isChgrpPrivilege || ec.getCurrentUserId().equals(details.getOwner().getId())) {
+        if (isChgrpPrivilege || details.getOwner() != null && ec.getCurrentUserId().equals(details.getOwner().getId())) {
             allow |= chgrpBit;
         }
-        if (isChownPrivilege || ec.getLeaderOfGroupsList().contains(details.getGroup().getId())) {
+        if (isChownPrivilege || details.getGroup() != null && ec.getLeaderOfGroupsList().contains(details.getGroup().getId())) {
             allow |= chownBit;
         }
         if ((allow & chgrpBit) > 0 && !chgrpPermittedClasses.isEmpty()) {

--- a/components/tools/OmeroJava/test/integration/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTest.java
@@ -4,12 +4,20 @@
  */
 package integration;
 
+import java.util.Map;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import omero.RBool;
+import omero.RMap;
+import omero.RType;
 import omero.model.CommentAnnotationI;
 import omero.model.DetailsI;
+import omero.model.Permissions;
 import omero.model.PermissionsI;
+import omero.sys.EventContext;
+import omero.sys.ParametersI;
 
 /**
  * Tests for the updated group permissions of 4.3 and 4.4.
@@ -66,4 +74,44 @@ public class PermissionsTest extends AbstractServerTest {
         Assert.assertNotNull(d.getEventContext());
     }
 
+    /**
+     * Test that {@link omero.api.IQueryPrx#get(String, long)} returns object permissions reporting that the <tt>root</tt> user
+     * <q>can</q> do everything.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testRootCanPermissionsByGet() throws Exception {
+        final EventContext normalUser = newUserAndGroup("rwr---");
+        final long projectId = iUpdate.saveAndReturnObject(mmFactory.simpleProject()).getId().getValue();
+        logRootIntoGroup(normalUser.groupId);
+        final Permissions projectPerms = iQuery.get("Project", projectId).getDetails().getPermissions();
+        Assert.assertTrue(projectPerms.canEdit());
+        Assert.assertTrue(projectPerms.canAnnotate());
+        Assert.assertTrue(projectPerms.canLink());
+        Assert.assertTrue(projectPerms.canDelete());
+        Assert.assertTrue(projectPerms.canChgrp());
+        Assert.assertTrue(projectPerms.canChown());
+    }
+
+    /**
+     * Test that {@link omero.api.IQueryPrx#projection(String, omero.sys.Parameters)} returns object permissions reporting that the
+     * <tt>root</tt> user <q>can</q> do everything.
+     * @throws Exception unexpected
+     */
+    @Test(groups = "broken")
+    public void testRootCanPermissionsByProjection() throws Exception {
+        final EventContext normalUser = newUserAndGroup("rwr---");
+        final long projectId = iUpdate.saveAndReturnObject(mmFactory.simpleProject()).getId().getValue();
+        logRootIntoGroup(normalUser.groupId);
+        final Map<String, RType> queriedMap = ((RMap) iQuery.projection(
+                "SELECT new map(project AS project_details_permissions) FROM Project AS project WHERE project.id = :id",
+                new ParametersI().addId(projectId)).get(0).get(0)).getValue();
+        final Map<String, RType> projectPermsMap = ((RMap) queriedMap.get("project_details_permissions")).getValue();
+        Assert.assertTrue(((RBool) projectPermsMap.get("canEdit")).getValue());
+        Assert.assertTrue(((RBool) projectPermsMap.get("canAnnotate")).getValue());
+        Assert.assertTrue(((RBool) projectPermsMap.get("canLink")).getValue());
+        Assert.assertTrue(((RBool) projectPermsMap.get("canDelete")).getValue());
+        Assert.assertTrue(((RBool) projectPermsMap.get("canChgrp")).getValue());
+        Assert.assertTrue(((RBool) projectPermsMap.get("canChown")).getValue());
+    }
 }

--- a/components/tools/OmeroJava/test/integration/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTest.java
@@ -98,7 +98,7 @@ public class PermissionsTest extends AbstractServerTest {
      * <tt>root</tt> user <q>can</q> do everything.
      * @throws Exception unexpected
      */
-    @Test(groups = "broken")
+    @Test
     public void testRootCanPermissionsByProjection() throws Exception {
         final EventContext normalUser = newUserAndGroup("rwr---");
         final long projectId = iUpdate.saveAndReturnObject(mmFactory.simpleProject()).getId().getValue();

--- a/components/tools/OmeroJava/test/integration/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTest.java
@@ -5,6 +5,8 @@
 package integration;
 
 import org.testng.Assert;
+import org.testng.annotations.Test;
+
 import omero.model.CommentAnnotationI;
 import omero.model.DetailsI;
 import omero.model.PermissionsI;
@@ -22,6 +24,7 @@ public class PermissionsTest extends AbstractServerTest {
     /*
      * See #8277 permissions returned from the server should now be immutable.
      */
+    @Test
     public void testImmutablePermissions() throws Exception {
 
         // Test on the raw object
@@ -45,12 +48,14 @@ public class PermissionsTest extends AbstractServerTest {
         }
     }
 
+    @Test
     public void testDisallow() {
         PermissionsI p = new omero.model.PermissionsI();
         Assert.assertTrue(p.canAnnotate());
         Assert.assertTrue(p.canEdit());
     }
 
+    @Test
     public void testClientSet() throws Exception {
         CommentAnnotationI c = new omero.model.CommentAnnotationI();
         c = (CommentAnnotationI) this.iUpdate.saveAndReturnObject(c);


### PR DESCRIPTION
# What this PR does

Activates some existing permissions testing and adds further simple integration testing for `canChgrp`, `canChown`. Also has ACL voter less willing to give up on setting those bits.

# Testing this PR

CI should be green and new tests should make sense. See https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/PermissionsTest/.

# Related reading

https://trello.com/c/QbdB9M8k/115-canchgrp-canchown-bug