### PR TITLE
Fix empty project filter

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -466,6 +466,11 @@ $(document).ready(function() {
             $("#dataIcons li.row").each(function(){
                 iids.push($(this).attr("data-id"));
             });
+            // Check to ensure images are available for filtering
+            if (iids.length === 0) {
+                // No images to filter
+                return;
+            }
             var query = "image=" + iids.join("&image=");
             $.getJSON("{% url 'api_annotations' %}?type=rating&" + query, function(data){
                 // map imageId to rating... rdata = {'iid': hide?}
@@ -502,6 +507,11 @@ $(document).ready(function() {
             $("#dataIcons li.row").each(function(){
                 iids.push($(this).attr("data-id"));
             });
+            // Check to ensure images are available for filtering
+            if (iids.length === 0) {
+                // No images to filter
+                return;
+            }
             var query = "image=" + iids.join("&image=");
             // get ratings...
             $.getJSON("{% url 'api_annotations' %}?type=rating&" + query, function(data){

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1164,8 +1164,6 @@ def api_annotations(request, conn=None, **kwargs):
 
     ann_type = r.get('type', None)
 
-    image_ids = [i for i in image_ids if i != '']
-
     anns, exps = tree.marshal_annotations(conn, project_ids=project_ids,
                                           dataset_ids=dataset_ids,
                                           image_ids=image_ids,

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -119,6 +119,11 @@ def get_long_or_default(request, name, default):
     return val
 
 
+def get_list(request, name):
+    val = request.GET.getlist(name)
+    return [i for i in val if i != '']
+
+
 def get_longs(request, name):
     warnings.warn(
         "Deprecated. Use omeroweb.webgateway.util.get_longs()",
@@ -1147,17 +1152,19 @@ def api_tags_and_tagged_list_DELETE(request, conn=None, **kwargs):
 def api_annotations(request, conn=None, **kwargs):
 
     r = request.GET
-    image_ids = r.getlist('image')
-    dataset_ids = r.getlist('dataset')
-    project_ids = r.getlist('project')
-    screen_ids = r.getlist('screen')
-    plate_ids = r.getlist('plate')
-    run_ids = r.getlist('acquisition')
-    well_ids = r.getlist('well')
+    image_ids = get_list(request, 'image')
+    dataset_ids = get_list(request, 'dataset')
+    project_ids = get_list(request, 'project')
+    screen_ids = get_list(request, 'screen')
+    plate_ids = get_list(request, 'plate')
+    run_ids = get_list(request, 'acquisition')
+    well_ids = get_list(request, 'well')
     page = get_long_or_default(request, 'page', 1)
     limit = get_long_or_default(request, 'limit', settings.PAGE)
 
     ann_type = r.get('type', None)
+
+    image_ids = [i for i in image_ids if i != '']
 
     anns, exps = tree.marshal_annotations(conn, project_ids=project_ids,
                                           dataset_ids=dataset_ids,


### PR DESCRIPTION
Adds fix to prevent a crash, due to a null encoded unicode string, when a user adds a filter _by rating_ to the centre grid when the **project** contains **no** images. 

### Testing

1. Create, or select, an empty project in the left hand tree
2. Select the filter dropdown on the centre grid and select to filter _by rating_
3. Nothing should happen (i.e. no exception should be thrown) 

### Links

Link to trello card:
https://trello.com/c/bLB0NdVw/116-error-when-selecting-unrated-in-the-centre-panel-in-an-empty-tree-container-eg-mapr-empty-dataset
