### PR TITLE
Reverse intensity rename Insight/Web

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ReverseIntensityAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/actions/ReverseIntensityAction.java
@@ -55,7 +55,7 @@ public class ReverseIntensityAction
 {
 
     /** The name of the action. */
-    private static final String NAME = "Reverse Intensity";
+    private static final String NAME = "Invert";
     
     /** The description of the action. */
     private static final String DESCRIPTION = "";

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/colourpicker/TabbedPaneUI.java
@@ -204,8 +204,8 @@ class TabbedPaneUI
         };
         colourSwatchButton.addActionListener(action);
         
-        revIntButton = new JCheckBox("Reverse Intensity");
-        revIntButton.setToolTipText("Reverse this channel's intensity");
+        revIntButton = new JCheckBox("Invert");
+        revIntButton.setToolTipText("Invert this channel's intensity");
         revIntButton.setSelected(control.getReverseIntensity());
         revIntButton.addActionListener(new ActionListener() {
             @Override

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.colorbtn.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.colorbtn.js
@@ -58,7 +58,7 @@ $.fn.colorbtn = function(cfg) {
       box.postit();
 
       var reverseIntensityHtml = '<div><input id="reverseIntensity" type="checkbox" style="width:20px"></input>';
-          reverseIntensityHtml += '<label for="reverseIntensity" style="font-size:15px; font-weight: normal;">Reverse Intensity</label></div>';
+          reverseIntensityHtml += '<label for="reverseIntensity" style="font-size:15px; font-weight: normal;">Invert</label></div>';
           reverseIntensityHtml += '<div style="clear:both"></div>';
       $(reverseIntensityHtml).appendTo(box);
 


### PR DESCRIPTION
# What this PR does

Simply renames the 'Reverse Intensity' checkbox to 'Invert' in Insight and Web UI.
Doesn't change anything codewise (method/variable names, documentation, etc.)

# Testing this PR

See above.

# Related reading

https://trello.com/c/AN7eXyM3/19-rename-in-viewers-reverse-intensity

