### PR TITLE
Deprecate ReverseIntensityMap/Context

### DIFF
--- a/components/common/src/omeis/providers/re/codomain/ReverseIntensityContext.java
+++ b/components/common/src/omeis/providers/re/codomain/ReverseIntensityContext.java
@@ -18,7 +18,7 @@ package omeis.providers.re.codomain;
  * @version 2.2
  * @since OME2.2
  * 
- * @deprecated This class will be renamed to InvertIntensityContext (or similar) in
+ * @deprecated This class will be renamed to InverseIntensityContext (or similar) in
  *             future versions
  */
 public class ReverseIntensityContext extends CodomainMapContext {

--- a/components/common/src/omeis/providers/re/codomain/ReverseIntensityContext.java
+++ b/components/common/src/omeis/providers/re/codomain/ReverseIntensityContext.java
@@ -17,6 +17,9 @@ package omeis.providers.re.codomain;
  *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
+ * 
+ * @deprecated This class will be renamed to InvertIntensityContext (or similar) in
+ *             future versions
  */
 public class ReverseIntensityContext extends CodomainMapContext {
 

--- a/components/common/src/omeis/providers/re/codomain/ReverseIntensityMap.java
+++ b/components/common/src/omeis/providers/re/codomain/ReverseIntensityMap.java
@@ -9,7 +9,7 @@ package omeis.providers.re.codomain;
 
 /**
  * Reverses the intensity levels of an image. It produces the equivalent of a
- * photographic negative. This type of transformation is suited fo enhancing
+ * photographic negative. This type of transformation is suited for enhancing
  * white or gray details embedded in dark regions of an image, especially when
  * the black areas are dominant in size.
  * 
@@ -21,6 +21,9 @@ package omeis.providers.re.codomain;
  *         href="mailto:a.falconi@dundee.ac.uk"> a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
+ * 
+ * @deprecated This class will be renamed to InvertCodomainMap (or similar) in
+ *             future versions
  */
 class ReverseIntensityMap implements CodomainMap {
 

--- a/components/common/src/omeis/providers/re/codomain/ReverseIntensityMap.java
+++ b/components/common/src/omeis/providers/re/codomain/ReverseIntensityMap.java
@@ -22,7 +22,7 @@ package omeis.providers.re.codomain;
  * @version 2.2
  * @since OME2.2
  * 
- * @deprecated This class will be renamed to InvertCodomainMap (or similar) in
+ * @deprecated This class will be renamed to InverseIntensityMap (or similar) in
  *             future versions
  */
 class ReverseIntensityMap implements CodomainMap {


### PR DESCRIPTION
# What this PR does

Deprecate 'ReverseIntensityMap' and 'ReverseIntensityContext'; added warning that these classes will be renamed in future

# Related reading

https://trello.com/c/AN7eXyM3/19-rename-in-viewers-reverse-intensity

Is that everything or are there more classes/methods to be renamend @jburel ?
