### PR TITLE
Unwrap PermDetails for canChgrp/canChown detection

### DIFF
--- a/components/model/src/ome/util/PermDetails.java
+++ b/components/model/src/ome/util/PermDetails.java
@@ -59,6 +59,15 @@ public class PermDetails implements IObject {
         this.context = context;
     }
 
+    /**
+     * In order to properly test the permissions for this object, it must be
+     * possible to get the internal context. This is for use by the security
+     * system only.
+     */
+    public IObject getInternalContext() {
+        return this.context;
+    }
+
     //
     // DELEGATE METHODS
     //

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -40,6 +40,7 @@ import ome.security.policy.PolicyService;
 import ome.system.EventContext;
 import ome.system.Roles;
 import ome.tools.hibernate.HibernateUtils;
+import ome.util.PermDetails;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Session;
@@ -655,6 +656,12 @@ public class BasicACLVoter implements ACLVoter {
 
     public void postProcess(IObject object) {
         if (object.isLoaded()) {
+            if (object instanceof PermDetails) {
+                object = ((PermDetails) object).getInternalContext();
+                if (!object.isLoaded()) {
+                    return; // EARLY EXIT
+                }
+            }
             Details details = object.getDetails();
             // Sets context values.
             this.currentUser.applyContext(details,


### PR DESCRIPTION
PermDetails objects are being passed to the BasicACLVoter.postProcess
method when `new map(x_details_permissions)` is used in the HQL query.
Not having access to the original object confuses the security system
leading to incorrect can* values. This permits unwrapping of internal
PermDetails instances.

See:

 * https://github.com/openmicroscopy/openmicroscopy/pull/3910
 * https://trello.com/c/QbdB9M8k/115-canchgrp-canchown-bug

# What this PR does

 * Makes the permission flags of `IQuery.projection(new map(...))` match those of `IQuery.get(...)`, e.g.

```
In [27]: q.get("Project", 1).getDetails().getPermissions().canChgrp()
Out[27]: True

In [28]: q.projection("select new map(p as p_details_permissions) from Project p where p.id = 1", None)[0][0]._val.values()[0]._val["canChgrp"]._val
Out[28]: True
```

# Testing this PR

1. create a single object (e.g. Project) belonging to root
2. load canChrp in the two ways shown above
3. compare that `True` is returned in both cases


# Related reading

1. https://trello.com/c/QbdB9M8k/115-canchgrp-canchown-bug
2. https://github.com/openmicroscopy/openmicroscopy/pull/5431