### PR TITLE
jsonp_server_id_fix (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1683,7 +1683,6 @@ def projectDetail_json(request, pid, conn=None, **kwargs):
     return rv
 
 
-@login_required()
 @jsonp
 def open_with_options(request, **kwargs):
     """

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1286,7 +1286,7 @@ def jsonp(f):
         logger.debug('jsonp')
         try:
             server_id = kwargs.get('server_id', None)
-            if server_id is None:
+            if server_id is None and request.session.get('connector'):
                 server_id = request.session['connector'].server_id
             kwargs['server_id'] = server_id
             rv = f(request, *args, **kwargs)


### PR DESCRIPTION
This is the same as gh-5433 but rebased onto metadata53.

**This reverts https://github.com/openmicroscopy/openmicroscopy/pull/5343 and replaces it with the mainline fix https://github.com/openmicroscopy/openmicroscopy/pull/5433**

----

# What this PR does

Fixes issue with ```@jsonp``` decorator when used without ```@login_required```, as reported from IDR and fixed in #5343 with a different solution. Also discussed in #5371(un-merged rebase of #5343). 

# Testing this PR

1. Log out of webclient

2. Go to ```/webgateway/open_with/```

3. Should see JSON data returned, no error message.

# Related reading

The fix in #5343 was to add ```@login_required``` to the ```open_with_options()``` views method, meaning that you had to be logged-in to access ```/webgateway/open_with/```. This works on IDR since public login is automatic, and is likely to be OK elsewhere since you don't really need o access this without being logged-in.
But the fix in this PR is preferred since it fixes a general issue with ```@jsonp``` and allows it to be used elsewhere without also needing ```@login_required```.

cc @manics

                