### PR TITLE
Table data full viewer fix

### DIFF
--- a/components/tests/ui/resources/web/tree.txt
+++ b/components/tests/ui/resources/web/tree.txt
@@ -539,12 +539,17 @@ Click Next Thumbnail
 Click Next Well
     Click Element  xpath=//td[contains(@class, 'well')][contains(@class, 'ui-selected')]/following-sibling::td/img
 
-Click Well By Name
+Double Click Well By Name
     [Arguments]    ${name}
+    Click Well By Name      ${name}         ${true}
+
+Click Well By Name
+    [Arguments]    ${name}      ${doubleClick}=${false}
     Wait Until Page Contains Element    xpath=//td[contains(@class,'well')]/img[@name='${name}']
     # Have to be sure that thumbnail itself has loaded before image is clickable!
     Sleep                               1
-    Click Element                       xpath=//td[contains(@class,'well')]/img[@name='${name}']
+    Run Keyword If      ${doubleClick}      Double Click Element    xpath=//td[contains(@class,'well')]/img[@name='${name}']
+    ...                 ELSE                Click Element           xpath=//td[contains(@class,'well')]/img[@name='${name}']
 
 
 Thumbnail Should Be Selected

--- a/components/tests/ui/testcases/web/view_image.txt
+++ b/components/tests/ui/testcases/web/view_image.txt
@@ -89,6 +89,10 @@ Test Prev Next Buttons
     # Clicking Next button will enable Prev button
     Click Element                       id=nextImage
     Wait Until Page Contains Element    xpath=//button[@id='prevImage' and not (@disabled='disabled')]
+    # Close Popup window for next test
+    Close Window
+    # Select parent window
+    Select Window
 
 
 Test Bulk Annotations

--- a/components/tests/ui/testcases/web/view_image.txt
+++ b/components/tests/ui/testcases/web/view_image.txt
@@ -10,6 +10,12 @@ Library           Collections
 Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
 Suite Teardown      Close all browsers
 
+
+*** Variables ***
+# robot_setup script has created data with these parameters
+${PLATE_NAME}               spwTests
+
+
 *** Keywords ***
 
 Check Image Viewer
@@ -83,3 +89,26 @@ Test Prev Next Buttons
     # Clicking Next button will enable Prev button
     Click Element                       id=nextImage
     Wait Until Page Contains Element    xpath=//button[@id='prevImage' and not (@disabled='disabled')]
+
+
+Test Bulk Annotations
+    [Documentation]     Test display of bulk annotations in viewer (tested in main webclient in spw_test.txt)
+
+    Select Experimenter
+    Select First Plate With Name        ${PLATE_NAME}
+    Select First Run
+    Click Well By Name                  A1
+
+    # Select Image to get Name
+    Wait Until Page Contains Element    xpath=//div[@id='wellImages']//li/a/img[1]
+    Click Element                       xpath=//div[@id='wellImages']//li/a/img[1]
+    ${imgName}=                         Wait For General Panel And Return Name          Image
+
+    Double Click Well By Name           A1
+    Wait Until Keyword Succeeds         ${TIMEOUT}     ${INTERVAL}     Select Window   title=${imgName}
+
+    Click Link                          Image Information
+    Wait Until Element Is Visible       id=bulk-annotations
+    Page Should Contain                 Well Type
+    Page Should Contain                 Control
+    Page Should Contain                 Concentration

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -205,7 +205,7 @@
             {% endif %}
 
             {% if not share %}
-            {% if image %}
+            {% if image and not omeTiffDisabled %}
             <li>
                 <a id="create-ometiff" href="{% url 'ome_tiff_script' image.id %}" 
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -205,7 +205,7 @@
             {% endif %}
 
             {% if not share %}
-            {% if image and not omeTiffDisabled %}
+            {% if image %}
             <li>
                 <a id="create-ometiff" href="{% url 'ome_tiff_script' image.id %}" 
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -103,13 +103,14 @@ def imageMarshal(image, key=None, request=None):
         # ImageWrapper.getDataset() with shares in mind.
         # -- Tue Sep  6 10:48:47 BST 2011 (See #6660)
         parents = image.listParents()
-        if parents is not None and len(parents) == 1:
-            if parents[0].OMERO_CLASS == 'Dataset':
-                ds = parents[0]
-            elif parents[0].OMERO_CLASS == 'WellSample':
-                wellsample = parents[0]
-                if wellsample.well is not None:
-                    well = wellsample.well
+        if parents is not None:
+            datasets = [p for p in parents if p.OMERO_CLASS == 'Dataset']
+            well_smpls = [p for p in parents if p.OMERO_CLASS == 'WellSample']
+            if len(datasets) == 1:
+                ds = datasets[0]
+            if len(well_smpls) == 1:
+                if well_smpls[0].well is not None:
+                    well = well_smpls[0].well
     except omero.SecurityViolation, e:
         # We're in a share so the Image's parent Dataset cannot be loaded
         # or some other permissions related issue has tripped us up.

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/omero_image.js
@@ -327,8 +327,8 @@
 
             var wellsUrl = PLATE_WELLS_URL_999.replace('999', tmp.wellId),
                 linksUrl = PLATE_LINKS_URL_999.replace('999', tmp.wellId);
-            loadBulkAnnotations(wellsUrl, tmp.wellId);
-            loadBulkAnnotations(linksUrl, tmp.wellId);
+            loadBulkAnnotations(wellsUrl, 'Well-' + tmp.wellId);
+            loadBulkAnnotations(linksUrl, 'Well-' + tmp.wellId);
         }
     };
 


### PR DESCRIPTION
# What this PR does

Fixes a bug reported in
https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8345
where the Tables data is not displayed in the full image viewer.

# Testing this PR

1. Create tables data on Sreen AND on a Plate, with rows corresponding to Wells, as described in http://help.openmicroscopy.org/scripts.html#metadata
1. Confirm that this data is shown in webclient right panel under Tables tab when Well is selected
1. Open images from that Well in full image viewer and check that Tables data is shown under "Image Information" popup

<img width="414" alt="screen shot 2017-08-16 at 23 08 38" src="https://user-images.githubusercontent.com/900055/29387460-021edbb0-82d8-11e7-96fd-918223062625.png">

TODO:
 - [ ] Add robot test
