### PR TITLE
Modify group membership only

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -292,51 +292,50 @@ PERMISSION_CHOICES = (
 
 class GroupForm(NonASCIIForm):
 
-    def __init__(self, name_check=False, group_is_current_or_system=False,
+    def __init__(self, name_check=False, group_is_system=False,
                  can_modify_group=True, can_add_member=True, *args, **kwargs):
         super(GroupForm, self).__init__(*args, **kwargs)
         self.name_check = name_check
-        try:
-            if kwargs['initial']['owners']:
-                pass
-            self.fields['owners'] = ExperimenterModelMultipleChoiceField(
-                queryset=kwargs['initial']['experimenters'],
-                initial=kwargs['initial']['owners'], required=False)
-        except:
-            self.fields['owners'] = ExperimenterModelMultipleChoiceField(
-                queryset=kwargs['initial']['experimenters'], required=False)
 
-        try:
-            if kwargs['initial']['members']:
-                pass
-            self.fields['members'] = ExperimenterModelMultipleChoiceField(
-                queryset=kwargs['initial']['experimenters'],
-                initial=kwargs['initial']['members'], required=False)
-        except:
-            self.fields['members'] = ExperimenterModelMultipleChoiceField(
-                queryset=kwargs['initial']['experimenters'], required=False)
+        if can_add_member:
+            try:
+                if kwargs['initial']['owners']:
+                    pass
+                self.fields['owners'] = ExperimenterModelMultipleChoiceField(
+                    queryset=kwargs['initial']['experimenters'],
+                    initial=kwargs['initial']['owners'], required=False)
+            except:
+                self.fields['owners'] = ExperimenterModelMultipleChoiceField(
+                    queryset=kwargs['initial']['experimenters'],
+                    required=False)
+
+            try:
+                if kwargs['initial']['members']:
+                    pass
+                self.fields['members'] = ExperimenterModelMultipleChoiceField(
+                    queryset=kwargs['initial']['experimenters'],
+                    initial=kwargs['initial']['members'], required=False)
+            except:
+                self.fields['members'] = ExperimenterModelMultipleChoiceField(
+                    queryset=kwargs['initial']['experimenters'],
+                    required=False)
 
         self.fields['permissions'] = forms.ChoiceField(
             choices=PERMISSION_CHOICES, widget=forms.RadioSelect(),
             required=True, label="Permissions")
 
-        if group_is_current_or_system:
+        if group_is_system:
             self.fields['name'].widget.attrs['readonly'] = True
             self.fields['name'].widget.attrs['title'] = \
-                "Changing of system groupname would be un-doable"
+                "Changing of system group name would be un-doable"
 
         self.fields.keyOrder = [
             'name', 'description', 'owners', 'members', 'permissions']
 
-        # If we can't modify group, ALL fields are disabled
+        # If we can't modify group, disable fields
         if not can_modify_group:
-            for field in self.fields.values():
+            for name, field in self.fields.items():
                 field.widget.attrs['disabled'] = True
-
-        # If we can't add members, disable owners and members fields
-        if not can_add_member:
-            self.fields['owners'].widget.attrs['disabled'] = True
-            self.fields['members'].widget.attrs['disabled'] = True
 
     name = forms.CharField(
         max_length=100,

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -320,9 +320,19 @@ class GroupForm(NonASCIIForm):
                     queryset=kwargs['initial']['experimenters'],
                     required=False)
 
-        self.fields['permissions'] = forms.ChoiceField(
-            choices=PERMISSION_CHOICES, widget=forms.RadioSelect(),
-            required=True, label="Permissions")
+        if can_modify_group:
+            self.fields['permissions'] = forms.ChoiceField(
+                choices=PERMISSION_CHOICES, widget=forms.RadioSelect(),
+                required=True, label="Permissions")
+
+            self.fields['name'] = forms.CharField(
+                max_length=100,
+                widget=forms.TextInput(attrs={'size': 25,
+                                              'autocomplete': 'off'}))
+            self.fields['description'] = forms.CharField(
+                max_length=250, required=False,
+                widget=forms.TextInput(attrs={'size': 25,
+                                              'autocomplete': 'off'}))
 
         if group_is_system:
             self.fields['name'].widget.attrs['readonly'] = True
@@ -335,15 +345,8 @@ class GroupForm(NonASCIIForm):
         # If we can't modify group, disable fields
         if not can_modify_group:
             for name, field in self.fields.items():
-                field.widget.attrs['disabled'] = True
-
-    name = forms.CharField(
-        max_length=100,
-        widget=forms.TextInput(attrs={'size': 25, 'autocomplete': 'off'}))
-    description = forms.CharField(
-        max_length=250,
-        widget=forms.TextInput(attrs={'size': 25, 'autocomplete': 'off'}),
-        required=False)
+                if name not in ('owners', 'members'):
+                    field.widget.attrs['disabled'] = True
 
     def clean_name(self):
         if self.name_check:

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -295,8 +295,18 @@ class GroupForm(NonASCIIForm):
     def __init__(self, name_check=False, group_is_system=False,
                  can_modify_group=True, can_add_member=True, *args, **kwargs):
         super(GroupForm, self).__init__(*args, **kwargs)
-        self.name_check = name_check
 
+        self.name_check = name_check
+        if can_modify_group:
+
+            self.fields['name'] = forms.CharField(
+                max_length=100,
+                widget=forms.TextInput(attrs={'size': 25,
+                                              'autocomplete': 'off'}))
+            self.fields['description'] = forms.CharField(
+                max_length=250, required=False,
+                widget=forms.TextInput(attrs={'size': 25,
+                                              'autocomplete': 'off'}))
         if can_add_member:
             try:
                 if kwargs['initial']['owners']:
@@ -324,15 +334,6 @@ class GroupForm(NonASCIIForm):
             self.fields['permissions'] = forms.ChoiceField(
                 choices=PERMISSION_CHOICES, widget=forms.RadioSelect(),
                 required=True, label="Permissions")
-
-            self.fields['name'] = forms.CharField(
-                max_length=100,
-                widget=forms.TextInput(attrs={'size': 25,
-                                              'autocomplete': 'off'}))
-            self.fields['description'] = forms.CharField(
-                max_length=250, required=False,
-                widget=forms.TextInput(attrs={'size': 25,
-                                              'autocomplete': 'off'}))
 
         if group_is_system:
             self.fields['name'].widget.attrs['readonly'] = True

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -50,8 +50,8 @@
                     var selected = $.grep($('#id_members').data('chosen').results_data, function(item){
                         return item.value == userId;
                     });
-                    $("#id_owners_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current').find("a").first().unbind("click").remove();
-                    $("#id_members_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current').find("a").first().unbind("click").remove();
+                    $("#id_owners_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current');
+                    $("#id_members_chosen a[data-option-array-index='"+selected[0].options_index+"']").parent().addClass('search-choice-current');
                 }
                 
                 // Since we want to disable removal of 'system' users from chosen, this hides the 'X'

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -136,9 +136,9 @@
             
             
             <input type="submit" 
-                {% if not can_modify_group %}
+                {% if not can_modify_group%}{% if not can_add_member %}
                     disabled title="You don't have permissions to edit Groups"
-                {% endif %}
+                {% endif %}{% endif %}
                 value="{% trans 'Save' %}" />
             <div style="clear: both"></div>
         </div>

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -683,7 +683,7 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
         conn.getAdminService().getSecurityRoles().systemGroupId,
         conn.getAdminService().getSecurityRoles().userGroupId,
         conn.getAdminService().getSecurityRoles().guestGroupId]
-        
+
     initial = {'experimenters': experimenters,
                'permissions': 0}
     group_is_system = False
@@ -698,16 +698,16 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
         initial['permissions'] = getActualPermissions(group)
         group_is_system = long(gid) in system_groups
     if request.method == 'POST':
-        data=request.POST.copy()
+        data = request.POST.copy()
         # name needs to be unique
         old_name = group.name if gid is not None else None
         name_check = conn.checkGroupName(request.POST.get('name'), old_name)
     form = GroupForm(initial=initial,
-        data=data,
-        name_check=name_check,
-        can_modify_group=can_modify_group,
-        can_add_member=can_add_member,
-        group_is_system=group_is_system)
+                     data=data,
+                     name_check=name_check,
+                     can_modify_group=can_modify_group,
+                     can_add_member=can_add_member,
+                     group_is_system=group_is_system)
 
     context = {'form': form}
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -672,58 +672,51 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
     template = "webadmin/group_form.html"
     msgs = []
 
+    user_privileges = conn.getCurrentAdminPrivileges()
+    can_modify_group = 'ModifyGroup' in user_privileges
+    can_add_member = 'ModifyGroupMembership' in user_privileges
+
     experimenters = list(conn.getObjects("Experimenter"))
     experimenters.sort(key=lambda x: x.getLastName().lower())
 
-    def getEditFormContext():
+    system_groups = [
+        conn.getAdminService().getSecurityRoles().systemGroupId,
+        conn.getAdminService().getSecurityRoles().userGroupId,
+        conn.getAdminService().getSecurityRoles().guestGroupId]
+        
+    initial = {'experimenters': experimenters,
+               'permissions': 0}
+    group_is_system = False
+    name_check = False
+    data = None
+    if gid is not None:
         group = conn.getObject("ExperimenterGroup", gid)
-        ownerIds = [e.id for e in group.getOwners()]
-        memberIds = [m.id for m in group.getMembers()]
-        permissions = getActualPermissions(group)
-        can_modify_group = 'ModifyGroup' in conn.getCurrentAdminPrivileges()
-        can_add_member = 'ModifyGroupMembership' in \
-            conn.getCurrentAdminPrivileges()
-        system_groups = [
-            conn.getAdminService().getSecurityRoles().systemGroupId,
-            conn.getAdminService().getSecurityRoles().userGroupId,
-            conn.getAdminService().getSecurityRoles().guestGroupId]
-        group_is_current_or_system = (
-            (conn.getEventContext().groupId == long(gid)) or
-            (long(gid) in system_groups))
-        form = GroupForm(initial={
-            'name': group.name,
-            'description': group.description,
-            'permissions': permissions,
-            'owners': ownerIds,
-            'members': memberIds,
-            'experimenters': experimenters},
-            can_modify_group=can_modify_group,
-            can_add_member=can_add_member,
-            group_is_current_or_system=group_is_current_or_system)
-        admins = [conn.getAdminService().getSecurityRoles().rootId]
-        if long(gid) in system_groups:
-            # prevent removing 'root' or yourself from group if it's a system
-            # group
-            admins.append(conn.getUserId())
-        return {'form': form, 'gid': gid, 'permissions': permissions,
-                'admins': admins, 'can_modify_group': can_modify_group}
+        initial['name'] = group.name
+        initial['description'] = group.description
+        initial['owners'] = [e.id for e in group.getOwners()]
+        initial['members'] = [m.id for m in group.getMembers()]
+        initial['permissions'] = getActualPermissions(group)
+        group_is_system = long(gid) in system_groups
+    if request.method == 'POST':
+        data=request.POST.copy()
+        name_check = conn.checkGroupName(request.POST.get('name'))
+    form = GroupForm(initial=initial,
+        data=data,
+        name_check=name_check,
+        can_modify_group=can_modify_group,
+        can_add_member=can_add_member,
+        group_is_system=group_is_system)
 
-    if action == 'new':
-        can_modify_group = 'ModifyGroup' in conn.getCurrentAdminPrivileges()
-        can_add_member = 'ModifyGroupMembership' in \
-            conn.getCurrentAdminPrivileges()
-        form = GroupForm(initial={'experimenters': experimenters,
-                                  'permissions': 0},
-                         can_add_member=can_add_member)
-        context = {'form': form, 'can_modify_group': can_modify_group}
+    context = {'form': form}
+
+    if action == 'new' or action == 'edit':
+        # form prepared above - nothing else needed
+        pass
     elif action == 'create':
         if request.method != 'POST':
             return HttpResponseRedirect(reverse(viewname="wamanagegroupid",
                                                 args=["new"]))
         else:
-            name_check = conn.checkGroupName(request.POST.get('name'))
-            form = GroupForm(initial={'experimenters': experimenters},
-                             data=request.POST.copy(), name_check=name_check)
             if form.is_valid():
                 logger.debug("Create group form:" + str(form.cleaned_data))
                 name = form.cleaned_data['name']
@@ -735,52 +728,31 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
                 perm = setActualPermissions(permissions)
                 listOfOwners = getSelectedExperimenters(conn, owners)
                 gid = conn.createGroup(name, perm, listOfOwners, description)
-                new_members = getSelectedExperimenters(
-                    conn, mergeLists(members, owners))
-                group = conn.getObject("ExperimenterGroup", gid)
-                conn.setMembersOfGroup(group, new_members)
+                if can_add_member:
+                    new_members = getSelectedExperimenters(
+                        conn, mergeLists(members, owners))
+                    group = conn.getObject("ExperimenterGroup", gid)
+                    conn.setMembersOfGroup(group, new_members)
 
                 return HttpResponseRedirect(reverse("wagroups"))
-            context = {'form': form}
-    elif action == 'edit':
-        context = getEditFormContext()
     elif action == 'save':
-        group = conn.getObject("ExperimenterGroup", gid)
-        can_add_member = 'ModifyGroupMembership' in \
-            conn.getCurrentAdminPrivileges()
-
         if request.method != 'POST':
             return HttpResponseRedirect(reverse(viewname="wamanagegroupid",
                                                 args=["edit", group.id]))
         else:
-            permissions = getActualPermissions(group)
-
-            name_check = conn.checkGroupName(request.POST.get('name'),
-                                             group.name)
-            form = GroupForm(initial={'experimenters': experimenters},
-                             data=request.POST.copy(), name_check=name_check,
-                             can_add_member=can_add_member)
-            context = {'form': form, 'gid': gid, 'permissions': permissions}
             if form.is_valid():
                 logger.debug("Update group form:" + str(form.cleaned_data))
                 name = form.cleaned_data['name']
                 description = form.cleaned_data['description']
-                owners = form.cleaned_data['owners']
                 permissions = form.cleaned_data['permissions']
-                members = form.cleaned_data['members']
 
-                listOfOwners = getSelectedExperimenters(conn, owners)
                 if permissions != int(permissions):
                     perm = setActualPermissions(permissions)
                 else:
                     perm = None
 
-                context = getEditFormContext()
-                context['ome'] = {}
-
                 try:
-                    msgs = conn.updateGroup(group, name, perm, listOfOwners,
-                                            description)
+                    msgs = conn.updateGroup(group, name, perm, description)
                 except omero.SecurityViolation, ex:
                     if ex.message.startswith('Cannot change permissions'):
                         msgs.append("Downgrade to private group not currently"
@@ -790,28 +762,38 @@ def manage_group(request, action, gid=None, conn=None, **kwargs):
 
                 removalFails = []
                 if can_add_member:
+                    owners = form.cleaned_data['owners']
+                    members = form.cleaned_data['members']
+
+                    listOfOwners = getSelectedExperimenters(conn, owners)
+                    conn.updateGroupOwners(group, owners)
                     new_members = getSelectedExperimenters(
                         conn, mergeLists(members, owners))
                     removalFails = conn.setMembersOfGroup(group, new_members)
 
-                if len(removalFails) == 0 and len(msgs) == 0:
-                    return HttpResponseRedirect(reverse("wagroups"))
-                # If we've failed to remove user...
+                    if len(removalFails) == 0 and len(msgs) == 0:
+                        return HttpResponseRedirect(reverse("wagroups"))
 
+                # If we've failed to remove user...
                 # prepare error messages
                 for e in removalFails:
                     url = reverse("wamanageexperimenterid",
                                   args=["edit", e.id])
                     msgs.append("Can't remove user <a href='%s'>%s</a> from"
                                 " their only group" % (url, e.getFullName()))
-                # refresh the form and add messages
-                context = getEditFormContext()
-
     else:
         return HttpResponseRedirect(reverse("wagroups"))
 
     context['userId'] = conn.getEventContext().userId
     context['template'] = template
+    context['can_modify_group'] = can_modify_group
+    context['can_add_member'] = can_add_member
+    context['gid'] = gid
+    # prevent removing 'root' or yourself from group if it's a system group
+    context['admins'] = [conn.getAdminService().getSecurityRoles().rootId]
+    if group_is_system:
+        admins.append(conn.getUserId())
+        return form
 
     if len(msgs) > 0:
         context['ome'] = {}

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1417,7 +1417,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
         # old list of owners
         old_owners = []
-        for oex in up_gr.copyGroupExperimenterMap():
+        for oex in group.copyGroupExperimenterMap():
             if oex is None:
                 continue
             if oex.owner.val:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -103,13 +103,14 @@ def imageMarshal(image, key=None, request=None):
         # ImageWrapper.getDataset() with shares in mind.
         # -- Tue Sep  6 10:48:47 BST 2011 (See #6660)
         parents = image.listParents()
-        if parents is not None and len(parents) == 1:
-            if parents[0].OMERO_CLASS == 'Dataset':
-                ds = parents[0]
-            elif parents[0].OMERO_CLASS == 'WellSample':
-                wellsample = parents[0]
-                if wellsample.well is not None:
-                    well = wellsample.well
+        if parents is not None:
+            datasets = [p for p in parents if p.OMERO_CLASS == 'Dataset']
+            well_smpls = [p for p in parents if p.OMERO_CLASS == 'WellSample']
+            if len(datasets) == 1:
+                ds = datasets[0]
+            if len(well_smpls) == 1:
+                if well_smpls[0].well is not None:
+                    well = well_smpls[0].well
     except omero.SecurityViolation, e:
         # We're in a share so the Image's parent Dataset cannot be loaded
         # or some other permissions related issue has tripped us up.

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -259,11 +259,18 @@ class TestGroups(IWebTest):
         ome_name = exp.omeName.val
         django_client = self.new_django_client(ome_name, ome_name)
 
+        # Only users with "ModifyGroup" see "Create Group" btn on groups page
+        can_modify = 'ModifyGroup' in privileges
+        request_url = reverse('wagroups')
+        rsp = get(django_client, request_url)
+        groups_html = rsp.content
+        assert ('<span>Add new Group</span>' in groups_html) == can_modify
+
+        # Check new group form has correct fields for privileges
         request_url = reverse('wamanagegroupid', args=["new"])
         rsp = get(django_client, request_url)
         form_html = rsp.content
 
-        can_modify = 'ModifyGroup' in privileges
         assert ('name="name"' in form_html) == can_modify
         assert ('name="description"' in form_html) == can_modify
         assert ('name="permissions"' in form_html) == can_modify
@@ -271,3 +278,50 @@ class TestGroups(IWebTest):
         can_add_members = 'ModifyGroupMembership' in privileges
         assert ('name="owners"' in form_html) == can_add_members
         assert ('name="members"' in form_html) == can_add_members
+
+    @pytest.mark.parametrize("permissions",
+                             [["0", [0, 0, 0]],
+                              ["1", [1, 0, 0]],
+                              ["2", [1, 1, 0]],
+                              ["3", [1, 1, 1]],
+                              ])
+    def test_create_group_permissions(self, permissions):
+        """Test simple group creation."""
+        uuid = self.uuid()
+        request_url = reverse('wamanagegroupid', args=["create"])
+        pvalue, perms = permissions
+        data = {
+            "name": uuid,
+            "permissions": pvalue
+        }
+        redirect = post(self.django_root_client, request_url, data,
+                        status_code=302)
+        # Redirect location should be to 'groups' page
+        assert redirect.get('Location').endswith(reverse('wagroups'))
+
+        # Check that group was created
+        admin = self.client.sf.getAdminService()
+        group = admin.lookupGroup(uuid)
+
+        # permissions are: isGroupRead, isGroupAnnotate, isGroupWrite
+        group_perms = group.getDetails().getPermissions()
+        attrs = ("isGroupRead", "isGroupAnnotate", "isGroupWrite")
+        for (p, a) in zip(perms, attrs):
+            assert p == getattr(group_perms, a)()
+
+    @pytest.mark.parametrize("required_field",
+                             [["name", "This field is required"],
+                              ["permissions", "This field is required"]
+                              ])
+    def test_required_fields(self, required_field):
+        """Test form validation with required fields missing."""
+        uuid = self.uuid()
+        request_url = reverse('wamanagegroupid', args=["create"])
+        data = {
+            "name": uuid,
+            "permissions": "0"
+        }
+        field, error = required_field
+        del data[field]
+        rsp = post(self.django_root_client, request_url, data)
+        assert error in rsp.content

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -264,10 +264,10 @@ class TestGroups(IWebTest):
         form_html = rsp.content
 
         can_modify = 'ModifyGroup' in privileges
-        assert ('id="id_name"' in form_html) == can_modify
-        assert ('id="id_description"' in form_html) == can_modify
-        assert ('id="id_permissions"' in form_html) == can_modify
+        assert ('name="name"' in form_html) == can_modify
+        assert ('name="description"' in form_html) == can_modify
+        assert ('name="permissions"' in form_html) == can_modify
 
         can_add_members = 'ModifyGroupMembership' in privileges
-        assert ('id="id_owners"' in form_html) == can_add_members
-        assert ('id="id_members"' in form_html) == can_add_members
+        assert ('name="owners"' in form_html) == can_add_members
+        assert ('name="members"' in form_html) == can_add_members

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -243,3 +243,31 @@ class TestExperimenters(IWebTest):
 
         privileges = [p.getValue().val for p in admin.getAdminPrivileges(exp)]
         assert privileges == ['Chown']
+
+
+class TestGroups(IWebTest):
+    """Test creation and editing of Groups."""
+
+    @pytest.mark.parametrize("privileges",
+                             [['ModifyGroup'],
+                              ['ModifyGroupMembership'],
+                              ['ModifyGroup', 'ModifyGroupMembership']
+                              ])
+    def test_new_group_form(self, privileges):
+        """Form should show correct fields for editing Group / Membership."""
+        exp = self.new_user(privileges=privileges)
+        ome_name = exp.omeName.val
+        django_client = self.new_django_client(ome_name, ome_name)
+
+        request_url = reverse('wamanagegroupid', args=["new"])
+        rsp = get(django_client, request_url)
+        form_html = rsp.content
+
+        can_modify = 'ModifyGroup' in privileges
+        assert ('id="id_name"' in form_html) == can_modify
+        assert ('id="id_description"' in form_html) == can_modify
+        assert ('id="id_permissions"' in form_html) == can_modify
+
+        can_add_members = 'ModifyGroupMembership' in privileges
+        assert ('id="id_owners"' in form_html) == can_add_members
+        assert ('id="id_members"' in form_html) == can_add_members


### PR DESCRIPTION
# What this PR does

Allows restricted Admins with only ```ModifyGroup``` privilege or only ```ModifyGroupMembership``` to use the edit-Group form without problems.
See https://trello.com/c/vX34H2wn/73-lightadmin-and-webadmin-ui

All the form functionality has been refactored, so needs a complete re-test:

# Testing this PR

1. Scenarios for user with only ```ModifyGroup``` privilege:
    - Create new group - Form should only show name, description & permissions (not add owners/members).
    - First omit the group name and Save, then enter the name of an existing group and Save (should see suitable error each time)
    - Then enter all valid details and Save. Should be returned to All Groups table with new Group created
    - Edit the group and try again to enter an existing group name or no group name and check for warnings.
    - Then enter valid new name and Save.
 1. [Now Login as root and create a new user who is ONLY in the above group]
 1. Scenarios for user with ```ModifyGroupMembership``` privilege:
    - Viewing webadmin/groups/ table, should see no "Create Group" button, but can edit groups.
    - Edit the group created above - Form should only show Owners and Members fields.
    - Add yourself and other users to be group members / owners & Save
    - Try to remove the user who is ONLY in this group - should see a suitable warning (and form should refresh to add user back).
    - Should be able to remove yourself from this group (but not from 'system' group).
 1. Scenarios for user with ```ModifyGroup``` AND ```ModifyGroupMembership``` privilege:
    - Create a new Group and add owners & members in one shot
    - Edit Group and Group Membership at the same time, testing Save with various invalid inputs as above.

![screen shot 2017-08-17 at 10 19 11](https://user-images.githubusercontent.com/900055/29405413-bdc596e4-8335-11e7-95da-ab2c6085aa2a.png)

![screen shot 2017-08-17 at 10 14 47](https://user-images.githubusercontent.com/900055/29405420-c301170a-8335-11e7-8400-5e6ef22f1d70.png)
