### PR TITLE
32bit minmax

### DIFF
--- a/components/blitz/resources/omero/Collections.ice
+++ b/components/blitz/resources/omero/Collections.ice
@@ -140,6 +140,7 @@ module omero {
         dictionary<long,   omero::model::Pixels>       LongPixelsMap;
         dictionary<int,    string>                     IntStringMap;
         dictionary<int,    IntegerArray>               IntegerIntegerArrayMap;
+        dictionary<int,    DoubleArray>                IntegerDoubleArrayMap;
         dictionary<string, omero::RType>               StringRTypeMap;
         dictionary<string, omero::model::Experimenter> UserMap;
         dictionary<string, omero::model::OriginalFile> OriginalFileMap;

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -337,7 +337,9 @@ module omero {
                 idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binCount, bool globalRange, omero::romio::PlaneDef plane) throws ServerError;
                 
                 /**
-                 * Find the minimum and maximum pixel values for the specified channels. This method can currently only handle non-pyramid images,
+                 * Find the minimum and maximum pixel values for the specified channels by iterating over a full plane.
+                 * In case of multi-z/t images only the 'middle' plane with index maxZ/2 ,respectively maxT/2 is taken into account.
+                 * Note: This method can currently only handle non-pyramid images,
                  * in which case an empty map will be returned.
                  * @param channels the channels
                  * @return See above.

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -338,7 +338,7 @@ module omero {
                 
                 /**
                  * Find the minimum and maximum pixel values for the specified channels by iterating over a full plane.
-                 * In case of multi-z/t images only the 'middle' plane with index maxZ/2 ,respectively maxT/2 is taken into account.
+                 * In case of multi-z/t images only the 'middle' plane with index maxZ/2, respectively maxT/2 is taken into account.
                  * Note: This method can currently only handle non-pyramid images,
                  * in which case an empty map will be returned.
                  * @param channels the channels

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -337,6 +337,14 @@ module omero {
                 idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binCount, bool globalRange, omero::romio::PlaneDef plane) throws ServerError;
                 
                 /**
+                 * Find the minimum and maximum pixel values for the specified channels. This method can currently only handle non-pyramid images,
+                 * in which case an empty map will be returned.
+                 * @param channels the channels
+                 * @return See above.
+                 **/
+                idempotent IntegerDoubleArrayMap findMinMax(IntegerArray channels) throws ServerError;
+                
+                /**
                  * Returns the byte width for the pixel store.
                  * @return See above.
                  **/

--- a/components/blitz/resources/omero/api/RawPixelsStore.ice
+++ b/components/blitz/resources/omero/api/RawPixelsStore.ice
@@ -339,8 +339,7 @@ module omero {
                 /**
                  * Find the minimum and maximum pixel values for the specified channels by iterating over a full plane.
                  * In case of multi-z/t images only the 'middle' plane with index maxZ/2, respectively maxT/2 is taken into account.
-                 * Note: This method can currently only handle non-pyramid images,
-                 * in which case an empty map will be returned.
+                 * Note: This method can currently only handle non-pyramid images, otherwise an empty map will be returned.
                  * @param channels the channels
                  * @return See above.
                  **/

--- a/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RawPixelsStoreI.java
@@ -13,6 +13,7 @@ import ome.api.RawPixelsStore;
 import ome.services.blitz.util.BlitzExecutor;
 import omero.ServerError;
 import omero.api.AMD_RawPixelsStore_calculateMessageDigest;
+import omero.api.AMD_RawPixelsStore_findMinMax;
 import omero.api.AMD_RawPixelsStore_getByteWidth;
 import omero.api.AMD_RawPixelsStore_getCol;
 import omero.api.AMD_RawPixelsStore_getHistogram;
@@ -249,6 +250,11 @@ public class RawPixelsStoreI extends AbstractPyramidServant implements
             int[] channels, int binCount, boolean globalRange, PlaneDef plane,
             Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, channels, binCount, globalRange, plane);
+    }
+    
+    public void findMinMax_async(AMD_RawPixelsStore_findMinMax __cb,
+            int[] channels, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, channels);
     }
 
     public void getCol_async(AMD_RawPixelsStore_getCol __cb, int x, int z,

--- a/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
+++ b/components/blitz/src/ome/services/blitz/repo/BfPixelsStoreI.java
@@ -21,6 +21,7 @@ import omero.api.AMD_PyramidService_getTileSize;
 import omero.api.AMD_PyramidService_requiresPixelsPyramid;
 import omero.api.AMD_PyramidService_setResolutionLevel;
 import omero.api.AMD_RawPixelsStore_calculateMessageDigest;
+import omero.api.AMD_RawPixelsStore_findMinMax;
 import omero.api.AMD_RawPixelsStore_getByteWidth;
 import omero.api.AMD_RawPixelsStore_getCol;
 import omero.api.AMD_RawPixelsStore_getHistogram;
@@ -350,6 +351,11 @@ public class BfPixelsStoreI extends _RawPixelsStoreDisp {
         throw new UnsupportedOperationException("NYI");
     }
 
+    public void findMinMax_async(AMD_RawPixelsStore_findMinMax __cb,
+            int[] channels, Current __current) throws ServerError {
+        throw new UnsupportedOperationException("NYI");
+    }
+    
     public void activate_async(AMD_StatefulServiceInterface_activate __cb,
             Current __current) throws ServerError {
         throw new UnsupportedOperationException("NYI");

--- a/components/common/src/ome/api/RawPixelsStore.java
+++ b/components/common/src/ome/api/RawPixelsStore.java
@@ -91,7 +91,9 @@ public interface RawPixelsStore extends StatefulServiceInterface {
     public byte[] getCol(int x, int z, int c, int t);
     
     public Map<Integer, int[]> getHistogram(int[] channels, int binCount, boolean globalRange, PlaneDef plane);
-
+    
+    public Map<Integer, double[]> findMinMax(int[] channels);
+    
     public byte[] getHypercube(@Validate(Integer.class) List<Integer> offset, @Validate(Integer.class) List<Integer> size, @Validate(Integer.class) List<Integer> step);
 
     public byte[] getPlaneRegion(int z, int c, int t, int count, int offset);

--- a/components/server/resources/ome/services/service-ome.api.IRenderingSettings.xml
+++ b/components/server/resources/ome/services/service-ome.api.IRenderingSettings.xml
@@ -23,6 +23,7 @@
 		class="ome.logic.RenderingSettingsImpl">
 		<property name="pixelsMetadata" ref="internal-ome.api.IPixels" />
 		<property name="pixelsData" ref="/OMERO/Pixels" />
+		<property name="rawPixStore" ref="internal-ome.api.RawPixelsStore"/>
 	</bean>
 
 	<bean id="managed-ome.api.IRenderingSettings"

--- a/components/server/resources/ome/services/service-ome.api.IRenderingSettings.xml
+++ b/components/server/resources/ome/services/service-ome.api.IRenderingSettings.xml
@@ -23,7 +23,7 @@
 		class="ome.logic.RenderingSettingsImpl">
 		<property name="pixelsMetadata" ref="internal-ome.api.IPixels" />
 		<property name="pixelsData" ref="/OMERO/Pixels" />
-		<property name="rawPixStore" ref="internal-ome.api.RawPixelsStore"/>
+		<property name="rawPixelsStore" ref="internal-ome.api.RawPixelsStore"/>
 	</bean>
 
 	<bean id="managed-ome.api.IRenderingSettings"

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -98,12 +98,6 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     /** Reference to the raw pixels store. */
     private RawPixelsStore rawPixStore;
     
-    /** Pixel types we can't use the global min/max as channel start/end window **/
-    private static final Set<String> minMaxPixelTypes = new HashSet<String>(
-            Arrays.<String> asList(new String[] { PixelsType.VALUE_FLOAT,
-                    PixelsType.VALUE_DOUBLE, PixelsType.VALUE_INT32,
-                    PixelsType.VALUE_UINT32 }));
-
     /**
      * Returns the min/max depending on the pixels type if the values
      * have not seen stored.
@@ -920,9 +914,11 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         
         Map<Integer, double[]> realMinMax = null;
         
-        // for some pixel types the channel window start/end must be set to 
+        StatsInfo stats = pixels.getPrimaryChannel().getStatsInfo();
+        
+        // if there are no stats available the channel window start/end must be set to 
         // reasonable (real min/max) values (note: that only affects non-pyramid images)
-        if (minMaxPixelTypes.contains(pixels.getPixelsType().getValue())) {
+        if (stats == null) {
             int[] channels = new int[pixels.getSizeC()];
             for (int i = 0; i < channels.length; i++)
                 channels[i] = i;

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -919,7 +919,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         // if there are no stats available the channel window start/end must be set to 
         // reasonable (real min/max) values (note: that only affects non-pyramid images)
         if (stats == null) {
-            int[] channels = new int[pixels.getSizeC()];
+            int[] channels = new int[pixels.sizeOfChannels()];
             for (int i = 0; i < channels.length; i++)
                 channels[i] = i;
             
@@ -949,13 +949,12 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
                     min = qs.getPixelsTypeMin();
                     max = qs.getPixelsTypeMax();
                 }
-                cb.setInputStart(new Double(min));
-                cb.setInputEnd(new Double(max));
+                cb.setInputStart(min);
+                cb.setInputEnd(max);
             } else {
                 // use real min/max value of the pixels
                 cb.setInputStart(realMinMax.get(w)[0]);
                 cb.setInputEnd(realMinMax.get(w)[1]);
-                cb.setNoiseReduction(false);
             }
         }
     }

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -943,7 +943,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
         	
             cb = cbs.get(w);
             
-            if (realMinMax == null) {
+            if (realMinMax == null || realMinMax.isEmpty()) {
                 // use global min/max according to pixeltype
                 sf.computeLocationStats(pixels, buf, planeDef, w);
                 cb.setNoiseReduction(sf.isNoiseReduction());

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -96,7 +96,7 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     protected transient IPixels pixelsMetadata;
  
     /** Reference to the raw pixels store. */
-    private RawPixelsStore rawPixStore;
+    private RawPixelsStore rawPixelsStore;
     
     /**
      * Returns the min/max depending on the pixels type if the values
@@ -923,8 +923,8 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             for (int i = 0; i < channels.length; i++)
                 channels[i] = i;
             
-            rawPixStore.setPixelsId(pixels.getId(), true);
-            realMinMax = rawPixStore.findMinMax(channels);
+            rawPixelsStore.setPixelsId(pixels.getId(), true);
+            realMinMax = rawPixelsStore.findMinMax(channels);
         }
         
         StatsFactory sf = new StatsFactory();
@@ -1191,12 +1191,12 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
     /**
      * Sets injector. For use during configuration. Can only be called once.
      * 
-     * @param rawPixStore
+     * @param rawPixelsStore
      *            The value to set.
      */
-    public void setRawPixStore(RawPixelsStore rawPixStore) {
-        getBeanHelper().throwIfAlreadySet(this.rawPixStore, rawPixStore);
-        this.rawPixStore = rawPixStore;
+    public void setRawPixelsStore(RawPixelsStore rawPixelsStore) {
+        getBeanHelper().throwIfAlreadySet(this.rawPixelsStore, rawPixelsStore);
+        this.rawPixelsStore = rawPixelsStore;
     }
 
     /**

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -929,7 +929,6 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             
             rawPixStore.setPixelsId(pixels.getId(), true);
             realMinMax = rawPixStore.findMinMax(channels);
-            rawPixStore.close();
         }
         
         StatsFactory sf = new StatsFactory();

--- a/components/server/src/ome/logic/RenderingSettingsImpl.java
+++ b/components/server/src/ome/logic/RenderingSettingsImpl.java
@@ -942,7 +942,6 @@ public class RenderingSettingsImpl extends AbstractLevel2Service implements
             if (realMinMax == null || realMinMax.isEmpty()) {
                 // use global min/max according to pixeltype
                 sf.computeLocationStats(pixels, buf, planeDef, w);
-                cb.setNoiseReduction(sf.isNoiseReduction());
                 min = sf.getInputStart();
                 max = sf.getInputEnd();
                 if (Math.abs(min - max) < EPSILON) {

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -745,6 +745,30 @@ public class RawPixelsBean extends AbstractStatefulBean implements
         return result;
     }
 
+    @RolesAllowed("user")
+    public synchronized Map<Integer, double[]> findMinMax(int[] channels) {
+        Map<Integer, double[]> result = new HashMap<Integer, double[]>();
+        
+        if (requiresPixelsPyramid())
+            return result;
+
+        try {
+            for (int ch : channels) {
+                Channel channel = pixelsInstance.getChannel(ch);
+                if (channel == null)
+                    continue;
+                int z = buffer.getSizeZ() > 1 ? (buffer.getSizeZ() - 1) / 2 : 0;
+                int t = buffer.getSizeT() > 1 ? (buffer.getSizeT() - 1) / 2 : 0;
+                PixelData px = buffer.getPlane(z, ch, t);
+                double[] minmax = determineHistogramMinMax(px, channel, false);
+                result.put(ch, minmax);
+            }
+        } catch (Exception e) {
+            handleException(e);
+        }
+        return result;
+    }
+    
     // ~ Helpers
     // =========================================================================
     
@@ -788,7 +812,10 @@ public class RawPixelsBean extends AbstractStatefulBean implements
 
         return new double[] { min, max };
     }
-    
+
+    // ~ Helpers
+    // =========================================================================
+
     private synchronized byte[] bufferAsByteArrayWithExceptionIfNull(ByteBuffer buffer) {
         byte[] b = new byte[buffer.capacity()];
         buffer.get(b, 0, buffer.capacity());

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -763,7 +763,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
                 double[] minmax = determineHistogramMinMax(px, channel, false);
                 result.put(ch, minmax);
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             handleException(e);
         }
         return result;

--- a/components/server/src/ome/services/RawPixelsBean.java
+++ b/components/server/src/ome/services/RawPixelsBean.java
@@ -812,10 +812,7 @@ public class RawPixelsBean extends AbstractStatefulBean implements
 
         return new double[] { min, max };
     }
-
-    // ~ Helpers
-    // =========================================================================
-
+    
     private synchronized byte[] bufferAsByteArrayWithExceptionIfNull(ByteBuffer buffer) {
         byte[] b = new byte[buffer.capacity()];
         buffer.get(b, 0, buffer.capacity());


### PR DESCRIPTION
# What this PR does

Adds a new method `findMinMax` to the RawPixelsStore, which gets the minimum and maximum pixel value of an image. This method is used ~~for certain pixel types (e.g. 32bit float)~~ when the `StatsInfo` is not available (e.g. for 32bit float images), to set the channel window start and end to reasonable values. It's called from the `computeLocationStats` method of the RenderingService, so that channel window start/end values are set on import of these kind of images. And for already imported images the clients can trigger it by clicking on the 'Imported' rendering setting button.

# Testing this PR

- Get the example file from https://www.openmicroscopy.org/qa2/qa/feedback/17841/
- Import it and check that a reasonable thumbnail is generated (not just a uniformly gray one) and the image looks ok with the default rendering settings.
- Log in as user-3, pick an image from dataset 'Pre-PR5445' (that's the same images but imported prior to this PR). Reset the rendering settings to 'Imported'. Check again that the proper thumbnail is generated and the image looks ok with these new rendering settings. **Note: Accidentaly uploaded the images to eel latest, so not possible to test that now**

# Related reading

https://trello.com/c/r4cINtil/105-32-bit-images-issue

