### PR TITLE
Travis update (rebased onto metadata53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ omero_version.py
 eclipse.log
 velocity.log*
 .idea
+.vscode

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2183,10 +2183,11 @@ div.paging input.button_pagination {
     position: relative;
 }
 #spw table td.well {
-    background: #eee;
+    background: #fff;
 }
 #spw table td.placeholder {
     vertical-align: top;
+    background: #fff;
 }
 
 #spw table td.ui-selecting { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -329,6 +329,95 @@
         overflow:           auto;
     }
 
+/*******************************************************************/
+/* Left bottom panel - displayed when a user clicks a well in grid */
+/*******************************************************************/
+.left_panel_inner {
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	overflow: auto;
+	border-top: solid 1px hsl(210,10%,85%);
+	border-right: solid 1px hsl(210, 10%, 85%);
+}
+
+.left_panel_inner__header {
+	position: relative;
+	padding: 4px 8px;
+	height: 24px;
+}
+
+.left_panel_inner__close {
+	position: absolute;
+	top: 50%;
+	left: 95%;
+	transform: translate(-50%, -50%);
+}
+
+.left_panel_inner__title--centered {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+}
+
+.left_panel_inner__title--medium {
+	font-size: medium;
+}
+/*******************************************************************/
+/* Well Fields Panel - displayed at the center bottom of a well grid */
+/*******************************************************************/
+.well-fields {
+	bottom: 0;
+	height: 160px; /*160*/
+}
+
+.well-fields__toolbar {
+	position: relative;
+	width: 100%;
+	height: 32px;
+	border-bottom: solid 1px #ddd;
+}
+.well-fields__toolbar-title {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+}
+
+.well-fields__toolbar-tools--left {
+	position: absolute;
+    top: 50%;
+    transform: translate(0, -50%);
+	margin-left: 8px;
+	margin-right: 8px;
+    text-align: center;
+}
+
+.well-fields__images {
+	top: 32px;
+	bottom: 25px;
+	margin: 8px 0;
+}
+
+.wrap-images-tool {
+	width: auto;
+	max-height: 32px;
+}
+
+.wrap-images-tool__input {
+	width: 36px;
+	font-size: medium;
+	font-weight: bold;
+	margin: 4px;
+}
+
+.text--medium {
+	font-size: medium;
+}
+/*******************************************************************/
+
 /*
 	===============================================
 	:: Right Panel

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2269,14 +2269,12 @@ div.paging input.button_pagination {
 #spw table td {
     padding: 1px;
     border: 1px solid #ccc;
-    position: relative;
 }
 #spw table td.well {
     background: #fff;
 }
 #spw table td.placeholder {
     vertical-align: top;
-    background: #fff;
 }
 
 #spw table td.ui-selecting { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -848,6 +848,7 @@
 
     <!-- Panel hidden unless needed for showing spatial birds eye view of Wells - see ome.spwgridview.js -->
     <div id="left_panel_bottom" class="left_panel_inner" style="top: auto; height: 0; border-top: solid 1px hsl(210,10%,85%);">
+        <label style="margin-top: 4px; margin-left: 4px;">Field positions in well</label>
         <a id="hide_well_birds_eye" href="#" class="action" style="position: absolute; right: 3px; top: 0">X</a>
         <div id="well_birds_eye_container">
             <div id="well_birds_eye" class="" style="top: 4px; left: -6px; position: relative; margin:auto; border-right: none; overflow: visible;"></div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -847,11 +847,20 @@
     </div>
 
     <!-- Panel hidden unless needed for showing spatial birds eye view of Wells - see ome.spwgridview.js -->
-    <div id="left_panel_bottom" class="left_panel_inner" style="top: auto; height: 0; border-top: solid 1px hsl(210,10%,85%);">
-        <label style="margin-top: 4px; margin-left: 4px;">Field positions in well</label>
-        <a id="hide_well_birds_eye" href="#" class="action" style="position: absolute; right: 3px; top: 0">X</a>
+{#    <div id="left_panel_bottom" class="left_panel_inner"#}
+{#         style="top: auto; height: 0; border-top: solid 1px hsl(210,10%,85%);">#}
+
+    <div id="left_panel_bottom" class="left_panel_inner">
+        <div class="left_panel_inner__header">
+            <span class="left_panel_inner__title--centered
+                         left_panel_inner__title--medium">
+                Field positions in well
+            </span>
+            <a id="hide_well_birds_eye" class="left_panel_inner__close action" href="#">X</a>
+        </div>
         <div id="well_birds_eye_container">
-            <div id="well_birds_eye" class="" style="top: 4px; left: -6px; position: relative; margin:auto; border-right: none; overflow: visible;"></div>
+            <div id="well_birds_eye" class=""
+                 style="top: 4px; left: -6px; position: relative; margin:auto; border-right: none; overflow: visible;"></div>
         </div>
     </div>
 {% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -334,10 +334,15 @@
     <div class="verticalDragHandle"></div>
 </div>
 <div id="wellImagesContainer" class="wellImages fillSpace" style="bottom: 0px; height: 150px">
-    <div class='fillSpace toolbarBg' style='top: 0; height: 26px; border-bottom: solid 1px #ddd; padding-left:10px'>
-        <span>Wrap</span>
-        <input type="number" id="imagesPerRow" min="0" style="margin: 2px; width: 30px;"/>
-        <span>images per row</span>
+    <div class='fillSpace toolbarBg' style='top: 0; height: 30px; border-bottom: solid 1px #ddd; padding-left:10px;'>
+        <div style="float:left;">
+            <span>Wrap</span>
+            <input type="number" id="imagesPerRow" min="0" style="margin: 2px; width: 30px;"/>
+            <span>images per row</span>
+        </div>
+        <div style='margin-top: 10px; margin-left: auto; margin-right: auto; transform: translate(-80px, 0px); text-align: center;'>
+            <span>Images from each field</span>
+        </div>
     </div>
     <!-- Scrollable container for wellImages -->
     <div id="wellImages" class='fillSpace' style='top: 26px; bottom: 25px'>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -76,13 +76,15 @@
             });
             // Resize Images in Well
             var well_images_size = $('body').data('well_images_size') || 64;
-            $("#wellImages").prop('class', 'fillSpace wellSize' + well_images_size);
+            var prev_well_images_size = well_images_size;
+            $("#wellImages").addClass('class', 'wellSize' + well_images_size);
             $("#wellImages_size_slider").slider({
                 max: 130,
                 min: 30,
                 value: well_images_size,
                 slide: function(event, ui) {
-                    $("#wellImages").prop('class', 'fillSpace wellSize' + ui.value);
+                    $("#wellImages").removeClass('wellSize' + prev_well_images_size).addClass('wellSize' + ui.value);
+                    prev_well_images_size = ui.value;
                 },
                 stop: function(event, ui) {
                     $('body').data('well_images_size', ui.value);
@@ -333,19 +335,21 @@
 <div id="wellImagesDragHandle" class='fillSpace' style="bottom: 150px; overflow: visible">
     <div class="verticalDragHandle"></div>
 </div>
-<div id="wellImagesContainer" class="wellImages fillSpace" style="bottom: 0px; height: 150px">
-    <div class='fillSpace toolbarBg' style='top: 0; height: 30px; border-bottom: solid 1px #ddd; padding-left:10px;'>
-        <div style="float:left;">
-            <span>Wrap</span>
-            <input type="number" id="imagesPerRow" min="0" style="margin: 2px; width: 30px;"/>
-            <span>images per row</span>
+<div id="wellImagesContainer" class="well-fields wellImages fillSpace">
+    <div class="well-fields__toolbar toolbarBg">
+        <div class="well-fields__toolbar-tools--left">
+            <div class="wrap-images-tool">
+                <span class="text--medium">wrap</span>
+                <input class="wrap-images-tool__input" id="imagesPerRow" type="number" min="0" max="99"/>
+                <span class="text--medium">images per row</span>
+            </div>
         </div>
-        <div style='margin-top: 10px; margin-left: auto; margin-right: auto; transform: translate(-80px, 0px); text-align: center;'>
-            <span>Images from each field</span>
+        <div class="well-fields__toolbar-title">
+            <span class="text--medium">Fields from well</span>
         </div>
     </div>
     <!-- Scrollable container for wellImages -->
-    <div id="wellImages" class='fillSpace' style='top: 26px; bottom: 25px'>
+    <div id="wellImages" class="well-fields__images fillSpace">
         <table style="width: 100%"></table>
     </div>
     <div class='fillSpace' style='bottom: 0; height: 25px; border-top: solid 1px #ddd; background: #EFF1F4' >
@@ -354,4 +358,15 @@
             <div id="wellImages_size_slider" class="thumb_size_slider" title="Zoom Plate"></div>
         </div>
     </div>
-</div>   
+</div>
+
+{#<div class='fillSpace toolbarBg' style='top: 0; height: 30px; border-bottom: solid 1px #ddd; padding-left:10px;'>#}
+{#        <div style="float:left;">#}
+{#            <span>Wrap</span>#}
+{#            <input type="number" id="imagesPerRow" min="0" style="margin: 2px; width: 30px;"/>#}
+{#            <span>images per row</span>#}
+{#        </div>#}
+{#        <div style='margin-top: 10px; margin-left: auto; margin-right: auto; transform: translate(-80px, 0px); text-align: center;'>#}
+{#            <span>Fields from well</span>#}
+{#        </div>#}
+{#    </div>#}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -359,14 +359,3 @@
         </div>
     </div>
 </div>
-
-{#<div class='fillSpace toolbarBg' style='top: 0; height: 30px; border-bottom: solid 1px #ddd; padding-left:10px;'>#}
-{#        <div style="float:left;">#}
-{#            <span>Wrap</span>#}
-{#            <input type="number" id="imagesPerRow" min="0" style="margin: 2px; width: 30px;"/>#}
-{#            <span>images per row</span>#}
-{#        </div>#}
-{#        <div style='margin-top: 10px; margin-left: auto; margin-right: auto; transform: translate(-80px, 0px); text-align: center;'>#}
-{#            <span>Fields from well</span>#}
-{#        </div>#}
-{#    </div>#}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -77,7 +77,7 @@
             // Resize Images in Well
             var well_images_size = $('body').data('well_images_size') || 64;
             var prev_well_images_size = well_images_size;
-            $("#wellImages").addClass('class', 'wellSize' + well_images_size);
+            $("#wellImages").addClass('wellSize' + well_images_size);
             $("#wellImages_size_slider").slider({
                 max: 130,
                 min: 30,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -1010,21 +1010,6 @@ li.menu_back a {
 	overflow:hidden;
 }
 
-
-
-	.left_panel_inner {
-	     position: absolute;
-	     left:0;
-	     right:0;
-	     bottom:0;
-	     top:0;
-	     overflow: auto;
-		 border-right:solid 1px hsl(210,10%,85%);
-	 }
-	 
-	 
-	
-
 #center_panel {
     left:0px; right:0px; top:0px; bottom:0px;
 	background:hsl(210,1%,98%);

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.spwgridview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.spwgridview.js
@@ -57,7 +57,7 @@ $(function(){
         });
 
         function showPanel() {
-            var height = 240;
+            var height = 280;
             $left_panel_tabs.css('bottom', height + 'px');
             $left_panel_bottom.css('height', height + 'px');
         }
@@ -65,7 +65,7 @@ $(function(){
         function getPos(attr) {
             return function(ws) {
                 return ws.position[attr] ? ws.position[attr].value : undefined;
-            }
+            };
         }
         function notUndef(p) {
             return p !== undefined;


### PR DESCRIPTION

This is the same as gh-5409 but rebased onto metadata53.

----

# What this PR does

Use trusty to build 
This is necessary to build with newer version of pytables
and newer version of ice

 * building using ``ant`` fails all the time, need to use ``./build.py``.
 * installation of python dependencies needs to be explicitly done via
``sudo apt-get`` during ``before_install:`` otherwise the dependencies will not be available to the container. This means that the python tests will fail with for example ``No module Ice``. Change ``sudo`` option to ``required``. I did not notice an increase in the build time with that change.  See https://github.com/travis-ci/travis-ci/issues/8048
 * update ``numexpr`` via pip to avoid some table test failure  e.g.
``test/unit/tablestest/test_servants.py:349:`` will fail with ``ValueError: Using `oa_ndim == 0` when `op_axes` is NULL. Use `oa_ndim == -1` or the MultiNew iterator for NumPy <1.8 compatibility``



# Testing this PR
Check that travis is green

See https://trello.com/c/gVsUkLH8/100-travis-upgrade

                