### PR TITLE
webgateway: make sure TIFF exports result in actual TIFF-formatted data

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -969,9 +969,14 @@ def render_image(request, iid, z=None, t=None, conn=None, **kwargs):
             jpeg_data = output.getvalue()
             output.close()
             rsp = HttpResponse(jpeg_data, content_type='image/png')
-        # don't seem to need to do this for tiff
         elif format == 'tif':
-            rsp = HttpResponse(jpeg_data, content_type='image/tif')
+            # convert jpeg data to TIFF
+            i = Image.open(StringIO(jpeg_data))
+            output = StringIO()
+            i.save(output, 'tiff')
+            jpeg_data = output.getvalue()
+            output.close()
+            rsp = HttpResponse(jpeg_data, content_type='image/tiff')
         fileName = img.getName().decode('utf8').replace(" ", "_")
         fileName = fileName.replace(",", ".")
         rsp['Content-Type'] = 'application/force-download'


### PR DESCRIPTION
# What this PR does

(On behalf of @melissalinkert)

This pretty much copies the logic for PNG export to the TIFF export case, so that the resulting exported file is a real TIFF and not a JPEG with the TIFF extension.

**Note:** As both PNG and TIFF export **recompress** the already JPEG compressed data stream it is somewhat at odds with the likely user expectation. It would be better to compress the raw output from the rendering engine but this is outside the scope of this PR.

# Testing this PR

Import any image and then open in web. Click the download arrow in the right-hand panel and then select "Export as TIFF". The downloaded file should have the .tif extension and be a valid TIFF rather than a JPEG.

Without this change, running the file command on the downloaded file should indicate that the file is in fact a JPEG. After the same test with this change, the file command should show that the file is now a TIFF as expected.

# Related reading

N/A

/cc @jburel 