### PR TITLE
Rendering engine bulk settings update

### DIFF
--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -475,13 +475,25 @@ module omero {
                  * definition and associated sub-objects.
                  * @param settings Rendering definition to copy from. Each sub-object
                  * will be processed as though the specific method was called with
-                 * related attributes provided as arguments.
-                 *
+                 * related attributes provided as arguments. The following methods are
+                 * called underneath: <ul>
+                 * <li>{@link RenderingEngine#setModel(RenderingModel)}</li>
+                 * <li>{@link RenderingEngine#setDefaultZ(int)}</li>
+                 * <li>{@link RenderingEngine#setDefaultT(int)}</li>
+                 * <li>{@link RenderingEngine#setQuantumStrategy(int)}</li>
+                 * <li>{@link RenderingEngine#setCodomainInterval(int, int)}</li>
+                 * <li>{@link RenderingEngine#setActive(int, boolean)}</li>
+                 * <li>{@link RenderingEngine#setChannelWindow(int, double, double)}</li>
+                 * <li>{@link RenderingEngine#setQuantizationMap(int, Family, double, boolean)}</li>
+                 * <li>{@link RenderingEngine#setRGBA(int, int, int, int, int)}</li>
+                 * <li>{@link RenderingEngine#setChannelLookupTable(int, String)}</li>
+                 * </ul>
                  * If one or more attributes that apply to a particular method are
-                 * null it will be skipped. The underlying Renderer is not able 
-                 * to handle partial field updates.
-                 *
-                 * NOTE: Codomain mappings are ignored.
+                 * <code>null</code> it will be <b>skipped</b> in its entirety. The
+                 * underlying Renderer is not able to handle partial field updates.
+                 * Furthermore, {@link ChannelBinding}s that are <code>null</code> and
+                 * indexes in the {@link RenderingDef#WAVERENDERING} array greater than the
+                 * currently looked up {@link Pixels#SIZEC} will be skipped.
                  */
                 idempotent void updateSettings(omero::model::RenderingDef settings) throws ServerError;
 

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -491,9 +491,10 @@ module omero {
                  * If one or more attributes that apply to a particular method are
                  * <code>null</code> it will be <b>skipped</b> in its entirety. The
                  * underlying Renderer is not able to handle partial field updates.
-                 * Furthermore, {@link ChannelBinding}s that are <code>null</code> and
-                 * indexes in the {@link RenderingDef#WAVERENDERING} array greater than the
-                 * currently looked up {@link Pixels#SIZEC} will be skipped.
+                 * Furthermore, {@link ome.model.display.ChannelBinding} references that are
+                 * <code>null</code> and indexes in the {@link RenderingDef#WAVERENDERING}
+                 * array greater than the currently looked up {@link Pixels#SIZEC} will be
+                 * skipped.
                  */
                 idempotent void updateSettings(omero::model::RenderingDef settings) throws ServerError;
 

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -470,6 +470,16 @@ module omero {
                  */
                 void removeCodomainMapFromChannel(omero::romio::CodomainMapContext mapCtx, int w) throws ServerError;
 
+                /**
+                 * Updates the current rendering settings based on a provided rendering
+                 * definition and associated sub-objects.
+                 * @param settings Rendering definition to copy from. Each sub-object
+                 * will be processed as though the specific method was called with
+                 * related attributes provided as arguments. NOTE: Codomain
+                 * mappings are ignored.
+                 */
+                idempotent void updateSettings(omero::model::RenderingDef settings) throws ServerError;
+
                 /** Saves the current rendering settings in the database. */
                 void saveCurrentSettings() throws ServerError;
 

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -475,8 +475,13 @@ module omero {
                  * definition and associated sub-objects.
                  * @param settings Rendering definition to copy from. Each sub-object
                  * will be processed as though the specific method was called with
-                 * related attributes provided as arguments. NOTE: Codomain
-                 * mappings are ignored.
+                 * related attributes provided as arguments.
+                 *
+                 * If one or more attributes that apply to a particular method are
+                 * null it will be skipped. The underlying Renderer is not able 
+                 * to handle partial field updates.
+                 *
+                 * NOTE: Codomain mappings are ignored.
                  */
                 idempotent void updateSettings(omero::model::RenderingDef settings) throws ServerError;
 

--- a/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RenderingEngineI.java
@@ -65,6 +65,7 @@ import omero.api.AMD_RenderingEngine_setQuantizationMap;
 import omero.api.AMD_RenderingEngine_setQuantumStrategy;
 import omero.api.AMD_RenderingEngine_setRGBA;
 import omero.api.AMD_RenderingEngine_updateCodomainMap;
+import omero.api.AMD_RenderingEngine_updateSettings;
 import omero.api.IRoiPrx;
 import omero.api._RenderingEngineOperations;
 import omero.constants.projection.ProjectionType;
@@ -73,6 +74,7 @@ import omero.grid.Data;
 import omero.grid.MaskColumn;
 import omero.grid.TablePrx;
 import omero.model.Family;
+import omero.model.RenderingDef;
 import omero.model.RenderingModel;
 import omero.romio.CodomainMapContext;
 import omero.romio.PlaneDef;
@@ -447,6 +449,12 @@ public class RenderingEngineI extends AbstractPyramidServant implements
             int green, int blue, int alpha, Current __current)
             throws ServerError {
         callInvokerOnRawArgs(__cb, __current, w, red, green, blue, alpha);
+    }
+
+    @Override
+    public void updateSettings_async(AMD_RenderingEngine_updateSettings __cb, RenderingDef settings, Current __current)
+            throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, settings);
     }
 
     public void updateCodomainMap_async(

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -11,6 +11,7 @@ import ome.api.StatefulServiceInterface;
 import ome.conditions.ValidationException;
 import ome.model.core.Pixels;
 import ome.model.display.QuantumDef;
+import ome.model.display.RenderingDef;
 import ome.model.enums.Family;
 import ome.model.enums.RenderingModel;
 import omeis.providers.re.codomain.CodomainMapContext;
@@ -506,6 +507,15 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * @see #addCodomainMapToChannel(CodomainMapContext, int)
      */
     public void removeCodomainMapFromChannel(CodomainMapContext mapCtx, int w);
+
+    /**
+     * Updates the current rendering settings based on a provided rendering
+     * definition and associated sub-objects.
+     * @param settings Rendering definition to copy from. Each sub-object
+     * will be processed as though the specific method was called with
+     * related attributes provided as arguments.
+     */
+    public void updateSettings(RenderingDef settings);
 
     /** Saves the current rendering settings in the database. */
     public void saveCurrentSettings();

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -529,9 +529,10 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * If one or more attributes that apply to a particular method are
      * <code>null</code> it will be <b>skipped</b> in its entirety. The
      * underlying Renderer is not able to handle partial field updates.
-     * Furthermore, {@link ChannelBinding}s that are <code>null</code> and
-     * indexes in the {@link RenderingDef#WAVERENDERING} array greater than the
-     * currently looked up {@link Pixels#SIZEC} will be skipped.
+     * Furthermore, {@link ome.model.display.ChannelBinding} references that are
+     * <code>null</code> and indexes in the {@link RenderingDef#WAVERENDERING}
+     * array greater than the currently looked up {@link Pixels#SIZEC} will be
+     * skipped.
      */
     public void updateSettings(RenderingDef settings);
 

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -527,10 +527,11 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * <li>{@link RenderingEngine#setChannelLookupTable(int, String)}</li>
      * </ul>
      * If one or more attributes that apply to a particular method are
-     * <code>null</code> it will be <b>skipped</b>. The underlying Renderer is
-     * not able to handle partial field updates.
-     *
-     * <b>NOTE:</b> Codomain mappings are ignored.
+     * <code>null</code> it will be <b>skipped</b> in its entirety. The
+     * underlying Renderer is not able to handle partial field updates.
+     * Furthermore, {@link ChannelBinding}s that are <code>null</code> and
+     * indexes in the {@link RenderingDef#WAVERENDERING} array greater than the
+     * currently looked up {@link Pixels#SIZEC} will be skipped.
      */
     public void updateSettings(RenderingDef settings);
 

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -513,8 +513,24 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * definition and associated sub-objects.
      * @param settings Rendering definition to copy from. Each sub-object
      * will be processed as though the specific method was called with
-     * related attributes provided as arguments. <b>NOTE:</b> Codomain
-     * mappings are ignored.
+     * related attributes provided as arguments. The following methods are
+     * called underneath: <ul>
+     * <li>{@link RenderingEngine#setModel(RenderingModel)}</li>
+     * <li>{@link RenderingEngine#setDefaultZ(int)}</li>
+     * <li>{@link RenderingEngine#setDefaultT(int)}</li>
+     * <li>{@link RenderingEngine#setQuantumStrategy(int)}</li>
+     * <li>{@link RenderingEngine#setCodomainInterval(int, int)}</li>
+     * <li>{@link RenderingEngine#setActive(int, boolean)}</li>
+     * <li>{@link RenderingEngine#setChannelWindow(int, double, double)}</li>
+     * <li>{@link RenderingEngine#setQuantizationMap(int, Family, double, boolean)}</li>
+     * <li>{@link RenderingEngine#setRGBA(int, int, int, int, int)}</li>
+     * <li>{@link RenderingEngine#setChannelLookupTable(int, String)}</li>
+     * </ul>
+     * If one or more attributes that apply to a particular method are
+     * <code>null</code> it will be <b>skipped</b>. The underlying Renderer is
+     * not able to handle partial field updates.
+     *
+     * <b>NOTE:</b> Codomain mappings are ignored.
      */
     public void updateSettings(RenderingDef settings);
 

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -513,7 +513,8 @@ public interface RenderingEngine extends StatefulServiceInterface {
      * definition and associated sub-objects.
      * @param settings Rendering definition to copy from. Each sub-object
      * will be processed as though the specific method was called with
-     * related attributes provided as arguments.
+     * related attributes provided as arguments. <b>NOTE:</b> Codomain
+     * mappings are ignored.
      */
     public void updateSettings(RenderingDef settings);
 

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -237,8 +237,6 @@ public class Quantization_8_16_bit extends QuantumStrategy {
         initNormalizedMap(k);
         // Initializes the decile map.
         double v = initDecileMap(dStart, dEnd);
-        QuantumMap normalize = new PolynomialMap();
-        
 
         // Build the LUT
         int x = lutMin;
@@ -249,7 +247,7 @@ public class Quantization_8_16_bit extends QuantumStrategy {
         for (; x < dEnd; ++x) {
         	if (x > Q1) {
                 if (x <= Q9) {
-                    v = aDecile * normalize.transform(x, 1) - bDecile;
+                    v = aDecile * x - bDecile;
                 } else {
                     v = cdEnd;
                 }

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -244,6 +244,10 @@ public class Quantization_8_16_bit extends QuantumStrategy {
             LUT[x - lutMin] = (byte) cdStart;
         }
 
+        boolean doTransform = true;
+        if (valueMapper instanceof PolynomialMap && k == 1.0) {
+            doTransform = false;
+        }
         for (; x < dEnd; ++x) {
         	if (x > Q1) {
                 if (x <= Q9) {
@@ -255,10 +259,10 @@ public class Quantization_8_16_bit extends QuantumStrategy {
                 v = cdStart;
             }
         	
-            if (valueMapper instanceof PolynomialMap && k == 1.0) {
-                v = aNormalized * (v - ysNormalized);
-            } else {
+            if (doTransform) {
                 v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
+            } else {
+                v = aNormalized * (v - ysNormalized);
             }
             v = Math.round(v);
             v = Math.round(a1 * v + cdStart);

--- a/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
+++ b/components/rendering/src/omeis/providers/re/quantum/Quantization_8_16_bit.java
@@ -255,7 +255,11 @@ public class Quantization_8_16_bit extends QuantumStrategy {
                 v = cdStart;
             }
         	
-            v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
+            if (valueMapper instanceof PolynomialMap && k == 1.0) {
+                v = aNormalized * (v - ysNormalized);
+            } else {
+                v = aNormalized * (valueMapper.transform(v, k) - ysNormalized);
+            }
             v = Math.round(v);
             v = Math.round(a1 * v + cdStart);
             LUT[x - lutMin] = (byte) v;

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1216,7 +1216,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
     @RolesAllowed("user")
     public void setChannelLookupTable(int w, String lookup) {
         StopWatch t0 = new Slf4JStopWatch(
-                "RenderingBean.setChannelLookupTable");
+                "omero.rendering_bean.setChannelLookupTable");
         rwl.readLock().lock();
 
         try {
@@ -1501,7 +1501,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setActive(int w, boolean active) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setActive");
+        StopWatch t0 = new Slf4JStopWatch("omero.rendering_bean.setActive");
         try {
             rwl.writeLock().lock();
             errorIfInvalidState();
@@ -1519,7 +1519,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setChannelWindow(int w, double start, double end) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setChannelWindow");
+        StopWatch t0 = new Slf4JStopWatch(
+                "omero.rendering_bean.setChannelWindow");
         rwl.writeLock().lock();
 
         try {
@@ -1538,7 +1539,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setCodomainInterval(int start, int end) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setCodomainInterval");
+        StopWatch t0 = new Slf4JStopWatch(
+                "omero.rendering_bean.setCodomainInterval");
         rwl.writeLock().lock();
         try {
             errorIfInvalidState();
@@ -1556,7 +1558,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setDefaultT(int t) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setDefaultT");
+        StopWatch t0 = new Slf4JStopWatch("omero.rendering_bean.setDefaultT");
         rwl.writeLock().lock();
 
         try {
@@ -1575,7 +1577,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setDefaultZ(int z) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setDefaultZ");
+        StopWatch t0 = new Slf4JStopWatch("omero.rendering_bean.setDefaultZ");
         rwl.writeLock().lock();
 
         try {
@@ -1594,7 +1596,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setModel(RenderingModel model) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setModel");
+        StopWatch t0 = new Slf4JStopWatch("omero.rendering_bean.setModel");
         rwl.writeLock().lock();
 
         try {
@@ -1615,7 +1617,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
     @RolesAllowed("user")
     public void setQuantizationMap(int w, Family family, double coefficient,
             boolean noiseReduction) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setQuantizationMap");
+        StopWatch t0 = new Slf4JStopWatch(
+                "omero.rendering_bean.setQuantizationMap");
         rwl.writeLock().lock();
 
         try {
@@ -1635,7 +1638,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setQuantumStrategy(int bitResolution) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setQuantumStrategy");
+        StopWatch t0 = new Slf4JStopWatch(
+                "omero.rendering_bean.setQuantumStrategy");
         rwl.writeLock().lock();
 
         try {
@@ -1654,7 +1658,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setRGBA(int w, int red, int green, int blue, int alpha) {
-        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setRGBA");
+        StopWatch t0 = new Slf4JStopWatch("omero.rendering_bean.setRGBA");
         rwl.writeLock().lock();
 
         try {

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -814,7 +814,10 @@ public class RenderingBean implements RenderingEngine, Serializable {
             Family family = cb.getFamily();
             Double coefficient = cb.getCoefficient();
             Boolean noiseReduction = cb.getNoiseReduction();
-            setQuantizationMap(w, family, coefficient, noiseReduction);
+            if (family != null && coefficient != null
+                    && noiseReduction != null) {
+                setQuantizationMap(w, family, coefficient, noiseReduction);
+            }
             // Emulate setChannelWindow(int, double, double)
             Double start = cb.getInputStart();
             Double end = cb.getInputEnd();

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -815,7 +815,16 @@ public class RenderingBean implements RenderingEngine, Serializable {
             }
         }
         for (int w = 0; w < settings.sizeOfWaveRendering(); w++) {
+            if (w >= this.pixelsObj.getSizeC()) {
+                // Skip application of settings for channels which are beyond
+                // the currently looked up Image's number of channels.
+                break;
+            }
+
             ChannelBinding cb = settings.getChannelBinding(w);
+            if (cb == null) {
+                continue;
+            }
             // Emulate setActive(boolean)
             Boolean active = cb.getActive();
             if (active != null) {

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -777,7 +777,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
     /**
      * Implemented as specified by the {@link RenderingEngine} interface.
      *
-     * @see RenderingEngine#updateSettings()
+     * @see RenderingEngine#updateSettings(RenderingDef)
      */
     @RolesAllowed("user")
     public void updateSettings(RenderingDef settings) {

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -774,6 +774,68 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
     /**
      * Implemented as specified by the {@link RenderingEngine} interface.
+     *
+     * @see RenderingEngine#updateSettings()
+     */
+    @RolesAllowed("user")
+    public void updateSettings(RenderingDef settings) {
+        if (settings == null) {
+            return;
+        }
+
+        // Emulate setModel(RenderingModel)
+        RenderingModel model = settings.getModel();
+        setModel(model);
+        // Emulate setDefaultZ(int)
+        Integer defaultZ = settings.getDefaultZ();
+        if (defaultZ != null) {
+            setDefaultZ(settings.getDefaultZ());
+        }
+        // Emulate setDefaultT(int)
+        Integer defaultT = settings.getDefaultT();
+        if (defaultT != null) {
+            setDefaultT(settings.getDefaultT());
+        }
+        QuantumDef quantumDef = settings.getQuantization();
+        if (quantumDef != null) {
+            // Emulate setQuantumStrategy(int)
+            Integer bitResolution = quantumDef.getBitResolution();
+            if (bitResolution != null) {
+                setQuantumStrategy(bitResolution);
+            }
+            // Emulate setCodmainInterval(int, int)
+            Integer start = quantumDef.getCdStart();
+            Integer end = quantumDef.getCdEnd();
+            setCodomainInterval(start, end);
+        }
+        for (int w = 0; w < settings.sizeOfWaveRendering(); w++) {
+            ChannelBinding cb = settings.getChannelBinding(w);
+            // Emulate setQuantizationMap(int, Family, double, boolean)
+            Family family = cb.getFamily();
+            Double coefficient = cb.getCoefficient();
+            Boolean noiseReduction = cb.getNoiseReduction();
+            setQuantizationMap(w, family, coefficient, noiseReduction);
+            // Emulate setChannelWindow(int, double, double)
+            Double start = cb.getInputStart();
+            Double end = cb.getInputEnd();
+            setChannelWindow(w, start, end);
+            // Emulate setRGBA(int, int, int, int, int)
+            Integer red = cb.getRed();
+            Integer green = cb.getGreen();
+            Integer blue = cb.getBlue();
+            Integer alpha = cb.getAlpha();
+            setRGBA(w, red, green, blue, alpha);
+            // Emulate setActive(boolean)
+            Boolean active = cb.getActive();
+            setActive(w, active);
+            // Emulate setChannelLookupTable(int, String)
+            String lookup = cb.getLookupTable();
+            setChannelLookupTable(w, lookup);
+        }
+    }
+
+    /**
+     * Implemented as specified by the {@link RenderingEngine} interface.
      * 
      * @see RenderingEngine#saveCurrentSettings()
      */

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -68,6 +68,8 @@ import omeis.providers.re.quantum.QuantumFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.hibernate.Session;
+import org.perf4j.StopWatch;
+import org.perf4j.slf4j.Slf4JStopWatch;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -1185,6 +1187,8 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
     @RolesAllowed("user")
     public void setChannelLookupTable(int w, String lookup) {
+        StopWatch t0 = new Slf4JStopWatch(
+                "RenderingBean.setChannelLookupTable");
         rwl.readLock().lock();
 
         try {
@@ -1192,6 +1196,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setChannelLookupTable(w, lookup);
         } finally {
             rwl.readLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1455,12 +1460,14 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setActive(int w, boolean active) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setActive");
         try {
             rwl.writeLock().lock();
             errorIfInvalidState();
             renderer.setActive(w, active);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1471,6 +1478,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setChannelWindow(int w, double start, double end) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setChannelWindow");
         rwl.writeLock().lock();
 
         try {
@@ -1478,6 +1486,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setChannelWindow(w, start, end);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1488,12 +1497,14 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setCodomainInterval(int start, int end) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setCodomainInterval");
         rwl.writeLock().lock();
         try {
             errorIfInvalidState();
             renderer.setCodomainInterval(start, end);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1504,6 +1515,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setDefaultT(int t) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setDefaultT");
         rwl.writeLock().lock();
 
         try {
@@ -1511,6 +1523,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setDefaultT(t);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1521,6 +1534,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setDefaultZ(int z) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setDefaultZ");
         rwl.writeLock().lock();
 
         try {
@@ -1528,6 +1542,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setDefaultZ(z);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1538,6 +1553,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setModel(RenderingModel model) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setModel");
         rwl.writeLock().lock();
 
         try {
@@ -1546,6 +1562,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setModel(m);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1557,6 +1574,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
     @RolesAllowed("user")
     public void setQuantizationMap(int w, Family family, double coefficient,
             boolean noiseReduction) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setQuantizationMap");
         rwl.writeLock().lock();
 
         try {
@@ -1565,6 +1583,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setQuantizationMap(w, f, coefficient, noiseReduction);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1575,6 +1594,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setQuantumStrategy(int bitResolution) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setQuantumStrategy");
         rwl.writeLock().lock();
 
         try {
@@ -1582,6 +1602,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setQuantumStrategy(bitResolution);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 
@@ -1592,6 +1613,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
      */
     @RolesAllowed("user")
     public void setRGBA(int w, int red, int green, int blue, int alpha) {
+        StopWatch t0 = new Slf4JStopWatch("RenderingBean.setRGBA");
         rwl.writeLock().lock();
 
         try {
@@ -1599,6 +1621,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
             renderer.setRGBA(w, red, green, blue, alpha);
         } finally {
             rwl.writeLock().unlock();
+            t0.stop();
         }
     }
 

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -848,6 +848,13 @@ public class RenderingBean implements RenderingEngine, Serializable {
             if (lookupTable != null) {
                 setChannelLookupTable(w, lookupTable);
             }
+            // Emulate addCodomainMapToChannel(CodomainMapContext, int)
+            for (int i = 0; i < cb.sizeOfSpatialDomainEnhancement(); i++) {
+                ome.model.display.CodomainMapContext ctx = cb.getCodomainMapContext(i);
+                if (ctx != null) {
+                    addCodomainMapToChannel(reverse(ctx), w);
+                }
+            }
         }
     }
 
@@ -1397,6 +1404,19 @@ public class RenderingBean implements RenderingEngine, Serializable {
             ome.model.display.ReverseIntensityContext c = new ome.model.display.ReverseIntensityContext();
             c.setReverse(true);
             return c;
+        }
+        return null;
+    }
+
+    /**
+     * Reverse the ome.model objectt into the corresponding codomain context.
+     * @param ctx The context to convert.
+     * @return See above.
+     */
+    private CodomainMapContext reverse(ome.model.display.CodomainMapContext ctx)
+    {
+        if (ctx instanceof ome.model.display.ReverseIntensityContext) {
+            return new ReverseIntensityContext();
         }
         return null;
     }

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -1418,7 +1418,7 @@ public class RenderingBean implements RenderingEngine, Serializable {
     }
 
     /**
-     * Reverse the ome.model objectt into the corresponding codomain context.
+     * Reverse the ome.model object into the corresponding codomain context.
      * @param ctx The context to convert.
      * @return See above.
      */

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -787,7 +787,9 @@ public class RenderingBean implements RenderingEngine, Serializable {
 
         // Emulate setModel(RenderingModel)
         RenderingModel model = settings.getModel();
-        setModel(model);
+        if (model != null) {
+            setModel(model);
+        }
         // Emulate setDefaultZ(int)
         Integer defaultZ = settings.getDefaultZ();
         if (defaultZ != null) {
@@ -808,13 +810,17 @@ public class RenderingBean implements RenderingEngine, Serializable {
             // Emulate setCodmainInterval(int, int)
             Integer start = quantumDef.getCdStart();
             Integer end = quantumDef.getCdEnd();
-            setCodomainInterval(start, end);
+            if (start != null && end != null) {
+                setCodomainInterval(start, end);
+            }
         }
         for (int w = 0; w < settings.sizeOfWaveRendering(); w++) {
             ChannelBinding cb = settings.getChannelBinding(w);
             // Emulate setActive(boolean)
             Boolean active = cb.getActive();
-            setActive(w, active);
+            if (active != null) {
+                setActive(w, active);
+            }
             // Emulate setChannelWindow(int, double, double)
             Double start = cb.getInputStart();
             Double end = cb.getInputEnd();

--- a/components/server/src/ome/services/RenderingBean.java
+++ b/components/server/src/ome/services/RenderingBean.java
@@ -812,6 +812,15 @@ public class RenderingBean implements RenderingEngine, Serializable {
         }
         for (int w = 0; w < settings.sizeOfWaveRendering(); w++) {
             ChannelBinding cb = settings.getChannelBinding(w);
+            // Emulate setActive(boolean)
+            Boolean active = cb.getActive();
+            setActive(w, active);
+            // Emulate setChannelWindow(int, double, double)
+            Double start = cb.getInputStart();
+            Double end = cb.getInputEnd();
+            if (start != null && end != null) {
+                setChannelWindow(w, start, end);
+            }
             // Emulate setQuantizationMap(int, Family, double, boolean)
             Family family = cb.getFamily();
             Double coefficient = cb.getCoefficient();
@@ -820,22 +829,19 @@ public class RenderingBean implements RenderingEngine, Serializable {
                     && noiseReduction != null) {
                 setQuantizationMap(w, family, coefficient, noiseReduction);
             }
-            // Emulate setChannelWindow(int, double, double)
-            Double start = cb.getInputStart();
-            Double end = cb.getInputEnd();
-            setChannelWindow(w, start, end);
             // Emulate setRGBA(int, int, int, int, int)
             Integer red = cb.getRed();
             Integer green = cb.getGreen();
             Integer blue = cb.getBlue();
             Integer alpha = cb.getAlpha();
-            setRGBA(w, red, green, blue, alpha);
-            // Emulate setActive(boolean)
-            Boolean active = cb.getActive();
-            setActive(w, active);
+            if (red != null && green != null && blue != null && alpha != null) {
+                setRGBA(w, red, green, blue, alpha);
+            }
             // Emulate setChannelLookupTable(int, String)
-            String lookup = cb.getLookupTable();
-            setChannelLookupTable(w, lookup);
+            String lookupTable = cb.getLookupTable();
+            if (lookupTable != null) {
+                setChannelLookupTable(w, lookupTable);
+            }
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -3481,6 +3481,7 @@ public class RenderingEngineTest extends AbstractServerTest {
             for (int l = 0; l < rgba.length; l++) {
                 Assert.assertNotEquals(rgba[l], prx.rgba[l]);
             }
+            cb.addCodomainMapContext(new ReverseIntensityContextI());
         }
         //Apply the setting
         re.updateSettings(rnd_def);
@@ -3509,6 +3510,11 @@ public class RenderingEngineTest extends AbstractServerTest {
             for (int k = 0; k < values.length; k++) {
                 Assert.assertEquals(values[k], prx.rgba[k]);
             }
+            List<IObject> codomains = re.getCodomainMapContext(i);
+            Assert.assertNotNull(codomains);
+            Assert.assertEquals(codomains.size(), 1);
+            CodomainMapContext ctx = (CodomainMapContext) codomains.get(0);
+            Assert.assertTrue(ctx instanceof ReverseIntensityContext);
         }
     }
 
@@ -3833,7 +3839,7 @@ public class RenderingEngineTest extends AbstractServerTest {
         def_null.setQuantization(new QuantumDefI());
         def_null.addChannelBinding(new ChannelBindingI());
         re.updateSettings(def_null);
-        //Check the values
+        //Check the values have not changed.
         Assert.assertEquals(re.getDefaultT(), rnd_def.getDefaultT().getValue());
         Assert.assertEquals(re.getDefaultZ(), rnd_def.getDefaultZ().getValue());
         Assert.assertEquals(re.getModel().getId().getValue(),

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -3743,7 +3743,6 @@ public class RenderingEngineTest extends AbstractServerTest {
      * with more channels than the one used to initialize the rendering engines.
      * @throws Exception
      */
-    @Test(expectedExceptions = omero.InternalException.class)
     public void testUpdateSettingsUsingSettingsfromImageWithMoreChannels() throws Exception {
         Image image = createBinaryImage(10, 10, 4, 4, 4);
         Image image_destination = createBinaryImage(10, 10, 4, 4, 3);

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -3366,4 +3366,307 @@ public class RenderingEngineTest extends AbstractServerTest {
             Assert.assertFalse(Arrays.equals(after, before));
         }
     }
+
+    /**
+     * Tests the update of the rendering settings.
+     * Checks that the values are correctly copied
+     * @throws Exception
+     */
+    @Test
+    public void testUpdateSettings() throws Exception {
+      //First import an image
+        Image image = createBinaryImage(10, 10, 4, 4, 2);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        //Change the rendering settings of the source
+        RenderingDef rnd_def = factory.getPixelsService().retrieveRndSettings(id);
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        // New value for Z and T
+        int t = 3;
+        int z = 0;
+        // Check that the values do not match
+        Assert.assertNotEquals(re.getDefaultT(), t);
+        Assert.assertNotEquals(re.getDefaultZ(), z);
+        rnd_def.setDefaultT(omero.rtypes.rint(t));
+        rnd_def.setDefaultZ(omero.rtypes.rint(z));
+        RenderingModel model = re.getModel();
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class.getName());
+        Iterator<IObject> j = models.iterator();
+        RenderingModel m;
+        long new_model_id = -1;
+        // Change the color model
+        while (j.hasNext()) {
+            m = (RenderingModel) j.next();
+            if (m.getId().getValue() != model.getId().getValue()) {
+                new_model_id = m.getId().getValue();
+                rnd_def.setModel(m);
+            }
+        }
+        Assert.assertTrue(new_model_id > -1);
+        Assert.assertNotEquals(model.getId().getValue(), new_model_id);
+        //Change the quantum Def
+        QuantumDef q_def = re.getQuantumDef();
+        int cd_start = 10;
+        int cd_end = 245;
+        int bit_resolution = 7; // 2^3-1
+        if (q_def != null) {
+            //Check that the values do not match
+            Assert.assertNotEquals(q_def.getCdStart().getValue(), cd_start);
+            Assert.assertNotEquals(q_def.getCdEnd().getValue(), cd_end);
+            Assert.assertNotEquals(q_def.getBitResolution().getValue(), bit_resolution);
+            QuantumDef def = rnd_def.getQuantization();
+            //Change codomain interval
+            def.setCdStart(omero.rtypes.rint(cd_start));
+            def.setCdEnd(omero.rtypes.rint(cd_end));
+            def.setBitResolution(omero.rtypes.rint(bit_resolution));
+        }
+        //Change the channels
+        //Channel should be Red/green/Blue
+        int sizeC = p.getSizeC().getValue();
+        List<IObject> families = re.getAvailableFamilies();
+        List<ChannelBindingPrx> channels = new ArrayList<ChannelBindingPrx>(sizeC);
+        ChannelBindingPrx prx;
+        for (int i = 0; i < sizeC; i++) {
+            prx = new ChannelBindingPrx();
+            channels.add(prx);
+            Family f = re.getChannelFamily(i);
+            double start = re.getChannelWindowStart(i);
+            double end = re.getChannelWindowEnd(i);
+            Boolean active = re.isActive(i);
+            prx.start = start+1;
+            prx.end = end-1;
+            prx.active = !active;
+            // Changing active flag and window interval
+            ChannelBinding cb = rnd_def.getChannelBinding(i);
+            cb.setInputStart(omero.rtypes.rdouble(prx.start));
+            cb.setInputEnd(omero.rtypes.rdouble(prx.end));
+            cb.setActive(omero.rtypes.rbool(prx.active));
+            Iterator<IObject> k = families.iterator();
+            while (k.hasNext()) {
+                Family ff = (Family) k.next();
+                if (ff.getId().getValue() != f.getId().getValue()) {
+                    cb.setFamily(ff);
+                    prx.family = ff;
+                    break;
+                }
+            }
+            prx.coefficient = re.getChannelCurveCoefficient(i) + 1;
+            cb.setCoefficient(omero.rtypes.rdouble(prx.coefficient));
+            prx.ns = !re.getChannelNoiseReduction(i);
+            cb.setNoiseReduction(omero.rtypes.rbool(prx.ns));
+            prx.lut = "channel_"+i;
+            cb.setLookupTable(omero.rtypes.rstring(prx.lut));
+            int[] rgba = re.getRGBA(i);
+            prx.rgba[0] = 125+i;
+            cb.setRed(omero.rtypes.rint(prx.rgba[0]));
+            prx.rgba[1] = 125+2*i;
+            cb.setGreen(omero.rtypes.rint(prx.rgba[1]));
+            prx.rgba[2] = 125+3*i;
+            cb.setBlue(omero.rtypes.rint(prx.rgba[2]));
+            prx.rgba[3] = 125+4*i;
+            cb.setAlpha(omero.rtypes.rint(prx.rgba[3]));
+            //Check that the colors do not match
+            for (int l = 0; l < rgba.length; l++) {
+                Assert.assertNotEquals(rgba[l], prx.rgba[l]);
+            }
+        }
+        //Apply the setting
+        re.updateSettings(rnd_def);
+        //Check the values
+        Assert.assertEquals(re.getDefaultT(), t);
+        Assert.assertEquals(re.getDefaultZ(), z);
+        Assert.assertEquals(re.getModel().getId().getValue(), new_model_id);
+        q_def = re.getQuantumDef();
+        if (q_def != null) {
+            Assert.assertEquals(q_def.getBitResolution().getValue(), bit_resolution);
+            Assert.assertEquals(q_def.getCdEnd().getValue(), cd_end);
+            Assert.assertEquals(q_def.getCdStart().getValue(), cd_start);
+        }
+        for (int i = 0; i < sizeC; i++) {
+            prx = channels.get(i);
+            Assert.assertEquals(re.getChannelFamily(i).getId().getValue(),
+                    prx.family.getId().getValue());
+            Assert.assertEquals(re.getChannelWindowStart(i), prx.start);
+            Assert.assertEquals(re.getChannelWindowEnd(i), prx.end);
+            Assert.assertEquals(re.isActive(i), prx.active);
+            Assert.assertEquals(re.getChannelCurveCoefficient(i),
+                    prx.coefficient);
+            Assert.assertEquals(re.getChannelNoiseReduction(i), prx.ns);
+            Assert.assertEquals(re.getChannelLookupTable(i), prx.lut);
+            int[] values = re.getRGBA(i);
+            for (int k = 0; k < values.length; k++) {
+                Assert.assertEquals(values[k], prx.rgba[k]);
+            }
+        }
+    }
+
+    /**
+     * Tests the update of the rendering settings using settings from another
+     * image.
+     * @throws Exception
+     */
+    @Test
+    public void testUpdateSettingsUsingSettingsfromOtherImage() throws Exception {
+        Image image = createBinaryImage(10, 10, 4, 4, 2);
+        Image image_destination = createBinaryImage(10, 10, 4, 4, 2);
+        Pixels p = image.getPrimaryPixels();
+        Pixels p_destination = image_destination.getPrimaryPixels();
+        long id = p.getId().getValue();
+        long id_destination = p_destination.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id,
+                        id_destination));
+        //Change the rendering settings of the source
+        RenderingDef rnd_def = factory.getPixelsService().retrieveRndSettings(id);
+        //By default no lut set
+        for (int i = 0; i < p.getSizeC().getValue(); i++) {
+            rnd_def.getChannelBinding(i).setLookupTable(omero.rtypes.rstring("channel"+i));
+        }
+        rnd_def = (RenderingDef) factory.getUpdateService().saveAndReturnObject(rnd_def);
+        RenderingDef rnd_def_destination = factory.getPixelsService().retrieveRndSettings(id_destination);
+      //Change the rendering settings of the source
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id_destination);
+        if (!(re.lookupRenderingDef(id_destination))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id_destination);
+        }
+        re.load();
+        re.updateSettings(rnd_def);
+        //Check the values
+        Assert.assertEquals(re.getDefaultT(), rnd_def.getDefaultT().getValue());
+        Assert.assertEquals(re.getDefaultZ(), rnd_def.getDefaultZ().getValue());
+        Assert.assertEquals(re.getModel().getId().getValue(),
+                rnd_def.getModel().getId().getValue());
+        QuantumDef q_def = re.getQuantumDef();
+        if (q_def != null) {
+            Assert.assertEquals(q_def.getBitResolution().getValue(),
+                    rnd_def.getQuantization().getBitResolution().getValue());
+            Assert.assertEquals(q_def.getCdEnd().getValue(),
+                    rnd_def.getQuantization().getCdEnd().getValue());
+            Assert.assertEquals(q_def.getCdStart().getValue(),
+                    rnd_def.getQuantization().getCdStart().getValue());
+        }
+        for (int i = 0; i < p.getSizeC().getValue(); i++) {
+            ChannelBinding cb = rnd_def.getChannelBinding(i);
+            Assert.assertEquals(re.getChannelFamily(i).getId().getValue(),
+                    cb.getFamily().getId().getValue());
+            Assert.assertEquals(re.getChannelWindowStart(i),
+                    cb.getInputStart().getValue());
+            Assert.assertEquals(re.getChannelWindowEnd(i),
+                    cb.getInputEnd().getValue());
+            Assert.assertEquals(re.isActive(i), cb.getActive().getValue());
+            Assert.assertEquals(re.getChannelCurveCoefficient(i),
+                    cb.getCoefficient().getValue());
+            Assert.assertEquals(re.getChannelNoiseReduction(i),
+                    cb.getNoiseReduction().getValue());
+            Assert.assertEquals(re.getChannelLookupTable(i),
+                    cb.getLookupTable().getValue());
+            Assert.assertNull(rnd_def_destination.getChannelBinding(i).getLookupTable());
+            int[] values = re.getRGBA(i);
+            Assert.assertEquals(values[0], cb.getRed().getValue());
+            Assert.assertEquals(values[1], cb.getGreen().getValue());
+            Assert.assertEquals(values[2], cb.getBlue().getValue());
+            Assert.assertEquals(values[3], cb.getAlpha().getValue());
+        }
+    }
+
+    /**
+     * Tests the update of the rendering settings using settings from another
+     * image. The settings are owned by another user in a RWR group
+     * @throws Exception
+     */
+    @Test
+    public void testUpdateSettingsUsingSettingsfromAnotherOtherUser() throws Exception {
+        EventContext ctx = newUserAndGroup("rwr---");
+        Image image = createBinaryImage(10, 10, 4, 4, 2);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        //Change the rendering settings of the source
+        RenderingDef rnd_def = factory.getPixelsService().retrieveRndSettings(id);
+        disconnect();
+        // login as another user.
+        EventContext ctx2 = newUserInGroup(ctx);
+        Image image_user2 = createBinaryImage(10, 10, 4, 4, 2);
+        Pixels p_user2 = image_user2.getPrimaryPixels();
+        long id_user2 = p_user2.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id_user2));
+        //Change the rendering settings of the source
+        RenderingDef rnd_def_user2 = factory.getPixelsService().retrieveRndSettings(id_user2);
+        //By default no lut set
+        for (int i = 0; i < p.getSizeC().getValue(); i++) {
+            rnd_def_user2.getChannelBinding(i).setLookupTable(omero.rtypes.rstring("channel"+i));
+        }
+        rnd_def_user2 = (RenderingDef) factory.getUpdateService().saveAndReturnObject(rnd_def_user2);
+        disconnect();
+        loginUser(ctx); //log in as first user
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        re.updateSettings(rnd_def_user2);
+      //Check the values
+        Assert.assertEquals(re.getDefaultT(), rnd_def_user2.getDefaultT().getValue());
+        Assert.assertEquals(re.getDefaultZ(), rnd_def_user2.getDefaultZ().getValue());
+        Assert.assertEquals(re.getModel().getId().getValue(),
+                rnd_def_user2.getModel().getId().getValue());
+        QuantumDef q_def = re.getQuantumDef();
+        if (q_def != null) {
+            Assert.assertEquals(q_def.getBitResolution().getValue(),
+                    rnd_def_user2.getQuantization().getBitResolution().getValue());
+            Assert.assertEquals(q_def.getCdEnd().getValue(),
+                    rnd_def_user2.getQuantization().getCdEnd().getValue());
+            Assert.assertEquals(q_def.getCdStart().getValue(),
+                    rnd_def_user2.getQuantization().getCdStart().getValue());
+        }
+        for (int i = 0; i < p.getSizeC().getValue(); i++) {
+            ChannelBinding cb = rnd_def_user2.getChannelBinding(i);
+            Assert.assertEquals(re.getChannelFamily(i).getId().getValue(),
+                    cb.getFamily().getId().getValue());
+            Assert.assertEquals(re.getChannelWindowStart(i),
+                    cb.getInputStart().getValue());
+            Assert.assertEquals(re.getChannelWindowEnd(i),
+                    cb.getInputEnd().getValue());
+            Assert.assertEquals(re.isActive(i), cb.getActive().getValue());
+            Assert.assertEquals(re.getChannelCurveCoefficient(i),
+                    cb.getCoefficient().getValue());
+            Assert.assertEquals(re.getChannelNoiseReduction(i),
+                    cb.getNoiseReduction().getValue());
+            Assert.assertEquals(re.getChannelLookupTable(i),
+                    cb.getLookupTable().getValue());
+            Assert.assertNull(rnd_def.getChannelBinding(i).getLookupTable());
+            int[] values = re.getRGBA(i);
+            Assert.assertEquals(values[0], cb.getRed().getValue());
+            Assert.assertEquals(values[1], cb.getGreen().getValue());
+            Assert.assertEquals(values[2], cb.getBlue().getValue());
+            Assert.assertEquals(values[3], cb.getAlpha().getValue());
+        }
+    }
+
+    //Inner class used to store rnd settings for channels
+    class ChannelBindingPrx {
+        Family family;
+        double start;
+        double end;
+        boolean active;
+        double coefficient;
+        boolean ns;
+        String lut;
+        int[] rgba = new int[4];
+    }
 }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -3743,6 +3743,7 @@ public class RenderingEngineTest extends AbstractServerTest {
      * with more channels than the one used to initialize the rendering engines.
      * @throws Exception
      */
+    @Test
     public void testUpdateSettingsUsingSettingsfromImageWithMoreChannels() throws Exception {
         Image image = createBinaryImage(10, 10, 4, 4, 4);
         Image image_destination = createBinaryImage(10, 10, 4, 4, 3);
@@ -3784,7 +3785,7 @@ public class RenderingEngineTest extends AbstractServerTest {
             Assert.assertEquals(q_def.getCdStart().getValue(),
                     rnd_def.getQuantization().getCdStart().getValue());
         }
-        for (int i = 0; i < p.getSizeC().getValue(); i++) {
+        for (int i = 0; i < p_destination.getSizeC().getValue(); i++) {
             ChannelBinding cb = rnd_def.getChannelBinding(i);
             Assert.assertEquals(re.getChannelFamily(i).getId().getValue(),
                     cb.getFamily().getId().getValue());

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -3875,6 +3875,197 @@ public class RenderingEngineTest extends AbstractServerTest {
         }
     }
 
+    /**
+     * Tests the update of the rendering settings.
+     * Specify null channel bindings
+     * @throws Exception
+     */
+    @Test
+    public void testUpdateSettingsWithNullChannelBindings() throws Exception {
+      //First import an image
+        Image image = createBinaryImage(10, 10, 4, 4, 3);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        //Change the rendering settings of the source
+        RenderingDef rnd_def_original = factory.getPixelsService().retrieveRndSettings(id);
+      //By default no lut set
+        for (int i = 0; i < p.getSizeC().getValue(); i++) {
+            rnd_def_original.getChannelBinding(i).setLookupTable(omero.rtypes.rstring("rnd_def_original_channel"+i));
+        }
+        rnd_def_original = (RenderingDef) factory.getUpdateService().saveAndReturnObject(rnd_def_original);
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        // New value for Z and T
+        int t = 3;
+        int z = 0;
+        RenderingDef rnd_def = new RenderingDefI();
+        // Check that the values do not match
+        Assert.assertNotEquals(re.getDefaultT(), t);
+        Assert.assertNotEquals(re.getDefaultZ(), z);
+        rnd_def.setDefaultT(omero.rtypes.rint(t));
+        rnd_def.setDefaultZ(omero.rtypes.rint(z));
+        RenderingModel model = re.getModel();
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class.getName());
+        Iterator<IObject> j = models.iterator();
+        RenderingModel m;
+        long new_model_id = -1;
+        // Change the color model
+        while (j.hasNext()) {
+            m = (RenderingModel) j.next();
+            if (m.getId().getValue() != model.getId().getValue()) {
+                new_model_id = m.getId().getValue();
+                rnd_def.setModel(m);
+            }
+        }
+        Assert.assertTrue(new_model_id > -1);
+        Assert.assertNotEquals(model.getId().getValue(), new_model_id);
+        //Change the quantum Def
+        QuantumDef q_def = re.getQuantumDef();
+        rnd_def.setQuantization(q_def);
+        int cd_start = 10;
+        int cd_end = 245;
+        int bit_resolution = 7; // 2^3-1
+        if (q_def != null) {
+            //Check that the values do not match
+            Assert.assertNotEquals(q_def.getCdStart().getValue(), cd_start);
+            Assert.assertNotEquals(q_def.getCdEnd().getValue(), cd_end);
+            Assert.assertNotEquals(q_def.getBitResolution().getValue(), bit_resolution);
+            QuantumDef def = rnd_def.getQuantization();
+            //Change codomain interval
+            def.setCdStart(omero.rtypes.rint(cd_start));
+            def.setCdEnd(omero.rtypes.rint(cd_end));
+            def.setBitResolution(omero.rtypes.rint(bit_resolution));
+        }
+        //Change the channels
+        //Channel should be Red/green/Blue
+        int sizeC = p.getSizeC().getValue();
+        List<IObject> families = re.getAvailableFamilies();
+        List<ChannelBindingPrx> channels = new ArrayList<ChannelBindingPrx>(sizeC);
+        ChannelBindingPrx prx;
+        int null_channel = 1;
+        for (int i = 0; i < sizeC; i++) {
+            if (i == null_channel) {
+                prx = null;
+                rnd_def.addChannelBinding(new ChannelBindingI());
+                rnd_def.setChannelBinding(i, null);
+            } else {
+                prx = new ChannelBindingPrx();
+            }
+            channels.add(prx);
+            if (prx == null) {
+                continue;
+            }
+            Family f = re.getChannelFamily(i);
+            double start = re.getChannelWindowStart(i);
+            double end = re.getChannelWindowEnd(i);
+            Boolean active = re.isActive(i);
+            prx.start = start+1;
+            prx.end = end-1;
+            prx.active = !active;
+            // Changing active flag and window interval
+            ChannelBinding cb = rnd_def_original.getChannelBinding(i);
+            rnd_def.addChannelBinding(cb);
+            cb.setInputStart(omero.rtypes.rdouble(prx.start));
+            cb.setInputEnd(omero.rtypes.rdouble(prx.end));
+            cb.setActive(omero.rtypes.rbool(prx.active));
+            Iterator<IObject> k = families.iterator();
+            while (k.hasNext()) {
+                Family ff = (Family) k.next();
+                if (ff.getId().getValue() != f.getId().getValue()) {
+                    cb.setFamily(ff);
+                    prx.family = ff;
+                    break;
+                }
+            }
+            prx.coefficient = re.getChannelCurveCoefficient(i) + 1;
+            cb.setCoefficient(omero.rtypes.rdouble(prx.coefficient));
+            prx.ns = !re.getChannelNoiseReduction(i);
+            cb.setNoiseReduction(omero.rtypes.rbool(prx.ns));
+            prx.lut = "channel_"+i;
+            cb.setLookupTable(omero.rtypes.rstring(prx.lut));
+            int[] rgba = re.getRGBA(i);
+            prx.rgba[0] = 125+i;
+            cb.setRed(omero.rtypes.rint(prx.rgba[0]));
+            prx.rgba[1] = 125+2*i;
+            cb.setGreen(omero.rtypes.rint(prx.rgba[1]));
+            prx.rgba[2] = 125+3*i;
+            cb.setBlue(omero.rtypes.rint(prx.rgba[2]));
+            prx.rgba[3] = 125+4*i;
+            cb.setAlpha(omero.rtypes.rint(prx.rgba[3]));
+            //Check that the colors do not match
+            for (int l = 0; l < rgba.length; l++) {
+                Assert.assertNotEquals(rgba[l], prx.rgba[l]);
+            }
+            cb.addCodomainMapContext(new ReverseIntensityContextI());
+        }
+        //Apply the setting
+        re.updateSettings(rnd_def);
+        //Check the values
+        Assert.assertEquals(re.getDefaultT(), t);
+        Assert.assertEquals(re.getDefaultZ(), z);
+        Assert.assertEquals(re.getModel().getId().getValue(), new_model_id);
+        q_def = re.getQuantumDef();
+        if (q_def != null) {
+            Assert.assertEquals(q_def.getBitResolution().getValue(), bit_resolution);
+            Assert.assertEquals(q_def.getCdEnd().getValue(), cd_end);
+            Assert.assertEquals(q_def.getCdStart().getValue(), cd_start);
+        }
+        for (int i = 0; i < sizeC; i++) {
+            prx = channels.get(i);
+            if (prx != null) {
+                Assert.assertEquals(re.getChannelFamily(i).getId().getValue(),
+                        prx.family.getId().getValue());
+                Assert.assertEquals(re.getChannelWindowStart(i), prx.start);
+                Assert.assertEquals(re.getChannelWindowEnd(i), prx.end);
+                Assert.assertEquals(re.isActive(i), prx.active);
+                Assert.assertEquals(re.getChannelCurveCoefficient(i),
+                        prx.coefficient);
+                Assert.assertEquals(re.getChannelNoiseReduction(i), prx.ns);
+                Assert.assertEquals(re.getChannelLookupTable(i), prx.lut);
+                int[] values = re.getRGBA(i);
+                for (int k = 0; k < values.length; k++) {
+                    Assert.assertEquals(values[k], prx.rgba[k]);
+                }
+                List<IObject> codomains = re.getCodomainMapContext(i);
+                Assert.assertNotNull(codomains);
+                Assert.assertEquals(codomains.size(), 1);
+                CodomainMapContext ctx = (CodomainMapContext) codomains.get(0);
+                Assert.assertTrue(ctx instanceof ReverseIntensityContext);
+            } else {
+                ChannelBinding cb = rnd_def_original.getChannelBinding(i);
+                Assert.assertEquals(re.getChannelFamily(i).getId().getValue(),
+                        cb.getFamily().getId().getValue());
+                Assert.assertEquals(re.getChannelWindowStart(i),
+                        cb.getInputStart().getValue());
+                Assert.assertEquals(re.getChannelWindowEnd(i),
+                        cb.getInputEnd().getValue());
+                Assert.assertEquals(re.isActive(i), cb.getActive().getValue());
+                Assert.assertEquals(re.getChannelCurveCoefficient(i),
+                        cb.getCoefficient().getValue());
+                Assert.assertEquals(re.getChannelNoiseReduction(i),
+                        cb.getNoiseReduction().getValue());
+                Assert.assertEquals(re.getChannelLookupTable(i),
+                        cb.getLookupTable().getValue());
+                int[] values = re.getRGBA(i);
+                Assert.assertEquals(values[0], cb.getRed().getValue());
+                Assert.assertEquals(values[1], cb.getGreen().getValue());
+                Assert.assertEquals(values[2], cb.getBlue().getValue());
+                Assert.assertEquals(values[3], cb.getAlpha().getValue());
+                List<IObject> codomains = re.getCodomainMapContext(i);
+                Assert.assertEquals(cb.sizeOfSpatialDomainEnhancement(), 0);
+                Assert.assertEquals(codomains.size(), cb.sizeOfSpatialDomainEnhancement());
+            }
+        }
+    }
+
     //Inner class used to store rnd settings for channels
     class ChannelBindingPrx {
         Family family;


### PR DESCRIPTION
# What this PR does

The rendering engine was designed with stateful use in mind. Unfortunately, this means that many remote calls are required to establish initial state. When the rendering engine is used with stateless environments like OMERO.web these remote calls generate excessive overhead on each and every rendering operation.

The above is of particular importance when the number of channels is high (>10).

This PR allows the remote caller to update a series of settings by passing a single populated RenderingDef via one remote method invocation rather than making a large number of them to achieve the same result.

During testing several performance related improvements were also made to linear quantization. `Math.pow()` is very expensive, especially when `k` is fractional. Attempts have been made to avoid it entirely when `k=1` and other similar situations where `x` is being raised to the power of `1`.

# Testing this PR

1. required setup

One or more imported images.

2. actions to perform

Make method calls both singularly and with the bulk `updateSettings()` and compare the results.

Check that the integration tests are green
3. expected observations

Identical behaviour to current methods.

# Related reading

N/A

/cc @will-moore, @waxenegger, @dominikl 