### PR TITLE
Fixed rgb_int2css and rgb_int2rgba

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -377,7 +377,7 @@ def rgb_int2css(rgbint):
     E.g. -1006567680 to '#00ff00', 0.5
     """
     alpha = rgbint % 256
-    alpha = float(alpha) / 256
+    alpha = float(alpha) / 255
     b = rgbint / 256 % 256
     g = rgbint / 256 / 256 % 256
     r = rgbint / 256 / 256 / 256 % 256
@@ -390,7 +390,7 @@ def rgb_int2rgba(rgbint):
     E.g. 1694433280 to (255, 0, 0, 0.390625)
     """
     alpha = rgbint % 256
-    alpha = float(alpha) / 256
+    alpha = float(alpha) / 255
     b = rgbint / 256 % 256
     g = rgbint / 256 / 256 % 256
     r = rgbint / 256 / 256 / 256 % 256

--- a/components/tools/OmeroWeb/test/unit/test_marshal.py
+++ b/components/tools/OmeroWeb/test/unit/test_marshal.py
@@ -41,7 +41,7 @@ def basic_line(default_id):
     shape.y1 = rdouble(1.0)
     shape.x2 = rdouble(2.0)
     shape.y2 = rdouble(3.0)
-    shape.strokeColor = rint(ctypes.c_int(0x112233FF).value) # r=17,g=34,b=51,a=255
+    shape.strokeColor = rint(ctypes.c_int(0x112233FF).value)
     return shape
 
 
@@ -64,7 +64,7 @@ def basic_polyline(request, default_id):
     shape = omero.model.PolylineI()
     shape.id = rlong(default_id)
     shape.points = rstring(points)
-    shape.strokeColor = rint(ctypes.c_int(0x11223300).value) # r=17,g=34,b=51,a=0
+    shape.strokeColor = rint(ctypes.c_int(0x11223300).value)
     return shape
 
 
@@ -125,8 +125,8 @@ def basic_ellipse(default_id):
     shape.y = rdouble(.1)
     shape.radiusX = rdouble(1.0)
     shape.radiusY = rdouble(.5)
-    shape.fillColor = rint(ctypes.c_int(0x11223344).value) # r=17,g=34,b=51,a=68
-    shape.strokeColor = rint(ctypes.c_int(0xfffefdfc).value) # r=255,g=254,b=253,a=252 (int value=-66052)
+    shape.fillColor = rint(ctypes.c_int(0x11223344).value)
+    shape.strokeColor = rint(ctypes.c_int(0xfffefdfc).value)
     return shape
 
 
@@ -190,14 +190,14 @@ class TestShapeMarshal(object):
         assert 0.5 == marshaled['radiusY']
 
     def test_rgba(self, basic_ellipse, basic_line, basic_polyline):
-        color = unwrap(basic_ellipse.getFillColor()) # 0x11223344
+        color = unwrap(basic_ellipse.getFillColor())  # 0x11223344
         result = rgb_int2rgba(color)
         assert result[0] == 17               # r
         assert result[1] == 34               # g
         assert result[2] == 51               # b
         assert result[3] == float(68) / 255  # a (as fraction)
 
-        color = unwrap(basic_ellipse.getStrokeColor()) # 0xfffefdfc
+        color = unwrap(basic_ellipse.getStrokeColor())  # 0xfffefdfc
         result = rgb_int2rgba(color)           # int rgb
         assert result[0] == 255                # r
         assert result[1] == 254                # g
@@ -207,12 +207,12 @@ class TestShapeMarshal(object):
         assert result[0] == "#fffefd"          # rgb
         assert result[1] == float(252) / 255   # a (as fraction)
 
-        color = unwrap(basic_line.getStrokeColor()) # 0x112233FF
+        color = unwrap(basic_line.getStrokeColor())  # 0x112233FF
         result = rgb_int2css(color)
         assert result[0] == "#112233"          # rgb
         assert result[1] == 1                  # a (as fraction)
 
-        color = unwrap(basic_polyline.getStrokeColor()) # 0x11223300
+        color = unwrap(basic_polyline.getStrokeColor())  # 0x11223300
         result = rgb_int2css(color)
         assert result[0] == "#112233"          # rgb
         assert result[1] == 0                  # a (as fraction)

--- a/components/tools/OmeroWeb/test/unit/test_marshal.py
+++ b/components/tools/OmeroWeb/test/unit/test_marshal.py
@@ -41,6 +41,7 @@ def basic_line(default_id):
     shape.y1 = rdouble(1.0)
     shape.x2 = rdouble(2.0)
     shape.y2 = rdouble(3.0)
+    # r=17,g=34,b=51,a=255
     shape.strokeColor = rint(ctypes.c_int(0x112233FF).value)
     return shape
 
@@ -64,6 +65,7 @@ def basic_polyline(request, default_id):
     shape = omero.model.PolylineI()
     shape.id = rlong(default_id)
     shape.points = rstring(points)
+    # r=17,g=34,b=51,a=0
     shape.strokeColor = rint(ctypes.c_int(0x11223300).value)
     return shape
 
@@ -125,7 +127,9 @@ def basic_ellipse(default_id):
     shape.y = rdouble(.1)
     shape.radiusX = rdouble(1.0)
     shape.radiusY = rdouble(.5)
+    # r=17,g=34,b=51,a=68
     shape.fillColor = rint(ctypes.c_int(0x11223344).value)
+    # r=255,g=254,b=253,a=252 (i.e. negative int value = -66052)
     shape.strokeColor = rint(ctypes.c_int(0xfffefdfc).value)
     return shape
 

--- a/components/tools/OmeroWeb/test/unit/test_marshal.py
+++ b/components/tools/OmeroWeb/test/unit/test_marshal.py
@@ -40,6 +40,7 @@ def basic_line(default_id):
     shape.y1 = rdouble(1.0)
     shape.x2 = rdouble(2.0)
     shape.y2 = rdouble(3.0)
+    shape.strokeColor = rlong(287454207)     # 0x112233FF,r=17,g=34,b=51,a=255
     return shape
 
 
@@ -62,6 +63,7 @@ def basic_polyline(request, default_id):
     shape = omero.model.PolylineI()
     shape.id = rlong(default_id)
     shape.points = rstring(points)
+    shape.strokeColor = rlong(287453952)     # 0x11223300,r=17,g=34,b=51,a=0
     return shape
 
 
@@ -186,15 +188,25 @@ class TestShapeMarshal(object):
         assert 1.0 == marshaled['radiusX']
         assert 0.5 == marshaled['radiusY']
 
-    def test_rgba(self, basic_ellipse):
+    def test_rgba(self, basic_ellipse, basic_line, basic_polyline):
         color = unwrap(basic_ellipse.getFillColor())
         result = rgb_int2rgba(color)         # 0x11223344
         assert result[0] == 17               # r
         assert result[1] == 34               # g
         assert result[2] == 51               # b
-        assert result[3] == float(68) / 256  # a (as fraction)
+        assert result[3] == float(68) / 255  # a (as fraction)
 
         color = unwrap(basic_ellipse.getStrokeColor())
         result = rgb_int2css(color)            # 0x55667788
         assert result[0] == "#556677"          # rgb
-        assert result[1] == float(136) / 256   # a (as fraction)
+        assert result[1] == float(136) / 255   # a (as fraction)
+
+        color = unwrap(basic_line.getStrokeColor())
+        result = rgb_int2css(color)            # 0x112233FF
+        assert result[0] == "#112233"          # rgb
+        assert result[1] == 1                  # a (as fraction)
+
+        color = unwrap(basic_polyline.getStrokeColor())
+        result = rgb_int2css(color)            # 0x11223300
+        assert result[0] == "#112233"          # rgb
+        assert result[1] == 0                  # a (as fraction)


### PR DESCRIPTION
Both methods calculated alpha as fraction of 256 whereas
it should have been 255 ( alpha int value [0, 255] )

(was introduced by #4995 , thanks for spotting this issue!)

/cc @jburel @chris-allan 