### PR TITLE
Revert "add interim compatibility wrapper IAdmin.createLightSystemUser"

### DIFF
--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -312,8 +312,6 @@ module omero {
                  */
                 long createSystemUser(omero::model::Experimenter experimenter) throws ServerError;
 
-                long createLightSystemUser(omero::model::Experimenter experimenter, AdminPrivilegeList privileges) throws ServerError;
-
                 /**
                  * Creates and returns a new system user. This user will be
                  * created with the <i>System</i> (administration) group as

--- a/components/blitz/src/ome/services/blitz/impl/AdminI.java
+++ b/components/blitz/src/ome/services/blitz/impl/AdminI.java
@@ -30,7 +30,6 @@ import omero.api.AMD_IAdmin_containedGroups;
 import omero.api.AMD_IAdmin_createExperimenter;
 import omero.api.AMD_IAdmin_createExperimenterWithPassword;
 import omero.api.AMD_IAdmin_createGroup;
-import omero.api.AMD_IAdmin_createLightSystemUser;
 import omero.api.AMD_IAdmin_createRestrictedSystemUser;
 import omero.api.AMD_IAdmin_createRestrictedSystemUserWithPassword;
 import omero.api.AMD_IAdmin_createSystemUser;
@@ -195,13 +194,6 @@ public class AdminI extends AbstractAmdServant implements _IAdminOperations {
     public void createSystemUser_async(AMD_IAdmin_createSystemUser __cb,
             Experimenter experimenter, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, experimenter);
-    }
-
-    @Override
-    public void createLightSystemUser_async(AMD_IAdmin_createLightSystemUser __cb,
-            Experimenter experimenter, List<AdminPrivilege> privileges,
-            Current __current) throws ServerError {
-        callInvokerOnRawArgs(__cb, __current, experimenter, privileges);
     }
 
     @Override

--- a/components/common/src/ome/api/IAdmin.java
+++ b/components/common/src/ome/api/IAdmin.java
@@ -307,9 +307,6 @@ public interface IAdmin extends ServiceInterface {
     long createSystemUser(@NotNull
     Experimenter newSystemUser);
 
-    long createLightSystemUser(@NotNull Experimenter newSystemUser,
-            @NotNull @Validate(AdminPrivilege.class) List<AdminPrivilege> privileges);
-
     /**
      * Create and return a new system user. This user will be created with the
      * "System" (administration) group as default and will also be in the "user"

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -670,13 +670,6 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
     @Override
     @RolesAllowed("system")
     @Transactional(readOnly = false)
-    public long createLightSystemUser(Experimenter newSystemUser, List<AdminPrivilege> privileges) {
-        return createRestrictedSystemUser(newSystemUser, privileges);
-    }
-
-    @Override
-    @RolesAllowed("system")
-    @Transactional(readOnly = false)
     public long createRestrictedSystemUser(Experimenter newSystemUser, List<AdminPrivilege> privileges) {
         newSystemUser.setConfig(getRestrictedSystemUserConfig(privileges));
         return createSystemUser(newSystemUser);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1950,7 +1950,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /* lightAdmin succeeds only if they have right permissions.*/
         try {
-            iAdmin.createLightSystemUser(createdAdmin, privileges);
+            iAdmin.createRestrictedSystemUser(createdAdmin, privileges);
             Assert.assertTrue(isExpectSuccessCreateLightAdmin);
         } catch (ServerError se) {
             Assert.assertFalse(isExpectSuccessCreateLightAdmin);


### PR DESCRIPTION
# What this PR does

We now call light admins "restricted" admins so this PR does not use "light" in the method name in the API.

# Testing this PR

Check that webadmin can still create light admins.

# Related reading

https://github.com/openmicroscopy/openmicroscopy/pull/5401#discussion_r133131710
https://trello.com/c/KPI5h2y3/90-admin-service-has-light-admins