### PR TITLE
Drop deprecated `bin/omero admin ports` command

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1783,14 +1783,6 @@ OMERO Diagnostics %s
                            stdout=sys.stdout, stderr=sys.stderr)
         self.ctx.rv = p.wait()
 
-    @with_rw_config
-    def ports(self, args, config):
-        self.ctx.err(
-            "WARNING: the admin ports subcommand is deprecated. Changes will"
-            " be overwritten the next time the configuration files are"
-            " regenerated. Use the omero.ports.xxx configuration properties"
-            " instead.")
-
     @admin_only(AdminPrivilegeReadSession)
     def cleanse(self, args):
         self.check_access()

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -42,7 +42,7 @@ from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
 
 from omero_ext import portalocker
 from omero_ext.which import whichall
-from omero_ext.argparse import FileType, SUPPRESS
+from omero_ext.argparse import FileType
 from omero_version import ice_compatibility
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -338,29 +338,6 @@ dt_socket,address=8787,suspend=y" \\
             "--finish", action="store_true",
             help="Re-enables the background indexer after for indexing")
 
-        ports = Action("ports", SUPPRESS).parser
-        ports.add_argument(
-            "--prefix",
-            help="Adds a prefix to each port ON TOP OF any other settings")
-        ports.add_argument(
-            "--registry", default="4061",
-            help="Registry port. (default: %(default)s)")
-        ports.add_argument(
-            "--tcp", default="4063",
-            help="The tcp port to be used by Glacier2 (default: %(default)s)")
-        ports.add_argument(
-            "--ssl", default="4064",
-            help="The ssl port to be used by Glacier2 (default: %(default)s)")
-        ports.add_argument(
-            "--webserver", default="4080",
-            help="The web application server port (default: %(default)s)")
-        ports.add_argument(
-            "--revert", action="store_true",
-            help="Used to rollback from the given settings to the defaults")
-        ports.add_argument(
-            "--skipcheck", action="store_true",
-            help="Skips the check if the server is already running")
-
         sessionlist = Action(
             "sessionlist", "List currently running sessions").parser
         sessionlist.add_login_arguments()

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -37,7 +37,7 @@ from omero.cli import UserGroupControl
 from omero.model.enums import AdminPrivilegeReadSession
 
 from omero.plugins.prefs import \
-    WriteableConfigControl, with_config, with_rw_config
+    WriteableConfigControl, with_config
 from omero.install.windows_warning import windows_warning, WINDOWS_WARNING
 
 from omero_ext import portalocker


### PR DESCRIPTION
This command was deprecated in 5.2 and has since been a no-op
issuing a warning. Removing for 5.4. (No tests etc. execute
the command.)

See: https://trello.com/c/hArgRqTe/125-deprecation-of-ports

# Testing this PR

1. `bin/omero admin ports` should now error ran than printing a warning.