### PR TITLE
remove comments about "createlang plpgsql"

### DIFF
--- a/components/dsl/resources/ome/dsl/psql-header.vm
+++ b/components/dsl/resources/ome/dsl/psql-header.vm
@@ -9,7 +9,6 @@
 -- To create your database:
 --
 --     createdb omero
---     createlang plpgsql omero
 --     psql omero < %(SCRIPT)s
 --
 --

--- a/components/tools/OmeroPy/src/omero/plugins/db.py
+++ b/components/tools/OmeroPy/src/omero/plugins/db.py
@@ -224,7 +224,6 @@ class DatabaseControl(BaseControl):
 -- To create your database:
 --
 --     createdb omero
---     createlang plpgsql omero
 --     psql omero < %s
 --
 

--- a/sql/misc/Makefile
+++ b/sql/misc/Makefile
@@ -66,10 +66,6 @@ HAS_TEST = test -e $(TEST)
 # in order to make the two versions approach one another
 MAKE_DIFF = $(DIFF_CMD) $(TARGET)/$(2).schema $(TARGET)/$(1).schema > $(TARGET)/$(2).diff
 
-# Now assuming that users have installed plpgsql centrally
-#   (grep "CREATE PROCEDURAL LANGUAGE plpgsql" $(TARGET)/$(1).sql ||\
-#   createlang plpgsql $(PREFIX)$(1)) &&\
-
 MAKE_DB = \
 	($(PSQL_DROP) $(PREFIX)$(1) || echo 'DNE') &&\
 	$(PSQL_CREATE) $(PREFIX)$(1) &&\


### PR DESCRIPTION
# What this PR does

Removes legacy comments that no longer apply now that PostgreSQL includes PL/pgSQL by default.

# Testing this PR

CI suffices.