### PR TITLE
remove_ns_from_conn.createOriginalFile

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3956,9 +3956,9 @@ class _BlitzGateway (object):
             origFilePathAndName = localPath
         path, name = os.path.split(origFilePathAndName)
         fileSize = os.path.getsize(localPath)
-        with open(localPath, 'rb') as fileHandle
-            return self.createOriginalFileFromFileObj(
-                fileHandle, path, name, fileSize, mimetype)
+        with open(localPath, 'rb') as fileHandle:
+            return self.createOriginalFileFromFileObj(fileHandle, path, name,
+                                                      fileSize, mimetype)
 
     def createFileAnnfromLocalFile(self, localPath, origFilePathAndName=None,
                                    mimetype=None, ns=None, desc=None):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3862,7 +3862,7 @@ class _BlitzGateway (object):
         return {'imageCount': len(imageIds), 'updateCount': updateCount}
 
     def createOriginalFileFromFileObj(self, fo, path, name, fileSize,
-                                      mimetype=None):
+                                      mimetype=None, ns=None):
         """
         Creates a :class:`OriginalFileWrapper` from a local file.
         File is uploaded to create an omero.model.OriginalFileI.
@@ -3875,8 +3875,15 @@ class _BlitzGateway (object):
         :param fileSize:                The file size
         :param mimetype:                The mimetype of the file. String.
                                         E.g. 'text/plain'
+        :param ns:                      Deprecated in 5.4.0. This is ignored
         :return:                        New :class:`OriginalFileWrapper`
         """
+        if ns is not None:
+            warnings.warn(
+                "Deprecated in 5.4.0. The ns parameter was added in error"
+                " and has always been ignored",
+                DeprecationWarning)
+
         updateService = self.getUpdateService()
         rawFileStore = self.createRawFileStore()
 
@@ -3924,7 +3931,7 @@ class _BlitzGateway (object):
 
     def createOriginalFileFromLocalFile(self, localPath,
                                         origFilePathAndName=None,
-                                        mimetype=None):
+                                        mimetype=None, ns=None):
         """
         Creates a :class:`OriginalFileWrapper` from a local file.
         File is uploaded to create an omero.model.OriginalFileI.
@@ -3937,8 +3944,14 @@ class _BlitzGateway (object):
                                         OriginalFile. If None, use localPath
         :param mimetype:                The mimetype of the file. String.
                                         E.g. 'text/plain'
+        :param ns:                      Deprecated in 5.4.0. This is ignored
         :return:                        New :class:`OriginalFileWrapper`
         """
+        if ns is not None:
+            warnings.warn(
+                "Deprecated in 5.4.0. The ns parameter was added in error"
+                " and has always been ignored",
+                DeprecationWarning)
         if origFilePathAndName is None:
             origFilePathAndName = localPath
         path, name = os.path.split(origFilePathAndName)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3946,7 +3946,7 @@ class _BlitzGateway (object):
         fileHandle = open(localPath, 'rb')
         try:
             return self.createOriginalFileFromFileObj(
-                fileHandle, path, name, fileSize, mimetype, ns)
+                fileHandle, path, name, fileSize, mimetype)
         finally:
             fileHandle.close()
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3862,7 +3862,7 @@ class _BlitzGateway (object):
         return {'imageCount': len(imageIds), 'updateCount': updateCount}
 
     def createOriginalFileFromFileObj(self, fo, path, name, fileSize,
-                                      mimetype=None, ns=None):
+                                      mimetype=None):
         """
         Creates a :class:`OriginalFileWrapper` from a local file.
         File is uploaded to create an omero.model.OriginalFileI.
@@ -3875,7 +3875,6 @@ class _BlitzGateway (object):
         :param fileSize:                The file size
         :param mimetype:                The mimetype of the file. String.
                                         E.g. 'text/plain'
-        :param ns:                      The file namespace
         :return:                        New :class:`OriginalFileWrapper`
         """
         updateService = self.getUpdateService()
@@ -3925,7 +3924,7 @@ class _BlitzGateway (object):
 
     def createOriginalFileFromLocalFile(self, localPath,
                                         origFilePathAndName=None,
-                                        mimetype=None, ns=None):
+                                        mimetype=None):
         """
         Creates a :class:`OriginalFileWrapper` from a local file.
         File is uploaded to create an omero.model.OriginalFileI.
@@ -3938,7 +3937,6 @@ class _BlitzGateway (object):
                                         OriginalFile. If None, use localPath
         :param mimetype:                The mimetype of the file. String.
                                         E.g. 'text/plain'
-        :param ns:                      The namespace of the file.
         :return:                        New :class:`OriginalFileWrapper`
         """
         if origFilePathAndName is None:
@@ -3975,7 +3973,7 @@ class _BlitzGateway (object):
 
         # create and upload original file
         originalFile = self.createOriginalFileFromLocalFile(
-            localPath, origFilePathAndName, mimetype, ns)
+            localPath, origFilePathAndName, mimetype)
 
         # create FileAnnotation, set ns & description and return wrapped obj
         fa = omero.model.FileAnnotationI()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -3956,12 +3956,9 @@ class _BlitzGateway (object):
             origFilePathAndName = localPath
         path, name = os.path.split(origFilePathAndName)
         fileSize = os.path.getsize(localPath)
-        fileHandle = open(localPath, 'rb')
-        try:
+        with open(localPath, 'rb') as fileHandle
             return self.createOriginalFileFromFileObj(
                 fileHandle, path, name, fileSize, mimetype)
-        finally:
-            fileHandle.close()
 
     def createFileAnnfromLocalFile(self, localPath, origFilePathAndName=None,
                                    mimetype=None, ns=None, desc=None):


### PR DESCRIPTION
# What this PR does

Removes the ```ns``` (namespace) argument from ```conn.createOriginalFileFromFileObj()``` and ```conn. createOriginalFileFromLocalFile()``` where it is ignored - probably got left over from a previous refactor.

# Testing this PR

1. Can be tested by saving an OMERO.figure since with this current PR https://github.com/ome/omero-figure/pull/239 figure now uses the ```conn.createOriginalFileFromFileObj()```.

# Related reading

Noticed this when looking into https://trello.com/c/4unMpwmq/128-createoriginalfilefromfileobj and finding that the method I wanted was already there!
