### PR TITLE
Base template script injection

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/custom_context_processor.py
+++ b/components/tools/OmeroWeb/omeroweb/custom_context_processor.py
@@ -8,4 +8,4 @@ def url_suffix(request):
 
 
 def base_include_template(request):
-	return {'base_include_template': settings.BASE_INCLUDE_TEMPLATE}
+    return {'base_include_template': settings.BASE_INCLUDE_TEMPLATE}

--- a/components/tools/OmeroWeb/omeroweb/custom_context_processor.py
+++ b/components/tools/OmeroWeb/omeroweb/custom_context_processor.py
@@ -1,6 +1,11 @@
 from omero_version import omero_version
+from django.conf import settings
 
 
 def url_suffix(request):
     suffix = u"?_%s" % omero_version
     return {'url_suffix': suffix}
+
+
+def base_include_template(request):
+	return {'base_include_template': settings.BASE_INCLUDE_TEMPLATE}

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -636,7 +636,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["BASE_INCLUDE_TEMPLATE",
          None,
          identity,
-         ("Template to be included in every page, at the bottom of the <body>")],
+         ("Template to be included in every page, at the end of the <body>")],
     "omero.web.login_redirect":
         ["LOGIN_REDIRECT",
          '{}',

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -1061,6 +1061,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 'omeroweb.custom_context_processor.url_suffix',
+                'omeroweb.custom_context_processor.base_include_template',
             ],
         },
     },

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -632,6 +632,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Define template used as an index page ``http://your_host/omero/``."
           "If None user is automatically redirected to the login page."
           "For example use 'webclient/index.html'. ")],
+    "omero.web.base_include_template":
+        ["BASE_INCLUDE_TEMPLATE",
+         None,
+         identity,
+         ("Template to be included in the header of every page.")],
     "omero.web.login_redirect":
         ["LOGIN_REDIRECT",
          '{}',

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -636,7 +636,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["BASE_INCLUDE_TEMPLATE",
          None,
          identity,
-         ("Template to be included in the header of every page.")],
+         ("Template to be included in every page, at the bottom of the <body>")],
     "omero.web.login_redirect":
         ["LOGIN_REDIRECT",
          '{}',

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -207,3 +207,6 @@ class render_response(omeroweb.decorators.render_response):
             c_plugins.append({
                 "label": label, "include": include, "plugin_id": plugin_id})
         context['ome']['center_plugins'] = c_plugins
+
+        if settings.BASE_INCLUDE_TEMPLATE:
+            context['base_include_template'] = settings.BASE_INCLUDE_TEMPLATE

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -207,6 +207,3 @@ class render_response(omeroweb.decorators.render_response):
             c_plugins.append({
                 "label": label, "include": include, "plugin_id": plugin_id})
         context['ome']['center_plugins'] = c_plugins
-
-        if settings.BASE_INCLUDE_TEMPLATE:
-            context['base_include_template'] = settings.BASE_INCLUDE_TEMPLATE

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/core_html.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/core_html.html
@@ -48,11 +48,6 @@
         {% include "webgateway/base/includes/shortcut_icon.html" %}
     {% endblock %}
 
-
-    {% if base_include_template %}
-      {% include base_include_template %}
-    {% endif %}
-
 </head>
 <body>
 
@@ -60,5 +55,10 @@
 
 {% endblock %}
 
+
+    <!-- settings.BASE_INCLUDE_TEMPLATE included here -->
+    {% if base_include_template %}
+      {% include base_include_template %}
+    {% endif %}
 </body>
 </html>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/core_html.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/core_html.html
@@ -48,6 +48,11 @@
         {% include "webgateway/base/includes/shortcut_icon.html" %}
     {% endblock %}
 
+
+    {% if base_include_template %}
+      {% include base_include_template %}
+    {% endif %}
+
 </head>
 <body>
 


### PR DESCRIPTION
# What this PR does

Allows an html template to be included in the base ```core_html``` template that is used for all webclient pages. See https://trello.com/c/mDE65WQK/132-inject-scripts-ga-etc
This can be used for adding ```<script>```, ```<link/>``` etc into the ```<head>``` of all pages.

# Testing this PR

Create an html file e.g.  ```base_include.html``` and save it to e.g. ```omero_web_templates``` dir.
```
<script>
alert("Hello World");
</script>
```
Then:
```
$ bin/omero config append omero.web.template_dirs '"/Users/wmoore/Desktop/omero_web_templates"'
$ bin/omero config set omero.web.base_include_template 'base_include.html'
```
Restart web....
