### PR TITLE
allow model types to be ignored during object deletion (rebased onto metadata53)

### DIFF
--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -202,6 +202,11 @@ module omero {
          * Delete model objects.
          **/
         class Delete2 extends GraphModify2 {
+                /**
+                 * Ignore in the operation all objects of these types.
+                 **/
+                ["deprecated:experimental: may be wholly removed in next major version"]
+                omero::api::StringSet typesToIgnore;
         };
 
         /**

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -123,6 +123,7 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
             final GraphUtil.ParameterReporter arguments = new GraphUtil.ParameterReporter();
             arguments.addParameter("targetObjects", targetObjects);
             arguments.addParameter("childOptions", childOptions);
+            arguments.addParameter("typesToIgnore", typesToIgnore);
             arguments.addParameter("dryRun", dryRun);
             LOGGER.debug("request: " + arguments);
         }

--- a/components/blitz/src/omero/cmd/graphs/Delete2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Delete2I.java
@@ -132,6 +132,8 @@ public class Delete2I extends Delete2 implements IRequest, WrappableRequest<Dele
         helper.setSteps(dryRun ? 4 : 6);
         this.graphHelper = new GraphHelper(helper, graphPathBean);
 
+        graphPolicy = IgnoreTypePolicy.getIgnoreTypePolicy(graphPolicy, graphHelper.getClassesFromNames(typesToIgnore));
+
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
                 aclVoter, systemTypes, graphPathBean, unnullable, new InternalProcessor(), dryRun);
 

--- a/components/blitz/src/omero/cmd/graphs/IgnoreTypePolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/IgnoreTypePolicy.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.cmd.graphs;
+
+import java.util.Collection;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+
+import ome.model.IObject;
+import ome.services.graphs.GraphPolicy;
+
+/**
+ * Adjust graph traversal policy to ignore objects according to their type.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.4.0
+ * @deprecated experimental: may be wholly removed in next major version
+ */
+@Deprecated
+public class IgnoreTypePolicy {
+
+    @SuppressWarnings("unused")
+    private static final Logger LOGGER = LoggerFactory.getLogger(IgnoreTypePolicy.class);
+
+    /**
+     * Adjust an existing graph traversal policy so that objects of certain types may be ignored.
+     * @param graphPolicyToAdjust the graph policy to adjust
+     * @param typesToIgnore the types to ignore as defined by {@link omero.cmd.Delete2#typesToIgnore}
+     * @return the adjusted graph policy
+     */
+    public static GraphPolicy getIgnoreTypePolicy(GraphPolicy graphPolicyToAdjust,
+            final Collection<Class<? extends IObject>> typesToIgnore) {
+        if (CollectionUtils.isEmpty(typesToIgnore)) {
+            return graphPolicyToAdjust;
+        }
+
+        final Predicate<Class<? extends IObject>> isTypeToIgnore = new Predicate<Class<? extends IObject>>() {
+            @Override
+            public boolean apply(Class<? extends IObject> objectClass) {
+                for (final Class<? extends IObject> typeToIgnore : typesToIgnore) {
+                    if (typeToIgnore.isAssignableFrom(objectClass)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+
+        return SkipTailPolicy.getSkipTailPolicy(graphPolicyToAdjust, isTypeToIgnore);
+    }
+}

--- a/components/blitz/src/omero/cmd/graphs/IgnoreTypePolicy.java
+++ b/components/blitz/src/omero/cmd/graphs/IgnoreTypePolicy.java
@@ -39,7 +39,6 @@ import ome.services.graphs.GraphPolicy;
 @Deprecated
 public class IgnoreTypePolicy {
 
-    @SuppressWarnings("unused")
     private static final Logger LOGGER = LoggerFactory.getLogger(IgnoreTypePolicy.class);
 
     /**
@@ -66,6 +65,18 @@ public class IgnoreTypePolicy {
             }
         };
 
-        return SkipTailPolicy.getSkipTailPolicy(graphPolicyToAdjust, isTypeToIgnore);
+        return new BaseGraphPolicyAdjuster(graphPolicyToAdjust) {
+            @Override
+            protected boolean isAdjustedBeforeReview(Details object) {
+                if (object.action == GraphPolicy.Action.EXCLUDE && isTypeToIgnore.apply(object.subject.getClass())) {
+                    object.action = GraphPolicy.Action.OUTSIDE;
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("ignoring all objects of its type, so making " + object);
+                    }
+                    return true;
+                }
+                return false;
+            }
+        };
     }
 }

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -560,7 +560,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         } while (++count < 5);
 
         /* clean up test data */
-        doChange(client, factory, Requests.delete().target(images.toArray(new IObject[images.size()])).build(), true, 5L);
+        doChange(client, factory, Requests.delete().target(images.toArray(new IObject[images.size()])).build(), true, null, 5);
 
         /* check that median performance is better when using typesToIgnore */
         final List<Long> timesWithIgnore = new ArrayList<>(durations.get(true));

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -512,7 +512,7 @@ public class AnnotationDeleteTest extends AbstractServerTest {
      * Test that {@link Delete2#typesToIgnore} runs faster than {@link omero.cmd.graphs.ChildOption#excludeType} on large data.
      * @throws Exception unexpected
      */
-    @Test
+    @Test(timeOut = 200000)
     public void testIgnoreTypesPerformance() throws Exception {
         newUserAndGroup("rwr---");
 

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -2,6 +2,7 @@
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration.delete;
 
 import integration.AbstractServerTest;
@@ -16,7 +17,9 @@ import ome.services.blitz.repo.path.FsFile;
 import omero.RLong;
 import omero.RString;
 import omero.api.RawFileStorePrx;
+import omero.cmd.CmdCallbackI;
 import omero.cmd.Delete2;
+import omero.cmd.HandlePrx;
 import omero.gateway.util.Requests;
 import omero.grid.ManagedRepositoryPrx;
 import omero.grid.ManagedRepositoryPrxHelper;
@@ -26,6 +29,8 @@ import omero.model.Annotation;
 import omero.model.AnnotationAnnotationLink;
 import omero.model.AnnotationAnnotationLinkI;
 import omero.model.Channel;
+import omero.model.CommentAnnotation;
+import omero.model.CommentAnnotationI;
 import omero.model.FileAnnotation;
 import omero.model.FileAnnotationI;
 import omero.model.IObject;
@@ -47,7 +52,10 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.SetMultimap;
+import com.google.common.primitives.Ints;
 
 /**
  * Tests for deleting user ratings.
@@ -445,5 +453,122 @@ public class AnnotationDeleteTest extends AbstractServerTest {
         doChange(request);
         assertDoesNotExist(files.get(1));
         assertDoesNotExist(attachments.get(2));
+    }
+
+    /**
+     * Test the effect of {@link Delete2#typesToIgnore}.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testIgnoreTypesEffect() throws Exception {
+        newUserAndGroup("rwr---");
+
+        /* create a commented image */
+        CommentAnnotation comment = new CommentAnnotationI();
+        comment.setTextValue(omero.rtypes.rstring("test for " + getClass().getSimpleName()));
+        ImageAnnotationLink link = (ImageAnnotationLink) iUpdate.saveAndReturnObject(
+                mmFactory.createAnnotationLink(mmFactory.simpleImage(), comment));
+        Image image = link.getParent();
+        comment = (CommentAnnotation) link.getChild();
+
+        assertAllExist(link, image, comment);
+
+        /* ignoring tags still has the comment deleted along with the image */
+        Delete2 request = Requests.delete().target(image).build();
+        request.typesToIgnore = Collections.singletonList("TagAnnotation");
+        doChange(request);
+
+        assertNoneExist(link, image, comment);
+
+        /* create a commented image */
+        comment = new CommentAnnotationI();
+        comment.setTextValue(omero.rtypes.rstring("test for " + getClass().getSimpleName()));
+        link = (ImageAnnotationLink) iUpdate.saveAndReturnObject(
+                mmFactory.createAnnotationLink(mmFactory.simpleImage(), comment));
+        image = link.getParent();
+        comment = (CommentAnnotation) link.getChild();
+
+        assertAllExist(link, image, comment);
+
+        /* ignoring links prevents image deletion because a link cannot have its parent removed */
+        request = Requests.delete().target(image).build();
+        request.typesToIgnore = Collections.singletonList("IAnnotationLink");
+        doChange(client, factory, request, false);
+
+        assertAllExist(link, image, comment);
+
+        /* ignoring all annotations allows image deletion although the comment remains */
+        request.typesToIgnore = Collections.singletonList("Annotation");
+        doChange(request);
+
+        assertDoesNotExist(link);
+        assertDoesNotExist(image);
+        assertExists(comment);
+
+        doChange(Requests.delete().target(comment).build());
+    }
+
+    /**
+     * Test that {@link Delete2#typesToIgnore} runs faster than {@link omero.cmd.graphs.ChildOption#excludeType} on large data.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testIgnoreTypesPerformance() throws Exception {
+        newUserAndGroup("rwr---");
+
+        /* add the same rating to many images */
+        LongAnnotation rating = new LongAnnotationI();
+        rating.setLongValue(omero.rtypes.rlong(3));
+        rating = (LongAnnotation) iUpdate.saveAndReturnObject(rating).proxy();
+        final List<IObject> toSave = new ArrayList<>();
+        while (toSave.size() < 2500) {
+            final ImageAnnotationLink link = new ImageAnnotationLinkI();
+            link.setParent(mmFactory.simpleImage());
+            link.setChild(rating);
+            toSave.add(link);
+        }
+        final List<ImageAnnotationLink> links = new ArrayList<>(toSave.size());
+        final List<Image> images = new ArrayList<>(toSave.size());
+        for (final IObject saved : iUpdate.saveAndReturnArray(toSave)) {
+            final ImageAnnotationLink link = (ImageAnnotationLink) saved;
+            links.add((ImageAnnotationLink) link.proxy());
+            images.add((Image) link.getParent().proxy());
+        }
+        final Iterator<ImageAnnotationLink> linkIterator = links.iterator();
+
+        /* repeatedly try deleting a single image annotation link */
+        final ListMultimap<Boolean, Long> durations = LinkedListMultimap.create();
+        int count = 0;
+        do {
+            for (final boolean isIgnoreTypes : new boolean[] {false, true}) {
+                /* can delete with excludeType or typesToIgnore for the rating */
+                final Delete2 request = Requests.delete().target(linkIterator.next()).build();
+                if (isIgnoreTypes) {
+                    request.typesToIgnore = Collections.singletonList("Annotation");
+                } else {
+                    request.childOptions = Collections.singletonList(Requests.option().excludeType("Annotation").build());
+                }
+                final long timeStart = System.currentTimeMillis();
+                final HandlePrx handle = factory.submit(request, null);
+                final CmdCallbackI callback = new CmdCallbackI(client, handle);
+                callback.loop(/* with Java 8 can use Math.toIntExact */
+                        Ints.checkedCast(scalingFactor), 20);
+                final long timeEnd = System.currentTimeMillis();
+                assertCmd(callback, true);
+                durations.put(isIgnoreTypes, timeEnd - timeStart);
+            }
+        } while (++count < 5);
+
+        /* clean up test data */
+        doChange(client, factory, Requests.delete().target(images.toArray(new IObject[images.size()])).build(), true, 5L);
+
+        /* check that median performance is better when using typesToIgnore */
+        final List<Long> timesWithIgnore = new ArrayList<>(durations.get(true));
+        final List<Long> timesWithoutIgnore = new ArrayList<>(durations.get(false));
+        Assert.assertEquals(timesWithIgnore.size(), count);
+        Assert.assertEquals(timesWithoutIgnore.size(), count);
+        Collections.sort(timesWithIgnore);
+        Collections.sort(timesWithoutIgnore);
+        Assert.assertTrue(timesWithIgnore.get(count / 2) < timesWithoutIgnore.get(count / 2));
     }
 }

--- a/components/tools/OmeroM/src/delete/deleteObjects.m
+++ b/components/tools/OmeroM/src/delete/deleteObjects.m
@@ -48,7 +48,7 @@ for i = 1 : numel(ids)
 end
 targetObject = java.util.Hashtable;
 targetObject.put(objectType.delete2,idlist);
-deleteCommands = omero.cmd.Delete2(targetObject, [], false);
+deleteCommands = omero.cmd.Delete2(targetObject, [], false, []);
 
 % Submit the delete commands
 session.submit(deleteCommands);

--- a/examples/Training/matlab/DeleteData.m
+++ b/examples/Training/matlab/DeleteData.m
@@ -91,7 +91,7 @@ try
     fprintf(1, 'Deleting ROI %g\n', roi.getId().getValue());
     targetObj = java.util.Hashtable;
     targetObj.put('ROI', toJavaList(roi.getId().getValue(), 'java.lang.Long'));
-    deleteCommand = omero.cmd.Delete2(targetObj, [], false);
+    deleteCommand = omero.cmd.Delete2(targetObj, [], false, []);
     session.submit(deleteCommand);
 
     % Delete the image. You can delete more than one image at a time.


### PR DESCRIPTION

This is the same as gh-5460 but rebased onto metadata53.

----

# What this PR does

This PR adds a `Delete2.typesToIgnore` property that can be used to stall graph traversal at nodes of those types. This is a strictly *experimental* feature that when misused has the potential to leave the model graph in an unfortunate state or to produce strange error messages. It is however a useful interim feature for IDR workflows until we upgrade Hibernate and adjust its query caching.

# Testing this PR

Set graphs logging to DEBUG using https://docs.openmicroscopy.org/omero/5.4.0-m3/developers/Server/ObjectGraphs.html#changing-the-log-level. (Alternatively, @manics has means to instrument PostgreSQL queries.)

Link a map annotation to multiple images. Using a Python script delete one of the links via `Delete2(..., typesToIgnore=['Annotation'])`. Observe that with the extra `typesToIgnore` a lot less processing than otherwise happens with the annotation's *other* links.

# Related reading

https://trello.com/c/mfW0N1an/89-poor-performance-when-deleting-many-one-annotation-links

                