### PR TITLE
Shape stats minimal

### DIFF
--- a/components/blitz/resources/omero/api/IRoi.ice
+++ b/components/blitz/resources/omero/api/IRoi.ice
@@ -177,6 +177,21 @@ module omero {
                 idempotent
                 ShapeStatsList getShapeStatsList(LongList shapeIdList) throws omero::ServerError;
 
+                /**
+                 * Calculate the stats for the points within the given Shapes.
+                 * Varies to the above in the following ways:
+                 * - does not allow tiled images
+                 * - shapes have to be all belonging to the same image
+                 * - unattached z/t use the fallback parameters zForUnattached/tForUnattached
+                 *   that is to say there is never more than 1 z/t combination queried
+                 * - if channel list is given, only the channels in that list are iterated over
+                 * - does not request data from reader on each iteration 
+                 **/
+                ["deprecated:IROI is deprecated."]
+                idempotent
+                ShapeStatsList getShapeStatsRestricted(
+                    LongList shapeIdList, int zForUnattached, int tForUnattached, IntegerArray channels) throws omero::ServerError;
+
                 //
                 // Measurement-based methods
                 //

--- a/components/blitz/src/ome/services/blitz/impl/RoiI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RoiI.java
@@ -48,6 +48,7 @@ import omero.api.AMD_IRoi_getRoiMeasurements;
 import omero.api.AMD_IRoi_getRoiStats;
 import omero.api.AMD_IRoi_getShapeStats;
 import omero.api.AMD_IRoi_getShapeStatsList;
+import omero.api.AMD_IRoi_getShapeStatsRestricted;
 import omero.api.AMD_IRoi_getTable;
 import omero.api.AMD_IRoi_uploadMask;
 import omero.api.RoiOptions;
@@ -240,6 +241,26 @@ public class RoiI extends AbstractAmdServant implements _IRoiOperations,
             public Object doWork(Session session, ServiceFactory sf) {
                 List<Long> shapesInRoi = sql.getShapeIds(roiId);
                 return geomTool.getStats(shapesInRoi);
+            }
+        }));
+    }
+
+    public void getShapeStatsRestricted_async(AMD_IRoi_getShapeStatsRestricted __cb,
+        final List<Long> shapeIdList, final int zForUnattached, final int tForUnattached,
+        final int[] channels, Current __current) throws ServerError {
+
+        final IceMapper mapper = new IceMapper(IceMapper.UNMAPPED);
+
+        runnableCall(__current, new Adapter(__cb, __current, mapper, factory
+                .getExecutor(), factory.principal, new SimpleWork(this,
+                "getShapeStatsRestricted", 
+                shapeIdList, zForUnattached, tForUnattached, channels) {
+
+            @Transactional(readOnly = true)
+            public Object doWork(Session session, ServiceFactory sf) {
+                return
+                    geomTool.getStatsRestricted(
+                        shapeIdList, zForUnattached, tForUnattached, channels);
             }
         }));
     }

--- a/components/blitz/src/ome/services/roi/GeomTool.java
+++ b/components/blitz/src/ome/services/roi/GeomTool.java
@@ -381,7 +381,10 @@ public class GeomTool {
                "join fetch r.image i join fetch i.pixels p " +
                "where s.id in (:ids)").
            setParameterList("ids", shapeIds).list();
-       
+       if (results.size() != shapeIds.size()) {
+           throw new ApiUsageException("Given hape id(s) invalid");
+       }
+
        ome.model.core.Image image = null;
        ome.model.core.Pixels pixels = null;
        for (final Object r : results) {
@@ -411,7 +414,6 @@ public class GeomTool {
            }
            lookupValue.add(shape);
        }
-       if (zt_lookup.size() == 0) return null;
 
        // any point iteration in a tiled image is a lost cause
        if (data.needsPyramid(pixels)) 
@@ -420,8 +422,11 @@ public class GeomTool {
       Set<Integer> validChannels = null;
        if (channels != null && channels.length > 0) {
            validChannels = new HashSet<Integer>(channels.length);
-           for (int ch : channels)
-               if (ch >= 0 && ch < pixels.getSizeC()) validChannels.add(ch);
+           for (int ch : channels) {
+               if (ch < 0 || ch >= pixels.getSizeC())
+                   throw new ApiUsageException("Given channel(s) out of bounds.");
+               validChannels.add(ch);
+           }
        }
        // common info for all shapes 
        final long pixelId = pixels.getId();

--- a/components/blitz/src/ome/services/roi/GeomTool.java
+++ b/components/blitz/src/ome/services/roi/GeomTool.java
@@ -382,7 +382,7 @@ public class GeomTool {
                "where s.id in (:ids)").
            setParameterList("ids", shapeIds).list();
        if (results.size() != shapeIds.size()) {
-           throw new ApiUsageException("Given hape id(s) invalid");
+           throw new ApiUsageException("Given shape id(s) invalid");
        }
 
        ome.model.core.Image image = null;

--- a/components/blitz/src/ome/services/roi/GeomTool.java
+++ b/components/blitz/src/ome/services/roi/GeomTool.java
@@ -396,7 +396,7 @@ public class GeomTool {
            if (image == null) {
                image = img;
                pixels = image.getPrimaryPixels();
-           } else if (image.getId() != img.getId())
+           } else if (!image.getId().equals(img.getId()))
                throw new ApiUsageException("All shapes have to be from the same image");
            // check if z/t unattached fallback values are not out of bounds
            if (zForUnattached < 0 || zForUnattached >= pixels.getSizeZ() ||
@@ -416,10 +416,10 @@ public class GeomTool {
        }
 
        // any point iteration in a tiled image is a lost cause
-       if (data.needsPyramid(pixels)) 
+       if (data.requiresPixelsPyramid(pixels)) 
            throw new ApiUsageException("This method can not handle tiled images yet.");
        // check for channels filter
-      Set<Integer> validChannels = null;
+       Set<Integer> validChannels = null;
        if (channels != null && channels.length > 0) {
            validChannels = new HashSet<Integer>(channels.length);
            for (int ch : channels) {
@@ -434,7 +434,7 @@ public class GeomTool {
        final int sizeY = pixels.getSizeY();
        // loop over shapes (grouped by z/t planes)
        for (final String key : zt_lookup.keySet()) {
-           final String [] keyTokens = key.split("/");
+           final String[] keyTokens = key.split("/");
            final int z = Integer.parseInt(keyTokens[0]);
            final int t = Integer.parseInt(keyTokens[1]);
 
@@ -451,7 +451,7 @@ public class GeomTool {
             	   int i = 0;
                    for (int c = 0; c < pixels.getSizeC(); c++) {
                        if (validChannels != null && 
-                           !validChannels.contains(new Integer(c))) continue;
+                           !validChannels.contains(c)) continue;
                        final int w = i;
                        stats.channelIds[w] = c;
                        final ome.util.PixelData pd = data.getPlane(buf, z, c, t);

--- a/components/blitz/src/ome/services/roi/GeomTool.java
+++ b/components/blitz/src/ome/services/roi/GeomTool.java
@@ -364,8 +364,10 @@ public class GeomTool {
             List<Long> shapeIds, 
             int zForUnattached, int tForUnattached,
             int[] channels) {
-        if (shapeIds == null || shapeIds.isEmpty()) 
+        if (shapeIds == null || shapeIds.isEmpty())
             throw new ApiUsageException("Provide a non empty list of shape ids.");
+        if (channels == null || channels.length == 0)
+            throw new ApiUsageException("Provide a non empty array of channels.");
 
        // fetch shapes from db and perform some basic checks
         final Session session = factory.getSession();
@@ -411,7 +413,8 @@ public class GeomTool {
        // any point iteration in a tiled image is a lost cause
        if (data.requiresPixelsPyramid(pixels)) 
            throw new ApiUsageException("This method cannot handle tiled images yet.");
-       // check for channels filter
+
+       // check if given channels are valid
        Set<Integer> validChannels = new HashSet<Integer>();
        if (channels != null && channels.length > 0) {
            for (int ch : channels) {
@@ -419,13 +422,9 @@ public class GeomTool {
                    throw new ApiUsageException("Given channel(s) out of bounds.");
                validChannels.add(ch);
            }
-       } else {
-           for (int j=0; j<pixels.getSizeC();j++) {
-               validChannels.add(j);
-           }
        }
 
-       // common info for all shapes 
+       // common info for all shapes
        final long pixelId = pixels.getId();
        final int sizeX = pixels.getSizeX();
        final int sizeY = pixels.getSizeY();

--- a/components/blitz/src/ome/services/roi/PixelData.java
+++ b/components/blitz/src/ome/services/roi/PixelData.java
@@ -61,7 +61,17 @@ public class PixelData {
         }
     }
 
-    public  ome.util.PixelData getPlane(PixelBuffer buf, int z, int c, int t) {
+    /**
+     * Returns the {@link ome.util.PixelData} for plane given its z, c and t
+     * as well as a {@link PixelBuffer}
+     *
+     * @param buf the {@link PixelBuffer}
+     * @param z the Z
+     * @param c the C
+     * @param t the T
+     * @return the ome.util.PixelData for the plane
+     */
+    public ome.util.PixelData getPlane(PixelBuffer buf, int z, int c, int t) {
         try {
             return buf.getPlane(z, c, t);
         } catch (IOException e) {
@@ -73,6 +83,16 @@ public class PixelData {
         }
     }
 
+    /**
+     * Returns whether a pyramid should be used for the given {@link Pixels}.
+     * This usually implies that this is a "Big image" and therefore will
+     * need tiling.
+     *
+     * @see PixelsService#requiresPixelsPyramid(Pixels)
+     * @param pix the pixels
+     * @return {@code true} if a pyramid should be used, {@code false}
+     *         otherwise
+     */
     public boolean requiresPixelsPyramid(Pixels pix) {
         return data.requiresPixelsPyramid(pix);
     }

--- a/components/blitz/src/ome/services/roi/PixelData.java
+++ b/components/blitz/src/ome/services/roi/PixelData.java
@@ -63,7 +63,7 @@ public class PixelData {
 
     public  ome.util.PixelData getPlane(PixelBuffer buf, int z, int c, int t) {
         try {
-            return  buf.getPlane(z, c, t);
+            return buf.getPlane(z, c, t);
         } catch (IOException e) {
             throw new ResourceError("IOException: " + e);
         } catch (DimensionsOutOfBoundsException e) {
@@ -73,7 +73,7 @@ public class PixelData {
         }
     }
 
-    public boolean needsPyramid(Pixels pix) {
+    public boolean requiresPixelsPyramid(Pixels pix) {
         return data.requiresPixelsPyramid(pix);
     }
 

--- a/components/blitz/src/ome/services/roi/PixelData.java
+++ b/components/blitz/src/ome/services/roi/PixelData.java
@@ -16,6 +16,7 @@ import ome.conditions.ValidationException;
 import ome.io.nio.DimensionsOutOfBoundsException;
 import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
+import ome.model.core.Pixels;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +59,22 @@ public class PixelData {
                 pd.dispose();
             }
         }
+    }
+
+    public  ome.util.PixelData getPlane(PixelBuffer buf, int z, int c, int t) {
+        try {
+            return  buf.getPlane(z, c, t);
+        } catch (IOException e) {
+            throw new ResourceError("IOException: " + e);
+        } catch (DimensionsOutOfBoundsException e) {
+            throw new ApiUsageException("DimensionsOutOfBounds: " + e);
+        } catch (IndexOutOfBoundsException iobe) {
+            throw new ValidationException("IndexOutOfBounds: " + iobe);
+        }
+    }
+
+    public boolean needsPyramid(Pixels pix) {
+        return data.requiresPixelsPyramid(pix);
     }
 
 }

--- a/components/blitz/src/omero/model/SmartEllipseI.java
+++ b/components/blitz/src/omero/model/SmartEllipseI.java
@@ -26,6 +26,7 @@ public class SmartEllipseI extends omero.model.EllipseI implements SmartShape {
         if (s == null) {
             return;
         }
+        if (transform != null) s = Util.transformAwtShape(s, transform);
         Rectangle2D r = s.getBounds2D();
         Util.pointsByBoundingBox(s, r, cb);
     }

--- a/components/blitz/src/omero/model/SmartEllipseI.java
+++ b/components/blitz/src/omero/model/SmartEllipseI.java
@@ -20,13 +20,12 @@ import java.util.List;
 import java.util.Random;
 
 public class SmartEllipseI extends omero.model.EllipseI implements SmartShape {
-
     public void areaPoints(PointCallback cb) {
         Shape s = asAwtShape();
         if (s == null) {
             return;
         }
-        if (transform != null) s = Util.transformAwtShape(s, transform);
+        if (transform != null) s = Util.transformAwtShape(s, this.transform);
         Rectangle2D r = s.getBounds2D();
         Util.pointsByBoundingBox(s, r, cb);
     }

--- a/components/blitz/src/omero/model/SmartLineI.java
+++ b/components/blitz/src/omero/model/SmartLineI.java
@@ -11,14 +11,23 @@ import static omero.rtypes.rdouble;
 
 import java.awt.Shape;
 import java.awt.geom.Line2D;
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.List;
 import java.util.Random;
 
 public class SmartLineI extends omero.model.LineI implements SmartShape {
 
     public void areaPoints(PointCallback cb) {
-        throw new UnsupportedOperationException();
+        Shape s = asAwtShape();
+        if (s == null) {
+            return;
+        }
+        if (transform != null) s = Util.transformAwtShape(s, transform);
+        final Set<Point2D> points = Util.getQuantizedLinePoints((Line2D) s, null);
+        for (Point2D p : points)
+            cb.handle((int) p.getX(), (int) p.getY());
     }
     
     public Shape asAwtShape() {

--- a/components/blitz/src/omero/model/SmartPointI.java
+++ b/components/blitz/src/omero/model/SmartPointI.java
@@ -29,7 +29,7 @@ public class SmartPointI extends omero.model.PointI implements SmartShape {
                     t.transform(new Point2D.Double(point_x, point_y), null);
                 point_x = p.getX();
                 point_y = p.getY();
-        	 }
+            }
             cb.handle((int) point_x, (int) point_y);
         } catch (NullPointerException npe) {
             return;

--- a/components/blitz/src/omero/model/SmartPointI.java
+++ b/components/blitz/src/omero/model/SmartPointI.java
@@ -10,6 +10,8 @@ package omero.model;
 import static omero.rtypes.rdouble;
 
 import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -18,7 +20,17 @@ public class SmartPointI extends omero.model.PointI implements SmartShape {
 
     public void areaPoints(PointCallback cb) {
         try {
-            cb.handle((int) x.getValue(), (int) y.getValue());
+            double point_x = x.getValue();
+            double point_y = y.getValue();
+            if (transform != null) {
+                final AffineTransform t = Util.getAwtTransform(transform);
+                
+                final Point2D p = 
+                    t.transform(new Point2D.Double(point_x, point_y), null);
+                point_x = p.getX();
+                point_y = p.getY();
+        	 }
+            cb.handle((int) point_x, (int) point_y);
         } catch (NullPointerException npe) {
             return;
         }

--- a/components/blitz/src/omero/model/SmartPolygonI.java
+++ b/components/blitz/src/omero/model/SmartPolygonI.java
@@ -10,13 +10,20 @@ package omero.model;
 import static omero.rtypes.rstring;
 
 import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
 import java.util.List;
 import java.util.Random;
 
 public class SmartPolygonI extends omero.model.PolygonI implements SmartShape {
 
     public void areaPoints(PointCallback cb) {
-        throw new UnsupportedOperationException();
+        Shape s = asAwtShape();
+        if (s == null) {
+            return;
+        }
+        if (transform != null) s = Util.transformAwtShape(s, transform);
+        Rectangle2D r = s.getBounds2D();
+        Util.pointsByBoundingBox(s, r, cb);
     }
     
     public Shape asAwtShape() {

--- a/components/blitz/src/omero/model/SmartPolylineI.java
+++ b/components/blitz/src/omero/model/SmartPolylineI.java
@@ -13,7 +13,6 @@ import java.awt.Shape;
 import java.awt.geom.Line2D;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -27,21 +26,18 @@ public class SmartPolylineI extends omero.model.PolylineI implements SmartShape 
         }
         final PathIterator it = s.getPathIterator(Util.getAwtTransform(transform));
         double [] vals = new double[] {0,0,0,0,0,0};
-        Set<Point2D> points = new LinkedHashSet<>();
         double [] last_point = null;
         while (!it.isDone()) {
             it.currentSegment(vals);
             double [] new_point = new double[] {vals[0], vals[1]};
-            if (last_point != null)
-                points = Util.getQuantizedLinePoints(
-                    new Line2D.Double(last_point[0], last_point[1], new_point[0], new_point[1]), points);
+            if (last_point != null) {
+                final Set<Point2D> points = Util.getQuantizedLinePoints(
+                    new Line2D.Double(last_point[0], last_point[1], new_point[0], new_point[1]), null);
+                for (Point2D p : points) cb.handle((int) p.getX(), (int) p.getY());
+            }
             last_point = new_point;
             it.next();
         }
-        
-        for (Point2D p : points)
-            cb.handle((int) p.getX(), (int) p.getY());
-
     }
     
     public Shape asAwtShape() {

--- a/components/blitz/src/omero/model/SmartPolylineI.java
+++ b/components/blitz/src/omero/model/SmartPolylineI.java
@@ -25,7 +25,7 @@ public class SmartPolylineI extends omero.model.PolylineI implements SmartShape 
             return;
         }
         final PathIterator it = s.getPathIterator(Util.getAwtTransform(transform));
-        double [] vals = new double[] {0,0,0,0,0,0};
+        double [] vals = new double[] {0, 0, 0, 0, 0, 0};
         double [] last_point = null;
         while (!it.isDone()) {
             it.currentSegment(vals);

--- a/components/blitz/src/omero/model/SmartPolylineI.java
+++ b/components/blitz/src/omero/model/SmartPolylineI.java
@@ -10,15 +10,38 @@ package omero.model;
 import static omero.rtypes.rstring;
 
 import java.awt.Shape;
+import java.awt.geom.Line2D;
+import java.awt.geom.PathIterator;
+import java.awt.geom.Point2D;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
-
-import omero.model.SmartShape.Util;
+import java.util.Set;
 
 public class SmartPolylineI extends omero.model.PolylineI implements SmartShape {
 
     public void areaPoints(PointCallback cb) {
-        throw new UnsupportedOperationException();
+        Shape s = asAwtShape();
+        if (s == null) {
+            return;
+        }
+        final PathIterator it = s.getPathIterator(Util.getAwtTransform(transform));
+        double [] vals = new double[] {0,0,0,0,0,0};
+        Set<Point2D> points = new LinkedHashSet<>();
+        double [] last_point = null;
+        while (!it.isDone()) {
+            it.currentSegment(vals);
+            double [] new_point = new double[] {vals[0], vals[1]};
+            if (last_point != null)
+                points = Util.getQuantizedLinePoints(
+                    new Line2D.Double(last_point[0], last_point[1], new_point[0], new_point[1]), points);
+            last_point = new_point;
+            it.next();
+        }
+        
+        for (Point2D p : points)
+            cb.handle((int) p.getX(), (int) p.getY());
+
     }
     
     public Shape asAwtShape() {

--- a/components/blitz/src/omero/model/SmartRectI.java
+++ b/components/blitz/src/omero/model/SmartRectI.java
@@ -21,6 +21,7 @@ public class SmartRectI extends omero.model.RectangleI implements SmartShape {
         if (s == null) {
             return;
         }
+        if (transform != null) s = Util.transformAwtShape(s, transform);
         Rectangle2D r = s.getBounds2D();
         Util.pointsByBoundingBox(s, r, cb);
     }

--- a/components/blitz/src/omero/model/SmartShape.java
+++ b/components/blitz/src/omero/model/SmartShape.java
@@ -241,17 +241,24 @@ public interface SmartShape {
         
         public static Set<Point2D> getQuantizedLinePoints(Line2D line, Set<Point2D> points) {
             if (line == null) return null;
-            
+
+            final Set<Point2D> set =
+                (points instanceof LinkedHashSet) ?
+                    points : new LinkedHashSet<Point2D>();
+
             Point2D start = line.getP1();
             Point2D end = line.getP2();
             Point2D m = new Point2D.Double(
                 end.getX()-start.getX(), end.getY()-start.getY());
             double lengthM = (Math.sqrt(m.getX()*m.getX()+m.getY()*m.getY()));
+            if (lengthM == 0) {
+                set.add(
+                    new Point2D.Double(
+                        Math.floor(start.getX()), Math.floor(start.getY())));
+                return set;
+            }
             Point2D mNorm = new Point2D.Double(m.getX()/lengthM,m.getY()/lengthM);
             
-            final Set<Point2D> set = 
-                (points instanceof LinkedHashSet) ? 
-                    points : new LinkedHashSet<Point2D>();
             for (double i = 0 ; i <= (lengthM + 0.1) ; i += 0.1) {
                 final Point2D pt = 
                     new Point2D.Double(

--- a/components/blitz/src/omero/model/SmartShape.java
+++ b/components/blitz/src/omero/model/SmartShape.java
@@ -252,7 +252,7 @@ public interface SmartShape {
             final Set<Point2D> set = 
                 (points instanceof LinkedHashSet) ? 
                     points : new LinkedHashSet<Point2D>();
-            for (double i = 0 ; i < lengthM ; i += 0.1) {
+            for (double i = 0 ; i <= (lengthM + 0.1) ; i += 0.1) {
                 final Point2D pt = 
                     new Point2D.Double(
                         start.getX()+i*mNorm.getX(),

--- a/components/blitz/src/omero/model/SmartTextI.java
+++ b/components/blitz/src/omero/model/SmartTextI.java
@@ -8,24 +8,28 @@
 
 package omero.model;
 
-import static omero.rtypes.rdouble;
-
 import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
-/**
- * THIS CLASS IS CURRENTLY BROKEN. A Text needs a position (an x/y-offset within
- * the image) which it is currently lacking. Therefore this implementation
- * blindly sets the offset to (0,0) so that all text will be in the upper-right
- * corner.
- */
 public class SmartTextI extends omero.model.LabelI implements SmartShape {
 
     public void areaPoints(PointCallback cb) {
         try {
-            cb.handle((int) x.getValue(), (int) y.getValue());
+            double point_x = x.getValue();
+            double point_y = y.getValue();
+            if (transform != null) {
+                final AffineTransform t = Util.getAwtTransform(transform);
+                
+                final Point2D p = 
+                    t.transform(new Point2D.Double(point_x, point_y), null);
+                point_x = p.getX();
+                point_y = p.getY();
+        	 }
+            cb.handle((int) point_x, (int) point_y);
         } catch (NullPointerException npe) {
             return;
         }

--- a/components/tools/OmeroJava/test/integration/RoiServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/RoiServiceTest.java
@@ -710,21 +710,25 @@ public class RoiServiceTest extends AbstractServerTest {
         // some basic inputs checks
         final List<Object[]> inputs = new ArrayList<Object[]>();
         inputs.add(new Object[] {
-            null, new Integer(0), new Integer(0), new int[] {}, "null ids"});
+            null, new Integer(0), new Integer(0), new int[] {0}, "null ids"});
         inputs.add(new Object[] {
-            new ArrayList<Long>(), new Integer(0), new Integer(0), new int[] {},
+            new ArrayList<Long>(), new Integer(0), new Integer(0), new int[] {0},
             "empty ids" });
         inputs.add(new Object[] {
             Arrays.asList(new Long[] {new Long (-1)}), new Integer(0), new Integer(0),
-            new int[] {}, "erroneous id" });
-        inputs.add(new Object[] { ids, new Integer(10), new Integer(10), new int[] {},
+            new int[] {0}, "erroneous id" });
+        inputs.add(new Object[] { ids, new Integer(10), new Integer(10), new int[] {0},
             "wrong fallback z" });
-        inputs.add(new Object[] { ids, new Integer(0), new Integer(-10), new int[] {},
+        inputs.add(new Object[] { ids, new Integer(0), new Integer(-10), new int[] {0},
             "wrong fallback t" });
         inputs.add(new Object[] { ids, new Integer(0), new Integer(0), new int[] {200},
             "wrong channels" });
+        inputs.add(new Object[] { ids, new Integer(0), new Integer(0), null,
+            "missing channels" });
+        inputs.add(new Object[] { ids, new Integer(0), new Integer(0), new int[] {},
+            "empty channels" });
 
-        // all these inputs should trigger an ApiUssageException
+        // all these inputs should trigger an ApiUsageException
         for (Object [] in : inputs) {
             boolean succeeded = false;
             try {
@@ -737,7 +741,7 @@ public class RoiServiceTest extends AbstractServerTest {
         }
 
         // call again with valid params and assert results
-        final ShapeStats [] stats = svc.getShapeStatsRestricted(ids, 0, 0, null);
+        final ShapeStats [] stats = svc.getShapeStatsRestricted(ids, 0, 0, new int[] {0});
         for (final ShapeStats calcStats : stats) {
             final ShapeStats expStats = testAndAssertData.get(calcStats.shapeId);
             assertEquals(calcStats.pointsCount[0], expStats.pointsCount[0]);

--- a/components/tools/OmeroJava/test/integration/RoiServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/RoiServiceTest.java
@@ -6,30 +6,50 @@
  */
 package integration;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import java.awt.Color;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import omero.ApiUsageException;
 import omero.ServerError;
 import omero.api.IRoiPrx;
+import omero.api.RawPixelsStorePrx;
 import omero.api.RoiOptions;
 import omero.api.RoiResult;
+import omero.api.ShapeStats;
 import omero.grid.Column;
 import omero.grid.LongColumn;
 import omero.grid.TablePrx;
+import omero.model.AffineTransform;
+import omero.model.AffineTransformI;
 import omero.model.Annotation;
+import omero.model.Ellipse;
+import omero.model.EllipseI;
 import omero.model.FileAnnotation;
 import omero.model.FileAnnotationI;
 import omero.model.IObject;
 import omero.model.Image;
+import omero.model.Line;
+import omero.model.LineI;
 import omero.model.OriginalFile;
 import omero.model.Plate;
 import omero.model.PlateAnnotationLink;
 import omero.model.PlateAnnotationLinkI;
 import omero.model.PlateI;
+import omero.model.Point;
+import omero.model.PointI;
+import omero.model.Polygon;
+import omero.model.PolygonI;
+import omero.model.Polyline;
+import omero.model.PolylineI;
 import omero.model.Rectangle;
 import omero.model.RectangleI;
 import omero.model.Roi;
@@ -517,5 +537,214 @@ public class RoiServiceTest extends AbstractServerTest {
         }
         roi = (RoiI) iUpdate.saveAndReturnObject(roi);
         return roi;
+    }
+
+    private Map<Long, ShapeStats> setUpForStatsTest() throws Exception {
+        // create image
+        Image img = mmFactory.createImage(
+            10, 10, 1, 1, 1, ModelMockFactory.UINT8);
+        img = (Image) iUpdate.saveAndReturnObject(img);
+
+        // set binary data to more easily check results
+        // we create a checkerboard pattern of 5x5 pixels
+        // left at 0,0 the quadrants alternate between all 0 or 0xFF
+        // 00 FF
+        // FF 00
+        RawPixelsStorePrx rawPixStore = factory.createRawPixelsStore();
+        rawPixStore.setPixelsId(img.getPrimaryPixels().getId().getValue(), true);
+        byte [] bytes = new byte[10*10];
+        for (int y=0;y<10;y++)
+            for (int x=0;x<10;x++) {
+                if ((y<5 && x>4) || (y>4 && x<5))
+                    bytes[y*10 + x] = Byte.MAX_VALUE;
+            }
+        rawPixStore.setPlane(bytes, 0, 0, 0);
+
+        // create roi with shapes
+        Roi roi = new RoiI();
+        roi.setImage(img);
+
+        // a rectangle fully in the FF quandrant
+        final Rectangle rect = new RectangleI();
+        rect.setX(omero.rtypes.rdouble(5));
+        rect.setY(omero.rtypes.rdouble(0));
+        rect.setWidth(omero.rtypes.rdouble(4));
+        rect.setHeight(omero.rtypes.rdouble(4));
+        rect.setTheC(omero.rtypes.rint(0));
+        rect.setTheZ(omero.rtypes.rint(0));
+        rect.setTheT(omero.rtypes.rint(0));
+        roi.addShape(rect);
+
+        // a line rectangle crossing 00/FF horizontally
+        final Line line = new LineI();
+        line.setX1(omero.rtypes.rdouble(0));
+        line.setY1(omero.rtypes.rdouble(1));
+        line.setX2(omero.rtypes.rdouble(9));
+        line.setY2(omero.rtypes.rdouble(1));
+        line.setTheC(omero.rtypes.rint(0));
+        line.setTheZ(omero.rtypes.rint(0));
+        line.setTheT(omero.rtypes.rint(0));
+        roi.addShape(line);
+
+        // an ellipse across the upper 2 quadrants
+        final Ellipse ellipse = new EllipseI();
+        ellipse.setX(omero.rtypes.rdouble(4.5));
+        ellipse.setY(omero.rtypes.rdouble(2.5));
+        ellipse.setRadiusX(omero.rtypes.rdouble(5));
+        ellipse.setRadiusY(omero.rtypes.rdouble(2.5));
+        ellipse.setTheC(omero.rtypes.rint(0));
+        ellipse.setTheZ(omero.rtypes.rint(0));
+        ellipse.setTheT(omero.rtypes.rint(0));
+        roi.addShape(ellipse);
+
+        // a point at the origin translated
+        // into the FF quandrant
+        final Point point = new PointI();
+        point.setX(omero.rtypes.rdouble(0.5));
+        point.setY(omero.rtypes.rdouble(0.5));
+        point.setTheC(omero.rtypes.rint(0));
+        point.setTheZ(omero.rtypes.rint(0));
+        point.setTheT(omero.rtypes.rint(0));
+        final AffineTransform t =  new AffineTransformI();
+        t.setA00(omero.rtypes.rdouble(1));
+        t.setA01(omero.rtypes.rdouble(0));
+        t.setA02(omero.rtypes.rdouble(2.5));
+        t.setA10(omero.rtypes.rdouble(0));
+        t.setA11(omero.rtypes.rdouble(1));
+        t.setA12(omero.rtypes.rdouble(7.5));
+        point.setTransform(t);
+        roi.addShape(point);
+
+        // a polyline (forming triangle)
+        final Polyline polyline = new PolylineI();
+        polyline.setPoints(
+            omero.rtypes.rstring("0,0 9,9 0,9 0,0"));
+        polyline.setTheC(omero.rtypes.rint(0));
+        polyline.setTheZ(omero.rtypes.rint(0));
+        polyline.setTheT(omero.rtypes.rint(0));
+        roi.addShape(polyline);
+
+        // a polygon the shape of a rectangle
+        // transformed onto the entire image
+        final Polygon polygon = new PolygonI();
+        polygon.setPoints(
+            omero.rtypes.rstring("-2.5,2.5 0,2.5 0,0 -2.5,0 -2.5,2.5"));
+        polygon.setTheC(omero.rtypes.rint(0));
+        polygon.setTheZ(omero.rtypes.rint(0));
+        polygon.setTheT(omero.rtypes.rint(0));
+        final AffineTransform t2 =  new AffineTransformI();
+        t2.setA00(omero.rtypes.rdouble(0));
+        t2.setA01(omero.rtypes.rdouble(4));
+        t2.setA02(omero.rtypes.rdouble(0));
+        t2.setA10(omero.rtypes.rdouble(-4));
+        t2.setA11(omero.rtypes.rdouble(0));
+        t2.setA12(omero.rtypes.rdouble(0));
+        polygon.setTransform(t2);
+        roi.addShape(polygon);
+        roi = (RoiI) iUpdate.saveAndReturnObject(roi);
+
+        // add all shape ids to the list to be queried
+        // and their expected stats
+        final Map<Long, ShapeStats> shapeList =
+            new HashMap<Long, ShapeStats>();
+        final ShapeStats [] expShapeStats = new ShapeStats[] {
+            new ShapeStats( // rectangle in FF
+                0, new long[] {0}, new long[] {16},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {16*Byte.MAX_VALUE},
+                new double[] {(double)Byte.MAX_VALUE},
+                new double[1]),
+            new ShapeStats( // horizontal line across
+                0, new long[] {0}, new long[] {10},
+                new double[] {0},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {5*Byte.MAX_VALUE},
+                new double[] {((double)5*Byte.MAX_VALUE)/10},
+                new double[1]),
+            new ShapeStats( // ellipse center upper half
+                0, new long[] {0}, new long[] {36},
+                new double[] {0},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {15*Byte.MAX_VALUE},
+                new double[] {((double)15*Byte.MAX_VALUE)/36},
+                new double[1]),
+            new ShapeStats( // point translated FF
+                0, new long[] {0}, new long[] {1},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {(double)Byte.MAX_VALUE},
+                new double[1]),
+            new ShapeStats( // a polyline (forming a triangle)
+                0, new long[] {0}, new long[] {3*10},
+                new double[] {0},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {10*Byte.MAX_VALUE},
+                new double[] {((double)10*Byte.MAX_VALUE)/30},
+                new double[1]),
+            new ShapeStats( // a polygon transformed onto image)
+                0, new long[] {0}, new long[] {10*10},
+                new double[] {0},
+                new double[] {Byte.MAX_VALUE},
+                new double[] {50*Byte.MAX_VALUE},
+                new double[] {((double) 50*Byte.MAX_VALUE)/100},
+                new double[1])
+        };
+        for (int i=0; i<roi.sizeOfShapes();i++) {
+            shapeList.put(
+                roi.getShape(i).getId().getValue(),
+                expShapeStats[i]);
+        }
+
+        return shapeList;
+    }
+
+    @Test
+    public void testStatsBasicUsageAndInputChecks() throws Exception {
+        IRoiPrx svc = factory.getRoiService();
+
+        final Map<Long,ShapeStats> testAndAssertData = setUpForStatsTest();
+        final List<Long> ids = new ArrayList<Long>(testAndAssertData.keySet());
+
+        // some basic inputs checks
+        final List<Object[]> inputs = new ArrayList<Object[]>();
+        inputs.add(new Object[] {
+            null, new Integer(0), new Integer(0), new int[] {}, "null ids"});
+        inputs.add(new Object[] {
+            new ArrayList<Long>(), new Integer(0), new Integer(0), new int[] {},
+            "empty ids" });
+        inputs.add(new Object[] {
+            Arrays.asList(new Long[] {new Long (-1)}), new Integer(0), new Integer(0),
+            new int[] {}, "erroneous id" });
+        inputs.add(new Object[] { ids, new Integer(10), new Integer(10), new int[] {},
+            "wrong fallback z" });
+        inputs.add(new Object[] { ids, new Integer(0), new Integer(-10), new int[] {},
+            "wrong fallback t" });
+        inputs.add(new Object[] { ids, new Integer(0), new Integer(0), new int[] {200},
+            "wrong channel" });
+
+        // all these inputs should trigger an ApiUssageException
+        for (Object [] in : inputs) {
+            boolean succeeded = false;
+            try {
+                svc.getShapeStatsRestricted(
+                    (List<Long>) in[0], (Integer) in[1], (Integer)in[2], (int []) in[3]);
+            } catch(ApiUsageException any) {
+                succeeded = true;
+            } catch (Exception anythingElse) {}
+            assertTrue(succeeded, "testStatsBasicUsageAndInputChecks: " + in[4]);
+        }
+
+        // call again with valid params and assert results
+        final ShapeStats [] stats = svc.getShapeStatsRestricted(ids, 0, 0, null);
+        for (final ShapeStats calcStats : stats) {
+            final ShapeStats expStats = testAndAssertData.get(calcStats.shapeId);
+            assertEquals(calcStats.pointsCount[0], expStats.pointsCount[0]);
+            assertEquals(calcStats.min[0], expStats.min[0]);
+            assertEquals(calcStats.max[0], expStats.max[0]);
+            assertEquals(calcStats.sum[0], expStats.sum[0]);
+            assertEquals(calcStats.mean[0], expStats.mean[0]);
+        }
     }
 }

--- a/components/tools/OmeroJava/test/integration/RoiServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/RoiServiceTest.java
@@ -722,7 +722,7 @@ public class RoiServiceTest extends AbstractServerTest {
         inputs.add(new Object[] { ids, new Integer(0), new Integer(-10), new int[] {},
             "wrong fallback t" });
         inputs.add(new Object[] { ids, new Integer(0), new Integer(0), new int[] {200},
-            "wrong channel" });
+            "wrong channels" });
 
         // all these inputs should trigger an ApiUssageException
         for (Object [] in : inputs) {


### PR DESCRIPTION
With clients other than insight potentially wanting to query some basic stats regarding intensity under rois there was a need to turn to the already deprecated RoiService in order to not reinvent the wheel.

There was a good deal there but some things needed fixing/changig:
- A new rois service method was created: 'getShapeStatsRestricted'
- the original sql in the old getShapeStats referenced a column that was not there.
- not all SmartShapes implemented the method 'public void areaPoints(PointCallback cb)' needed for point iteration/stats accumulation but threw an error instead.
- transforms were not integrated in the calculation
- the old point iteration requested the same row of data a countless number of times and looped inefficiently
- the old method allowed querying of big, tiled source which it could not cope with, the new one disallows it for now (perhaps tiled iteration is an option later)
- the old method used the entire z/t range if shapes were not linked to a particular z/t, the new one forces 'fallback' z/t as parameters (the idea is that the z/t that one is looking at is used instead of going through all z*t combinations.
- the new method restricts to using only rois on the same image in one call and groups rois by common z/t/c before looping so that that common combination is not requested from the reader more than once.

TEST: check that the integration test (testStatsBasicUsageAndInputChecks) in https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/RoiServiceTest/ passes.