### PR TITLE
Adminfacility add remove

### DIFF
--- a/components/blitz/src/omero/gateway/facility/AdminFacility.java
+++ b/components/blitz/src/omero/gateway/facility/AdminFacility.java
@@ -21,9 +21,7 @@
 package omero.gateway.facility;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
@@ -352,7 +350,7 @@ public class AdminFacility extends Facility {
      * @param user
      *            The user.
      * @param privileges
-     *            The admin privileges
+     *            The admin privileges.
      * @throws DSOutOfServiceException
      *             If the connection is broken, or not logged in.
      * @throws DSAccessException
@@ -371,6 +369,21 @@ public class AdminFacility extends Facility {
         }
     }
 
+    /**
+     * Grant an user additional admin privileges.
+     * 
+     * @param ctx
+     *            The security context.
+     * @param user
+     *            The user.
+     * @param privileges
+     *            The admin privileges to grant.
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in.
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
     public void addAdminPrivileges(SecurityContext ctx, ExperimenterData user,
             List<String> privileges) throws DSOutOfServiceException,
             DSAccessException {
@@ -385,6 +398,21 @@ public class AdminFacility extends Facility {
         }
     }
 
+    /**
+     * Revoke admin privileges for a user
+     * 
+     * @param ctx
+     *            The security context.
+     * @param user
+     *            The user.
+     * @param privileges
+     *            The admin privileges to revoke.
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in.
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
     public void removeAdminPrivileges(SecurityContext ctx,
             ExperimenterData user, List<String> privileges)
             throws DSOutOfServiceException, DSAccessException {
@@ -395,7 +423,7 @@ public class AdminFacility extends Facility {
                     privs.remove(priv);
             setAdminPrivileges(ctx, user, privs);
         } catch (Exception e) {
-            handleException(this, e, "Cannot set admin privileges.");
+            handleException(this, e, "Cannot remove admin privileges.");
         }
     }
 

--- a/components/blitz/src/omero/gateway/facility/AdminFacility.java
+++ b/components/blitz/src/omero/gateway/facility/AdminFacility.java
@@ -21,7 +21,9 @@
 package omero.gateway.facility;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
@@ -364,6 +366,34 @@ public class AdminFacility extends Facility {
             IAdminPrx adm = gateway.getAdminService(ctx);
             adm.setAdminPrivileges(user.asExperimenter(), Utils.toEnum(
                     AdminPrivilege.class, AdminPrivilegeI.class, privileges));
+        } catch (Exception e) {
+            handleException(this, e, "Cannot set admin privileges.");
+        }
+    }
+
+    public void addAdminPrivileges(SecurityContext ctx, ExperimenterData user,
+            List<String> privileges) throws DSOutOfServiceException,
+            DSAccessException {
+        try {
+            List<String> privs = getAdminPrivileges(ctx, user);
+            for (String priv : privileges)
+                if (!privs.contains(priv))
+                    privs.add(priv);
+            setAdminPrivileges(ctx, user, privs);
+        } catch (Exception e) {
+            handleException(this, e, "Cannot add admin privileges.");
+        }
+    }
+
+    public void removeAdminPrivileges(SecurityContext ctx,
+            ExperimenterData user, List<String> privileges)
+            throws DSOutOfServiceException, DSAccessException {
+        try {
+            List<String> privs = getAdminPrivileges(ctx, user);
+            for (String priv : privileges)
+                if (privs.contains(priv))
+                    privs.remove(priv);
+            setAdminPrivileges(ctx, user, privs);
         } catch (Exception e) {
             handleException(this, e, "Cannot set admin privileges.");
         }

--- a/components/blitz/src/omero/gateway/facility/AdminFacility.java
+++ b/components/blitz/src/omero/gateway/facility/AdminFacility.java
@@ -21,6 +21,7 @@
 package omero.gateway.facility;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -308,7 +309,7 @@ public class AdminFacility extends Facility {
      *             If an error occurred while trying to retrieve data from OMERO
      *             service.
      */
-    public List<String> getAdminPrivileges(SecurityContext ctx)
+    public Collection<String> getAdminPrivileges(SecurityContext ctx)
             throws DSOutOfServiceException, DSAccessException {
         return getAdminPrivileges(ctx, gateway.getLoggedInUser());
     }
@@ -328,7 +329,7 @@ public class AdminFacility extends Facility {
      *             If an error occurred while trying to retrieve data from OMERO
      *             service.
      */
-    public List<String> getAdminPrivileges(SecurityContext ctx,
+    public Collection<String> getAdminPrivileges(SecurityContext ctx,
             ExperimenterData user) throws DSOutOfServiceException,
             DSAccessException {
         try {
@@ -358,7 +359,7 @@ public class AdminFacility extends Facility {
      *             service.
      */
     public void setAdminPrivileges(SecurityContext ctx, ExperimenterData user,
-            List<String> privileges) throws DSOutOfServiceException,
+            Collection<String> privileges) throws DSOutOfServiceException,
             DSAccessException {
         try {
             IAdminPrx adm = gateway.getAdminService(ctx);
@@ -385,10 +386,10 @@ public class AdminFacility extends Facility {
      *             service.
      */
     public void addAdminPrivileges(SecurityContext ctx, ExperimenterData user,
-            List<String> privileges) throws DSOutOfServiceException,
+            Collection<String> privileges) throws DSOutOfServiceException,
             DSAccessException {
         try {
-            List<String> privs = getAdminPrivileges(ctx, user);
+            Collection<String> privs = getAdminPrivileges(ctx, user);
             for (String priv : privileges)
                 if (!privs.contains(priv))
                     privs.add(priv);
@@ -414,10 +415,10 @@ public class AdminFacility extends Facility {
      *             service.
      */
     public void removeAdminPrivileges(SecurityContext ctx,
-            ExperimenterData user, List<String> privileges)
+            ExperimenterData user, Collection<String> privileges)
             throws DSOutOfServiceException, DSAccessException {
         try {
-            List<String> privs = getAdminPrivileges(ctx, user);
+            Collection<String> privs = getAdminPrivileges(ctx, user);
             privs.removeAll(privileges);
             setAdminPrivileges(ctx, user, privs);
         } catch (Exception e) {

--- a/components/blitz/src/omero/gateway/facility/AdminFacility.java
+++ b/components/blitz/src/omero/gateway/facility/AdminFacility.java
@@ -418,9 +418,7 @@ public class AdminFacility extends Facility {
             throws DSOutOfServiceException, DSAccessException {
         try {
             List<String> privs = getAdminPrivileges(ctx, user);
-            for (String priv : privileges)
-                if (privs.contains(priv))
-                    privs.remove(priv);
+            privs.removeAll(privileges);
             setAdminPrivileges(ctx, user, privs);
         } catch (Exception e) {
             handleException(this, e, "Cannot remove admin privileges.");

--- a/components/tools/OmeroJava/test/integration/gateway/AdminFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/AdminFacilityTest.java
@@ -36,6 +36,7 @@ import org.testng.annotations.Test;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.GroupData;
 import omero.model.enums.AdminPrivilegeChgrp;
+import omero.model.enums.AdminPrivilegeChown;
 
 
 /**
@@ -116,10 +117,24 @@ public class AdminFacilityTest extends GatewayTest {
         SecurityContext userCtx = new SecurityContext(exp.getGroupId());
         List<String> privs = adminFacility.getAdminPrivileges(userCtx, exp);
         Assert.assertTrue(privs.isEmpty());
+        
         adminFacility.setAdminPrivileges(userCtx, exp,
                 Collections.singletonList(AdminPrivilegeChgrp.value));
         privs = adminFacility.getAdminPrivileges(userCtx, exp);
         Assert.assertEquals(privs.size(), 1);
         Assert.assertEquals(privs.iterator().next(), AdminPrivilegeChgrp.value);
+        
+        adminFacility.addAdminPrivileges(userCtx, exp,
+                Collections.singletonList(AdminPrivilegeChown.value));
+        privs = adminFacility.getAdminPrivileges(userCtx, exp);
+        Assert.assertEquals(privs.size(), 2);
+        Assert.assertTrue(privs.contains(AdminPrivilegeChgrp.value));
+        Assert.assertTrue(privs.contains(AdminPrivilegeChown.value));
+        
+        adminFacility.removeAdminPrivileges(userCtx, exp,
+                Collections.singletonList(AdminPrivilegeChown.value));
+        privs = adminFacility.getAdminPrivileges(userCtx, exp);
+        Assert.assertEquals(privs.size(), 1);
+        Assert.assertTrue(privs.contains(AdminPrivilegeChgrp.value));
     }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/AdminFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/AdminFacilityTest.java
@@ -21,6 +21,7 @@
 package integration.gateway;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -115,7 +116,7 @@ public class AdminFacilityTest extends GatewayTest {
     public void testAdminPrivileges() throws DSOutOfServiceException,
             DSAccessException {
         SecurityContext userCtx = new SecurityContext(exp.getGroupId());
-        List<String> privs = adminFacility.getAdminPrivileges(userCtx, exp);
+        Collection<String> privs = adminFacility.getAdminPrivileges(userCtx, exp);
         Assert.assertTrue(privs.isEmpty());
         
         adminFacility.setAdminPrivileges(userCtx, exp,


### PR DESCRIPTION
# What this PR does

Adds 'add' and 'remove' admin privileges to the Java Gateway.

# Testing this PR

Check that the `testAdminPrivileges` integration test passes.


# Related reading

https://trello.com/c/FjayBnvM/39-gateway-support-for-roles

