### PR TITLE
Disable UI when no sudo/upload permission

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ImporterAgent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -33,7 +33,6 @@ import javax.swing.JButton;
 import javax.swing.JMenuItem;
 
 import org.apache.commons.collections.CollectionUtils;
-
 import org.openmicroscopy.shoola.agents.events.importer.LoadImporter;
 import org.openmicroscopy.shoola.agents.events.treeviewer.ActivitiesEvent;
 import org.openmicroscopy.shoola.agents.events.treeviewer.BrowserSelectionEvent;
@@ -108,6 +107,19 @@ public class ImporterAgent
         Boolean b = (Boolean) registry.lookup(LookupNames.USER_ADMINISTRATOR);
         if (b == null) return false;
         return b.booleanValue();
+    }
+    
+    /**
+     * Returns <code>true</code> if the currently logged in user is allowed to
+     * import for another user, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isImportAs() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_SUDO);
+        if (b == null)
+            b = Boolean.FALSE;
+        return isAdministrator() && b.booleanValue();
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -557,7 +557,7 @@ class ImporterModel
      */
     boolean canImportAs()
     {
-        if (ImporterAgent.isAdministrator()) return true;
+        if (ImporterAgent.isImportAs()) return true;
         return CollectionUtils.isNotEmpty(getGroupsLeaderOf());
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -147,7 +147,7 @@ public class TreeViewerAgent
 	}
 	
     /**
-     * Returns <code>true</code> if the currently logged in user is is allowed
+     * Returns <code>true</code> if the currently logged in user is allowed
      * to move objects to/from groups, <code>false</code> otherwise.
      * 
      * @return See above.
@@ -161,7 +161,7 @@ public class TreeViewerAgent
     }
 
     /**
-     * Returns <code>true</code> if the currently logged in user is is allowed
+     * Returns <code>true</code> if the currently logged in user is allowed
      * to edit groups, <code>false</code> otherwise.
      * 
      * @return See above.
@@ -175,7 +175,7 @@ public class TreeViewerAgent
     }
     
     /**
-     * Returns <code>true</code> if the currently logged in user is is allowed
+     * Returns <code>true</code> if the currently logged in user is allowed
      * to to add users to groups, <code>false</code> otherwise.
      * 
      * @return See above.
@@ -189,7 +189,7 @@ public class TreeViewerAgent
     }
 
     /**
-     * Returns <code>true</code> if the currently logged in user is is allowed
+     * Returns <code>true</code> if the currently logged in user is allowed
      * to edit users, <code>false</code> otherwise.
      * 
      * @return See above.
@@ -203,7 +203,7 @@ public class TreeViewerAgent
     }
     
     /**
-     * Returns <code>true</code> if the currently logged in user is is allowed
+     * Returns <code>true</code> if the currently logged in user is allowed
      * to upload scripts, <code>false</code> otherwise.
      * 
      * @return See above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/TreeViewerAgent.java
@@ -202,6 +202,20 @@ public class TreeViewerAgent
         return isAdministrator() && b.booleanValue();
     }
     
+    /**
+     * Returns <code>true</code> if the currently logged in user is is allowed
+     * to upload scripts, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isUploadScript() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_UPLOAD_SCRIPT);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
+    }
+    
 	/**
 	 * Returns the context for an administrator.
 	 * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/view/ToolBar.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -658,7 +658,7 @@ class ToolBar
                 controller.getAction(TreeViewerControl.FULLSCREEN));
         fullScreen.setSelected(model.isFullScreen());
         //bar.add(fullScreen);
-        if (TreeViewerAgent.isAdministrator()) {
+        if (TreeViewerAgent.isUploadScript()) {
             b = new JButton(controller.getAction(
                     TreeViewerControl.UPLOAD_SCRIPT));
             UIUtilities.unifiedButtonLookAndFeel(b);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -169,7 +169,10 @@ public class LookupNames
 
     /** Field indicating if the user is an administrator. */
     public static final String USER_ADMINISTRATOR = "/users/administrator";
-    
+
+    /** Field indicating if the user can edit users. */
+    public static final String PRIV_SUDO = "/users/sudo";
+
     /** Field indicating if the user can edit users. */
     public static final String PRIV_EDIT_USER = "/users/edit";
     
@@ -181,6 +184,9 @@ public class LookupNames
     
     /** Field indicating if the user add group members. */
     public static final String PRIV_GROUP_ADD = "/groups/add";
+
+    /** Field indicating if the user add group members. */
+    public static final String PRIV_UPLOAD_SCRIPT = "/scripts/upload";
 
     /** Field to indicate if the connection is fast or not. */
     public static final String IMAGE_QUALITY_LEVEL = "/connection/speed";

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -697,6 +697,10 @@ public class DataServicesFactory
                         .contains(omero.model.enums.AdminPrivilegeModifyGroupMembership.value));
                 registry.bind(LookupNames.PRIV_MOVE_GROUP, privs
                         .contains(omero.model.enums.AdminPrivilegeChgrp.value));
+                registry.bind(LookupNames.PRIV_UPLOAD_SCRIPT, privs
+                        .contains(omero.model.enums.AdminPrivilegeWriteScriptRepo.value));
+                registry.bind(LookupNames.PRIV_SUDO, privs
+                        .contains(omero.model.enums.AdminPrivilegeSudo.value));
             } catch (ServerError e1) {
                 registry.bind(LookupNames.PRIV_EDIT_USER, false);
                 registry.bind(LookupNames.PRIV_EDIT_GROUP, false);
@@ -732,6 +736,8 @@ public class DataServicesFactory
 				reg.bind(LookupNames.PRIV_EDIT_GROUP, registry.lookup(LookupNames.PRIV_EDIT_GROUP));
 				reg.bind(LookupNames.PRIV_MOVE_GROUP, registry.lookup(LookupNames.PRIV_MOVE_GROUP));
 				reg.bind(LookupNames.PRIV_GROUP_ADD, registry.lookup(LookupNames.PRIV_GROUP_ADD));
+				reg.bind(LookupNames.PRIV_SUDO, registry.lookup(LookupNames.PRIV_SUDO));
+				reg.bind(LookupNames.PRIV_UPLOAD_SCRIPT, registry.lookup(LookupNames.PRIV_UPLOAD_SCRIPT));
 			}
 		}
 	}


### PR DESCRIPTION
# What this PR does

Disables the specific UI elements if a light admin lacks the upload scripts and sudo permissions.

# Testing this PR

- Light admin (in group with other users but **not** group owner) without 'sudo' permission: Make sure you don't see the 'Import For' box.
- Same light admin but with 'sudo' permission: Now you should see the 'Import For' element.
- Normal user but group owner (of group with other users): Now you should also see the 'Import For' element.
![screen shot 2017-08-24 at 15 11 02](https://user-images.githubusercontent.com/6575139/29670702-67504ee4-88df-11e7-9713-4140ab035318.png)

- Light admin without 'Upload scripts' permission: You shouldn't see the upload scripts button.
- Light admin with 'Upload scripts' permission: Now you should see the upload scripts button.
![screen shot 2017-08-24 at 14 51 31](https://user-images.githubusercontent.com/6575139/29670739-894be4a4-88df-11e7-9ac1-f3a6be1778ed.png)


# Related reading

https://trello.com/c/4dvUYSjS/126-definition-of-ultimate-admin

