### PR TITLE
Javadoc character escaping

### DIFF
--- a/components/blitz/src/omero/gateway/LoginCredentials.java
+++ b/components/blitz/src/omero/gateway/LoginCredentials.java
@@ -74,7 +74,7 @@ public class LoginCredentials {
      * 
      * @param args
      *            The connection arguments. Note: When using this constructor
-     *            the '#' character has to be escaped!
+     *            the '#' character has to be escaped with a backslash!
      */
     public LoginCredentials(String[] args) {
         this();

--- a/components/blitz/src/omero/gateway/LoginCredentials.java
+++ b/components/blitz/src/omero/gateway/LoginCredentials.java
@@ -71,10 +71,12 @@ public class LoginCredentials {
 
     /**
      * Creates a new instance.
-     * @param args The connection arguments.
+     * 
+     * @param args
+     *            The connection arguments. Note: When using this constructor
+     *            the '#' character has to be escaped!
      */
-    public LoginCredentials(String[] args)
-    {
+    public LoginCredentials(String[] args) {
         this();
         if (args == null) {
             throw new IllegalArgumentException("No connection arguments");


### PR DESCRIPTION
# What this PR does

Tiny PR which simply adds a javadoc warning to the `LoginCredentials(String[] args)` constructor about the escaping of the '#' character.

# Testing this PR

Nothing to test.

# Related reading

Replaces https://github.com/ome/minimal-omero-client/pull/24 

