### PR TITLE
Connection cleanup on 404

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -475,7 +475,7 @@ class login_required(object):
             try:
                 retval = f(request, *args, **kwargs)
             finally:
-                # If f() raised Exception, e.g. Http404() we still need to cleanup services
+                # If f() raised Exception, e.g. Http404() we must still cleanup
                 try:
                     logger.debug(
                         'Doing connection cleanup? %s' % doConnectionCleanup)
@@ -485,7 +485,7 @@ class login_required(object):
                                 v.close()
                             conn.c.closeSession()
                 except:
-                    logger.warn('Failed to clean up connection.', exc_info=True)
+                    logger.warn('Failed to clean up connection', exc_info=True)
             return retval
         return update_wrapper(wrapped, f)
 

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -421,7 +421,7 @@ class login_required(object):
             return None
 
         session['connector'] = connector
-        return connection
+        return
 
     def __call__(ctx, f):
         """

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -472,18 +472,20 @@ class login_required(object):
 
                     # kwargs['error'] = request.GET.get('error')
                     kwargs['url'] = url
-
-            retval = f(request, *args, **kwargs)
             try:
-                logger.debug(
-                    'Doing connection cleanup? %s' % doConnectionCleanup)
-                if doConnectionCleanup:
-                    if conn is not None and conn.c is not None:
-                        for v in conn._proxies.values():
-                            v.close()
-                        conn.c.closeSession()
-            except:
-                logger.warn('Failed to clean up connection.', exc_info=True)
+                retval = f(request, *args, **kwargs)
+            finally:
+                # If f() raised Exception, e.g. Http404() we still need to cleanup services
+                try:
+                    logger.debug(
+                        'Doing connection cleanup? %s' % doConnectionCleanup)
+                    if doConnectionCleanup:
+                        if conn is not None and conn.c is not None:
+                            for v in conn._proxies.values():
+                                v.close()
+                            conn.c.closeSession()
+                except:
+                    logger.warn('Failed to clean up connection.', exc_info=True)
             return retval
         return update_wrapper(wrapped, f)
 


### PR DESCRIPTION
# What this PR does

Try to fix the increase in number of processes seen with 404 pages: https://trello.com/c/2fI9hSVQ/127-demo-internal-server-error-briefly

The ```@login_required``` decorator normally closes all BlitzGateway services but if an exception is raised by the wrapped method then this wasn't happening. This included ```Http404()``` which is raised if e.g. ```conn.getObject("Image", id)``` returns None in many webgateway views methods.

We now wrap the calling of the wrapped method with a try/finally to make sure we always try to close services.

cc @chris-allan 

# Testing this PR

1. Previously, every request to a ```webgateway``` view that returns 404 resulted in an increase of 4 processes. E.g. on web-dev-latest:
```
[centos@spider-1 OMERO.py]$ ps -efT | grep gunicorn | wc
    122    2915   36623
# Then refresh  webgateway/img_detail/1
[centos@spider-1 OMERO.py]$ ps -efT | grep gunicorn | wc
    126    3011   37831
```
This should be fixed - Number of processes should not increase.
