### PR TITLE
Allow ome tiff export

### DIFF
--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -20,6 +20,7 @@ IMAGE_NAME=${IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00&sizeZ=3&sizeT=
 MULTI_C_IMAGE_NAME=${MULTI_C_IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00&sizeC=3&sizeZ=3&sizeT=10.fake}
 TINY_IMAGE_NAME=${TINY_IMAGE_NAME:-test&acquisitionDate=2012-01-01_00-00-00.fake}
 MIF_IMAGE_NAME=${MIF_IMAGE_NAME:-test&series=3.fake}
+BIG_IMAGE_NAME=${BIG_IMAGE_NAME:-test&sizeX=4000&sizeY=4000.fake}
 PLATE_NAME=${PLATE_NAME:-test&plates=1&plateAcqs=2&plateRows=2&plateCols=3&fields=5&screens=0.fake}
 TINY_PLATE_NAME=${TINY_PLATE_NAME:-test&plates=1&plateAcqs=1&plateRows=1&plateCols=1&fields=1&screens=0.fake}
 BULK_ANNOTATION_CSV=${BULK_ANNOTATION_CSV:-bulk_annotation.csv}
@@ -97,6 +98,10 @@ for (( k=1; k<=2; k++ ))
 do
   bin/omero import -d $mcDs $MULTI_C_IMAGE_NAME --debug ERROR
 done
+
+# Create Dataset with Big Image
+bigDs=$(bin/omero obj new Dataset name='Big Images')
+bin/omero import -d $bigDs $BIG_IMAGE_NAME --debug ERROR
 
 # Import Plate and rename
 bin/omero import $PLATE_NAME --debug ERROR > plate_import.log 2>&1

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -41,6 +41,7 @@ touch $TINY_IMAGE_NAME
 touch $PLATE_NAME
 touch $TINY_PLATE_NAME
 touch $MIF_IMAGE_NAME
+touch $BIG_IMAGE_NAME
 
 # Python script for setting posX and posY on wellsamples
 # Used below after importing a plate

--- a/components/tests/ui/testcases/web/center_right_panel_tests.txt
+++ b/components/tests/ui/testcases/web/center_right_panel_tests.txt
@@ -11,83 +11,83 @@ Suite Teardown      Close all browsers
 *** Keywords ***
 
 Wait Until Right Panel Loads For MultiSelection
-	[arguments]						${numOfObjects}
+    [arguments]                     ${numOfObjects}
 
-	Wait Until Element Is Visible	xpath=//*[@id="batch_ann_title"]/span[contains(text(), '${numOfObjects} objects:')]
-	Wait Until Element Is Visible	xpath=//*[@id="batch_ann_title"]/span/span[contains(@class, 'btn_info')]
+    Wait Until Element Is Visible   xpath=//*[@id="batch_ann_title"]/span[contains(text(), '${numOfObjects} objects:')]
+    Wait Until Element Is Visible   xpath=//*[@id="batch_ann_title"]/span/span[contains(@class, 'btn_info')]
 
-	Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/button[contains(@title, 'Publishing Options')]
-	Wait Until Element Is Visible     xpath=//*[@id="show_image_hierarchy"]
-	Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/button[contains(@title, 'Download Image as...')]
-	Wait Until Element Is Visible	  xpath=//*[@id="show_link_btn"]/span
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/button[contains(@title, 'Publishing Options')]
+    Wait Until Element Is Visible     xpath=//*[@id="show_image_hierarchy"]
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/button[contains(@title, 'Download Image as...')]
+    Wait Until Element Is Visible     xpath=//*[@id="show_link_btn"]/span
 
-	Wait Until Element Is Visible 	  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Attachments')]
-	Wait Until Element Is Visible 	  xpath=//*[@id="annotationFilter"]
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Attachments')]
+    Wait Until Element Is Visible     xpath=//*[@id="annotationFilter"]
 
-	Wait Until Element Is Visible 	  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Ratings')]
-	Click Element 					  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Ratings')]
-	Wait Until Element Is Visible 	  xpath=//*[@id="rating_annotations"]
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Ratings')]
+    Click Element                     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Ratings')]
+    Wait Until Element Is Visible     xpath=//*[@id="rating_annotations"]
 
-	Wait Until Element Is Visible 	  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Tags')]
-	Click Element 					  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Tags')]
-	Wait Until Element Is Visible 	  xpath=//*[@id="launch_tags_form"]/span
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Tags')]
+    Click Element                     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Tags')]
+    Wait Until Element Is Visible     xpath=//*[@id="launch_tags_form"]/span
 
-	Wait Until Element Is Visible 	  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Attachments')]
-	Click Element 					  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Attachments')]
-	Wait Until Element Is Visible 	  xpath=//*[@id="metadata_general"]//div/input[contains(@title, 'Select files for scripts')]
-	Wait Until Element Is Visible 	  xpath=//*[@id="choose_file_anns"]/span
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Attachments')]
+    Click Element                     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Attachments')]
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/input[contains(@title, 'Select files for scripts')]
+    Wait Until Element Is Visible     xpath=//*[@id="choose_file_anns"]/span
 
-	Wait Until Element Is Visible 	  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Comments')]
-	Click Element 					  xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Comments')]
-	Wait Until Element Is Visible 	  xpath=//*[@id="id_comment"]
+    Wait Until Element Is Visible     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Comments')]
+    Click Element                     xpath=//*[@id="metadata_general"]//div/h1[contains(text(), 'Comments')]
+    Wait Until Element Is Visible     xpath=//*[@id="id_comment"]
 
-	Element Should Not Be Visible 	  xpath=//*[@id="general_tab"]
+    Element Should Not Be Visible     xpath=//*[@id="general_tab"]
 
 Get Number Of Selected Objects From Tree
-	${numOfObjects}=				Get Matching Xpath Count 		xpath=//li[contains(@role, 'treeitem')]//a[contains(@class, 'jstree-clicked')]
-	[return]						${numOfObjects}
+    ${numOfObjects}=                Get Matching Xpath Count        xpath=//li[contains(@role, 'treeitem')]//a[contains(@class, 'jstree-clicked')]
+    [return]                        ${numOfObjects}
 
 Get Number Of Selected Objects From Center Panel
-	${numOfObjects}= 				Get Matching Xpath Count 		xpath=//div[@id="icon_table"]//li[contains(@class, 'ui-selected')]
-	[return]						${numOfObjects}
+    ${numOfObjects}=                Get Matching Xpath Count        xpath=//div[@id="icon_table"]//li[contains(@class, 'ui-selected')]
+    [return]                        ${numOfObjects}
 
 *** Test Cases ***
 
 Select First Dataset
     ${datasetId}=                   Select Node By Icon      ${datasetIcon}
-    Wait Until Right Panel Loads Everything    	Dataset                  ${datasetId}
-    Wait Until Center Panel Loads 				Dataset
+    Wait Until Right Panel Loads Everything     Dataset                  ${datasetId}
+    Wait Until Center Panel Loads               Dataset
 
 Check Center and Right Panel Sync For Image
-	${imageId}=						Select First Image
-	Wait Until Right Panel Loads Everything		Image 					 ${imageId}
+    ${imageId}=                     Select First Image
+    Wait Until Right Panel Loads Everything     Image                    ${imageId}
 
-	${imageId1}=					Get Id From Selected Item In Tree
-	${imageId2}						Get Id From Selected Thumbnail
-	${imageId3}						Get Id From Right Panel
+    ${imageId1}=                    Get Id From Selected Item In Tree
+    ${imageId2}                     Get Id From Selected Thumbnail
+    ${imageId3}                     Get Id From Right Panel
 
-	Should Be Equal 				${imageId1}		${imageId}
-	Should Be Equal					${imageId2}		${imageId}
-	Should Be Equal 				${imageId3}		${imageId}
+    Should Be Equal                 ${imageId1}     ${imageId}
+    Should Be Equal                 ${imageId2}     ${imageId}
+    Should Be Equal                 ${imageId3}     ${imageId}
 
-	Click Next Thumbnail
-	${imageId1}						Get Id From Selected Item In Tree
-	${imageId2}						Get Id From Selected Thumbnail
-	${imageId3}						Get Id From Right Panel
+    Click Next Thumbnail
+    ${imageId1}                     Get Id From Selected Item In Tree
+    ${imageId2}                     Get Id From Selected Thumbnail
+    ${imageId3}                     Get Id From Right Panel
 
-	Should Be Equal 				${imageId1}		${imageId2}
-	Should Be Equal					${imageId2}		${imageId3}
-	Should Be Equal 				${imageId3}		${imageId1}
+    Should Be Equal                 ${imageId1}     ${imageId2}
+    Should Be Equal                 ${imageId2}     ${imageId3}
+    Should Be Equal                 ${imageId3}     ${imageId1}
 
 Check Multi Selections
 
-	${imageId}						Select First Orphaned Image
-	Click Next Thumbnail
-	${imageId1}						Get Id From Selected Thumbnail
-	Meta Click Thumbnail 			${imageId}
+    ${imageId}                      Select First Orphaned Image
+    Click Next Thumbnail
+    ${imageId1}                     Get Id From Selected Thumbnail
+    Meta Click Thumbnail            ${imageId}
 
-	${numOfObjects}					Get Number Of Selected Objects From Tree
-	${numOfObjects1}				Get Number Of Selected Objects From Center Panel
+    ${numOfObjects}                 Get Number Of Selected Objects From Tree
+    ${numOfObjects1}                Get Number Of Selected Objects From Center Panel
 
-	Should Be Equal 				${numOfObjects}		${numOfObjects1}
-	Wait Until Right Panel Loads For MultiSelection 	${numOfObjects}
+    Should Be Equal                 ${numOfObjects}     ${numOfObjects1}
+    Wait Until Right Panel Loads For MultiSelection     ${numOfObjects}

--- a/components/tests/ui/testcases/web/center_right_panel_tests.txt
+++ b/components/tests/ui/testcases/web/center_right_panel_tests.txt
@@ -8,6 +8,10 @@ Resource          ../../resources/web/tree.txt
 Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
 Suite Teardown      Close all browsers
 
+*** Variables ***
+# robot_setup script has created data with these parameters
+${PLATE_NAME}               spwTests
+
 *** Keywords ***
 
 Wait Until Right Panel Loads For MultiSelection
@@ -51,43 +55,118 @@ Get Number Of Selected Objects From Center Panel
     ${numOfObjects}=                Get Matching Xpath Count        xpath=//div[@id="icon_table"]//li[contains(@class, 'ui-selected')]
     [return]                        ${numOfObjects}
 
+Assert No Download Button
+    Element Should Not Be Visible   xpath=//button[contains(@class, 'btn_download')]
+
+Show Download Menu
+    Wait Until Element Is Visible   xpath=//button[contains(@class, 'btn_download')]
+    Click Element                   xpath=//button[contains(@class, 'btn_download')]
+    Wait Until Element Is Visible   xpath=//div[contains(@class, 'toolbar_dropdown')]
+
+Download Option Available
+    [Arguments]                     ${linkText}         ${expected}=${true}
+    # We want the link to be available and not 'disabled'
+    Run Keyword If  ${expected}     Element Should Be Visible       xpath=//div[contains(@class, 'toolbar_dropdown')]//li[not(contains(@class, 'disabled'))]/a[contains(text(), "${linkText}")]
+    ...             ELSE            Element Should Not Be Visible   xpath=//div[contains(@class, 'toolbar_dropdown')]//li[not(contains(@class, 'disabled'))]/a[contains(text(), "${linkText}")]
+
+Download Option Not Available
+    [Arguments]                     ${linkText}
+    Download Option Available       ${linkText}         ${false}
+
+
 *** Test Cases ***
 
-Select First Dataset
-    ${datasetId}=                   Select Node By Icon      ${datasetIcon}
-    Wait Until Right Panel Loads Everything     Dataset                  ${datasetId}
-    Wait Until Center Panel Loads               Dataset
+# Select First Dataset
+#     ${datasetId}=                   Select Node By Icon      ${datasetIcon}
+#     Wait Until Right Panel Loads Everything     Dataset                  ${datasetId}
+#     Wait Until Center Panel Loads               Dataset
 
-Check Center and Right Panel Sync For Image
-    ${imageId}=                     Select First Image
-    Wait Until Right Panel Loads Everything     Image                    ${imageId}
+# Check Center and Right Panel Sync For Image
+#     ${imageId}=                     Select First Image
+#     Wait Until Right Panel Loads Everything     Image                    ${imageId}
 
-    ${imageId1}=                    Get Id From Selected Item In Tree
-    ${imageId2}                     Get Id From Selected Thumbnail
-    ${imageId3}                     Get Id From Right Panel
+#     ${imageId1}=                    Get Id From Selected Item In Tree
+#     ${imageId2}                     Get Id From Selected Thumbnail
+#     ${imageId3}                     Get Id From Right Panel
 
-    Should Be Equal                 ${imageId1}     ${imageId}
-    Should Be Equal                 ${imageId2}     ${imageId}
-    Should Be Equal                 ${imageId3}     ${imageId}
+#     Should Be Equal                 ${imageId1}     ${imageId}
+#     Should Be Equal                 ${imageId2}     ${imageId}
+#     Should Be Equal                 ${imageId3}     ${imageId}
 
-    Click Next Thumbnail
-    ${imageId1}                     Get Id From Selected Item In Tree
-    ${imageId2}                     Get Id From Selected Thumbnail
-    ${imageId3}                     Get Id From Right Panel
+#     Click Next Thumbnail
+#     ${imageId1}                     Get Id From Selected Item In Tree
+#     ${imageId2}                     Get Id From Selected Thumbnail
+#     ${imageId3}                     Get Id From Right Panel
 
-    Should Be Equal                 ${imageId1}     ${imageId2}
-    Should Be Equal                 ${imageId2}     ${imageId3}
-    Should Be Equal                 ${imageId3}     ${imageId1}
+#     Should Be Equal                 ${imageId1}     ${imageId2}
+#     Should Be Equal                 ${imageId2}     ${imageId3}
+#     Should Be Equal                 ${imageId3}     ${imageId1}
 
-Check Multi Selections
+# Check Multi Selections
 
-    ${imageId}                      Select First Orphaned Image
-    Click Next Thumbnail
-    ${imageId1}                     Get Id From Selected Thumbnail
-    Meta Click Thumbnail            ${imageId}
+#     ${imageId}                      Select First Orphaned Image
+#     Click Next Thumbnail
+#     ${imageId1}                     Get Id From Selected Thumbnail
+#     Meta Click Thumbnail            ${imageId}
 
-    ${numOfObjects}                 Get Number Of Selected Objects From Tree
-    ${numOfObjects1}                Get Number Of Selected Objects From Center Panel
+#     ${numOfObjects}                 Get Number Of Selected Objects From Tree
+#     ${numOfObjects1}                Get Number Of Selected Objects From Center Panel
 
-    Should Be Equal                 ${numOfObjects}     ${numOfObjects1}
-    Wait Until Right Panel Loads For MultiSelection     ${numOfObjects}
+#     Should Be Equal                 ${numOfObjects}     ${numOfObjects1}
+#     Wait Until Right Panel Loads For MultiSelection     ${numOfObjects}
+
+Test Download Menu
+
+    # Go To                           ${WELCOME URL}
+    Select Experimenter
+    # Project and Dataset should have no Download button
+    Select First Project With Children
+    Assert No Download Button
+    Select First Dataset With Children
+    Assert No Download Button
+
+    # Regular image
+    Select First Image
+    Show Download Menu
+    Download Option Available       Download...
+    Download Option Available       Download Original Metadata
+    Download Option Available       Export as OME-TIFF...
+    Download Option Available       Export as JPEG
+    Download Option Available       Export as PNG
+    Download Option Available       Export as TIFF
+
+    # Big Image
+    Go To                           ${WELCOME URL}
+    Select And Expand Node          Big Images
+    Select First Image
+    Show Download Menu
+    Download Option Available       Download...
+    Download Option Available       Download Original Metadata
+    Download Option Not Available   Export as OME-TIFF...
+    Download Option Available       Export as JPEG
+    Download Option Available       Export as PNG
+    Download Option Available       Export as TIFF
+
+    # SPW Well
+    Select First Plate With Name    ${PLATE_NAME}
+    Select First Run
+    Click Well By Name              A1
+    Wait For General Panel          Well
+    Show Download Menu
+    Download Option Not Available   Download...
+    Download Option Not Available   Download Original Metadata
+    Download Option Available       Export as OME-TIFF...
+    Download Option Available       Export as JPEG
+    Download Option Available       Export as PNG
+    Download Option Available       Export as TIFF
+
+    # SPW Image
+    Click Element                   xpath=//div[@id='wellImages']//li/a/img[1]
+    Wait For General Panel          Image
+    Show Download Menu
+    Download Option Not Available   Download...
+    Download Option Not Available   Download Original Metadata
+    Download Option Available       Export as OME-TIFF...
+    Download Option Available       Export as JPEG
+    Download Option Available       Export as PNG
+    Download Option Not Available   Export as TIFF

--- a/components/tests/ui/testcases/web/center_right_panel_tests.txt
+++ b/components/tests/ui/testcases/web/center_right_panel_tests.txt
@@ -169,4 +169,4 @@ Test Download Menu
     Download Option Available       Export as OME-TIFF...
     Download Option Available       Export as JPEG
     Download Option Available       Export as PNG
-    Download Option Not Available   Export as TIFF
+    Download Option Available       Export as TIFF

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8230,16 +8230,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             rp.close()
 
     @assert_pixels
-    def requiresPixelsPyramid(self):
-        pixels_id = self._obj.getPrimaryPixels().getId().val
-        rp = self._conn.createRawPixelsStore()
-        try:
-            rp.setPixelsId(pixels_id, True, self._conn.SERVICE_OPTS)
-            return rp.requiresPixelsPyramid()
-        finally:
-            rp.close()
-
-    @assert_pixels
     def getPrimaryPixels(self):
         """
         Loads pixels and returns object in a :class:`PixelsWrapper`
@@ -9558,7 +9548,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     def requiresPixelsPyramid(self):
         """Returns True if Image Plane is over the max plane size."""
         max_sizes = self._conn.getMaxPlaneSize()
-        print "BIG?", self.getSizeX() * self.getSizeY() > max_sizes[0] * max_sizes[1]
         return self.getSizeX() * self.getSizeY() > max_sizes[0] * max_sizes[1]
 
     def clearDefaults(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -9555,6 +9555,12 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         return self._obj.getPrimaryPixels().getSizeC().val
 
+    def requiresPixelsPyramid(self):
+        """Returns True if Image Plane is over the max plane size."""
+        max_sizes = self._conn.getMaxPlaneSize()
+        print "BIG?", self.getSizeX() * self.getSizeY() > max_sizes[0] * max_sizes[1]
+        return self.getSizeX() * self.getSizeY() > max_sizes[0] * max_sizes[1]
+
     def clearDefaults(self):
         """
         Removes specific color settings from channels

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -205,7 +205,7 @@
             {% endif %}
 
             {% if not share %}
-            {% if image and not omeTiffDisabled %}
+            {% if image %}
             <li>
                 <a id="create-ometiff" href="{% url 'ome_tiff_script' image.id %}" 
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -149,7 +149,7 @@
             <span></span>
         </button>
         <ul class="dropdown">
-            {% if canDownload %}
+        {% if canDownload %}
             <!-- Here we handle a single image (in metadata general) - see below for multiple images (batch annotate) -->
             {% if not share and image.getImportedFilesInfo.count %}
               {% with filesetInfo=image.getImportedFilesInfo %}
@@ -203,22 +203,22 @@
               <a title="No original imported files to download">Download...</a>
             </li>
             {% endif %}
+        <!-- endif canDownload -->
+        {% endif %}
 
-            {% if not share %}
-            {% if image %}
+        {% if not share %}
+            {% if image and not image.requiresPixelsPyramid %}
             <li>
                 <a id="create-ometiff" href="{% url 'ome_tiff_script' image.id %}" 
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>
             </li>
             {% else %}
             <li class="disabled">
-                <a id="create-ometiff" href="#" class="disabled"
+                <a href="#" class="disabled"
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>
             </li>
-            <li>{{ manager.}}
             {% endif %}
-            {% endif %}
-            {% endif %}
+        {% endif %}
             
             {% if image %}
               {% with ex=canExportAsJpg %}


### PR DESCRIPTION
# What this PR does

Allows export of image as OME-TIFF, even if you can't download the original image file.
See https://trello.com/c/bxkT6Jla/107-export-ome-tiff-export-disabled-in-web-when-available-from-cli

# Testing this PR

Check which options are available in the 'Download' drop-down menu:

1. For small image:
     - Download - YES
     - Export as OME-TIFF - YES
1. SPW image or Well:
    - Download - NO
    - Export as OME-TIFF - YES
1. Big Image:
    - Download - YES
    - Export as OME-TIFF - NO
1. Image in Share (not owned by user):
    - Download - NO
    - Export as OME-TIFF - NO
1. Multiple Images selected:
    - Download - YES except for SPW images
    - Export as OME-TIFF - NO