### PR TITLE
Web diagnostics

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -956,7 +956,7 @@ class DiagnosticsControl(BaseControl):
         diagnostics = parser.add(
             sub, self.diagnostics,
             "Run a set of checks on the current, "
-            "preferably active ")
+            "preferably active server")
         diagnostics.add_argument(
             "--no-logs", action="store_true",
             help="Skip log parsing")

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -943,6 +943,32 @@ class BaseControl(object):
             out += ","
         return out.rstrip(",")
 
+
+class DiagnosticsControl(BaseControl):
+    """
+    Superclass (and SPI-interface) for any control commands that would
+    like to provide a "diagnostics" method, like bin/omero admin diagnostics
+    and bin/omero web diagnostics. The top-level diagnostics command then
+    can find each such plugin and iterate over it.
+    """
+
+    def _add_diagnostics(self, parser, sub):
+        diagnostics = parser.add(
+            sub, self.diagnostics,
+            "Run a set of checks on the current, "
+            "preferably active ")
+        diagnostics.add_argument(
+            "--no-logs", action="store_true",
+            help="Skip log parsing")
+
+    def _diagnostics_banner(self, control_name):
+
+        self.ctx.out("""
+%s
+OMERO Diagnostics (%s) %s
+%s
+        """ % ("="*80, control_name, VERSION, "="*80))
+
     def _sz_str(self, sz):
         for x in ["KB", "MB", "GB"]:
             sz /= 1000

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -943,6 +943,49 @@ class BaseControl(object):
             out += ","
         return out.rstrip(",")
 
+    def _sz_str(self, sz):
+        for x in ["KB", "MB", "GB"]:
+            sz /= 1000
+            if sz < 1000:
+                break
+        sz = "%.1f %s" % (sz, x)
+        return sz
+
+    def _item(self, cat, msg):
+        cat = cat + ":"
+        cat = "%-12s" % cat
+        self.ctx.out(cat, False)
+        msg = "%-30s " % msg
+        self.ctx.out(msg, False)
+
+    def _exists(self, p):
+        if p.isdir():
+            if not p.exists():
+                self.ctx.out("doesn't exist")
+            else:
+                self.ctx.out("exists")
+        else:
+            if not p.exists():
+                self.ctx.out("n/a")
+            else:
+                warn_regex = ('(-! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
+                              'warn(i(ng:)?)?\s')
+                err_regex = ('(!! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
+                             'error:?\s')
+                warn = 0
+                err = 0
+                for l in p.lines():
+                    # ensure errors/warnings search is case-insensitive
+                    lcl = l.lower()
+                    if re.match(warn_regex, lcl):
+                        warn += 1
+                    elif re.match(err_regex, lcl):
+                        err += 1
+                msg = ""
+                if warn or err:
+                    msg = " errors=%-4s warnings=%-4s" % (err, warn)
+                self.ctx.out("%-12s %s" % (self._sz_str(p.size), msg))
+
 
 class CLI(cmd.Cmd, Context):
     """

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1295,7 +1295,7 @@ OMERO Diagnostics %s
             known_log_files = [
                 "Blitz-0.log", "Tables-0.log", "Processor-0.log",
                 "Indexer-0.log", "FileServer.log", "MonitorServer.log",
-                "DropBox.log", "TestDropBox.log", "OMEROweb.log"]
+                "DropBox.log", "TestDropBox.log"]
             files = log_dir.files()
             files = set([x.basename() for x in files])
             # Adding known names just in case

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1422,22 +1422,6 @@ OMERO Diagnostics %s
                 item("JVM settings", " %s" % (k[0].upper() + k[1:]))
                 self.ctx.out("%s" % sb)
 
-        # OMERO.web diagnostics
-        self.ctx.out("")
-        from omero.plugins.web import WebControl
-        try:
-            WebControl().status(args)
-        except Exception, e:
-            try:
-                self.ctx.out("OMERO.web error: %s" % e.message[1].message)
-            except:
-                self.ctx.out("OMERO.web not installed!")
-        try:
-            import django
-            self.ctx.out("Django version: %s" % django.get_version())
-        except:
-            self.ctx.err("Django not installed!")
-
     def email(self, args):
         client = self.ctx.conn(args)
         iadmin = client.sf.getAdminService()

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1301,7 +1301,7 @@ OMERO Diagnostics %s
                         for k, v in issues.items():
                             if k.match(line):
                                 self._item('Parsing %s' % file,
-                                     "[line:%s] %s" % (lno, v))
+                                           "[line:%s] %s" % (lno, v))
                                 self.ctx.out("")
                                 break
             except:
@@ -1314,7 +1314,7 @@ OMERO Diagnostics %s
 
         def env_val(val):
             self._item("Environment", "%s=%s"
-                 % (val, os.environ.get(val, "(unset)")))
+                       % (val, os.environ.get(val, "(unset)")))
             self.ctx.out("")
         env_val("OMERO_HOME")
         env_val("OMERO_NODE")
@@ -1344,7 +1344,7 @@ OMERO Diagnostics %s
             for s in applications:
                 def port_val(port_type, value):
                     self._item("%s %s port" % (s, port_type),
-                         "%s" % value or "Not found")
+                               "%s" % value or "Not found")
                     self.ctx.out("")
                 p2 = self.ctx.popen(
                     self._cmd("-e", "application describe %s" % s))

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -24,6 +24,7 @@ from omero_ext.argparse import FileType
 
 from omero.cli import BaseControl
 from omero.cli import CLI
+from omero.cli import DiagnosticsControl
 from omero.cli import VERSION
 
 
@@ -240,6 +241,29 @@ class HelpControl(BaseControl):
         elif args.topic:
             self.print_single_command_or_topic(args)
 
+
+DIAGNOSTICS_HELP = """ Call diagnostics on all subplugins """
+
+
+class CollectingDiagnosticsControl(BaseControl):
+    """
+    """
+
+    def _configure(self, parser):
+        self.__parser__ = parser  # For formatting later
+        parser.set_defaults(func=self.__call__)
+        parser.add_argument(
+            "--no-logs", action="store_true",
+            help="Skip log parsing")
+        # Argument list must match that of the
+        # DiagnosticsControl._add_diagnostics method
+
+    def __call__(self, args):
+        for name, control in sorted(self.ctx.controls.items()):
+            if isinstance(control, DiagnosticsControl):
+                control.diagnostics(args)
+
+
 controls = {
     "help": (HelpControl, "Syntax help for all commands"),
     "quit": (QuitControl, "Quit application"),
@@ -248,7 +272,9 @@ controls = {
 All arguments not understood vi %(prog)s will be passed to the shell.
 Use "--" to end parsing, e.g. '%(prog)s -- --help' for IPython help"""),
     "version": (VersionControl, "Version number"),
-    "load": (LoadControl, LOAD_HELP)}
+    "load": (LoadControl, LOAD_HELP),
+    "diagnostics": (CollectingDiagnosticsControl, DIAGNOSTICS_HELP),
+}
 
 try:
     for k, v in controls.items():

--- a/components/tools/OmeroPy/src/omero/plugins/basics.py
+++ b/components/tools/OmeroPy/src/omero/plugins/basics.py
@@ -24,7 +24,6 @@ from omero_ext.argparse import FileType
 
 from omero.cli import BaseControl
 from omero.cli import CLI
-from omero.cli import DiagnosticsControl
 from omero.cli import VERSION
 
 
@@ -241,29 +240,6 @@ class HelpControl(BaseControl):
         elif args.topic:
             self.print_single_command_or_topic(args)
 
-
-DIAGNOSTICS_HELP = """ Call diagnostics on all subplugins """
-
-
-class CollectingDiagnosticsControl(BaseControl):
-    """
-    """
-
-    def _configure(self, parser):
-        self.__parser__ = parser  # For formatting later
-        parser.set_defaults(func=self.__call__)
-        parser.add_argument(
-            "--no-logs", action="store_true",
-            help="Skip log parsing")
-        # Argument list must match that of the
-        # DiagnosticsControl._add_diagnostics method
-
-    def __call__(self, args):
-        for name, control in sorted(self.ctx.controls.items()):
-            if isinstance(control, DiagnosticsControl):
-                control.diagnostics(args)
-
-
 controls = {
     "help": (HelpControl, "Syntax help for all commands"),
     "quit": (QuitControl, "Quit application"),
@@ -272,9 +248,7 @@ controls = {
 All arguments not understood vi %(prog)s will be passed to the shell.
 Use "--" to end parsing, e.g. '%(prog)s -- --help' for IPython help"""),
     "version": (VersionControl, "Version number"),
-    "load": (LoadControl, LOAD_HELP),
-    "diagnostics": (CollectingDiagnosticsControl, DIAGNOSTICS_HELP),
-}
+    "load": (LoadControl, LOAD_HELP)}
 
 try:
     for k, v in controls.items():

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -10,7 +10,8 @@
 
 import traceback
 from datetime import datetime
-from omero.cli import BaseControl, CLI
+from omero.cli import DiagnosticsControl
+from omero.cli import CLI
 import platform
 import sys
 import os
@@ -116,7 +117,7 @@ def assert_config_argtype(func):
     return wraps(func)(config_argtype(func))
 
 
-class WebControl(BaseControl):
+class WebControl(DiagnosticsControl):
 
     # DEPRECATED: apache
     config_choices = (
@@ -130,6 +131,7 @@ class WebControl(BaseControl):
 
     def _configure(self, parser):
         sub = parser.sub()
+        self._add_diagnostics(parser, sub)
 
         parser.add(sub, self.help, "Extended help")
         start = parser.add(
@@ -201,14 +203,6 @@ class WebControl(BaseControl):
         clearsessions.add_argument(
             "--no-wait", action="store_true",
             help="Do not wait on expired sessions clean-up")
-
-        diagnostics = parser.add(
-            sub, self.diagnostics,
-            "Run a set of checks on the current, "
-            "preferably active web server")
-        diagnostics.add_argument(
-            "--no-logs", action="store_true",
-            help="Skip log parsing")
 
         #
         # Developer
@@ -695,8 +689,7 @@ class WebControl(BaseControl):
                                  self.ctx.dir / 'bin')
 
     def diagnostics(self, args):
-        # OMERO.web diagnostics
-        self.ctx.out("")
+        self._diagnostics_banner("web")
         try:
             self.status(args)
         except Exception, e:

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -202,10 +202,13 @@ class WebControl(BaseControl):
             "--no-wait", action="store_true",
             help="Do not wait on expired sessions clean-up")
 
-        parser.add(
+        diagnostics = parser.add(
             sub, self.diagnostics,
             "Run a set of checks on the current, "
             "preferably active web server")
+        diagnostics.add_argument(
+            "--no-logs", action="store_true",
+            help="Skip log parsing")
 
         #
         # Developer
@@ -692,6 +695,49 @@ class WebControl(BaseControl):
                                  self.ctx.dir / 'bin')
 
     def diagnostics(self, args):
+        def sz_str(sz):
+            for x in ["KB", "MB", "GB"]:
+                sz /= 1000
+                if sz < 1000:
+                    break
+            sz = "%.1f %s" % (sz, x)
+            return sz
+
+        def item(cat, msg):
+            cat = cat + ":"
+            cat = "%-12s" % cat
+            self.ctx.out(cat, False)
+            msg = "%-30s " % msg
+            self.ctx.out(msg, False)
+
+        def exists(p):
+            if p.isdir():
+                if not p.exists():
+                    self.ctx.out("doesn't exist")
+                else:
+                    self.ctx.out("exists")
+            else:
+                if not p.exists():
+                    self.ctx.out("n/a")
+                else:
+                    warn_regex = ('(-! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
+                                  'warn(i(ng:)?)?\s')
+                    err_regex = ('(!! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
+                                 'error:?\s')
+                    warn = 0
+                    err = 0
+                    for l in p.lines():
+                        # ensure errors/warnings search is case-insensitive
+                        lcl = l.lower()
+                        if re.match(warn_regex, lcl):
+                            warn += 1
+                        elif re.match(err_regex, lcl):
+                            err += 1
+                    msg = ""
+                    if warn or err:
+                        msg = " errors=%-4s warnings=%-4s" % (err, warn)
+                    self.ctx.out("%-12s %s" % (sz_str(p.size), msg))
+
         # OMERO.web diagnostics
         self.ctx.out("")
         from omero.plugins.web import WebControl
@@ -707,6 +753,20 @@ class WebControl(BaseControl):
             self.ctx.out("Django version: %s" % django.get_version())
         except:
             self.ctx.err("Django not installed!")
+
+        if not args.no_logs:
+            log_dir = self.ctx.dir / "var" / "log"
+            self.ctx.out("")
+            item("Log dir", "%s" % log_dir.abspath())
+            if not log_dir.exists():
+                self.ctx.out("")
+                self.ctx.out("No logs available")
+                return
+            else:
+                exists(log_dir)
+                log_file = "OMEROweb.log"
+                item("Log file ", log_file)
+                exists(log_dir / log_file)
 
 try:
     register("web", WebControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -202,6 +202,11 @@ class WebControl(BaseControl):
             "--no-wait", action="store_true",
             help="Do not wait on expired sessions clean-up")
 
+        parser.add(
+            sub, self.diagnostics,
+            "Run a set of checks on the current, "
+            "preferably active web server")
+
         #
         # Developer
         #
@@ -685,6 +690,23 @@ class WebControl(BaseControl):
             str(self.ctx.dir / "etc" / "ice.config") or str(ice_config)
         os.environ['PATH'] = str(os.environ.get('PATH', '.') + ':' +
                                  self.ctx.dir / 'bin')
+
+    def diagnostics(self, args):
+        # OMERO.web diagnostics
+        self.ctx.out("")
+        from omero.plugins.web import WebControl
+        try:
+            WebControl().status(args)
+        except Exception, e:
+            try:
+                self.ctx.out("OMERO.web error: %s" % e.message[1].message)
+            except:
+                self.ctx.out("OMERO.web not installed!")
+        try:
+            import django
+            self.ctx.out("Django version: %s" % django.get_version())
+        except:
+            self.ctx.err("Django not installed!")
 
 try:
     register("web", WebControl, HELP)

--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -695,54 +695,10 @@ class WebControl(BaseControl):
                                  self.ctx.dir / 'bin')
 
     def diagnostics(self, args):
-        def sz_str(sz):
-            for x in ["KB", "MB", "GB"]:
-                sz /= 1000
-                if sz < 1000:
-                    break
-            sz = "%.1f %s" % (sz, x)
-            return sz
-
-        def item(cat, msg):
-            cat = cat + ":"
-            cat = "%-12s" % cat
-            self.ctx.out(cat, False)
-            msg = "%-30s " % msg
-            self.ctx.out(msg, False)
-
-        def exists(p):
-            if p.isdir():
-                if not p.exists():
-                    self.ctx.out("doesn't exist")
-                else:
-                    self.ctx.out("exists")
-            else:
-                if not p.exists():
-                    self.ctx.out("n/a")
-                else:
-                    warn_regex = ('(-! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
-                                  'warn(i(ng:)?)?\s')
-                    err_regex = ('(!! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
-                                 'error:?\s')
-                    warn = 0
-                    err = 0
-                    for l in p.lines():
-                        # ensure errors/warnings search is case-insensitive
-                        lcl = l.lower()
-                        if re.match(warn_regex, lcl):
-                            warn += 1
-                        elif re.match(err_regex, lcl):
-                            err += 1
-                    msg = ""
-                    if warn or err:
-                        msg = " errors=%-4s warnings=%-4s" % (err, warn)
-                    self.ctx.out("%-12s %s" % (sz_str(p.size), msg))
-
         # OMERO.web diagnostics
         self.ctx.out("")
-        from omero.plugins.web import WebControl
         try:
-            WebControl().status(args)
+            self.status(args)
         except Exception, e:
             try:
                 self.ctx.out("OMERO.web error: %s" % e.message[1].message)
@@ -757,16 +713,16 @@ class WebControl(BaseControl):
         if not args.no_logs:
             log_dir = self.ctx.dir / "var" / "log"
             self.ctx.out("")
-            item("Log dir", "%s" % log_dir.abspath())
+            self._item("Log dir", "%s" % log_dir.abspath())
             if not log_dir.exists():
                 self.ctx.out("")
                 self.ctx.out("No logs available")
                 return
             else:
-                exists(log_dir)
+                self._exists(log_dir)
                 log_file = "OMEROweb.log"
-                item("Log file ", log_file)
-                exists(log_dir / log_file)
+                self._item("Log file ", log_file)
+                self._exists(log_dir / log_file)
 
 try:
     register("web", WebControl, HELP)


### PR DESCRIPTION
# What this PR does

`./omero admin diagnostics` also checks status and logs of OMERO.web, but as OMERO.web could be run independantly, it falsely reports an error in that case.
This PR removes the 'web' part from 'admin diagnostics' and puts it into the web module as 'web diagnostics'

# Testing this PR

- Run `./omero admin diagnostics` and check that you don't see any web related output.
- Run `./omero web diagnostics` and check that you see all the web related output.

# Related reading

https://trello.com/c/XdIDdBNS/137-omero-admin-diagnostics-web-status-is-misleading
