### PR TITLE
min/max float default

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7412,8 +7412,8 @@ class _ChannelWrapper (BlitzObjectWrapper):
                            PixelsTypeuint16: 0,
                            PixelsTypeint32: -32768,
                            PixelsTypeuint32: 0,
-                           PixelsTypefloat: -32768,
-                           PixelsTypedouble: -32768}
+                           PixelsTypefloat: -2147483648,
+                           PixelsTypedouble: -2147483648}
                 pixtype = self._obj.getPixels(
                     ).getPixelsType().getValue().getValue()
                 return minVals[pixtype]
@@ -7438,8 +7438,8 @@ class _ChannelWrapper (BlitzObjectWrapper):
                            PixelsTypeuint16: 65535,
                            PixelsTypeint32: 32767,
                            PixelsTypeuint32: 65535,
-                           PixelsTypefloat: 32767,
-                           PixelsTypedouble: 32767}
+                           PixelsTypefloat: 2147483647,
+                           PixelsTypedouble: 2147483647}
                 pixtype = self._obj.getPixels(
                     ).getPixelsType().getValue().getValue()
                 return maxVals[pixtype]

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7406,17 +7406,20 @@ class _ChannelWrapper (BlitzObjectWrapper):
         if si is None:
             logger.info("getStatsInfo() is null. See #9695")
             try:
-                minVals = {PixelsTypeint8: -128,
-                           PixelsTypeuint8: 0,
-                           PixelsTypeint16: -32768,
-                           PixelsTypeuint16: 0,
-                           PixelsTypeint32: -32768,
-                           PixelsTypeuint32: 0,
-                           PixelsTypefloat: -2147483648,
-                           PixelsTypedouble: -2147483648}
-                pixtype = self._obj.getPixels(
-                    ).getPixelsType().getValue().getValue()
-                return minVals[pixtype]
+                if self._re is not None:
+                    return self._re.getPixelsTypeLowerBound(0)
+                else:
+                    minVals = {PixelsTypeint8: -128,
+                               PixelsTypeuint8: 0,
+                               PixelsTypeint16: -32768,
+                               PixelsTypeuint16: 0,
+                               PixelsTypeint32: -2147483648,
+                               PixelsTypeuint32: 0,
+                               PixelsTypefloat: -2147483648,
+                               PixelsTypedouble: -2147483648}
+                    pixtype = self._obj.getPixels(
+                        ).getPixelsType().getValue().getValue()
+                    return minVals[pixtype]
             except:     # Just in case we don't support pixType above
                 return None
         return si.getGlobalMin().val
@@ -7432,17 +7435,20 @@ class _ChannelWrapper (BlitzObjectWrapper):
         if si is None:
             logger.info("getStatsInfo() is null. See #9695")
             try:
-                maxVals = {PixelsTypeint8: 127,
-                           PixelsTypeuint8: 255,
-                           PixelsTypeint16: 32767,
-                           PixelsTypeuint16: 65535,
-                           PixelsTypeint32: 32767,
-                           PixelsTypeuint32: 65535,
-                           PixelsTypefloat: 2147483647,
-                           PixelsTypedouble: 2147483647}
-                pixtype = self._obj.getPixels(
-                    ).getPixelsType().getValue().getValue()
-                return maxVals[pixtype]
+                if self._re is not None:
+                    return self._re.getPixelsTypeUpperBound(0)
+                else:
+                    maxVals = {PixelsTypeint8: 127,
+                               PixelsTypeuint8: 255,
+                               PixelsTypeint16: 32767,
+                               PixelsTypeuint16: 65535,
+                               PixelsTypeint32: 2147483647,
+                               PixelsTypeuint32: 4294967295,
+                               PixelsTypefloat: 2147483647,
+                               PixelsTypedouble: 2147483647}
+                    pixtype = self._obj.getPixels(
+                        ).getPixelsType().getValue().getValue()
+                    return maxVals[pixtype]
             except:     # Just in case we don't support pixType above
                 return None
         return si.getGlobalMax().val

--- a/components/tools/OmeroPy/src/omero/gateway/pytest_fixtures.py
+++ b/components/tools/OmeroPy/src/omero/gateway/pytest_fixtures.py
@@ -100,3 +100,13 @@ def author_testimg_big(request, gatewaywrapper):
     gatewaywrapper.loginAsAuthor()
     rv = gatewaywrapper.getBigTestImage(autocreate=True)
     return rv
+
+
+@pytest.fixture(scope='function')
+def author_testimg_32float(request, gatewaywrapper):
+    """
+    logs in as Author and returns the float image, creating it first if needed.
+    """
+    gatewaywrapper.loginAsAuthor()
+    rv = gatewaywrapper.get32FloatTestImage(autocreate=True)
+    return rv

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
@@ -415,8 +415,9 @@ class ImageEntry (ObjectEntry):
                     # print "Trying to get test image from " + TESTIMG_URL +
                     # self.filename
                     sys.stderr.write('<')
-                    f = urllib2.urlopen(TESTIMG_URL + self.filename)
-                    open(fpath, 'wb').write(f.read())
+                    fin = urllib2.urlopen(TESTIMG_URL + self.filename)
+                    with open(fpath, 'wb') as fout:
+                        fout.write(fin.read())
                 except urllib2.HTTPError:
                     raise IOError('No such file %s' % fpath)
         host = dataset._conn.c.ic.getProperties().getProperty(

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/dbhelpers.py
@@ -406,15 +406,19 @@ class ImageEntry (ObjectEntry):
         if not os.path.exists(fpath):
             if not os.path.exists(os.path.dirname(fpath)):
                 os.makedirs(os.path.dirname(fpath))
-            # First try to download the image
-            try:
-                # print "Trying to get test image from " + TESTIMG_URL +
-                # self.filename
-                sys.stderr.write('<')
-                f = urllib2.urlopen(TESTIMG_URL + self.filename)
-                open(fpath, 'wb').write(f.read())
-            except urllib2.HTTPError:
-                raise IOError('No such file %s' % fpath)
+            if self.filename.endswith('.fake'):
+                # If it's a .fake file, simply create it
+                os.close(os.open(fpath, os.O_CREAT | os.O_EXCL))
+            else:
+                # First try to download the image
+                try:
+                    # print "Trying to get test image from " + TESTIMG_URL +
+                    # self.filename
+                    sys.stderr.write('<')
+                    f = urllib2.urlopen(TESTIMG_URL + self.filename)
+                    open(fpath, 'wb').write(f.read())
+                except urllib2.HTTPError:
+                    raise IOError('No such file %s' % fpath)
         host = dataset._conn.c.ic.getProperties().getProperty(
             'omero.host') or 'localhost'
         port = dataset._conn.c.ic.getProperties().getProperty(

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
@@ -47,6 +47,9 @@ dbhelpers.IMAGES = {
         'weblitz_test_priv_image_tiny3', 'tinyTest.d3d.dv', 'testds3'),
     'bigimg': dbhelpers.ImageEntry(
         'weblitz_test_priv_image_big', 'big.tiff', 'testds3'),
+    '32float': dbhelpers.ImageEntry(
+        'weblitz_test_priv_image_32float',
+        '32bitfloat&pixelType=float&sizeX=8192&sizeY=8192.fake', 'testds3'),
 }
 
 
@@ -166,6 +169,10 @@ class TestDBHelper(object):
 
     def getBigTestImage(self, dataset=None, autocreate=False):
         return dbhelpers.getImage(self.gateway, 'bigimg', forceds=dataset,
+                                  autocreate=autocreate)
+
+    def get32FloatTestImage(self, dataset=None, autocreate=False):
+        return dbhelpers.getImage(self.gateway, '32float', forceds=dataset,
                                   autocreate=autocreate)
 
     def prepTestDB(self, onlyUsers=False, skipImages=True):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -117,6 +117,13 @@ class TestRDefs (object):
             assert channel.getWindowStart() == start
             assert channel.getWindowEnd() == end
 
+    def testFloatDefaultMinMax(self, author_testimg_32float):
+        """ Test the default min/max values for 32bit float images """
+        channels = author_testimg_32float.getChannels()
+        for channel in channels:
+            assert channel.getWindowMin() == -2147483648
+            assert channel.getWindowMax() == 2147483647
+
     def testEmissionWave(self, author_testimg_tiny):
         """ """
         assert self.channels[0].getEmissionWave() == 457
@@ -231,7 +238,6 @@ class TestRDefs (object):
         Test we can list rdefs for an image and they correspond to the
         rdefs we've set.
         """
-
         # Admin saves Rdef (greyscale)
         gatewaywrapper.loginAsAdmin()
         adminId = gatewaywrapper.gateway.getUserId()


### PR DESCRIPTION
# What this PR does

If a float image doesn't have statsinfo, use `-2147483648` and `2147483647` as default pixel range.

# Testing this PR

Web / iViewer:
Use the same image as for testing #5445 . In the image preview click on 'Min/Max'. Check that above values are used as pixel window (should also match Insight).

# Related reading

https://trello.com/c/F7zMjEbh/134-clients-no-stats-controls-check

