### PR TITLE
use root's connection properties in test

### DIFF
--- a/components/tools/OmeroJava/test/integration/AdminServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/AdminServiceTest.java
@@ -2010,8 +2010,8 @@ public class AdminServiceTest extends AbstractServerTest {
         }
         Assert.assertTrue(isInSystemGroup, "new light system user must be member of system group");
         final LoginCredentials credentials = new LoginCredentials();
-        credentials.getServer().setHostname(client.getProperty("omero.host"));
-        credentials.getServer().setPort(Integer.parseInt(client.getProperty("omero.port")));
+        credentials.getServer().setHostname(root.getProperty("omero.host"));
+        credentials.getServer().setPort(Integer.parseInt(root.getProperty("omero.port")));
         credentials.getUser().setUsername(lightAdminName);
         credentials.getUser().setPassword(lightAdminPassword);
         final Gateway gateway = new Gateway(new SimpleLogger());


### PR DESCRIPTION
# What this PR does

Adjusts `AdminServiceTest.testCreateRestrictedSystemUserWithPassword` to not rely on an existing logged-in session.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/AdminServiceTest/testCreateRestrictedSystemUserWithPassword/ should be green.