### PR TITLE
Update use of omerocmd for docs build

### DIFF
--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -96,7 +96,7 @@ version.
 The :source:`etc/omero.properties` file of your distribution defines all the
 default configuration properties used by the server. Changes made to the file
 are *not* recognized by the server. Instead, configuration options can be set
-using the :omerocmd:`config set` command:
+using the :program:`omero config set` command:
 
 ::
 
@@ -123,7 +123,7 @@ You can also review all your settings by using:
 
 which should return values without quotation marks.
 
-A final useful option of :omerocmd:`config edit` is:
+A final useful option of :program:`omero config edit` is:
 
 ::
 


### PR DESCRIPTION
# What this PR does

As part of the effort to get the OMERO docs to build with newer sphinx versions, I need to remove `:omerocmd:` and use `:program:` instead. This page generates the content for http://docs.openmicroscopy.org/omero/5.3.3/sysadmins/config.html#id2 so needs to be updated so it doesn't overwrite changes to the docs next time the content is changed.

# Testing this PR

Proofread.

Possibly you can also generate the doc page but you'll have to ask someone else for instructions.

# Related reading

https://trello.com/c/ccx2knE7/141-check-whether-sphinx-can-be-upgraded-for-all-docs-jobs