### PR TITLE
Fix double-loading of right panel

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -47,6 +47,7 @@ $(function() {
     })
     .on('selection_change.ome', function(e, nElements) {
         multiselection = nElements > 1;
+        // NB: Don't return false - let event bubble up to $("body")
     })
     .on('copy_node.jstree', function(e, data) {
         /**

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -691,10 +691,8 @@ $(document).ready(function() {
         }
 
         // Tell jsTree how many elements are selected
+        // This event also bubbles up to $("body")
         $("#dataTree").trigger('selection_change.ome', inst.get_selected(true).length);
-
-        // Trigger the selection changed event
-        $("body").trigger('selection_change.ome');
 
         return false;
     }


### PR DESCRIPTION
# What this PR does

Fixes the double-loading of the right panel when Dataset thumbnails are clicked.

# Testing this PR

1. To see the bug, e.g. in idr /nightshade / web-dev-latest,  open dev-tools (right-click on page and "Inspect Element") and view the Network tab. Clicking on a Dataset thumbnail will show 2 requests for /metadata_details/image/id/ 
2. Repeat with this PR web-dev-merge and see that only a single request is made to load the right panel.
3. Check that other selection changes are still working OK. Single/multi-select of various objects and check they are loaded in right panel correctly.