### PR TITLE
Isfulladmin Python gateway

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2324,6 +2324,21 @@ class _BlitzGateway (object):
 
         return self.getEventContext().isAdmin
 
+    def isFullAdmin(self):
+        """
+        Checks if a user has full administration privileges.
+
+        :return:    Boolean
+        """
+
+        if self.getEventContext().isAdmin:
+            allPrivs = []
+            for p in self.getEnumerationEntries('AdminPrivilege'):
+                allPrivs.append(p.getValue())
+            return len(allPrivs) == len(self.getCurrentAdminPrivileges())
+
+        return False
+
     def isLeader(self, gid=None):
         """
         Is the current group (or a specified group) led by the current user?

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_permissions.py
@@ -43,3 +43,25 @@ class TestPrivileges(ITest):
 
         expected = ['Sudo', 'ModifyGroup', 'ModifyUser']
         assert set(expected) == set(conn.getAdminPrivileges(exp.id.val))
+
+    def test_full_admin_privileges(self):
+        """Test full admin privileges check."""
+        conn = BlitzGateway(client_obj=self.root, try_super=True)
+        allPrivs = []
+        for p in conn.getEnumerationEntries('AdminPrivilege'):
+            allPrivs.append(p.getValue())
+        conn.updateAdminPrivileges(self.user.id.val, add=allPrivs)
+        test = conn.getCurrentAdminPrivileges()
+        assert set(allPrivs) == set(test)
+        assert conn.isFullAdmin()
+
+        conn.updateAdminPrivileges(self.user.id.val, remove=['Chown'])
+
+        privs = set(conn.getCurrentAdminPrivileges())
+        print "privs:"
+        print privs
+
+        print "all:"
+        print allPrivs
+
+        assert not conn.isFullAdmin()


### PR DESCRIPTION
# What this PR does

Adds another method isFullAdmin to the Python gateway, which checks if the user is an administrator with full admin privileges. 

# Testing this PR

Check that `test_full_admin_privileges` integration test still passes.
Which does not at the moment, therefore
--exclude

# Related reading

https://trello.com/c/FjayBnvM/39-gateway-support-for-roles

Same for Java gateway: #5482
