### PR TITLE
fix login redirect

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -50,7 +50,7 @@ def parse_url(lookup_view):
     url = None
     try:
         url = reverse_with_params(
-            lookup_view['viewname'],
+            viewname=lookup_view['viewname'],
             args=lookup_view['args'],
             query_string=lookup_view['query_string']
         )

--- a/components/tools/OmeroWeb/omeroweb/utils.py
+++ b/components/tools/OmeroWeb/omeroweb/utils.py
@@ -41,7 +41,9 @@ def reverse_with_params(*args, **kwargs):
     except NoReverseMatch:
         return url
     if qs:
-        url += '?' + urlencode(qs)
+        if not isinstance(qs, basestring):
+            qs = urlencode(qs)
+        url += '?' + qs
     return url
 
 


### PR DESCRIPTION
# What this PR does

While reviewing docs I tried setting https://docs.openmicroscopy.org/omero/5.3.3/sysadmins/customization.html#login-redirection
and found it didn't work for me.
Not sure this has ever worked?

# Testing this PR

1. Set the config as in the docs:
```
bin/omero config set omero.web.login_redirect '{"redirect": ["webindex"], "viewname": "load_template", "args":["userdata"], "query_string": "experimenter=-1"}'
```
1. Restart web
1. Go to /webclient/, you will be redirected to login page.
1. On login, you should be redirected to /webclient/userdata/?experimenter=-1