### PR TITLE
share_add_no_images

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2593,6 +2593,8 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
         if o_type == "share":
             img_ids = request.GET.getlist('image',
                                           request.POST.getlist('image'))
+            if request.method == 'GET' and len(img_ids) == 0:
+                return HttpResponse("No images specified")
             images_to_share = list(conn.getObjects("Image", img_ids))
             if request.method == 'POST':
                 form = BasketShareForm(


### PR DESCRIPTION
# What this PR does

Fixes error at ```webclient/action/add/share/``` if no images are specified with ```?image=1```.
Not sure how user got this error, since webclient only loads the create-share form when Images are selected in the UI.

# Testing this PR

1. Go to ```webclient/action/add/share/``` and check you get a message instead of an error.

2. Try creating a share as normal in webclient to check that this still works OK.

