### PR TITLE
Api eventContext

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -59,6 +59,13 @@ api_login = url(r'^v(?P<api_version>%s)/login/$' % versions,
 Login to OMERO. POST with 'username', 'password' and 'server' index
 """
 
+api_event_context = url(r'^v(?P<api_version>%s)/eventcontext/$' % versions,
+                        views.api_eventcontext,
+                        name='api_eventcontext')
+"""
+Get the current eventContext.
+"""
+
 api_save = url(r'^v(?P<api_version>%s)/m/save/$' % versions,
                views.SaveView.as_view(),
                name='api_save')
@@ -299,6 +306,7 @@ urlpatterns = patterns(
     api_token,
     api_servers,
     api_login,
+    api_event_context,
     api_save,
     api_projects,
     api_project,

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -38,6 +38,7 @@ from api_exceptions import BadRequestError, \
     NotFoundError
 from omeroweb.api.decorators import login_required, json_response
 from omeroweb.webgateway.util import getIntOrDefault
+from omeroweb.webgateway.marshal import eventContextMarshal
 
 
 def build_url(request, name, api_version, **kwargs):
@@ -87,6 +88,7 @@ def api_base(request, api_version=None, **kwargs):
           'url:token': build_url(request, 'api_token', v),
           'url:servers': build_url(request, 'api_servers', v),
           'url:login': build_url(request, 'api_login', v),
+          'url:eventcontext': build_url(request, 'api_eventcontext'. v),
           'url:save': build_url(request, 'api_save', v),
           'url:schema': OME_SCHEMA_URL}
     return rv
@@ -112,6 +114,14 @@ def api_servers(request, api_version, **kwargs):
             s['server'] = obj.server
         servers.append(s)
     return {'data': servers}
+
+
+@login_required()
+@json_response()
+def api_eventcontext(request, conn=None, **kwargs):
+    """Get the current eventContext."""
+    c = conn.getEventContext()
+    return eventContextMarshal(c)
 
 
 class ApiView(View):

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -88,7 +88,7 @@ def api_base(request, api_version=None, **kwargs):
           'url:token': build_url(request, 'api_token', v),
           'url:servers': build_url(request, 'api_servers', v),
           'url:login': build_url(request, 'api_login', v),
-          'url:eventcontext': build_url(request, 'api_eventcontext'. v),
+          'url:eventcontext': build_url(request, 'api_eventcontext', v),
           'url:save': build_url(request, 'api_save', v),
           'url:schema': OME_SCHEMA_URL}
     return rv

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -33,7 +33,8 @@ from omero.constants.namespaces import NSBULKANNOTATIONS
 from omero.util.ROI_utils import pointsStringToXYlist, xyListToBbox
 from plategrid import PlateGrid
 from omero_version import build_year
-from marshal import imageMarshal, shapeMarshal, rgb_int2rgba
+from marshal import imageMarshal, shapeMarshal, rgb_int2rgba, \
+    eventContextMarshal
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.views.generic import View
 from omeroweb.webadmin.forms import LoginForm
@@ -2792,12 +2793,7 @@ class LoginView(View):
     def handle_logged_in(self, request, conn, connector):
         """Return a response for successful login."""
         c = conn.getEventContext()
-        ctx = {}
-        for a in ['sessionId', 'sessionUuid', 'userId', 'userName', 'groupId',
-                  'groupName', 'isAdmin', 'eventId', 'eventType',
-                  'memberOfGroups', 'leaderOfGroups']:
-            if (hasattr(c, a)):
-                ctx[a] = getattr(c, a)
+        ctx = eventContextMarshal(c)
         return JsonResponse({"success": True, "eventContext": ctx})
 
     def handle_not_logged_in(self, request, error=None, form=None):


### PR DESCRIPTION
# What this PR does

Adds support for ```/api/v0/eventcontext/``` which returns the current eventContext.
Needed for clients to retrieve the current context some time after logging in.

# Needs discussion:
We need to restrict public_user from accessing this since they will be able to access their sessionId and join session as a fully logged-in public user.

# Testing this PR

1. Go to  ```/api/v0/eventcontext/``` after logging in.
1. Should see event contest JSON data.

TODO:
 - [ ] Add test
