### PR TITLE
fix well position css

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2328,24 +2328,36 @@ div.paging input.button_pagination {
 }
 
 #spw table {
-    background:#fff none repeat scroll 0 0;
+    background: #fff none repeat scroll 0 0;
     width: 0;
     table-layout: auto;
 }
+
 #spw table th {
     vertical-align: middle;
 }
+
 #spw table td {
     padding: 1px;
     border: 1px solid #ccc;
-	position: relative;
+    position: relative;
 }
+
 #spw table td.placeholder {
     vertical-align: top;
 }
 
-#spw table td.ui-selecting { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}
-#spw table td.ui-selected { border: 1px dashed #555; padding: 1px; background-color:#87ABD2;}
+#spw table td.ui-selecting {
+    border: 1px dashed #555;
+    padding: 1px;
+    background-color: #87ABD2;
+}
+
+#spw table td.ui-selected {
+    border: 1px dashed #555;
+    padding: 1px;
+    background-color: #87ABD2;
+}
 
 .wellLabel {
     display: none;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2338,9 +2338,7 @@ div.paging input.button_pagination {
 #spw table td {
     padding: 1px;
     border: 1px solid #ccc;
-}
-#spw table td.well {
-    background: #fff;
+	position: relative;
 }
 #spw table td.placeholder {
     vertical-align: top;


### PR DESCRIPTION
# What this PR does

Fixes an issue were labels for a well in the centre panel appear to the top left of the image grid, rather than the top left of their respective image.


# Testing this PR

1. Select a plate with images
2. Hover mouse over an image in centre grid
3. Ensure the grid coordinate is displayed in the top left of that images cell
4. Ensure cell borders are displayed on FireFox and any other browser


# Related reading

Issue reported here:
https://github.com/openmicroscopy/openmicroscopy/pull/5403

What it should look like (note the "B2" position):
![screen shot 2017-09-04 at 14 31 35](https://user-images.githubusercontent.com/3717090/30028679-f0bc1d56-917d-11e7-9e93-6bd5034b7373.png)

