### PR TITLE
Add update tables method

### DIFF
--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -521,5 +521,59 @@ public class TablesFacility extends Facility {
         }
         return result;
     }
-    
+
+    /**
+     * Saves the (modified) {@link TableData} back to the server.
+     * Note: The size of Double/Float/Long arrays can't be changed!
+     * 
+     * @param ctx
+     *            The {@link SecurityContext}
+     * @param data
+     *            The {@link TableData} to save
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in
+     * @throws DSAccessException
+     *             If an error occurred while trying to retrieve data from OMERO
+     *             service.
+     */
+    public void updateTable(SecurityContext ctx, TableData data)
+            throws DSOutOfServiceException, DSAccessException {
+        TablePrx table = null;
+        try {
+            if (data.getOriginalFileId() == -1)
+                throw new IllegalArgumentException(
+                        "This TableData object is not associated with a table yet, use addTable method instead.");
+
+            OriginalFile file = new OriginalFileI(data.getOriginalFileId(),
+                    false);
+            SharedResourcesPrx sr = gateway.getSharedResources(ctx);
+            if (!sr.areTablesEnabled()) {
+                throw new DSAccessException(
+                        "Tables feature is not enabled on this server!");
+            }
+
+            table = sr.openTable(file);
+
+            long[] colIndex = new long[data.getColumns().length];
+            for (int i = 0; i < data.getColumns().length; i++)
+                colIndex[i] = data.getColumns()[i].getIndex();
+
+            Data toUpdate = table.read(colIndex, data.getOffset(),
+                    data.getOffset() + data.getData()[0].length);
+
+            TablesFacilityHelper.updateData(toUpdate, data);
+
+            table.update(toUpdate);
+        } catch (Exception e) {
+            handleException(this, e, "Could not udpate table");
+        } finally {
+            if (table != null)
+                try {
+                    table.close();
+                } catch (ServerError e) {
+                    logError(this, "Could not close table", e);
+                }
+        }
+    }
+
 }

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -523,8 +523,11 @@ public class TablesFacility extends Facility {
     }
 
     /**
-     * Saves the (modified) {@link TableData} back to the server.
-     * Note: The size of Double/Float/Long arrays can't be changed!
+     * Saves the (modified) {@link TableData} back to the server. 
+     * Note:
+     * - Addition/Removal of columns/rows is not supported, only modification of
+     *   the values.
+     * - The size of Double/Float/Long arrays can't be changed!
      * 
      * @param ctx
      *            The {@link SecurityContext}

--- a/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacilityHelper.java
@@ -26,6 +26,7 @@ import omero.gateway.model.PlateData;
 import omero.gateway.model.ROIData;
 import omero.gateway.model.TableData;
 import omero.gateway.model.TableDataColumn;
+import omero.gateway.model.WellData;
 import omero.gateway.model.WellSampleData;
 import omero.grid.BoolColumn;
 import omero.grid.Column;
@@ -225,6 +226,8 @@ public class TablesFacilityHelper {
                 for (int j = 0; j < nRows; j++) {
                     MaskData md = new MaskData(mc.x[j], mc.y[j], mc.w[j],
                             mc.h[j], mc.bytes[j]);
+                    md.setZ(mc.theZ[j]);
+                    md.setT(mc.theT[j]);
                     rowData[j] = md;
                 }
                 dataArray[i] = rowData;
@@ -467,4 +470,198 @@ public class TablesFacilityHelper {
         return gridColumns;
     }
 
+    /**
+     * Update omero.grid.Data with the provided {@link TableData} data.
+     * Note:
+     * - Size and data types must match!
+     * - Size of Double/Float/Long arrays can't be changed!
+     * 
+     * @param toUpdate
+     *            The omero.grid.Data object to update
+     * @param data
+     *            The new data
+     */
+    static void updateData(Data toUpdate, TableData data) {
+        if (toUpdate.columns.length != data.getData().length)
+            throw new IllegalArgumentException("Column size is different!");
+        if (toUpdate.rowNumbers.length != data.getData()[0].length)
+            throw new IllegalArgumentException("Row size is different!");
+
+        for (int c = 0; c < data.getColumns().length; c++) {
+            Column col = toUpdate.columns[c];
+
+            for (int r = 0; r < data.getData()[0].length; r++) {
+                if (col instanceof BoolColumn) {
+                    if (!data.getColumns()[c].getType().equals(Boolean.class))
+                        throw new IllegalArgumentException(
+                                "Boolean type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((BoolColumn) col).values[r] = (Boolean) data.getData()[c][r];
+                }
+                if (col instanceof DoubleArrayColumn) {
+                    if (!data.getColumns()[c].getType().equals(Double[].class))
+                        throw new IllegalArgumentException(
+                                "Double[] type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    if (((DoubleArrayColumn) col).size != ((Double[]) data
+                            .getData()[c][r]).length)
+                        throw new IllegalArgumentException(
+                                "Can't change the length of the array");
+
+                    Double[] a = (Double[]) data.getData()[c][r];
+                    double[] b = new double[a.length];
+                    for (int i = 0; i < a.length; i++)
+                        b[i] = a[i].doubleValue();
+                    ((DoubleArrayColumn) col).values[r] = b;
+                }
+                if (col instanceof DoubleColumn) {
+                    if (!data.getColumns()[c].getType().equals(Double.class))
+                        throw new IllegalArgumentException(
+                                "Double type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((DoubleColumn) col).values[r] = (Double) data.getData()[c][r];
+                }
+                if (col instanceof FileColumn) {
+                    if (!data.getColumns()[c].getType().equals(
+                            FileAnnotationData.class))
+                        throw new IllegalArgumentException(
+                                "FileAnnotationData type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((FileColumn) col).values[r] = ((FileAnnotationData) data
+                            .getData()[c][r]).getFileID();
+                }
+                if (col instanceof FloatArrayColumn) {
+                    if (!data.getColumns()[c].getType().equals(Float[].class))
+                        throw new IllegalArgumentException(
+                                "Float[] type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    if (((FloatArrayColumn) col).size != ((Float[]) data
+                            .getData()[c][r]).length)
+                        throw new IllegalArgumentException(
+                                "Can't change the length of the array");
+
+                    Float[] a = (Float[]) data.getData()[c][r];
+                    float[] b = new float[a.length];
+                    for (int i = 0; i < a.length; i++)
+                        b[i] = a[i].floatValue();
+                    ((FloatArrayColumn) col).values[r] = b;
+                }
+                if (col instanceof ImageColumn) {
+                    if (!data.getColumns()[c].getType().equals(ImageData.class))
+                        throw new IllegalArgumentException(
+                                "ImageData type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((ImageColumn) col).values[r] = ((ImageData) data.getData()[c][r])
+                            .getId();
+                }
+                if (col instanceof LongArrayColumn) {
+                    if (!data.getColumns()[c].getType().equals(Long[].class))
+                        throw new IllegalArgumentException(
+                                "Long[] type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    if (((LongArrayColumn) col).size != ((Long[]) data
+                            .getData()[c][r]).length)
+                        throw new IllegalArgumentException(
+                                "Can't change the length of the array");
+
+                    Long[] a = (Long[]) data.getData()[c][r];
+                    long[] b = new long[a.length];
+                    for (int i = 0; i < a.length; i++)
+                        b[i] = a[i].longValue();
+                    ((LongArrayColumn) col).values[r] = b;
+                }
+                if (col instanceof LongColumn) {
+                    if (!data.getColumns()[c].getType().equals(Long.class))
+                        throw new IllegalArgumentException(
+                                "Long type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((LongColumn) col).values[r] = (Long) data.getData()[c][r];
+                }
+                if (col instanceof MaskColumn) {
+                    if (!data.getColumns()[c].getType().equals(MaskData.class))
+                        throw new IllegalArgumentException(
+                                "MaskData type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    MaskData md = (MaskData) data.getData()[c][r];
+                    ((MaskColumn) col).bytes[r] = md.getMask();
+                    ((MaskColumn) col).x[r] = md.getX();
+                    ((MaskColumn) col).y[r] = md.getY();
+                    ((MaskColumn) col).w[r] = md.getWidth();
+                    ((MaskColumn) col).h[r] = md.getHeight();
+                    ((MaskColumn) col).theZ[r] = md.getZ();
+                    ((MaskColumn) col).theT[r] = md.getT();
+                }
+                if (col instanceof PlateColumn) {
+                    if (!data.getColumns()[c].getType().equals(PlateData.class))
+                        throw new IllegalArgumentException(
+                                "PlateData type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((PlateColumn) col).values[r] = ((PlateData) data.getData()[c][r])
+                            .getId();
+                }
+                if (col instanceof RoiColumn) {
+                    if (!data.getColumns()[c].getType().equals(ROIData.class))
+                        throw new IllegalArgumentException(
+                                "ROIData type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((RoiColumn) col).values[r] = ((ROIData) data.getData()[c][r])
+                            .getId();
+                }
+                if (col instanceof StringColumn) {
+                    if (!data.getColumns()[c].getType().equals(String.class))
+                        throw new IllegalArgumentException(
+                                "String type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((StringColumn) col).values[r] = (String) data.getData()[c][r];
+                }
+                if (col instanceof WellColumn) {
+                    if (!data.getColumns()[c].getType().equals(WellData.class))
+                        throw new IllegalArgumentException(
+                                "WellData type expected for column "
+                                        + c
+                                        + ", but is "
+                                        + data.getColumns()[c].getType()
+                                                .getSimpleName() + " !");
+                    ((WellColumn) col).values[r] = ((WellData) data.getData()[c][r])
+                            .getId();
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
# What this PR does

At the moment there are only `add` and `get` methods in the `TablesFacility`. This PR adds an `update` method. It is quite limited, i.e. one can only modify values, but not add or delete rows/columns (that's because the OMERO tables interface doesn't have methods for addition/deleting of rows/column, afaik).

# Testing this PR

Not really much to test, check the `testUpdateTable` integration test makes sense and passes, should be sufficient.

# Related reading

https://trello.com/c/aXTsTn5U/221-gateway
https://github.com/imagej/imagej-omero/pull/65#issuecomment-321252703
