### PR TITLE
public url regex default

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -508,10 +508,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "Enable and disable the OMERO.web public user functionality."],
     "omero.web.public.url_filter":
         ["PUBLIC_URL_FILTER",
-         r'a^',
+         r'(?#This regular expression matches nothing)a^',
          re.compile,
-         ("Set a filter for URLS which the public user is allowed to access."
-          " If this is not set, no URLS will be publicly available.")],
+         ("Set a regular expression that matches URLs the public user is"
+          "allowed to access. If this is not set, no URLS will be"
+          "publicly available.")],
     "omero.web.public.get_only":
         ["PUBLIC_GET_ONLY",
          "true",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -508,12 +508,10 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "Enable and disable the OMERO.web public user functionality."],
     "omero.web.public.url_filter":
         ["PUBLIC_URL_FILTER",
-         r'^/(?!webadmin)',
+         r'a^',
          re.compile,
-         ("Set a URL filter for which the OMERO.web public user is allowed to"
-          " navigate. The idea is that you can create the public pages"
-          " yourself (see OMERO.web framework since we do not provide public"
-          " pages.")],
+         ("Set a filter for URLS which the public user is allowed to access."
+          " If this is not set, no URLS will be publicly available.")],
     "omero.web.public.get_only":
         ["PUBLIC_GET_ONLY",
          "true",


### PR DESCRIPTION
# What this PR does

Updates the public url_filter default value so that it matches nothing.
This means users will need to set this, instead of relying on the default value.

# Testing this PR

1. Set public user as on https://docs.openmicroscopy.org/omero/5.3.3/sysadmins/public.html#public-user without setting the ```url_filter```.
1. Should find that NO urls are publicly available (will get redirected to login page)
1. Setting the url_filter to e.g. ```"^/(webgateway)"``` should still work OK.

# Related reading

See discussion at https://github.com/openmicroscopy/openmicroscopy/pull/5315 about ```/api/``` urls being available with the default url_filter setting.
The "regex that matches nothing" in this PR came from: https://stackoverflow.com/questions/940822/regular-expression-syntax-for-match-nothing for 