### PR TITLE
Unify style with other `return` statements

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -421,7 +421,7 @@ class login_required(object):
             return None
 
         session['connector'] = connector
-        return
+        return None
 
     def __call__(ctx, f):
         """


### PR DESCRIPTION
# What this PR does

Unify style with other `return` statements in the `get_authenticated_connection()` block. Follow up from comment on #5471.

# Testing this PR

N/A; purely stylistic.

# Related reading

* #5471 
