### PR TITLE
Matlab deleteObjects use Requests util

### DIFF
--- a/components/tools/OmeroM/src/annotations/linkAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/linkAnnotation.m
@@ -39,6 +39,10 @@ ip.addRequired('parentId', @(x) isempty(x) || (isvector(x) && isnumeric(x)));
 ip.parse(session, annotation, parentType, parentId);
 objectType = objectTypes(strcmp(parentType, objectNames));
 
+% Throw exception if type is roi
+assert(~strcmp(objectType.class, 'omero.model.Roi'),...
+    ['Cannot link annotations to rois. ']);
+
 % Get the parent object
 if isnumeric(parentId),
     parent = getObjects(session, parentType, parentId);

--- a/components/tools/OmeroM/src/delete/deleteObjects.m
+++ b/components/tools/OmeroM/src/delete/deleteObjects.m
@@ -48,7 +48,7 @@ for i = 1 : numel(ids)
 end
 targetObject = java.util.Hashtable;
 targetObject.put(objectType.delete2,idlist);
-deleteCommands = omero.cmd.Delete2(targetObject, [], false, []);
+deleteCommands = omero.gateway.util.Requests.delete().target(targetObject).build();
 
 % Submit the delete commands
 session.submit(deleteCommands);

--- a/components/tools/OmeroM/src/getObjectTypes.m
+++ b/components/tools/OmeroM/src/getObjectTypes.m
@@ -22,8 +22,8 @@ function types = getObjectTypes()
 % with this program; if not, write to the Free Software Foundation, Inc.,
 % 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-names = {'project', 'dataset', 'image', 'screen', 'plate', 'plateacquisition'};
-classnames = {'Project', 'Dataset', 'Image', 'Screen', 'Plate', 'PlateAcquisition'};
+names = {'project', 'dataset', 'image', 'screen', 'plate', 'plateacquisition', 'roi'};
+classnames = {'Project', 'Dataset', 'Image', 'Screen', 'Plate', 'PlateAcquisition', 'Roi'};
 types = createObjectDictionary(names, classnames);
 
 for i = 1 : numel(types)

--- a/components/tools/OmeroM/src/io/getObjects.m
+++ b/components/tools/OmeroM/src/io/getObjects.m
@@ -70,6 +70,10 @@ assert(~strcmp(objectType.class, 'omero.model.PlateAcquisition'),...
     ['Plate acquisitions are loaded together with plates. '...
     'Use getPlates() instead.']);
 
+% Throw exception if type is roi
+assert(~strcmp(objectType.class, 'omero.model.Roi'),...
+    ['Rois are loaded via Roi server. ']);
+
 % Check optional input parameters
 defaultParameters = omero.sys.ParametersI();
 defaultContext = java.util.HashMap;

--- a/components/tools/OmeroM/src/io/getObjects.m
+++ b/components/tools/OmeroM/src/io/getObjects.m
@@ -72,7 +72,7 @@ assert(~strcmp(objectType.class, 'omero.model.PlateAcquisition'),...
 
 % Throw exception if type is roi
 assert(~strcmp(objectType.class, 'omero.model.Roi'),...
-    ['Rois are loaded via Roi server. ']);
+    ['Rois have to be loaded via roi service. ']);
 
 % Check optional input parameters
 defaultParameters = omero.sys.ParametersI();

--- a/components/tools/OmeroM/src/libs
+++ b/components/tools/OmeroM/src/libs
@@ -1,0 +1,1 @@
+../target/libs

--- a/components/tools/OmeroM/src/libs
+++ b/components/tools/OmeroM/src/libs
@@ -1,1 +1,0 @@
-../target/libs

--- a/examples/Training/matlab/DeleteData.m
+++ b/examples/Training/matlab/DeleteData.m
@@ -86,17 +86,14 @@ try
         end
         roi = session.getUpdateService().saveAndReturnObject(roi);
     end
-        
+ 
     % Delete ROI
     fprintf(1, 'Deleting ROI %g\n', roi.getId().getValue());
-    targetObj = java.util.Hashtable;
-    targetObj.put('ROI', toJavaList(roi.getId().getValue(), 'java.lang.Long'));
-    deleteCommand = omero.cmd.Delete2(targetObj, [], false, []);
-    session.submit(deleteCommand);
-
+    deleteObjects(session, roi.getId().getValue(), 'roi');
+    
     % Delete the image. You can delete more than one image at a time.
     fprintf(1, 'Deleting image %g\n', imageId);
-    deleteImages(session, imageId);
+    deleteObjects(session, imageId, 'image');
     
     % Check the image has been deleted
     pause(5)


### PR DESCRIPTION
# What this PR does

- Updates Matlab's `deleteObjects` method to use the Java `Requests` utils.
- Updates the Delete example to use the `deleteObjects` method.

# Testing this PR

Run the `examples/Training/matlab/DeleteData.m` example.

# Related reading
 
Follow up for #5460

