### PR TITLE
Redis

### DIFF
--- a/components/tools/OmeroWeb/requirements-py27-ice35.txt
+++ b/components/tools/OmeroWeb/requirements-py27-ice35.txt
@@ -9,4 +9,4 @@ django-pipeline==1.3.20
 gunicorn>=19.3
 
 omero-marshal==0.5.1
--r requirements-redis.txt
+django-redis>=4.4

--- a/components/tools/OmeroWeb/requirements-py27-ice35.txt
+++ b/components/tools/OmeroWeb/requirements-py27-ice35.txt
@@ -9,3 +9,4 @@ django-pipeline==1.3.20
 gunicorn>=19.3
 
 omero-marshal==0.5.1
+-r requirements-redis.txt

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -10,3 +10,4 @@ django-pipeline==1.3.20
 gunicorn>=19.3
 
 omero-marshal==0.5.1
+-r requirements-redis.txt

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -10,4 +10,4 @@ django-pipeline==1.3.20
 gunicorn>=19.3
 
 omero-marshal==0.5.1
--r requirements-redis.txt
+django-redis>=4.4

--- a/components/tools/OmeroWeb/requirements-redis.txt
+++ b/components/tools/OmeroWeb/requirements-redis.txt
@@ -1,5 +1,5 @@
-# Python installation requirements for OMERO.web
-# ==============================================
+# Deprecated: Python installation requirements for OMERO.web
+# ==========================================================
 #
 #     pip install -r requirements-redis.txt
 #


### PR DESCRIPTION
# What this PR does

Install dependency required to use redis
Including this requirement file will not change any workflow when installing web dependencies



# Testing this PR

Check that the dependency is installed


# Related reading

https://trello.com/c/mPY2uYY6/124-include-django-redis-in-the-default-requirementstxt-for-omeroweb

Doc PR, omero-install and omeroweb-install PRs are also needed

cc @sbesson @joshmoore 