### PR TITLE
travis_numpy uninstall failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ before_install:
     # Changing the value for sudo will also need to be reviewed at the same time
     # This will need to be reviewed when the issue above is fixed
     - export PATH=/usr/bin/:$PATH
-    # Use latest numexpr to fix table test failures
-    - pip install numexpr
-    - sudo apt-get install -y zeroc-ice35 python-imaging python-tables python-yaml
+    - sudo apt-get install -y zeroc-ice35 python-imaging python-numpy python-tables python-yaml
+    # upgrade numexpr to fix table test failures
+    - sudo pip install -U numexpr
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi
     - export PATH=$PATH:$HOME/.local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ before_install:
     # see https://github.com/travis-ci/travis-ci/issues/8048
     # Changing the value for sudo will also need to be reviewed at the same time
     # This will need to be reviewed when the issue above is fixed
+    - export PATH=/usr/bin/:$PATH
     # Use latest numexpr to fix table test failures
     - pip install numexpr
-    - export PATH=/usr/bin/:$PATH
     - sudo apt-get install -y zeroc-ice35 python-imaging python-tables python-yaml
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ before_install:
     # see https://github.com/travis-ci/travis-ci/issues/8048
     # Changing the value for sudo will also need to be reviewed at the same time
     # This will need to be reviewed when the issue above is fixed
+    # Use latest numexpr to fix table test failures
+    - pip install numexpr
     - export PATH=/usr/bin/:$PATH
     - sudo apt-get install -y zeroc-ice35 python-imaging python-tables python-yaml
-    # upgrade numexpr to fix table test failures
-    - pip install -U numexpr
     - pip install --user pytest
     - if [[ $BUILD == 'build-python' ]]; then pip install --user -r ./components/tools/OmeroWeb/requirements-py27-all-ice35.txt; fi
     - export PATH=$PATH:$HOME/.local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
     # Changing the value for sudo will also need to be reviewed at the same time
     # This will need to be reviewed when the issue above is fixed
     - export PATH=/usr/bin/:$PATH
-    - sudo apt-get install -y zeroc-ice35 python-imaging python-numpy python-tables python-yaml
+    - sudo apt-get install -y zeroc-ice35 python-imaging python-tables python-yaml
     # upgrade numexpr to fix table test failures
     - pip install -U numexpr
     - pip install --user pytest


### PR DESCRIPTION
# What this PR does

Attempt to fix travis failure...

```
[?25hCollecting numpy>=1.6 (from numexpr)
  Using cached numpy-1.13.1-cp27-cp27mu-manylinux1_x86_64.whl
Installing collected packages: numpy, numexpr
  Found existing installation: numpy 1.8.2
[31m    DEPRECATION: Uninstalling a distutils installed project (numpy) has been deprecated and will be removed in a future version. This is due to the fact that uninstalling a distutils project will only partially uninstall the project.[0m
    Uninstalling numpy-1.8.2:
[31mException:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/usr/local/lib/python2.7/dist-packages/pip/commands/install.py", line 342, in run
    prefix=options.prefix_path,
  File "/usr/local/lib/python2.7/dist-packages/pip/req/req_set.py", line 778, in install
    requirement.uninstall(auto_confirm=True)
  File "/usr/local/lib/python2.7/dist-packages/pip/req/req_install.py", line 754, in uninstall
    paths_to_remove.remove(auto_confirm)
  File "/usr/local/lib/python2.7/dist-packages/pip/req/req_uninstall.py", line 115, in remove
    renames(path, new_path)
  File "/usr/local/lib/python2.7/dist-packages/pip/utils/__init__.py", line 267, in renames
    shutil.move(old, new)
  File "/usr/lib/python2.7/shutil.py", line 303, in move
    os.unlink(src)
OSError: [Errno 13] Permission denied: '/usr/lib/python2.7/dist-packages/numpy-1.8.2.egg-info'[0m
/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#insecureplatformwarning.
```