### PR TITLE
Add tests for cleanse

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -100,7 +100,7 @@ class ITest(object):
     DEFAULT_SYSTEM = False
     # If the new user created in setup_class is system group member
     # default value None makes the new user to Full Admin
-    # For Restricted Admin with no privileges, set the value to []
+    # For Restricted Admin with no privileges, set the value to ()
     # Can be overriden by test instances
     DEFAULT_PRIVILEGES = None
 

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -535,7 +535,10 @@ class ITest(object):
                  email=None, privileges=None):
         """
         :owner: If user is to be an owner of the created group
-        :system: If user is to be a system admin
+        :system: If user is to be a system group member
+        :privileges: If system group member is to have privileges
+                     privileges=None gives all privileges (full admin)
+                     privileges=[] gives no privileges
         """
 
         if not cls.root:

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -93,6 +93,16 @@ class ITest(object):
     # If the new user created in setup_class should own their group
     # Can be overriden by test instances
     DEFAULT_GROUP_OWNER = False
+    # If the new user created in setup_class should
+    # be member of system group. This is to be
+    # set to True if the new user should be Restricted Admin
+    # Can be overriden by test instances
+    DEFAULT_SYSTEM = False
+    # If the new user created in setup_class is system group member
+    # default value None makes the new user to Full Admin
+    # For Restricted Admin with no privileges, set the value to []
+    # Can be overriden by test instances
+    DEFAULT_PRIVILEGES = None
 
     @classmethod
     def setup_class(cls):
@@ -115,7 +125,10 @@ class ITest(object):
             raise Exception("Could not initiate a root connection")
 
         cls.group = cls.new_group(perms=cls.DEFAULT_PERMS)
-        cls.user = cls.new_user(group=cls.group, owner=cls.DEFAULT_GROUP_OWNER)
+        cls.user = cls.new_user(group=cls.group,
+                                owner=cls.DEFAULT_GROUP_OWNER,
+                                system=cls.DEFAULT_SYSTEM,
+                                privileges=cls.DEFAULT_PRIVILEGES)
         cls.client = omero.client()  # ok because adds self
         cls.__clients.add(cls.client)
         cls.client.setAgent("OMERO.py.test")

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -538,7 +538,7 @@ class ITest(object):
         :system: If user is to be a system group member
         :privileges: If system group member is to have privileges
                      privileges=None gives all privileges (full admin)
-                     privileges=[] gives no privileges
+                     privileges=() gives no privileges
         """
 
         if not cls.root:

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -20,7 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-from test.integration.clitest.cli import CLITest, RootCLITest
+from test.integration.clitest.cli import CLITest
 from omero.cli import NonZeroReturnCode
 from omero.cmd import Delete2
 
@@ -47,7 +47,7 @@ class TestCleanse(CLITest):
         assert err.endswith("SecurityViolation: Admins only!\n")
 
 
-class TestCleanseFullAdmin(RootCLITest):
+class TestCleanseFullAdmin(CLITest):
 
     # make the user in this test a member of system group
     DEFAULT_SYSTEM = True
@@ -71,7 +71,7 @@ class TestCleanseFullAdmin(RootCLITest):
         return path.replace("//", "/")
 
     def testCleanseBasic(self, capsys):
-        """Test cleanse works for root with expected output"""
+        """Test cleanse works for Full Admin with expected output"""
         self.args += [self.data_dir]
         self.cli.invoke(self.args, strict=True)
         out, err = capsys.readouterr()

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -62,5 +62,5 @@ class TestCleanseRoot(RootCLITest):
         out, err = capsys.readouterr()
         output_string_start = "Removing empty directories from...\n "
         mrepo_dir = config_service.getConfigValue("omero.managed.dir")
-        output_string = mrepo_dir.replace("//", "/")
+        output_string = output_string_start + mrepo_dir.replace("//", "/")
         assert output_string in out

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -47,10 +47,15 @@ class TestCleanse(CLITest):
         assert err.endswith("SecurityViolation: Admins only!\n")
 
 
-class TestCleanseRoot(RootCLITest):
+class TestCleanseFullAdmin(RootCLITest):
+
+    # make the user in this test a member of system group
+    DEFAULT_SYSTEM = True
+    # make the new member of system group to a Full Admin
+    DEFAULT_PRIVILEGES = None
 
     def setup_method(self, method):
-        super(TestCleanseRoot, self).setup_method(method)
+        super(TestCleanseFullAdmin, self).setup_method(method)
         self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
         self.args += ["admin", "cleanse"]
         self.group_ctx = {'omero.group': str(self.group.id.val)}
@@ -157,7 +162,7 @@ class TestCleanseRestrictedAdmin(CLITest):
     DEFAULT_SYSTEM = True
     # make the new member of system group to a Restricted
     # Admin with no privileges
-    DEFAULT_PRIVILEGES = []
+    DEFAULT_PRIVILEGES = ()
 
     def setup_method(self, method):
         super(TestCleanseRestrictedAdmin, self).setup_method(method)

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from test.integration.clitest.cli import CLITest, RootCLITest
+from omero.cli import NonZeroReturnCode
+
+import omero.plugins.admin
+import pytest
+import omero
+
+
+class TestCleanse(CLITest):
+
+    def setup_method(self, method):
+        super(TestCleanse, self).setup_method(method)
+        self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
+        self.args += ["admin", "cleanse"]
+
+    def testCleanseAdminOnly(self, capsys):
+        """Test cleanse is admin-only"""
+        data_dir = self.root.sf.getConfigService().getConfigValue("omero.data.dir")
+        self.args += [data_dir]
+        with pytest.raises(NonZeroReturnCode):
+            self.cli.invoke(self.args, strict=True)
+        out, err = capsys.readouterr()
+        assert err.endswith("SecurityViolation: Admins only!\n")
+
+class TestCleanseRoot(RootCLITest):
+
+    def setup_method(self, method):
+        super(TestCleanseRoot, self).setup_method(method)
+        self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
+        self.args += ["admin", "cleanse"]
+
+    def testCleanseAdminOnly(self, capsys):
+        """Test cleanse works for root with expected output"""
+        data_dir = self.root.sf.getConfigService().getConfigValue("omero.data.dir")
+        self.args += [data_dir]
+        self.cli.invoke(self.args, strict=True)
+        out, err = capsys.readouterr()
+        output_string = "Removing empty directories from...\n " + data_dir + "ManagedRepository\n"
+        assert output_string in out

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -37,12 +37,14 @@ class TestCleanse(CLITest):
 
     def testCleanseAdminOnly(self, capsys):
         """Test cleanse is admin-only"""
-        data_dir = self.root.sf.getConfigService().getConfigValue("omero.data.dir")
+        config_service = self.root.sf.getConfigService()
+        data_dir = config_service.getConfigValue("omero.data.dir")
         self.args += [data_dir]
         with pytest.raises(NonZeroReturnCode):
             self.cli.invoke(self.args, strict=True)
         out, err = capsys.readouterr()
         assert err.endswith("SecurityViolation: Admins only!\n")
+
 
 class TestCleanseRoot(RootCLITest):
 
@@ -53,9 +55,11 @@ class TestCleanseRoot(RootCLITest):
 
     def testCleanseAdminOnly(self, capsys):
         """Test cleanse works for root with expected output"""
-        data_dir = self.root.sf.getConfigService().getConfigValue("omero.data.dir")
+        config_service = self.root.sf.getConfigService()
+        data_dir = config_service.getConfigValue("omero.data.dir")
         self.args += [data_dir]
         self.cli.invoke(self.args, strict=True)
         out, err = capsys.readouterr()
-        output_string = "Removing empty directories from...\n " + data_dir + "ManagedRepository\n"
+        output_string_start = "Removing empty directories from...\n "
+        output_string = output_string_start + data_dir + "ManagedRepository\n"
         assert output_string in out

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -61,5 +61,6 @@ class TestCleanseRoot(RootCLITest):
         self.cli.invoke(self.args, strict=True)
         out, err = capsys.readouterr()
         output_string_start = "Removing empty directories from...\n "
-        output_string = output_string_start + data_dir + "ManagedRepository\n"
+        mrepo_dir = config_service.getConfigValue("omero.managed.dir")
+        output_string = mrepo_dir.replace("//", "/")
         assert output_string in out


### PR DESCRIPTION
# What this PR does

Adds tests for ``bin/omero admin cleanse`` command on CLI.
Atm,4 tests are added, "admin-only" when the executor of the command is not an admin, and a successful execution of the command for root with expected ending of the output checked.
Also, a more detailed test of functionality (checking that a file and directory were really removed, and Restricted Admin test as well were added.
See https://trello.com/c/3gBK3okF/752-integration-test-for-bin-omero-admin-cleanse
and https://trello.com/c/vsLBC6Aq/35-define-additional-markers-for-local-tests

As discussed, we can attempt to merge this PR, so putting for review for tomorrow.

@joshmoore @mtbc @sbesson 
Ready for review