### PR TITLE
robot fix searching_form

### DIFF
--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -27,7 +27,7 @@ ${XpathWellThumb}       xpath=//table[@id='dataTable']//img[contains(@src,'well1
 ${XpathTable}           xpath=//table[@id='dataTable']
 ${XpathTableColumn}     xpath=//table[@id='dataTable']//tr/td[position()=3]
 ${XPathAlertText}       xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//p
-${RandomClick}          xpath=//form[@id="searching_form"]/h2
+${RandomClick}          xpath=//form[@id="searching_form"]//h2
 ${AlertWindow}          xpath=//div[contains(@class,'ui-dialog')][contains(@style,'display: block')]//div[contains(@class, 'ui-dialog-buttonset')]//*[contains(text(),"OK")]
 ${SearchInProgress}     xpath=//div[@id='content_details']//img[contains(@src,'webgateway/img/spinner.gif')]
 ${QueryError}           xpath=//div[@id='content_details']//div[contains(@class,'error')]


### PR DESCRIPTION
# What this PR does

Fixes robot test failing since selector broke with changes to left panel in #5428.
The ```<h2>``` element is no-longer a direct descendant of the ```#searching_form```.

https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/707/robot/Web%20&%20Web/Web_1/Search/Test%20Key%20Word%20Search/


# Testing this PR

1. Test should now be green.