### PR TITLE
Rendering settings exposure - quantization maps

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7496,7 +7496,7 @@ class _ChannelWrapper (BlitzObjectWrapper):
         Returns the channel coefficient
 
         :return:    the channel coefficient
-        :rtype:     double
+        :rtype:     float
         """
         if self._re is None:
             return None

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8761,12 +8761,16 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     @assert_re()
     def setQuantizationMap(self, channelIndex, family, coefficient):
         """
-        Sets the quantization strategy according to the given family
+        Sets the quantization strategy to the given family
+        and coefficient
 
         :param channelIndex:    The index of channel (int)
         :param family:          The family (string)
         :param coefficient:     The coefficient (float)
         """
+        if channelIndex < 0 or channelIndex >= self.getSizeC():
+            return
+
         f = self.getFamilies().get("linear")
         try:
             f = self._qf.get(family.lower(), f)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8771,9 +8771,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if channelIndex < 0 or channelIndex >= self.getSizeC():
             return
 
-        f = self.getFamilies().get("linear")
+        families = self.getFamilies()
+        f = families.get("linear")
         try:
-            f = self._qf.get(family.lower(), f)
+            f = families.get(family.lower(), f)
         except:
             pass
 
@@ -8799,13 +8800,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if not isinstance(maps, list):
             return
 
-        i = 0
-        for m in maps:
+        for i, m in enumerate(maps):
             if isinstance(m, dict):
                 family = m.get('family', None)
                 coefficient = m.get('coefficient', 1.0)
                 self.setQuantizationMap(i, family, coefficient)
-            i += 1
 
     @assert_re(ignoreExceptions=(omero.ConcurrencyException))
     def getRenderingDefId(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8787,6 +8787,26 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         self._re.setQuantizationMap(channelIndex, f._obj, c, False)
 
+    @assert_re()
+    def setQuantizationMaps(self, maps):
+        """
+        Sets the quantization strategy using the given list
+        of mapping information (for each entry, i.e. channel)
+        e.g. [{'family': 'linear', coefficient: 1.0}]
+
+        :param maps:     list of quantization settings
+        """
+        if not isinstance(maps, list):
+            return
+
+        i = 0
+        for m in maps:
+            if isinstance(m, dict):
+                family = m.get('family', None)
+                coefficient = m.get('coefficient', 1.0)
+                self.setQuantizationMap(i, family, coefficient)
+            i += 1
+
     @assert_re(ignoreExceptions=(omero.ConcurrencyException))
     def getRenderingDefId(self):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8747,16 +8747,16 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     @assert_re()
     def getFamilies(self):
         """
-        Gets a list of available families.
+        Gets a dict of available families.
 
         :return:    Families
-        :rtype:     List of :class:`BlitzObjectWrapper`
+        :rtype:     Dict
         """
         if not len(self._qf):
             for f in [BlitzObjectWrapper(self._conn, f)
                       for f in self._re.getAvailableFamilies()]:
                 self._qf[f.value.lower()] = f
-        return self._qf.values()
+        return self._qf
 
     @assert_re()
     def setQuantizationMap(self, channelIndex, family, coefficient):
@@ -8767,10 +8767,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param family:          The family (string)
         :param coefficient:     The coefficient (float)
         """
-        self.getFamilies()
-        f = self._qf.get("linear")
+        f = self.getFamilies().get("linear")
         try:
-            f = self._qf.get(str(family).lower(), f)
+            f = self._qf.get(family.lower(), f)
         except:
             pass
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -353,3 +353,51 @@ class TestRDefs (object):
         # Try resetting (save=True will be ignored, but reset will work)
         i.resetDefaults(save=True)
         assert i.isGreyscaleRenderingModel()
+
+    def testQuantizationSettings(self, gatewaywrapper):
+        """
+        Tests whether quantization settings are properly applied
+        """
+        self.image = gatewaywrapper.getTestImage()
+        channels = self.image.getChannels()
+
+        # collect initial values
+        settings = []
+        for chan in channels:
+            settings.append({
+                "family": chan.getFamily().getValue(),
+                "coefficient": chan.getCoefficient()
+            })
+
+        # channel bounds exceeded check
+        self.image.setQuantizationMap(-1, "logarithmic", 0.1)
+        self.image.setQuantizationMap(200, "exponential", 0.5)
+        # input checks for family (checking against initial values)
+        self.image.setQuantizationMap(0, None, 1)
+        assert settings[0] == {
+            "family": channels[0].getFamily().getValue(),
+            "coefficient": channels[0].getCoefficient()
+        }
+        self.image.setQuantizationMap(0, "no_good_family", 1)
+        assert settings[0] == {
+            "family": channels[0].getFamily().getValue(),
+            "coefficient": channels[0].getCoefficient()
+        }
+        # input checks for coefficient (checking against initial values)
+        self.image.setQuantizationMap(1, "linear", "coefficient")
+        self.image.setQuantizationMap(1, "linear", 100)
+        assert settings[1] == {
+            "family": channels[1].getFamily().getValue(),
+            "coefficient": channels[1].getCoefficient()
+        }
+
+        # change settings looping over all families
+        families = self.image.getFamilies().values()
+        for fam in families:
+            i = 0
+            # change and assert for new value per channel
+            for c in channels:
+                self.image.setQuantizationMap(i, fam.getValue(), 0.5)
+                assert c.getFamily().getValue() == fam.getValue()
+                assert c.getCoefficient() == 0.5
+                i += 1

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -401,3 +401,58 @@ class TestRDefs (object):
                 assert c.getFamily().getValue() == fam.getValue()
                 assert c.getCoefficient() == 0.5
                 i += 1
+
+    def testQuantizationSettingsBulk(self, gatewaywrapper):
+        """
+        Tests whether quantization settings are properly applied
+        using the 'bulk' method
+        """
+        self.image = gatewaywrapper.getTestImage()
+        channels = self.image.getChannels()
+
+        # collect initial values
+        settings = []
+        for chan in channels:
+            settings.append({
+                "family": chan.getFamily().getValue(),
+                "coefficient": chan.getCoefficient()
+            })
+
+        # input checks that leave the original values unaffected
+        self.image.setQuantizationMaps(None)
+        i = 0
+        for chan in channels:
+            assert settings[i] == {
+                "family": channels[i].getFamily().getValue(),
+                "coefficient": channels[i].getCoefficient()
+            }
+            i += 0
+        self.image.setQuantizationMaps(["nonsense", 8])
+        i = 0
+        for chan in channels:
+            assert settings[i] == {
+                "family": channels[i].getFamily().getValue(),
+                "coefficient": channels[i].getCoefficient()
+            }
+            i += 0
+
+        # now try to set 1 more channel than the image has
+        # also: channel 0 setting is invalid, channel 2 correct
+        error_case = {
+            "family": "error",
+            "coefficient": 10000
+        }
+        correct_case = {
+            "family": "logarithmic",
+            "coefficient": 0.3
+        }
+        test_cases = [error_case, correct_case, correct_case]
+        self.image.setQuantizationMaps(test_cases)
+        assert settings[0] == {
+            "family": channels[0].getFamily().getValue(),
+            "coefficient": channels[0].getCoefficient()
+        }
+        assert correct_case == {
+            "family": channels[1].getFamily().getValue(),
+            "coefficient": channels[1].getCoefficient()
+        }

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -420,21 +420,17 @@ class TestRDefs (object):
 
         # input checks that leave the original values unaffected
         self.image.setQuantizationMaps(None)
-        i = 0
-        for chan in channels:
+        for i, chan in enumerate(channels):
             assert settings[i] == {
                 "family": channels[i].getFamily().getValue(),
                 "coefficient": channels[i].getCoefficient()
             }
-            i += 0
         self.image.setQuantizationMaps(["nonsense", 8])
-        i = 0
-        for chan in channels:
+        for i, chan in enumerate(channels):
             assert settings[i] == {
                 "family": channels[i].getFamily().getValue(),
                 "coefficient": channels[i].getCoefficient()
             }
-            i += 0
 
         # now try to set 1 more channel than the image has
         # also: channel 0 setting is invalid, channel 2 correct

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -820,12 +820,10 @@ def _get_prepared_image(request, iid, server_id=None, conn=None,
         if reverses is not None and invert_flags is not None:
             invert_flags = [z[0] if z[0] is not None else z[1] for z in
                             zip(invert_flags, reverses)]
-
-    # more rendering settings per channel: quantization maps
-    # just applied, not saved at the moment
-    if 'quant_maps' in r:
         try:
-            img.setQuantizationMaps(json.loads(r['quant_maps']))
+            # quantization maps (just applied, not saved at the moment)
+            qm = [m['quantization'] for m in json.loads(r['maps'])]
+            img.setQuantizationMaps(qm)
         except:
             logger.debug('Failed to set quantization maps')
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -822,7 +822,7 @@ def _get_prepared_image(request, iid, server_id=None, conn=None,
                             zip(invert_flags, reverses)]
         try:
             # quantization maps (just applied, not saved at the moment)
-            qm = [m['quantization'] for m in json.loads(r['maps'])]
+            qm = [m.get('quantization') for m in json.loads(r['maps'])]
             img.setQuantizationMaps(qm)
         except:
             logger.debug('Failed to set quantization maps')

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -775,7 +775,7 @@ def _set_quantization_maps(quant_json, img):
             quant_json = json.loads(quant_json)
 
         size_c = len(quant_json)
-        if size_c is None:
+        if size_c == 0:
             return
 
         channels = img.getChannels()
@@ -786,12 +786,12 @@ def _set_quantization_maps(quant_json, img):
         for c in range(size_c):
             family = quant_json[i]['family']
             if family is None:
+                i += 1
                 continue
             if img.getFamilies().get(family.lower(), None) is None:
+                i += 1
                 continue
-            coeff = quant_json[i].get('coefficient', None)
-            if coeff is None:
-                coeff = 1.0
+            coeff = quant_json[i].get('coefficient', 1.0)
             img.setQuantizationMap(i, family, float(coeff))
             i += 1
     except:
@@ -892,10 +892,8 @@ def _get_prepared_image(request, iid, server_id=None, conn=None,
             pass
     img.setProjection(p)
     img.setProjectionRange(pStart, pEnd)
-
     img.setInvertedAxis(bool(r.get('ia', "0") == "1"))
     compress_quality = r.get('q', None)
-
     if saveDefs:
         'z' in r and img.setDefaultZ(long(r['z'])-1)
         't' in r and img.setDefaultT(long(r['t'])-1)


### PR DESCRIPTION
Certain rendering options such as quantization maps have only been used in insight.

To enable web clients to use these options -since they rely on the render methods in the webgateway-
 the most sensible approach seems to me to add a parameter to the query string.

TEST: use the render methods/requests to fetch an image, adding a "quantization" object to the json that is handed of maps parameter (which already contains invert). "quantization" can contain properties family and coefficient, e.g.
```
...&maps=[{"reverse":{"enabled":true},"quantization":{"family":"logarithmic","coefficient":0.2}},{"reverse":{"enabled":true},"quantization":{"family":"exponential","coefficient":1.0}}]
```

Check that the tests are green: https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.gatewaytest.test_rdefs/