### PR TITLE
Add tests for light admin

### DIFF
--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2507,25 +2507,33 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Resets the enumerations
+     * Tests if deleted enumeration can be reset
      * @throws Exception
      */
     @Test
     public void testResetEnumerationsbyRestrictedSystemUser() throws Exception {
         logNewAdminWithoutPrivileges();
-        ContrastMethod ho = new ContrastMethodI();
-        ho.setValue(omero.rtypes.rstring("testResetEnumerationsbyRestrictedSystemUser"));
         final ITypesPrx types_svc = factory.getTypesService();
         List<IObject> types = types_svc.allEnumerations(ContrastMethod.class.getName());
-        //original number of enumerations
         int n = types.size();
-        ho = (ContrastMethod) types_svc.createEnumeration(ho);
+        Iterator<IObject> i = types.iterator();
+        int count = 0;
+        while (i.hasNext()) {
+            try {
+                types_svc.deleteEnumeration(i.next());
+                count++;
+            } catch (Exception e) {
+                //Cannot delete the enumeration since it is used
+            }
+        }
+        //not all enum are used so we should have deleted at least one
+        Assert.assertTrue(count > 0);
         types = types_svc.allEnumerations(ContrastMethod.class.getName());
-        //check that an enumeration has been added
-        Assert.assertEquals(types.size(), (n+1));
-        types_svc.deleteEnumeration(ho);
+        Assert.assertEquals(types.size(), (n-count));
+        //reset the deleted enumerations
         types_svc.resetEnumerations(ContrastMethod.class.getName());
         types = types_svc.allEnumerations(ContrastMethod.class.getName());
+        //We should be back to the original list
         Assert.assertEquals(types.size(), n);
     }
 
@@ -2576,7 +2584,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Tests f it possible to modify a script using the upload method from
+     * Tests if it possible to modify a script using the upload method from
      * omero.client
      * @throws Exception
      */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
-import ome.model.acquisition.Detector;
+import ome.model.enums.DetectorType;
 import ome.model.enums.EventType;
 import omero.RLong;
 import omero.RString;
@@ -112,7 +112,7 @@ public class LightAdminRolesTest extends RolesTests {
     public void tearDown() throws Exception {
         final ITypesPrx svc = root.getSession().getTypesService();
         svc.resetEnumerations(ContrastMethod.class.getName());
-        svc.resetEnumerations(Detector.class.getName());
+        svc.resetEnumerations(DetectorType.class.getName());
         super.tearDown();
     }
 
@@ -2516,7 +2516,7 @@ public class LightAdminRolesTest extends RolesTests {
     public void testResetEnumerationsbyRestrictedSystemUser() throws Exception {
         logNewAdminWithoutPrivileges();
         final ITypesPrx types_svc = factory.getTypesService();
-        List<IObject> types = types_svc.allEnumerations(Detector.class.getName());
+        List<IObject> types = types_svc.allEnumerations(DetectorType.class.getName());
         int n = types.size();
         Iterator<IObject> i = types.iterator();
         int count = 0;
@@ -2530,11 +2530,11 @@ public class LightAdminRolesTest extends RolesTests {
         }
         //not all enum are used so we should have deleted at least one
         Assert.assertTrue(count > 0);
-        types = types_svc.allEnumerations(Detector.class.getName());
+        types = types_svc.allEnumerations(DetectorType.class.getName());
         Assert.assertEquals(types.size(), (n-count));
         //reset the deleted enumerations
-        types_svc.resetEnumerations(Detector.class.getName());
-        types = types_svc.allEnumerations(Detector.class.getName());
+        types_svc.resetEnumerations(DetectorType.class.getName());
+        types = types_svc.allEnumerations(DetectorType.class.getName());
         //We should be back to at the original list. Other enum might have been
         //added by other tests.
         Assert.assertTrue(types.size() >= n);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2535,7 +2535,7 @@ public class LightAdminRolesTest extends RolesTests {
         //reset the deleted enumerations
         types_svc.resetEnumerations(DetectorType.class.getName());
         types = types_svc.allEnumerations(DetectorType.class.getName());
-        //We should be back to at the original list. Other enum might have been
+        //We should be back to the original list. Other enum might have been
         //added by other tests.
         Assert.assertTrue(types.size() >= n);
     }
@@ -2587,8 +2587,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Tests if it possible to modify a script using the upload method from
-     * omero.client
+     * Tests if a script can be modified using the upload method from omero.client.
      * @throws Exception
      */
     @Test(expectedExceptions = omero.SecurityViolation.class)
@@ -2616,8 +2615,8 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Tests if it possible to upload a file owned by another user using
-     * the upload method from omero.client
+     * Tests if a file owned by another usert can be uploaded using the upload
+     * method from omero.client.
      * @throws Exception
      */
     @Test(expectedExceptions = omero.SecurityViolation.class)

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2615,7 +2615,7 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Tests if a file owned by another usert can be uploaded using the upload
+     * Tests if a file owned by another user can be uploaded using the upload
      * method from omero.client.
      * @throws Exception
      */

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1622,7 +1622,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @throws Exception unexpected
      */
     @Test(dataProvider = "isPrivileged cases")
-    public void testOfficialSciptUploadNoSudo(boolean isPrivileged, String groupPermissions) throws Exception {
+    public void testOfficialScriptUploadNoSudo(boolean isPrivileged, String groupPermissions) throws Exception {
         /* isPrivileged translates in this test into WriteScriptRepo permission, see below.*/
         boolean isExpectSuccessUploadOfficialScript = isPrivileged;
         final EventContext normalUser = newUserAndGroup(groupPermissions);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
+import ome.model.acquisition.Detector;
 import ome.model.enums.EventType;
 import omero.RLong;
 import omero.RString;
@@ -111,6 +112,7 @@ public class LightAdminRolesTest extends RolesTests {
     public void tearDown() throws Exception {
         final ITypesPrx svc = root.getSession().getTypesService();
         svc.resetEnumerations(ContrastMethod.class.getName());
+        svc.resetEnumerations(Detector.class.getName());
         super.tearDown();
     }
 
@@ -2514,7 +2516,7 @@ public class LightAdminRolesTest extends RolesTests {
     public void testResetEnumerationsbyRestrictedSystemUser() throws Exception {
         logNewAdminWithoutPrivileges();
         final ITypesPrx types_svc = factory.getTypesService();
-        List<IObject> types = types_svc.allEnumerations(ContrastMethod.class.getName());
+        List<IObject> types = types_svc.allEnumerations(Detector.class.getName());
         int n = types.size();
         Iterator<IObject> i = types.iterator();
         int count = 0;
@@ -2528,11 +2530,11 @@ public class LightAdminRolesTest extends RolesTests {
         }
         //not all enum are used so we should have deleted at least one
         Assert.assertTrue(count > 0);
-        types = types_svc.allEnumerations(ContrastMethod.class.getName());
+        types = types_svc.allEnumerations(Detector.class.getName());
         Assert.assertEquals(types.size(), (n-count));
         //reset the deleted enumerations
-        types_svc.resetEnumerations(ContrastMethod.class.getName());
-        types = types_svc.allEnumerations(ContrastMethod.class.getName());
+        types_svc.resetEnumerations(Detector.class.getName());
+        types = types_svc.allEnumerations(Detector.class.getName());
         //We should be back to at the original list. Other enum might have been
         //added by other tests.
         Assert.assertTrue(types.size() >= n);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -209,8 +209,7 @@ public class LightAdminRolesTest extends RolesTests {
         List<String> permissions = new ArrayList<String>();
         permissions.add(AdminPrivilegeSudo.value);
         if (permWriteOwned) permissions.add(AdminPrivilegeWriteOwned.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         /* lightAdmin possibly sudoes on behalf of normalUser, depending on test case.*/
         if (isSudoing) sudo(new ExperimenterI(normalUser.userId, false));
 
@@ -1107,8 +1106,8 @@ public class LightAdminRolesTest extends RolesTests {
         /* lightAdmin or otherUser try to create links between their own image and normalUser's Dataset
          * and between their own Dataset and normalUser's Project.*/
         try {
-            DatasetImageLink linkOfDatasetImage = linkParentToChild(sentDat, sentOwnImage);
-            ProjectDatasetLink linkOfProjectDataset = linkParentToChild(sentProj, sentOwnDat);
+            linkParentToChild(sentDat, sentOwnImage);
+            linkParentToChild(sentProj, sentOwnDat);
             Assert.assertTrue(isExpectLinkingSuccess);
         } catch (ServerError se) {
             Assert.assertFalse(isExpectLinkingSuccess, se.toString());
@@ -1363,7 +1362,7 @@ public class LightAdminRolesTest extends RolesTests {
         loginUser(normalUser);
         Image image = mmFactory.createImage();
         Image sentImage = (Image) iUpdate.saveAndReturnObject(image);
-        Pixels pixelsOfImage = sentImage.getPrimaryPixels();
+        sentImage.getPrimaryPixels();
         Roi roi = new RoiI();
         roi.addShape(new RectangleI());
         roi.setImage((Image) sentImage.proxy());
@@ -1371,7 +1370,7 @@ public class LightAdminRolesTest extends RolesTests {
         assertOwnedBy(sentImage, normalUser);
         assertOwnedBy(roi, normalUser);
         /* lightAdmin logs in and tries to delete the ROI.*/
-        final EventContext lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         doChange(client, factory, Requests.delete().target(roi).build(), isExpectSuccessDeleteROI);
         /* Check the ROI was deleted, whereas the image exists.*/
@@ -1630,8 +1629,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Set up the light admin's permissions for this test.*/
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeWriteScriptRepo.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         client.getImplicitContext().put("omero.group", Long.toString(normalUser.groupId));
         IScriptPrx iScript = factory.getScriptService();
         /* lightAdmin fetches a script from the server.*/
@@ -1705,7 +1703,7 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /* Another light admin (anotherLightAdmin) with appropriate permissions
          * uploads the script as a new script.*/
-        final EventContext anotherLightAdmin = loginNewAdmin(true, AdminPrivilegeWriteScriptRepo.value);
+        loginNewAdmin(true, AdminPrivilegeWriteScriptRepo.value);
         iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         final long testScriptId = iScript.uploadOfficialScript(testScriptName, actualScript);
@@ -1771,8 +1769,7 @@ public class LightAdminRolesTest extends RolesTests {
         final EventContext otherUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
         final ExperimenterGroup group = new ExperimenterGroupI(otherUser.groupId, false);
         try {
@@ -1802,8 +1799,7 @@ public class LightAdminRolesTest extends RolesTests {
         final ExperimenterGroup otherGroup = newGroupAddUser("rwr-r-", normalUser.userId);
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
         try {
             iAdmin.removeGroups(user, Collections.singletonList(otherGroup));
@@ -1827,8 +1823,7 @@ public class LightAdminRolesTest extends RolesTests {
         final EventContext normalUser = newUserAndGroup(groupPermissions);
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
         final ExperimenterGroup group = new ExperimenterGroupI(normalUser.groupId, false);
         try {
@@ -1856,8 +1851,7 @@ public class LightAdminRolesTest extends RolesTests {
         final EventContext normalUser = newUserAndGroup(groupPermissions, true);
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroupMembership.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         final Experimenter user = new ExperimenterI(normalUser.userId, false);
         final ExperimenterGroup group = new ExperimenterGroupI(normalUser.groupId, false);
         try {
@@ -1889,8 +1883,7 @@ public class LightAdminRolesTest extends RolesTests {
         final long newGroupId = newUserAndGroup(groupPermissions).groupId;
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyUser.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         final Experimenter newUser = new ExperimenterI();
         newUser.setOmeName(omero.rtypes.rstring(UUID.randomUUID().toString()));
         newUser.setFirstName(omero.rtypes.rstring("August"));
@@ -1947,7 +1940,7 @@ public class LightAdminRolesTest extends RolesTests {
             permissions.add(AdminPrivilegeWriteFile.value);
             permissions.add(AdminPrivilegeWriteOwned.value);
         }
-        final EventContext lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         /* lightAdmin declares and defines the createdAdmin they are
          * attempting to create (createdAdmin). Permissions will be the same for lightAdmin
          * and createdAdmin.*/
@@ -1986,8 +1979,7 @@ public class LightAdminRolesTest extends RolesTests {
         final long newUserId = newUserAndGroup(groupPermissions).userId;
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyUser.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         final Experimenter newUser = (Experimenter) iQuery.get("Experimenter", newUserId);
         newUser.setConfig(ImmutableList.of(new NamedValue("color", "green")));
         try {
@@ -2017,8 +2009,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Set up the permissions for lightAdmin.*/
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroup.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         try {
             iAdmin.createGroup(newGroup);
             Assert.assertTrue(isExpectSuccessCreateGroup);
@@ -2045,8 +2036,7 @@ public class LightAdminRolesTest extends RolesTests {
         /* Set up the permissions for the lightAdmin.*/
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeModifyGroup.value);
-        final EventContext lightAdmin;
-        lightAdmin = loginNewAdmin(true, permissions);
+        loginNewAdmin(true, permissions);
         /* lightAdmin tries to downgrade the group to all possible permission levels and
          * also tries to edit the LDAP settings.*/
         final ExperimenterGroup newGroup = (ExperimenterGroup) iQuery.get("ExperimenterGroup", newGroupId);

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2533,8 +2533,9 @@ public class LightAdminRolesTest extends RolesTests {
         //reset the deleted enumerations
         types_svc.resetEnumerations(ContrastMethod.class.getName());
         types = types_svc.allEnumerations(ContrastMethod.class.getName());
-        //We should be back to the original list
-        Assert.assertEquals(types.size(), n);
+        //We should be back to at the original list. Other enum might have been
+        //added by other tests.
+        Assert.assertTrue(types.size() >= n);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -23,10 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import ome.model.enums.EventType;
@@ -34,7 +32,6 @@ import omero.RLong;
 import omero.RString;
 import omero.SecurityViolation;
 import omero.ServerError;
-import omero.api.IAdminPrx;
 import omero.api.IRenderingSettingsPrx;
 import omero.api.IScriptPrx;
 import omero.api.ITypesPrx;
@@ -57,7 +54,6 @@ import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
 import omero.model.ExperimenterI;
 import omero.model.FileAnnotation;
-import omero.model.GroupExperimenterMap;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.ImageAnnotationLink;
@@ -105,6 +101,14 @@ import com.google.common.collect.ImmutableList;
  * @since 5.4.0
  */
 public class LightAdminRolesTest extends RolesTests {
+
+    /**
+     * Creates a new administrator without any privileges
+     * and create a new {@link omero.client}.
+     */
+    protected EventContext logNewAdminWithoutPrivileges() throws Exception {
+        return loginNewAdmin(true, new ArrayList<String>());
+    }
 
     /**
      * Create a light administrator, with a specific privilege, and log in as them.
@@ -2456,17 +2460,7 @@ public class LightAdminRolesTest extends RolesTests {
      */
     @Test
     public void testDeleteEnumerationsbyRestrictedSystemUser() throws Exception {
-        final IAdminPrx svc = root.getSession().getAdminService();
-        final List<AdminPrivilege> expectedPrivileges = new ArrayList<AdminPrivilege>();
-        final String lightAdminName = UUID.randomUUID().toString();
-        final String lightAdminPassword = UUID.randomUUID().toString();
-        Experimenter lightAdmin = createExperimenterI(lightAdminName, "test", "user");
-        final long lightAdminId = svc.createRestrictedSystemUserWithPassword(lightAdmin,
-                expectedPrivileges, omero.rtypes.rstring(lightAdminPassword));
-        lightAdmin = svc.getExperimenter(lightAdminId);
-        omero.client client = newOmeroClient();
-        client.createSession(lightAdminName, lightAdminPassword);
-        init(client);
+        logNewAdminWithoutPrivileges();
         //try to delete an enum type. The type is not important
         final ITypesPrx types_svc = factory.getTypesService();
         List<IObject> types = types_svc.allEnumerations(ContrastMethod.class.getName());
@@ -2485,17 +2479,7 @@ public class LightAdminRolesTest extends RolesTests {
      */
     @Test(expectedExceptions = omero.ValidationException.class)
     public void testDeleteUsedEnumerationsbyRestrictedSystemUser() throws Exception {
-        final IAdminPrx svc = root.getSession().getAdminService();
-        final List<AdminPrivilege> expectedPrivileges = new ArrayList<AdminPrivilege>();
-        final String lightAdminName = UUID.randomUUID().toString();
-        final String lightAdminPassword = UUID.randomUUID().toString();
-        Experimenter lightAdmin = createExperimenterI(lightAdminName, "test", "user");
-        final long lightAdminId = svc.createRestrictedSystemUserWithPassword(lightAdmin,
-                expectedPrivileges, omero.rtypes.rstring(lightAdminPassword));
-        lightAdmin = svc.getExperimenter(lightAdminId);
-        omero.client client = newOmeroClient();
-        client.createSession(lightAdminName, lightAdminPassword);
-        init(client);
+        logNewAdminWithoutPrivileges();
         //try to delete an enum type. The type is not important
         final ITypesPrx types_svc = factory.getTypesService();
         List<IObject> types = types_svc.allEnumerations(EventType.class.getName());
@@ -2511,17 +2495,7 @@ public class LightAdminRolesTest extends RolesTests {
      */
     @Test
     public void testResetEnumerationsbyRestrictedSystemUser() throws Exception {
-        final IAdminPrx svc = root.getSession().getAdminService();
-        final List<AdminPrivilege> expectedPrivileges = new ArrayList<AdminPrivilege>();
-        final String lightAdminName = UUID.randomUUID().toString();
-        final String lightAdminPassword = UUID.randomUUID().toString();
-        Experimenter lightAdmin = createExperimenterI(lightAdminName, "test", "user");
-        final long lightAdminId = svc.createRestrictedSystemUserWithPassword(lightAdmin,
-                expectedPrivileges, omero.rtypes.rstring(lightAdminPassword));
-        lightAdmin = svc.getExperimenter(lightAdminId);
-        omero.client client = newOmeroClient();
-        client.createSession(lightAdminName, lightAdminPassword);
-        init(client);
+        logNewAdminWithoutPrivileges();
         final ITypesPrx types_svc = factory.getTypesService();
         List<IObject> types = types_svc.allEnumerations(ContrastMethod.class.getName());
         int n = types.size();
@@ -2543,18 +2517,8 @@ public class LightAdminRolesTest extends RolesTests {
      */
     @Test(expectedExceptions = omero.ValidationException.class)
     public void testUpdateEnumerationsbyRestrictedSystemUser() throws Exception {
-        final IAdminPrx svc = root.getSession().getAdminService();
-        final List<AdminPrivilege> expectedPrivileges = new ArrayList<AdminPrivilege>();
-        final String lightAdminName = UUID.randomUUID().toString();
-        final String lightAdminPassword = UUID.randomUUID().toString();
-        Experimenter lightAdmin = createExperimenterI(lightAdminName, "test", "user");
-        final long lightAdminId = svc.createRestrictedSystemUserWithPassword(lightAdmin,
-                expectedPrivileges, omero.rtypes.rstring(lightAdminPassword));
-        lightAdmin = svc.getExperimenter(lightAdminId);
-        omero.client client = newOmeroClient();
-        client.createSession(lightAdminName, lightAdminPassword);
-        init(client);
-        //try to delete an enum type. The type is not important
+        logNewAdminWithoutPrivileges();
+        //try to update an enum type. The type is not important
         final ITypesPrx types_svc = factory.getTypesService();
         List<IObject> types = types_svc.allEnumerations(ContrastMethod.class.getName());
         Iterator<IObject> i = types.iterator();
@@ -2571,17 +2535,7 @@ public class LightAdminRolesTest extends RolesTests {
      */
     @Test
     public void testIndexObjectbyRestrictedSystemUser() throws Exception {
-        final IAdminPrx svc = root.getSession().getAdminService();
-        final List<AdminPrivilege> expectedPrivileges = new ArrayList<AdminPrivilege>();
-        final String lightAdminName = UUID.randomUUID().toString();
-        final String lightAdminPassword = UUID.randomUUID().toString();
-        Experimenter lightAdmin = createExperimenterI(lightAdminName, "test", "user");
-        final long lightAdminId = svc.createRestrictedSystemUserWithPassword(lightAdmin,
-                expectedPrivileges, omero.rtypes.rstring(lightAdminPassword));
-        lightAdmin = svc.getExperimenter(lightAdminId);
-        omero.client client = newOmeroClient();
-        client.createSession(lightAdminName, lightAdminPassword);
-        init(client);
+        logNewAdminWithoutPrivileges();
         final IUpdatePrx service = factory.getUpdateService();
         Image image = new ImageI();
         image.setName(omero.rtypes.rstring("Image with A - 11 reagent"));

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -119,7 +119,7 @@ public class LightAdminRolesTest extends RolesTests {
      * and create a new {@link omero.client}.
      */
     protected EventContext logNewAdminWithoutPrivileges() throws Exception {
-        return loginNewAdmin(true, new ArrayList<String>());
+        return loginNewAdmin(true, Collections.<String>emptyList());
     }
 
     /**
@@ -2491,7 +2491,7 @@ public class LightAdminRolesTest extends RolesTests {
 
     /**
      * Tests if an enumeration already used can be deleted.
-     * This should fail.
+     * An exception should be thrown.
      * @throws Exception
      */
     @Test(expectedExceptions = omero.ValidationException.class)
@@ -2507,28 +2507,26 @@ public class LightAdminRolesTest extends RolesTests {
     }
 
     /**
-     * Tests if a deleted enumeration can be restored.
+     * Resets the enumerations
      * @throws Exception
      */
     @Test
     public void testResetEnumerationsbyRestrictedSystemUser() throws Exception {
-      //root create an enumeration first
+        logNewAdminWithoutPrivileges();
         ContrastMethod ho = new ContrastMethodI();
         ho.setValue(omero.rtypes.rstring("testResetEnumerationsbyRestrictedSystemUser"));
-        final ITypesPrx ts = root.getSession().getTypesService();
-        List<IObject> types = ts.allEnumerations(ContrastMethod.class.getName());
-        int n = types.size();
-        ho = (ContrastMethod) ts.createEnumeration(ho);
-        types = ts.allEnumerations(ContrastMethod.class.getName());
-        Assert.assertEquals(types.size(), (n+1));
-        logNewAdminWithoutPrivileges();
         final ITypesPrx types_svc = factory.getTypesService();
+        List<IObject> types = types_svc.allEnumerations(ContrastMethod.class.getName());
+        //original number of enumerations
+        int n = types.size();
+        ho = (ContrastMethod) types_svc.createEnumeration(ho);
         types = types_svc.allEnumerations(ContrastMethod.class.getName());
-        int m = types.size();
+        //check that an enumeration has been added
         Assert.assertEquals(types.size(), (n+1));
+        types_svc.deleteEnumeration(ho);
         types_svc.resetEnumerations(ContrastMethod.class.getName());
         types = types_svc.allEnumerations(ContrastMethod.class.getName());
-        Assert.assertEquals(types.size(), m);
+        Assert.assertEquals(types.size(), n);
     }
 
     /**
@@ -2577,6 +2575,11 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertTrue(found);
     }
 
+    /**
+     * Tests f it possible to modify a script using the upload method from
+     * omero.client
+     * @throws Exception
+     */
     @Test(expectedExceptions = omero.SecurityViolation.class)
     public void testModifyScriptUsingUploadFromClientbyRestrictedSystemUser() throws Exception {
         logNewAdminWithoutPrivileges();
@@ -2601,6 +2604,11 @@ public class LightAdminRolesTest extends RolesTests {
         client.upload(file, scriptFile);
     }
 
+    /**
+     * Tests if it possible to upload a file owned by another user using
+     * the upload method from omero.client
+     * @throws Exception
+     */
     @Test(expectedExceptions = omero.SecurityViolation.class)
     public void testUploadFromClientbyRestrictedSystemUser() throws Exception {
         newUserAndGroup("rwrw--");
@@ -2622,4 +2630,5 @@ public class LightAdminRolesTest extends RolesTests {
         FileUtils.writeStringToFile(file, "test");
         client.upload(file, of);
     }
+
 }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2486,7 +2486,7 @@ public class LightAdminRolesTest extends RolesTests {
             }
         }
         types = types_svc.allEnumerations(ContrastMethod.class.getName());
-        Assert.assertEquals(m, n);
+        Assert.assertEquals(types.size(), n);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -2565,6 +2565,10 @@ public class LightAdminRolesTest extends RolesTests {
         }
     }
 
+    /**
+     * Tests that any member in the system group can index the data.
+     * @throws Exception
+     */
     @Test
     public void testIndexObjectbyRestrictedSystemUser() throws Exception {
         final IAdminPrx svc = root.getSession().getAdminService();


### PR DESCRIPTION
# What this PR does

Tests the manipulation of enumeration
Context:
* Create a user in the system group with no privileges.
* User is allowed to delete/reset enumeration
From a discussion with @mtbc, this should not be allowed