### PR TITLE
info_panel z-index fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -288,7 +288,7 @@
 			
 		    color: #000;
 			position:absolute;
-			z-index: 1;
+			z-index: 2;
 		}
 		
 		.info_panel {


### PR DESCRIPTION
# What this PR does

Fixes the overlay of 'info_panel' and the divider between centre and right panels.

![screen shot 2017-09-14 at 11 38 38](https://user-images.githubusercontent.com/900055/30426160-d7805e70-9942-11e7-90b8-09b798e32c38.png)


# Testing this PR

 - Show 'Activities' menu or 'Scripts' menu.
 - Should overlay correctly over divider.
