### PR TITLE
core_html_not_for_right_panel

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/annotations_share.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/annotations_share.html
@@ -1,4 +1,3 @@
-{% extends "webgateway/core_html.html" %}
 {% load i18n %}
 {% load common_tags %}
 {% load common_filters %}
@@ -7,7 +6,7 @@
 
 {% comment %}
 <!--
-  Copyright (C) 2011-2013 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2011-2017 University of Dundee & Open Microscopy Environment.
   All rights reserved.
 
   This program is free software: you can redistribute it and/or modify
@@ -25,12 +24,6 @@
 -->
 {% endcomment %}
 
-{% block link %}
-    <!-- overwrite body.css -->
-{% endblock %}
-
-{% block script %}
-    {{ block.super }}
 
     <script type="text/javascript">
         $(document).ready(function() 
@@ -137,10 +130,7 @@
                 {% endif %}
             });
     </script>
-    
-{% endblock %}
 
-{% block body %}
 
     <!-- This is used by AJAX loading the right panel, to check it matches current selection -->
     <div id='object-id' style="display:none">{{manager.obj_type}}-{{ manager.obj_id }}</div>
@@ -286,5 +276,3 @@
     <form id="edit_share_form" action="#" method="post" title="Edit Share" class="standard_form">{% csrf_token %}
     </form>
     {% endif %}
-
-{% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/batch_annotate.html
@@ -1,4 +1,3 @@
-{% extends "webgateway/core_html.html" %}
 {% load i18n %}
 {% load common_filters %}
 {% load common_tags %}
@@ -6,7 +5,7 @@
 
 {% comment %}
 <!--
-  Copyright (C) 2011-2014 University of Dundee & Open Microscopy Environment.
+  Copyright (C) 2011-2017 University of Dundee & Open Microscopy Environment.
   All rights reserved.
 
   This program is free software: you can redistribute it and/or modify
@@ -24,11 +23,6 @@
 -->
 {% endcomment %}
 
-{% block link %}
-    <!-- overwrite body.css -->
-{% endblock %}
-
-{% block script %}
 
     <script type="text/javascript">
 
@@ -107,9 +101,7 @@
             
     </script>
     
-{% endblock %}
 
-{% block body %}
 
 <!-- Used to check against current selection when loading panel via AJAX -->
 <div id="object-ids" style="display:none">{{ link_string }}</div>
@@ -179,4 +171,3 @@
     {% endfor %}
 
 </div>
-{% endblock %}


### PR DESCRIPTION
# What this PR does

As noted in https://trello.com/c/BQyJ0Ay7/47-django-templates-cleanup, the "batch annotate" and "shares" in right panel are extending the ```webgateway/core_html.html``` template, so that anything added there such as base_template include from #5463 is loaded in the right panel.

Although this doesn't "break" anything, it's probably not expected. E.g. for Google analytics, we don't want to count "hits" when the right panel is loaded (although we will get hits when the image viewer is opened etc).

# Testing this PR

1. Quick check that right panel looks OK and functionality is not broken (E.g. add annotations etc).
2. Since Google analytics is deployed on eel, can check that script is not loaded for "batch annotate" panel when multiple objects are selected, or when "share" is loaded in right panel in Shares page.
2. Open dev-tools (e.g. by right-click on page -> Inspect element) then choose Network tab and JS to only show scripts.
3. Shouldn't see script loaded when right panel loads. Currently we see:

![screen shot 2017-09-14 at 11 54 43](https://user-images.githubusercontent.com/900055/30426880-9374eb76-9945-11e7-9c7b-4b9147f5488c.png)
