### PR TITLE
Insight light admin issues with right hand side user profile panel

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/MetadataViewerAgent.java
@@ -131,7 +131,21 @@ public class MetadataViewerAgent
 		if (b == null) return false;
 		return b.booleanValue();
 	}
-	
+    
+    /**
+     * Returns <code>true</code> if the currently logged in user is a full
+     * administrator
+     * 
+     * @return See above.
+     */
+    public static boolean isFullAdministrator() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_FULL);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
+    }
+    
 	/**
 	 * Returns the context for an administrator.
 	 * 
@@ -449,7 +463,7 @@ public class MetadataViewerAgent
     }
 
     /**
-     * Returns <code>true</code> if the currently logged in user is is allowed
+     * Returns <code>true</code> if the currently logged in user is allowed
      * to edit groups, <code>false</code> otherwise.
      * 
      * @return See above.
@@ -462,4 +476,17 @@ public class MetadataViewerAgent
         return isAdministrator() && b.booleanValue();
     }
 
+    /**
+     * Returns <code>true</code> if the currently logged in user is allowed
+     * to edit users, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public static boolean isEditUser() {
+        Boolean b = (Boolean) registry.lookup(LookupNames.PRIV_EDIT_USER);
+        if (b == null)
+            b = Boolean.FALSE;
+
+        return isAdministrator() && b.booleanValue();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
@@ -669,8 +669,8 @@ class UserProfile
         loginArea.setText(user.getUserName());
         loginArea.setEnabled(false);
         loginArea.setEditable(false);
-        if (MetadataViewerAgent.isAdministrator() &&
-                !model.isSystemUser(user.getId()) && !model.isSelf()) {
+        if (MetadataViewerAgent.isEditUser() &&
+                !model.isSystemUser(user.getId())) {
             loginArea.setEnabled(true);
             loginArea.getDocument().addDocumentListener(this);
         }
@@ -910,8 +910,8 @@ class UserProfile
             add(Box.createVerticalStrut(5), c);
             c.gridy++;
             boolean ldap = model.isLDAP();
-            loginArea.setEnabled(!ldap);
-            loginArea.setEditable(!ldap);
+            loginArea.setEnabled(!ldap && MetadataViewerAgent.isEditUser());
+            loginArea.setEditable(!ldap && MetadataViewerAgent.isEditUser());
             if (ldap) {
                 model.fireLDAPDetailsLoading();
             } else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/UserProfile.java
@@ -304,7 +304,7 @@ class UserProfile
         UIUtilities.unifiedButtonLookAndFeel(deletePhoto);
         deletePhoto.setVisible(false);
         loginArea = new JTextField();
-        boolean a = MetadataViewerAgent.isAdministrator();
+        boolean a = MetadataViewerAgent.isEditUser();
         loginArea.setEnabled(a);
         loginArea.setEditable(a);
         adminBox = new JCheckBox();
@@ -359,6 +359,7 @@ class UserProfile
         GroupData defaultGroup = user.getDefaultGroup();
 
         groupsBox = new JComboBox();
+        groupsBox.setEnabled(MetadataViewerAgent.isEditUser() || model.isSelf());
         SelectableComboBoxModel m = new SelectableComboBoxModel();
         Iterator<GroupData> i = groups.iterator();
         GroupData g;
@@ -385,7 +386,7 @@ class UserProfile
         permissionsPane.disablePermissions();
 
         ExperimenterData logUser = model.getCurrentUser();
-        if (MetadataViewerAgent.isAdministrator()) {
+        if (MetadataViewerAgent.isEditUser()) {
             //Check that the user is not the one currently logged.
             oldPassword.setVisible(false);
             adminBox.setVisible(true);
@@ -399,8 +400,9 @@ class UserProfile
             //indicate if the user is an administrator
             admin = isUserAdministrator();
             adminBox.setSelected(admin);
-            adminBox.setEnabled(!model.isSelf() &&
-                    !model.isSystemUser(user.getId()));
+            adminBox.setEnabled(!model.isSelf()
+                    && !model.isSystemUser(user.getId())
+                    && MetadataViewerAgent.isFullAdministrator());
             ownerBox.addChangeListener(this);
             ownerBox.setEnabled(!model.isSystemUser(user.getId()));
         } else {
@@ -483,7 +485,7 @@ class UserProfile
                     setUserPhoto(null);
                 }
             });
-            if (groups.size() > 1) {
+            if (groups.size() > 1 && MetadataViewerAgent.isEditUser()) {
                 groupsBox.addActionListener(new ActionListener() {
 
                     /**
@@ -528,7 +530,7 @@ class UserProfile
         ExperimenterData user = (ExperimenterData) model.getRefObject();
         ExperimenterData loggedInUser = MetadataViewerAgent.getUserDetails();
         if (user.getId() == loggedInUser.getId())
-            return MetadataViewerAgent.isAdministrator();
+            return MetadataViewerAgent.isEditUser();
         List<GroupData> groups = user.getGroups();
         Iterator<GroupData> i = groups.iterator();
         GroupData g;
@@ -629,7 +631,7 @@ class UserProfile
     {
         ExperimenterData user = (ExperimenterData) model.getRefObject();
         boolean editable = model.isUserOwner(user);
-        if (!editable) editable = MetadataViewerAgent.isAdministrator();
+        if (!editable) editable = MetadataViewerAgent.isEditUser();
         details = EditorUtil.convertExperimenter(user);
         JPanel content = new JPanel();
         content.setBorder(BorderFactory.createTitledBorder("User"));
@@ -807,7 +809,7 @@ class UserProfile
         c.gridwidth = GridBagConstraints.RELATIVE; //next-to-last
         c.fill = GridBagConstraints.NONE;
         c.weightx = 0.0; 
-        if (MetadataViewerAgent.isAdministrator()) {
+        if (MetadataViewerAgent.isEditUser()) {
             content.add(UIUtilities.setTextFont(PASSWORD_NEW), c);
             c.gridx++;
             c.gridwidth = GridBagConstraints.REMAINDER;
@@ -899,7 +901,7 @@ class UserProfile
         c.weightx = 1.0;
         add(buildContentPanel(), c);
         if (model.isUserOwner(model.getRefObject()) ||
-                MetadataViewerAgent.isAdministrator()) {
+                MetadataViewerAgent.isEditUser()) {
             c.gridy++;
             JPanel buttonPanel = UIUtilities.buildComponentPanel(saveButton);
             buttonPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
@@ -1087,7 +1089,7 @@ class UserProfile
         }
         if (!original.getUserName().equals(value)) a = true;
         //if admin 
-        if (MetadataViewerAgent.isAdministrator()) a = true;
+        if (MetadataViewerAgent.isEditUser()) a = true;
         if (a) {
             Map<ExperimenterData, UserCredentials> m =
                     new HashMap<ExperimenterData, UserCredentials>();

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -169,9 +169,12 @@ public class LookupNames
 
     /** Field indicating if the user is an administrator. */
     public static final String USER_ADMINISTRATOR = "/users/administrator";
-
+    
     /** Field indicating if the user can edit users. */
     public static final String PRIV_SUDO = "/users/sudo";
+    
+    /** Field indicating if the user has all admin privileges. */
+    public static final String PRIV_FULL = "/fulladministrator";
 
     /** Field indicating if the user can edit users. */
     public static final String PRIV_EDIT_USER = "/users/edit";
@@ -185,7 +188,7 @@ public class LookupNames
     /** Field indicating if the user add group members. */
     public static final String PRIV_GROUP_ADD = "/groups/add";
 
-    /** Field indicating if the user add group members. */
+    /** Field indicating if the user is allowed to upload scripts */
     public static final String PRIV_UPLOAD_SCRIPT = "/scripts/upload";
 
     /** Field to indicate if the connection is fast or not. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -54,6 +54,7 @@ import omero.gateway.LoginCredentials;
 import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
+import omero.gateway.facility.AdminFacility;
 
 import org.openmicroscopy.shoola.env.data.views.DataViewsFactory;
 import org.openmicroscopy.shoola.env.event.EventBus;
@@ -687,6 +688,8 @@ public class DataServicesFactory
             try {
                 List<String> privs = omeroGateway.getGateway()
                         .getAdminService(ctx).getEventContext().adminPrivileges;
+                registry.bind(LookupNames.PRIV_FULL, omeroGateway.getGateway()
+                        .getFacility(AdminFacility.class).isFullAdmin(ctx));
                 registry.bind(
                         LookupNames.PRIV_EDIT_USER,
                         privs.contains(omero.model.enums.AdminPrivilegeModifyUser.value));
@@ -701,7 +704,8 @@ public class DataServicesFactory
                         .contains(omero.model.enums.AdminPrivilegeWriteScriptRepo.value));
                 registry.bind(LookupNames.PRIV_SUDO, privs
                         .contains(omero.model.enums.AdminPrivilegeSudo.value));
-            } catch (ServerError e1) {
+            } catch (Exception e1) {
+                registry.bind(LookupNames.PRIV_FULL, false);
                 registry.bind(LookupNames.PRIV_EDIT_USER, false);
                 registry.bind(LookupNames.PRIV_EDIT_GROUP, false);
                 registry.bind(LookupNames.PRIV_GROUP_ADD, false);
@@ -732,6 +736,7 @@ public class DataServicesFactory
 				reg.bind(LookupNames.BINARY_AVAILABLE, b);
 				reg.bind(LookupNames.HELP_ON_LINE_SEARCH, url);
 				
+				reg.bind(LookupNames.PRIV_FULL, registry.lookup(LookupNames.PRIV_FULL));
 				reg.bind(LookupNames.PRIV_EDIT_USER, registry.lookup(LookupNames.PRIV_EDIT_USER));
 				reg.bind(LookupNames.PRIV_EDIT_GROUP, registry.lookup(LookupNames.PRIV_EDIT_GROUP));
 				reg.bind(LookupNames.PRIV_MOVE_GROUP, registry.lookup(LookupNames.PRIV_MOVE_GROUP));


### PR DESCRIPTION
# What this PR does

Fixes some light admin related issues with the right hand side 'metadata' panel, when a user is selected. Some fields were enabled (editable) although the light admin lacks permission to edit users. With this PR the respective fields are not editable if the light admin doesn't have the appropriate permissions.

# Testing this PR

Check that a light admin without permissions can't edit a user. Make sure he still can when he has the edit permissions. Also make sure, that a user can still edit his own profile.

