### PR TITLE
Metadata plugin testtables for robot

### DIFF
--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -109,7 +109,8 @@ bin/omero import $PLATE_NAME --debug ERROR > plate_import.log 2>&1
 plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 bin/omero obj update Plate:$plateid name=spwTests
 # Use populate_metadata to upload and attach bulk annotation csv
-OMERO_DEV_PLUGINS=1 bin/omero metadata populate Plate:$plateid --file $BULK_ANNOTATION_CSV
+# We use testtables to only try populate if tables are working
+OMERO_DEV_PLUGINS=1 bin/omero metadata testtables && bin/omero metadata populate Plate:$plateid --file $BULK_ANNOTATION_CSV
 
 # Run script to populate WellSamples with posX and posY values
 PYTHONPATH=./lib/python python $WELLSCRIPT $HOSTNAME $PORT $key $plateid

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -143,7 +143,7 @@ class MetadataControl(BaseControl):
         bulkanns = parser.add(sub, self.bulkanns)
         mapanns = parser.add(sub, self.mapanns)
         allanns = parser.add(sub, self.allanns)
-        testtables = parser.add(sub, self.testtables)
+        parser.add(sub, self.testtables)
         rois = parser.add(sub, self.rois)
         populate = parser.add(sub, self.populate)
         populateroi = parser.add(sub, self.populateroi)

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -426,7 +426,6 @@ class MetadataControl(BaseControl):
         if not initialized:
             self.ctx.die(100, "Failed to initialize Table")
 
-
     # WRITE
 
     def populate(self, args):

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -143,6 +143,7 @@ class MetadataControl(BaseControl):
         bulkanns = parser.add(sub, self.bulkanns)
         mapanns = parser.add(sub, self.mapanns)
         allanns = parser.add(sub, self.allanns)
+        testtables = parser.add(sub, self.testtables)
         rois = parser.add(sub, self.rois)
         populate = parser.add(sub, self.populate)
         populateroi = parser.add(sub, self.populateroi)
@@ -394,6 +395,20 @@ class MetadataControl(BaseControl):
         if args.report:
             indent = 0
         self._output_ann(md, get_anns, args.parents, indent)
+
+    def testtables(self, args):
+        "Tests whether tables can be created and initialized"
+        client = self.ctx.conn(args)
+
+        sf = client.getSession()
+        sr = sf.sharedResources()
+        table = sr.newTable(1, 'testtables')
+        if table is None:
+            self.ctx.die(100, "Failed to create Table")
+        try:
+            table.initialize([])
+        except:
+            self.ctx.die(100, "Failed to initialize Table")
 
     # WRITE
 

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -398,17 +398,34 @@ class MetadataControl(BaseControl):
 
     def testtables(self, args):
         "Tests whether tables can be created and initialized"
-        client = self.ctx.conn(args)
+        client, conn = self._clientconn(args)
 
         sf = client.getSession()
         sr = sf.sharedResources()
         table = sr.newTable(1, 'testtables')
         if table is None:
             self.ctx.die(100, "Failed to create Table")
+
+        # If we have a table...
+        initialized = False
         try:
             table.initialize([])
+            initialized = True
         except:
+            pass
+        finally:
+            table.close()
+
+        try:
+            orig_file = table.getOriginalFile()
+            conn.deleteObject(orig_file)
+        except:
+            # Anything else to do here?
+            pass
+
+        if not initialized:
             self.ctx.die(100, "Failed to initialize Table")
+
 
     # WRITE
 


### PR DESCRIPTION
# What this PR does

This attempts to prevent failure of the ```robot_setup.py``` script when tables are not available
or working correctly, since this means that NO robot tests are run.

Adds a new command ```testtables``` to the metadata plugin.
Can be used like this to only run ```populate``` if ```testtables``` doesn't fail.

```bin/omero metadata testtables && bin/omero metadata populate...```

# Testing this PR

1. Shouldn't see complete failures of robot tests with setup failing due to tables. E.g. today: https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/712/

1. Instead, robot tests that actually test the tables functionality will fail, in the same way that they do for integration tests.