### PR TITLE
Java gateway bugfixes

### DIFF
--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -140,9 +141,6 @@ public class Gateway {
 
     /** Property to indicate that a stateless service has been created */
     public static final String PROP_STATELESS_SERVICE_CREATED = "PROP_STATELESS_SERVICE_CREATED";
-
-    /** Regex matching ICE Session ID */
-    public static final String ICE_SESSION_ID_REGEX = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
     
     /** Reference to a {@link Logger} */
     private Logger log;
@@ -1107,7 +1105,12 @@ public class Gateway {
      *         otherwise.
      */
     private boolean isSessionID(String s) {
-        return s != null && s.matches(ICE_SESSION_ID_REGEX);
+        try {
+            UUID.fromString(s);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
     }
     
     /**

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -142,7 +142,7 @@ public class Gateway {
     public static final String PROP_STATELESS_SERVICE_CREATED = "PROP_STATELESS_SERVICE_CREATED";
 
     /** Regex matching ICE Session ID */
-    private static final String ICE_SESSION_ID_REGEX = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
+    public static final String ICE_SESSION_ID_REGEX = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}";
     
     /** Reference to a {@link Logger} */
     private Logger log;
@@ -402,15 +402,15 @@ public class Gateway {
      * @param user
      *            The user to get the session ID for
      * @return See above
+     * @throws DSOutOfServiceException
+     *             If the connection is broken, or not logged in
      */
-    public String getSessionId(ExperimenterData user) {
-        try {
-            Connector c = getConnector(new SecurityContext(user.getGroupId()),
-                    false, false);
-            if (c != null) {
-                return c.getClient().getSessionId();
-            }
-        } catch (DSOutOfServiceException e) {
+    public String getSessionId(ExperimenterData user)
+            throws DSOutOfServiceException {
+        Connector c = getConnector(new SecurityContext(user.getGroupId()),
+                false, false);
+        if (c != null) {
+            return c.getClient().getSessionId();
         }
         return null;
     }

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -179,7 +179,7 @@ public class Gateway implements AutoCloseable {
     
     /** Flag to indicate that executor threads should be shutdown on disconnect */
     private boolean executorShutdownOnDisconnect = false;
-    
+
     /**
      * Creates a new Gateway instance
      * @param log A {@link Logger}
@@ -1234,7 +1234,9 @@ public class Gateway implements AutoCloseable {
             c = i.next();
             if (c.needsKeepAlive()) {
                 if (!c.keepSessionAlive()) {
-                    throw new DSOutOfServiceException("Network not available");
+                    // Session has died, e. g. due to server restart.
+                    // Remove connectors, so new ones will be created as requested.
+                    groupConnectorMap.removeAll(c.getGroupID());
                 }
             }
         }
@@ -1517,9 +1519,10 @@ public class Gateway implements AutoCloseable {
                             ConnectionStatus.NETWORK);
                 }
                 if (!c.keepSessionAlive()) {
-                    throw new DSOutOfServiceException(
-                            "Network down. Session not alive",
-                            ConnectionStatus.LOST_CONNECTION);
+                    // Session has died, e. g. due to server restart.
+                    // Remove connectors, so a new ones will be created.
+                    groupConnectorMap.removeAll(c.getGroupID());
+                    c = null;
                 }
             }
         }

--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -101,7 +101,7 @@ import com.google.common.collect.Multimaps;
  * @since 5.1
  */
 
-public class Gateway {
+public class Gateway implements AutoCloseable {
 
     /** Property to indicate that a {@link Connector} has been created */
     public static final String PROP_CONNECTOR_CREATED = "PROP_CONNECTOR_CREATED";
@@ -1653,5 +1653,11 @@ public class Gateway {
             }
         }
         return c;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (connected)
+            disconnect();
     }
 }

--- a/components/blitz/src/omero/gateway/JoinSessionCredentials.java
+++ b/components/blitz/src/omero/gateway/JoinSessionCredentials.java
@@ -20,6 +20,8 @@
  */
 package omero.gateway;
 
+import java.util.UUID;
+
 /**
  * Holds all necessary information needed for joining an active OMERO server
  * session
@@ -41,11 +43,9 @@ public class JoinSessionCredentials extends LoginCredentials {
         // simply set the session ID as username, everything else is
         // handled in Gateway.createSession(LoginCredentials)
         super(sessionId, "", host);
-
-        if (sessionId == null
-                || !sessionId.matches(Gateway.ICE_SESSION_ID_REGEX))
-            throw new IllegalArgumentException(sessionId
-                    + " is not a valid session ID.");
+        
+        // Check that the sessionId is an UUID
+        UUID.fromString(sessionId);
     }
 
     /**
@@ -62,10 +62,8 @@ public class JoinSessionCredentials extends LoginCredentials {
         // simply set the session ID as username, everything else is
         // handled in Gateway.createSession(LoginCredentials)
         super(sessionId, "", host, port);
-
-        if (sessionId == null
-                || !sessionId.matches(Gateway.ICE_SESSION_ID_REGEX))
-            throw new IllegalArgumentException(sessionId
-                    + " is not a valid session ID.");
+        
+        // Check that the sessionId is an UUID
+        UUID.fromString(sessionId);
     }
 }

--- a/components/blitz/src/omero/gateway/JoinSessionCredentials.java
+++ b/components/blitz/src/omero/gateway/JoinSessionCredentials.java
@@ -1,0 +1,71 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2017 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package omero.gateway;
+
+/**
+ * Holds all necessary information needed for joining an active OMERO server
+ * session
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class JoinSessionCredentials extends LoginCredentials {
+
+    /**
+     * Creates a new instance
+     * 
+     * @param sessionId
+     *            The session ID
+     * @param host
+     *            The server hostname
+     */
+    public JoinSessionCredentials(String sessionId, String host) {
+        // simply set the session ID as username, everything else is
+        // handled in Gateway.createSession(LoginCredentials)
+        super(sessionId, "", host);
+
+        if (sessionId == null
+                || !sessionId.matches(Gateway.ICE_SESSION_ID_REGEX))
+            throw new IllegalArgumentException(sessionId
+                    + " is not a valid session ID.");
+    }
+
+    /**
+     * Creates a new instance
+     * 
+     * @param sessionId
+     *            The session ID
+     * @param host
+     *            The server hostname
+     * @param port
+     *            The server port
+     */
+    public JoinSessionCredentials(String sessionId, String host, int port) {
+        // simply set the session ID as username, everything else is
+        // handled in Gateway.createSession(LoginCredentials)
+        super(sessionId, "", host, port);
+
+        if (sessionId == null
+                || !sessionId.matches(Gateway.ICE_SESSION_ID_REGEX))
+            throw new IllegalArgumentException(sessionId
+                    + " is not a valid session ID.");
+    }
+}

--- a/components/blitz/src/omero/gateway/facility/AdminFacility.java
+++ b/components/blitz/src/omero/gateway/facility/AdminFacility.java
@@ -26,6 +26,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
 import omero.ApiUsageException;
 import omero.ServerError;
 import omero.api.IAdminPrx;
@@ -38,13 +41,13 @@ import omero.model.AdminPrivilegeI;
 import omero.model.Experimenter;
 import omero.model.ExperimenterGroup;
 import omero.model.ExperimenterGroupI;
-import omero.model.IObject;
 import omero.model.Permissions;
 import omero.model.PermissionsI;
 import omero.sys.Roles;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.GroupData;
 import omero.gateway.util.PojoMapper;
+import omero.gateway.util.Pojos;
 import omero.gateway.util.Utils;
 
 /**
@@ -258,7 +261,9 @@ public class AdminFacility extends Facility {
      */
     public GroupData lookupGroup(SecurityContext ctx, String name)
             throws DSOutOfServiceException, DSAccessException {
-
+        if(StringUtils.isBlank(name))
+            return null;
+        
         try {
             IAdminPrx svc = gateway.getAdminService(ctx);
             ExperimenterGroup g =  svc.lookupGroup(name);
@@ -288,7 +293,9 @@ public class AdminFacility extends Facility {
      */
     public ExperimenterData lookupExperimenter(SecurityContext ctx, String name)
             throws DSOutOfServiceException, DSAccessException {
-
+        if(StringUtils.isBlank(name))
+            return null;
+                    
         try {
             IAdminPrx svc = gateway.getAdminService(ctx);
             Experimenter exp = svc.lookupExperimenter(name);
@@ -336,6 +343,8 @@ public class AdminFacility extends Facility {
     public Collection<String> getAdminPrivileges(SecurityContext ctx,
             ExperimenterData user) throws DSOutOfServiceException,
             DSAccessException {
+        if (!Pojos.hasID(user))
+            return null;
         try {
             IAdminPrx adm = gateway.getAdminService(ctx);
             return Utils
@@ -365,6 +374,9 @@ public class AdminFacility extends Facility {
     public void setAdminPrivileges(SecurityContext ctx, ExperimenterData user,
             Collection<String> privileges) throws DSOutOfServiceException,
             DSAccessException {
+        if (!Pojos.hasID(user))
+            return;
+        
         try {
             IAdminPrx adm = gateway.getAdminService(ctx);
             adm.setAdminPrivileges(user.asExperimenter(), Utils.toEnum(
@@ -392,6 +404,9 @@ public class AdminFacility extends Facility {
     public void addAdminPrivileges(SecurityContext ctx, ExperimenterData user,
             Collection<String> privileges) throws DSOutOfServiceException,
             DSAccessException {
+        if(!Pojos.hasID(user) || CollectionUtils.isEmpty(privileges))
+            return;
+        
         try {
             Collection<String> privs = getAdminPrivileges(ctx, user);
             for (String priv : privileges)
@@ -421,6 +436,8 @@ public class AdminFacility extends Facility {
     public void removeAdminPrivileges(SecurityContext ctx,
             ExperimenterData user, Collection<String> privileges)
             throws DSOutOfServiceException, DSAccessException {
+        if(!Pojos.hasID(user) || CollectionUtils.isEmpty(privileges))
+            return;
         try {
             Collection<String> privs = getAdminPrivileges(ctx, user);
             privs.removeAll(privileges);
@@ -489,6 +506,8 @@ public class AdminFacility extends Facility {
      */
     public boolean isFullAdmin(SecurityContext ctx, ExperimenterData user)
             throws DSOutOfServiceException, DSAccessException {
+        if (!Pojos.hasID(user))
+            return false;
         try {
             return getAdminPrivileges(ctx, user).size() == getAvailableAdminPrivileges(
                     ctx).size();

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -113,19 +113,24 @@ public class BrowseFacility extends Facility {
     }
 
     /**
-     * Retrieves hierarchy trees rooted by a given node.
-     * i.e. the requested node as root and all of its descendants.
+     * Retrieves hierarchy trees rooted by a given node. i.e. the requested node
+     * as root and all of its descendants.
      *
-     * @param ctx The security context.
-     * @param rootType The type of node to handle.
-     * @param rootIDs The node's id.
-     * @param options The retrieval options.
+     * @param ctx
+     *            The security context.
+     * @param rootType
+     *            The type of node to handle.
+     * @param rootIDs
+     *            The ids of the root nodes. Can be <code>null</code>, in which
+     *            case all root nodes the user has access to are loaded.
+     * @param options
+     *            The retrieval options.
      * @return See above.
      * @throws DSOutOfServiceException
      *             If the connection is broken, or not logged in
      * @throws DSAccessException
      *             If an error occurred while trying to retrieve data from OMERO
-     *             service. 
+     *             service.
      */
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -130,7 +130,7 @@ public class BrowseFacility extends Facility {
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
             throws DSOutOfServiceException, DSAccessException {
-        if (rootType == null || CollectionUtils.isEmpty(rootIDs))
+        if (rootType == null)
             return Collections.emptySet();
         
         try {

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -121,8 +121,9 @@ public class BrowseFacility extends Facility {
      * @param rootType
      *            The type of node to handle.
      * @param rootIDs
-     *            The ids of the root nodes. Can be <code>null</code>, in which
-     *            case all root nodes the user has access to are loaded.
+     *            The ids of the root nodes. Can be <code>null</code> or empty,
+     *            in which case all root nodes the user has access to are
+     *            loaded.
      * @param options
      *            The retrieval options.
      * @return See above.

--- a/components/blitz/src/omero/gateway/facility/BrowseFacility.java
+++ b/components/blitz/src/omero/gateway/facility/BrowseFacility.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 
 import omero.api.IContainerPrx;
 import omero.api.IQueryPrx;
@@ -58,6 +59,7 @@ import omero.gateway.model.ProjectData;
 import omero.gateway.model.ScreenData;
 import omero.gateway.model.WellData;
 import omero.gateway.util.PojoMapper;
+import omero.gateway.util.Pojos;
 
 /**
  * A {@link Facility} for browsing the data hierarchy and retrieving
@@ -99,6 +101,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             long userId) throws DSOutOfServiceException, DSAccessException {
+        if (rootType == null)
+            return Collections.emptySet();
+        
         ParametersI param = new ParametersI();
         if (userId >= 0) {
             param.exp(omero.rtypes.rlong(userId));
@@ -125,6 +130,9 @@ public class BrowseFacility extends Facility {
     public Collection<DataObject> getHierarchy(SecurityContext ctx, Class rootType,
             List<Long> rootIDs, Parameters options)
             throws DSOutOfServiceException, DSAccessException {
+        if (rootType == null || CollectionUtils.isEmpty(rootIDs))
+            return Collections.emptySet();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             return PojoMapper.convertToDataObjects(service.loadContainerHierarchy(
@@ -181,6 +189,9 @@ public class BrowseFacility extends Facility {
     public <T extends DataObject> T findObject(SecurityContext ctx,
             Class<T> klass, long id, boolean allGroups)
             throws DSOutOfServiceException, DSAccessException {
+        if (klass == null || id < 0)
+            return null;
+        
         String klassName = PojoMapper.getModelType(klass).getSimpleName();
         IObject obj = findIObject(ctx, klassName, id, allGroups);
         if (obj == null)
@@ -252,6 +263,9 @@ public class BrowseFacility extends Facility {
     public IObject findIObject(SecurityContext ctx, String klassName, long id,
             boolean allGroups) throws DSOutOfServiceException,
             DSAccessException {
+        if (StringUtils.isBlank(klassName) || id < 0)
+            return null;
+        
         try {
             Map<String, String> m = new HashMap<String, String>();
             if (allGroups) {
@@ -293,6 +307,9 @@ public class BrowseFacility extends Facility {
     public DataObject findObject(SecurityContext ctx, String pojoName, long id,
             boolean allGroups) throws DSOutOfServiceException,
             DSAccessException {
+        if (StringUtils.isBlank(pojoName) || id < 0)
+            return null;
+        
         try {
             Map<String, String> m = new HashMap<String, String>();
             if (allGroups) {
@@ -335,6 +352,7 @@ public class BrowseFacility extends Facility {
             throws DSOutOfServiceException, DSAccessException {
         if (o == null || o.getId() == null)
             return null;
+        
         try {
             IQueryPrx service = gateway.getQueryService(ctx);
             return service.find(o.getClass().getName(), o.getId().getValue());
@@ -364,6 +382,9 @@ public class BrowseFacility extends Facility {
             ExperimenterData user) throws DSOutOfServiceException,
             DSAccessException {
         Set<GroupData> pojos = new HashSet<GroupData>();
+        if (!Pojos.hasID(user))
+            return pojos;
+        
         try {
             IQueryPrx service = gateway.getQueryService(ctx);
             // Need method server side.
@@ -488,7 +509,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ProjectData> getProjects(SecurityContext ctx,
             long ownerId, Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
-        if (ids == null || ids.isEmpty())
+        if (CollectionUtils.isEmpty(ids))
             return Collections.emptyList();
         
         try {
@@ -574,8 +595,6 @@ public class BrowseFacility extends Facility {
      */
     public Collection<DatasetData> getDatasets(SecurityContext ctx, long ownerId) throws DSOutOfServiceException, DSAccessException {
         try {
-            
-            
             ParametersI param = null;
             if (ownerId >= 0) {
                 param = new ParametersI();
@@ -617,7 +636,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<DatasetData> getDatasets(SecurityContext ctx,
             long ownerId, Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
-        if (ids == null || ids.isEmpty())
+        if (CollectionUtils.isEmpty(ids))
             return Collections.emptyList();
         
         try {
@@ -742,7 +761,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ScreenData> getScreens(SecurityContext ctx, long ownerId,
             Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
-        if (ids == null || ids.isEmpty())
+        if (CollectionUtils.isEmpty(ids))
             return Collections.emptyList();
         
         try {
@@ -868,7 +887,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<PlateData> getPlates(SecurityContext ctx, long ownerId,
             Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
-        if (ids == null || ids.isEmpty())
+        if (CollectionUtils.isEmpty(ids))
             return Collections.emptyList();
         
         try {
@@ -1045,6 +1064,9 @@ public class BrowseFacility extends Facility {
      *             service.
      */
     public ImageData getImage(SecurityContext ctx, long id) throws DSOutOfServiceException, DSAccessException {
+        if (id < 0)
+            return null;
+        
         return getImages(ctx, Collections.singleton(id)).iterator().next();
     }
     
@@ -1065,6 +1087,9 @@ public class BrowseFacility extends Facility {
      *             service.
      */
     public ImageData getImage(SecurityContext ctx, long id, ParametersI params) throws DSOutOfServiceException, DSAccessException {
+        if (id < 0)
+            return null;
+        
         return getImages(ctx, Collections.singleton(id), params).iterator()
                 .next();
     }
@@ -1085,6 +1110,9 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImages(SecurityContext ctx,
             Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
+        if (CollectionUtils.isEmpty(ids))
+            return Collections.emptyList();
+        
         return getImages(ctx, ids, null);
     }
     
@@ -1106,7 +1134,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImages(SecurityContext ctx,
             Collection<Long> ids, ParametersI params) throws DSOutOfServiceException, DSAccessException {
-        if (ids == null || ids.isEmpty())
+        if (CollectionUtils.isEmpty(ids))
             return Collections.emptyList();
         
         try {
@@ -1184,7 +1212,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImages(SecurityContext ctx, long ownerId,
             Collection<Long> ids) throws DSOutOfServiceException, DSAccessException {
-        if (ids == null || ids.isEmpty())
+        if (CollectionUtils.isEmpty(ids))
             return Collections.emptyList();
         
         try {
@@ -1232,7 +1260,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImagesForDatasets(SecurityContext ctx,
             Collection<Long> datasetIds) throws DSOutOfServiceException, DSAccessException {
-        if (datasetIds == null || datasetIds.isEmpty())
+        if (CollectionUtils.isEmpty(datasetIds))
             return Collections.emptyList();
         
         try {
@@ -1270,7 +1298,7 @@ public class BrowseFacility extends Facility {
      */
     public Collection<ImageData> getImagesForProjects(SecurityContext ctx,
             Collection<Long> projectIds) throws DSOutOfServiceException, DSAccessException {
-        if (projectIds == null || projectIds.isEmpty())
+        if (CollectionUtils.isEmpty(projectIds))
             return Collections.emptyList();
         
         try {
@@ -1307,6 +1335,9 @@ public class BrowseFacility extends Facility {
     public Collection<FolderData> loadFolders(SecurityContext ctx,
             Collection<Long> ids) throws DSOutOfServiceException,
             DSAccessException {
+        if (CollectionUtils.isEmpty(ids))
+            return Collections.emptyList();
+        
         try {
             IQueryPrx qs = gateway.getQueryService(ctx);
             ParametersI param = new ParametersI();
@@ -1333,7 +1364,7 @@ public class BrowseFacility extends Facility {
             handleException(this, e, "Cannot load folders.");
         }
 
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
     
     /**
@@ -1369,7 +1400,7 @@ public class BrowseFacility extends Facility {
             handleException(this, e, "Cannot load folders.");
         }
 
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**
@@ -1392,6 +1423,9 @@ public class BrowseFacility extends Facility {
     public Collection<FolderData> getFolders(SecurityContext ctx,
             Collection<Long> ids) throws DSOutOfServiceException,
             DSAccessException {
+        if (CollectionUtils.isEmpty(ids))
+            return Collections.emptyList();
+        
         try {
             IQueryPrx qs = gateway.getQueryService(ctx);
             ParametersI param = new ParametersI();
@@ -1413,7 +1447,7 @@ public class BrowseFacility extends Facility {
             handleException(this, e, "Cannot load folders.");
         }
 
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**
@@ -1456,7 +1490,7 @@ public class BrowseFacility extends Facility {
             handleException(this, e, "Cannot load folders.");
         }
 
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
     
     /**
@@ -1484,6 +1518,6 @@ public class BrowseFacility extends Facility {
         } catch (Throwable t) {
             handleException(this, t, "Could not load lookup tables.");
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 }

--- a/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
+++ b/components/blitz/src/omero/gateway/facility/DataManagerFacility.java
@@ -37,6 +37,9 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
 import omero.ServerError;
 import omero.api.IContainerPrx;
 import omero.api.IUpdatePrx;
@@ -159,6 +162,9 @@ public class DataManagerFacility extends Facility {
             Collection<FolderData> folders, boolean includeSubFolders,
             boolean includeContent) throws DSOutOfServiceException,
             DSAccessException {
+        if (CollectionUtils.isEmpty(folders))
+            return null;
+        
         try {
             Map<String, List<Long>> targetObjects = new HashMap<String, List<Long>>();
             targetObjects.put(PojoMapper.getGraphType(FolderData.class),
@@ -203,6 +209,9 @@ public class DataManagerFacility extends Facility {
      */
     public CmdCallbackI delete(SecurityContext ctx, List<IObject> objects)
             throws DSOutOfServiceException, DSAccessException {
+        if (CollectionUtils.isEmpty(objects))
+            return null;
+        
         try {
             final Delete2Builder request = Requests.delete();
             for (final IObject object : objects) {
@@ -234,6 +243,9 @@ public class DataManagerFacility extends Facility {
      */
     public IObject saveAndReturnObject(SecurityContext ctx, IObject object,
             Map options) throws DSOutOfServiceException, DSAccessException {
+        if (object == null)
+            return null;
+        
         try {
             IUpdatePrx service = gateway.getUpdateService(ctx);
             if (options == null)
@@ -262,6 +274,9 @@ public class DataManagerFacility extends Facility {
      */
     public DataObject saveAndReturnObject(SecurityContext ctx, DataObject object)
             throws DSOutOfServiceException, DSAccessException {
+        if (object == null)
+            return null;
+        
         return PojoMapper.asDataObject(saveAndReturnObject(ctx,
                 object.asIObject()));
     }
@@ -283,6 +298,9 @@ public class DataManagerFacility extends Facility {
      */
     public IObject saveAndReturnObject(SecurityContext ctx, IObject object)
             throws DSOutOfServiceException, DSAccessException {
+        if (object == null)
+            return null;
+        
         try {
             IUpdatePrx service = gateway.getUpdateService(ctx);
             IObject result = service.saveAndReturnObject(object);
@@ -315,6 +333,9 @@ public class DataManagerFacility extends Facility {
     public IObject saveAndReturnObject(SecurityContext ctx, IObject object,
             Map options, String userName) throws DSOutOfServiceException,
             DSAccessException {
+        if (object == null)
+            return null;
+        
         try {
             IUpdatePrx service = gateway.getUpdateService(ctx, userName);
 
@@ -347,6 +368,9 @@ public class DataManagerFacility extends Facility {
     public DataObject saveAndReturnObject(SecurityContext ctx,
             DataObject object, String userName) throws DSOutOfServiceException,
             DSAccessException {
+        if (object == null)
+            return null;
+        
         return PojoMapper.asDataObject(saveAndReturnObject(ctx,
                 object.asIObject(), userName));
     }
@@ -370,6 +394,9 @@ public class DataManagerFacility extends Facility {
      */
     public IObject saveAndReturnObject(SecurityContext ctx, IObject object,
             String userName) throws DSOutOfServiceException, DSAccessException {
+        if (object == null)
+            return null;
+        
         try {
             IUpdatePrx service = gateway.getUpdateService(ctx, userName);
             IObject result = service.saveAndReturnObject(object);
@@ -402,6 +429,9 @@ public class DataManagerFacility extends Facility {
     public List<IObject> saveAndReturnObject(SecurityContext ctx,
             List<IObject> objects, Map options, String userName)
             throws DSOutOfServiceException, DSAccessException {
+        if (CollectionUtils.isEmpty(objects))
+            return Collections.emptyList();
+        
         try {
             IUpdatePrx service = gateway.getUpdateService(ctx, userName);
             return service.saveAndReturnArray(objects);
@@ -431,6 +461,9 @@ public class DataManagerFacility extends Facility {
     public IObject updateObject(SecurityContext ctx, IObject object,
             Parameters options) throws DSOutOfServiceException,
             DSAccessException {
+        if (object == null)
+            return null;
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             IObject r = service.updateDataObject(object, options);
@@ -462,6 +495,9 @@ public class DataManagerFacility extends Facility {
     public List<IObject> updateObjects(SecurityContext ctx,
             List<IObject> objects, Parameters options)
             throws DSOutOfServiceException, DSAccessException {
+        if (CollectionUtils.isEmpty(objects))
+            return Collections.emptyList();
+        
         try {
             IContainerPrx service = gateway.getPojosService(ctx);
             List<IObject> l = service.updateDataObjects(objects, options);
@@ -499,6 +535,9 @@ public class DataManagerFacility extends Facility {
      */
     public void addImageToDataset(SecurityContext ctx, ImageData image,
             DatasetData ds) throws DSOutOfServiceException, DSAccessException {
+        if (image == null || ds == null)
+            return;
+        
         List<ImageData> l = new ArrayList<ImageData>(1);
         l.add(image);
         addImagesToDataset(ctx, l, ds);
@@ -522,6 +561,9 @@ public class DataManagerFacility extends Facility {
     public void addImagesToDataset(SecurityContext ctx,
             Collection<ImageData> images, DatasetData ds)
             throws DSOutOfServiceException, DSAccessException {
+        if (ds == null || CollectionUtils.isEmpty(images))
+            return;
+        
         List<IObject> links = new ArrayList<IObject>();
         for (ImageData img : images) {
             DatasetImageLink l = new DatasetImageLinkI();
@@ -549,6 +591,9 @@ public class DataManagerFacility extends Facility {
     public DatasetData createDataset(SecurityContext ctx, DatasetData dataset,
             ProjectData project) throws DSOutOfServiceException,
             DSAccessException {
+        if (dataset == null)
+            return null;
+        
         if (project != null) {
             ProjectDatasetLink link = new ProjectDatasetLinkI();
             link = new ProjectDatasetLinkI();
@@ -581,6 +626,9 @@ public class DataManagerFacility extends Facility {
     public Future<FileAnnotationData> attachFile(final SecurityContext ctx,
             final File file, String mimetype, final String description,
             final String namespace, final DataObject target) {
+        if (file == null || target == null)
+            return null;
+        
         final String name = file.getName();
         String absolutePath = file.getAbsolutePath();
         final String path = absolutePath.substring(0, absolutePath.length()
@@ -685,6 +733,9 @@ public class DataManagerFacility extends Facility {
     public <T extends AnnotationData> T attachAnnotation(SecurityContext ctx,
             T annotation, DataObject target) throws DSOutOfServiceException,
             DSAccessException {
+        if (annotation == null)
+            return null;
+        
         if (target != null) {
             if (target instanceof ProjectData) {
                 ProjectData project = browse.findObject(ctx, ProjectData.class,

--- a/components/blitz/src/omero/gateway/facility/Facility.java
+++ b/components/blitz/src/omero/gateway/facility/Facility.java
@@ -285,9 +285,9 @@ public abstract class Facility {
 
         ConnectionStatus b = getConnectionStatus(t);
         if (b != ConnectionStatus.OK)
-            return;
+            throw new DSOutOfServiceException("Connection lost.", t);
         if (!gateway.isConnected())
-            return;
+            throw new DSOutOfServiceException("Gateway is disconnected.", t);
         Throwable cause = t.getCause();
         if (cause instanceof SecurityViolation) {
             String s = "For security reasons, cannot access data. \n";

--- a/components/blitz/src/omero/gateway/facility/MetadataFacility.java
+++ b/components/blitz/src/omero/gateway/facility/MetadataFacility.java
@@ -21,12 +21,15 @@
 package omero.gateway.facility;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
 import java.util.Arrays;
+
+import org.apache.commons.collections.CollectionUtils;
 
 import omero.api.IMetadataPrx;
 import omero.gateway.Gateway;
@@ -43,6 +46,7 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.ImageAcquisitionData;
 import omero.gateway.model.ImageData;
 import omero.gateway.util.PojoMapper;
+import omero.gateway.util.Pojos;
 
 
 /**
@@ -83,6 +87,9 @@ public class MetadataFacility extends Facility {
      */
     public ImageAcquisitionData getImageAcquisitionData(SecurityContext ctx,
             long imageId) throws DSOutOfServiceException, DSAccessException {
+        if(imageId < 0)
+            return null;
+        
         ParametersI params = new ParametersI();
         params.acquisitionData();
         ImageData img = browse.getImage(ctx, imageId, params);
@@ -106,7 +113,9 @@ public class MetadataFacility extends Facility {
     public List<ChannelData> getChannelData(SecurityContext ctx, long imageId)
             throws DSOutOfServiceException, DSAccessException {
         List<ChannelData> result = new ArrayList<ChannelData>();
-
+        if(imageId < 0)
+            return result;
+        
         try {
             ImageData img = browse.getImage(ctx, imageId);
 
@@ -165,6 +174,9 @@ public class MetadataFacility extends Facility {
             List<Class<? extends AnnotationData>> annotationTypes,
             List<Long> userIds) throws DSOutOfServiceException,
             DSAccessException {
+        if (!Pojos.hasID(object))
+            return Collections.emptyList();
+        
         Map<DataObject, List<AnnotationData>> result = getAnnotations(ctx,
                 Arrays.asList(new DataObject[] { object }), annotationTypes,
                 userIds);
@@ -198,7 +210,9 @@ public class MetadataFacility extends Facility {
             List<Long> userIds) throws DSOutOfServiceException,
             DSAccessException {
         Map<DataObject, List<AnnotationData>> result = new HashMap<DataObject, List<AnnotationData>>();
-
+        if (CollectionUtils.isEmpty(objects))
+            return result;
+        
         String type = null;
         List<Long> ids = new ArrayList<Long>();
         for (DataObject obj : objects) {

--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -115,6 +115,9 @@ public class ROIFacility extends Facility {
      */
     public int getROICount(SecurityContext ctx, long imageId)
             throws DSOutOfServiceException, DSAccessException {
+        if (imageId < 0)
+            return -1;
+        
         try {
             ParametersI p = new ParametersI();
             p.addId(imageId);
@@ -157,6 +160,9 @@ public class ROIFacility extends Facility {
      */
     public ROIResult loadROI(SecurityContext ctx, long roiId)
             throws DSOutOfServiceException, DSAccessException {
+        if (roiId < 0)
+            return null;
+        
         try {
             IRoiPrx svc = gateway.getROIService(ctx);
             RoiOptions options = new RoiOptions();
@@ -191,6 +197,9 @@ public class ROIFacility extends Facility {
     public List<ROIResult> loadROIsByPlane(SecurityContext ctx, long imageID, int z, int t)
             throws DSOutOfServiceException, DSAccessException {
         List<ROIResult> results = new ArrayList<ROIResult>();
+        if (imageID < 0)
+            return results;
+        
         try {
             IRoiPrx svc = gateway.getROIService(ctx);
             RoiOptions options = new RoiOptions();
@@ -265,7 +274,9 @@ public class ROIFacility extends Facility {
             List<Long> measurements, long userID)
             throws DSOutOfServiceException, DSAccessException {
         List<ROIResult> results = new ArrayList<ROIResult>();
-
+        if (imageID < 0)
+            return results;
+        
         try {
             IRoiPrx svc = gateway.getROIService(ctx);
             RoiOptions options = new RoiOptions();
@@ -372,9 +383,10 @@ public class ROIFacility extends Facility {
     public Map<FolderData, Collection<ROIData>> addRoisToFolders(SecurityContext ctx, long imageID,
             Collection<ROIData> roiList, Collection<FolderData> folders, boolean removeFromOtherFolders)
             throws DSOutOfServiceException, DSAccessException {
-
+        if (CollectionUtils.isEmpty(roiList) || CollectionUtils.isEmpty(folders))
+            return Collections.emptyMap();
+        
         try {
-            
             // 1. Save unsaved folders
             List<FolderData> savedFolders = new ArrayList<FolderData>();
             List<IObject> foldersToSave = new ArrayList<IObject>();
@@ -518,7 +530,9 @@ public class ROIFacility extends Facility {
     public void removeRoisFromFolders(SecurityContext ctx, long imageID,
             Collection<ROIData> roiList, Collection<FolderData> folders)
             throws DSOutOfServiceException, DSAccessException {
-
+        if (CollectionUtils.isEmpty(roiList) || CollectionUtils.isEmpty(folders))
+            return;
+        
         try {
             Collection<Long> roiIds = Pojos.extractIds(roiList);
             Collection<Roi> serverRoiList = loadServerRois(ctx, roiIds);
@@ -577,7 +591,9 @@ public class ROIFacility extends Facility {
     public Collection<ROIData> saveROIs(SecurityContext ctx, long imageID,
             long userID, Collection<ROIData> roiList) throws DSOutOfServiceException,
             DSAccessException {
-
+        if (CollectionUtils.isEmpty(roiList))
+            return Collections.emptyList();
+        
         try {
             IUpdatePrx updateService = gateway.getUpdateService(ctx);
             IRoiPrx svc = gateway.getROIService(ctx);
@@ -880,6 +896,9 @@ public class ROIFacility extends Facility {
      */
     public Collection<FolderData> getROIFolders(SecurityContext ctx,
             long imageId) throws DSOutOfServiceException, DSAccessException {
+        if (imageId < 0)
+            return Collections.emptyList();
+        
         try {
             IQueryPrx qs = gateway.getQueryService(ctx);
             StringBuilder sb = new StringBuilder();
@@ -941,6 +960,9 @@ public class ROIFacility extends Facility {
     public Collection<ROIResult> loadROIsForFolder(SecurityContext ctx,
             long imageId, long folderId) throws DSOutOfServiceException,
             DSAccessException {
+        if (imageId < 0 && folderId < 0)
+            return Collections.emptyList();
+        
         try {
             // TODO: This should actually happen on the server; replace
             //      with server-side method when available
@@ -1006,6 +1028,9 @@ public class ROIFacility extends Facility {
     private Collection<Roi> loadServerRois(SecurityContext ctx,
             Collection<Long> ids) throws DSOutOfServiceException,
             DSAccessException {
+        if (CollectionUtils.isEmpty(ids))
+            return Collections.emptyList();
+        
         try {
             IQueryPrx service = gateway.getQueryService(ctx);
             ParametersI p = new ParametersI();

--- a/components/blitz/src/omero/gateway/facility/RawDataFacility.java
+++ b/components/blitz/src/omero/gateway/facility/RawDataFacility.java
@@ -20,6 +20,7 @@
  */
 package omero.gateway.facility;
 
+import java.util.Collections;
 import java.util.Map;
 
 import omero.gateway.Gateway;
@@ -121,6 +122,9 @@ public class RawDataFacility extends Facility implements AutoCloseable {
             PixelsData pixels, int[] channels, int binCount,
             boolean globalRange, PlaneDef plane)
             throws DSOutOfServiceException, DSAccessException {
+        if (pixels == null)
+            return Collections.emptyMap();
+        
         try {
             if (plane == null)
                 plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0,
@@ -156,6 +160,9 @@ public class RawDataFacility extends Facility implements AutoCloseable {
      */
     public Plane2D getPlane(SecurityContext ctx, PixelsData pixels, int z,
             int t, int c) throws DSOutOfServiceException, DSAccessException {
+        if (pixels == null)
+            return null;
+        
         try {
             return getDataSink(ctx, pixels, gateway).getPlane(z, t, c);
         } catch (Exception e) {
@@ -194,6 +201,9 @@ public class RawDataFacility extends Facility implements AutoCloseable {
     public Plane2D getTile(SecurityContext ctx, PixelsData pixels, int z,
             int t, int c, int x, int y, int w, int h)
             throws DataSourceException {
+        if (pixels == null)
+            return null;
+        
         try {
             return getDataSink(ctx, pixels, gateway).getTile(z, t, c, x, y, w,
                     h);

--- a/components/blitz/src/omero/gateway/facility/SearchFacility.java
+++ b/components/blitz/src/omero/gateway/facility/SearchFacility.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.commons.collections.CollectionUtils;
+
 import ome.util.search.LuceneQueryBuilder;
 import omero.ApiUsageException;
 import omero.InternalException;
@@ -92,10 +94,9 @@ public class SearchFacility extends Facility {
             throws DSOutOfServiceException, DSAccessException {
 
         SearchResultCollection result = new SearchResultCollection();
-
-        if (context.getTypes().isEmpty()) {
+        
+        if (context == null || CollectionUtils.isEmpty(context.getTypes()))
             return result;
-        }
 
         SearchPrx service = gateway.getSearchService(ctx);
 

--- a/components/blitz/src/omero/gateway/facility/TablesFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TablesFacility.java
@@ -20,6 +20,7 @@ package omero.gateway.facility;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,6 +35,7 @@ import omero.gateway.model.DataObject;
 import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.TableData;
 import omero.gateway.model.TableDataColumn;
+import omero.gateway.util.Pojos;
 import omero.grid.Column;
 import omero.grid.Data;
 import omero.grid.SharedResourcesPrx;
@@ -88,6 +90,9 @@ public class TablesFacility extends Facility {
     public TableData addTable(SecurityContext ctx, DataObject target,
             String name, TableData data) throws DSOutOfServiceException,
             DSAccessException {
+        if (!Pojos.hasID(target))
+            return null;
+        
         TablePrx table = null;
         try {
             if (name == null)
@@ -263,6 +268,9 @@ public class TablesFacility extends Facility {
     public long[] query(SecurityContext ctx, long fileId, String condition,
             long start, long stop, long step) throws DSOutOfServiceException,
             DSAccessException {
+        if (fileId < 0)
+            return new long[0];
+        
         TablePrx table = null;
         try {
             OriginalFile file = new OriginalFileI(fileId, false);
@@ -344,6 +352,9 @@ public class TablesFacility extends Facility {
      */
     public TableData getTable(SecurityContext ctx, long fileId, long... rows)
             throws DSOutOfServiceException, DSAccessException {
+        if (fileId < 0)
+            return null;
+        
         TablePrx table = null;
         try {
             OriginalFile file = new OriginalFileI(fileId, false);
@@ -412,6 +423,9 @@ public class TablesFacility extends Facility {
     public TableData getTable(SecurityContext ctx, long fileId, long rowFrom,
             long rowTo, long... columns) throws DSOutOfServiceException,
             DSAccessException {
+        if (fileId < 0)
+            return null;
+        
         TablePrx table = null;
         try {
             OriginalFile file = new OriginalFileI(fileId, false);
@@ -499,6 +513,9 @@ public class TablesFacility extends Facility {
     public Collection<FileAnnotationData> getAvailableTables(
             SecurityContext ctx, DataObject parent)
             throws DSOutOfServiceException, DSAccessException {
+        if (!Pojos.hasID(parent))
+            return Collections.emptyList();
+        
         Collection<FileAnnotationData> result = new ArrayList<FileAnnotationData>();
         try {
             MetadataFacility mf = gateway.getFacility(MetadataFacility.class);

--- a/components/blitz/src/omero/gateway/facility/TransferFacility.java
+++ b/components/blitz/src/omero/gateway/facility/TransferFacility.java
@@ -20,6 +20,7 @@
 package omero.gateway.facility;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -64,6 +65,8 @@ public class TransferFacility extends Facility {
      */
     public List<File> downloadImage(SecurityContext context, String targetPath,
             long imageId) throws DSAccessException, DSOutOfServiceException {
+        if (imageId < 0)
+            return Collections.emptyList();
         return helper.downloadImage(context, targetPath, imageId);
     }
 

--- a/components/blitz/src/omero/gateway/util/Pojos.java
+++ b/components/blitz/src/omero/gateway/util/Pojos.java
@@ -1,3 +1,24 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2015-2017 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
 package omero.gateway.util;
 
 import java.util.ArrayList;
@@ -63,5 +84,16 @@ public class Pojos {
                 result.add(t);
         }
         return result;
+    }
+    
+    /**
+     * Checks if a DataObject Pojo is not null and has an ID
+     * 
+     * @param obj
+     *            The DataObject
+     * @return See above.
+     */
+    public static boolean hasID(DataObject obj) {
+        return obj != null && obj.getId() >= 0;
     }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -1442,7 +1442,12 @@ class OMEROGateway
 	 * @return See above.
 	 */
 	String getSessionId(ExperimenterData user) {
-	    return gw.getSessionId(user);
+	    try {
+            return gw.getSessionId(user);
+        } catch (DSOutOfServiceException e) {
+            dsFactory.getLogger().warn(this, "Cannot get session ID.");
+        }
+	    return null;
 	}
 	
     /**

--- a/components/tools/OmeroJava/test/gateway.testng.xml
+++ b/components/tools/OmeroJava/test/gateway.testng.xml
@@ -3,14 +3,15 @@
 	<test name="OmeroJava.Gateway">
 		<classes>
 		    <!-- Explicitly list all test classes to ensure they are run in the right sequence -->
-			<class name="integration.gateway.AdminFacilityTest" />
+		    <class name="integration.gateway.GatewayUsageTest" />
+			<!--  <class name="integration.gateway.AdminFacilityTest" />
 			<class name="integration.gateway.DataManagerFacilityTest" />
 			<class name="integration.gateway.BrowseFacilityTest" />
 			<class name="integration.gateway.SearchFacilityTest" />
 			<class name="integration.gateway.RawDataFacilityTest" />
 			<class name="integration.gateway.MetadataFacilityTest" />
 			<class name="integration.gateway.ROIFacilityTest" />
-			<class name="integration.gateway.TablesFacilityTest" />
+			<class name="integration.gateway.TablesFacilityTest" /> -->
 		</classes>
 	</test>
 </suite>

--- a/components/tools/OmeroJava/test/gateway.testng.xml
+++ b/components/tools/OmeroJava/test/gateway.testng.xml
@@ -4,14 +4,14 @@
 		<classes>
 		    <!-- Explicitly list all test classes to ensure they are run in the right sequence -->
 		    <class name="integration.gateway.GatewayUsageTest" />
-			<!--  <class name="integration.gateway.AdminFacilityTest" />
+			<class name="integration.gateway.AdminFacilityTest" />
 			<class name="integration.gateway.DataManagerFacilityTest" />
 			<class name="integration.gateway.BrowseFacilityTest" />
 			<class name="integration.gateway.SearchFacilityTest" />
 			<class name="integration.gateway.RawDataFacilityTest" />
 			<class name="integration.gateway.MetadataFacilityTest" />
 			<class name="integration.gateway.ROIFacilityTest" />
-			<class name="integration.gateway.TablesFacilityTest" /> -->
+			<class name="integration.gateway.TablesFacilityTest" />
 		</classes>
 	</test>
 </suite>

--- a/components/tools/OmeroJava/test/integration/gateway/DataManagerFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/DataManagerFacilityTest.java
@@ -319,8 +319,8 @@ public class DataManagerFacilityTest extends GatewayTest {
      * 
      * @throws Exception
      */
-    @Test(groups = "broken") // marked as 'broken', works fine locally, but flaky on CI
-    //@Test(dependsOnMethods = { "testSaveAndReturnObject" })
+    //@Test(groups = "broken") // marked as 'broken', works fine locally, but flaky on CI
+    @Test(dependsOnMethods = { "testSaveAndReturnObject" })
     public void testPerformanceAttachFile() throws Exception {
         long start = System.currentTimeMillis();
 

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -58,8 +58,7 @@ public class GatewayUsageTest extends AbstractServerTest
             ExperimenterData root = gw.connect(c);
             Assert.assertNotNull(root);
         } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail();
+            Assert.fail("Gateway credentials login failed.", e);
         }
     }
 
@@ -77,8 +76,7 @@ public class GatewayUsageTest extends AbstractServerTest
             ExperimenterData root = gw.connect(c);
             Assert.assertNotNull(root);
         } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail();
+            Assert.fail("Gateway args login failed.", e);
         }
     }
     
@@ -103,12 +101,10 @@ public class GatewayUsageTest extends AbstractServerTest
                 Assert.assertNotNull(root2);
                 Assert.assertEquals(gw2.getSessionId(root2), sessionId);
             } catch (Exception e) {
-                e.printStackTrace();
-                Assert.fail();
+                Assert.fail("Gateway sessionId login failed.", e);
             }
         } catch (Exception e1) {
-            e1.printStackTrace();
-            Assert.fail();
+            Assert.fail("Gateway credentials login failed.", e1);
         }
     }
     
@@ -128,8 +124,7 @@ public class GatewayUsageTest extends AbstractServerTest
             // do nothing; checks that auto close of non-connected Gateway
             // doesn't throw any exceptions.
         } catch (Exception e1) {
-            e1.printStackTrace();
-            Assert.fail();
+            Assert.fail("Gateway autoclose threw exception.", e1);
         }
 
         try (Gateway gw = new Gateway(new SimpleLogger())) {
@@ -146,8 +141,7 @@ public class GatewayUsageTest extends AbstractServerTest
             gw.connect(c);
             Assert.assertTrue(sessionActive);
         } catch (Exception e1) {
-            e1.printStackTrace();
-            Assert.fail();
+            Assert.fail("Gateway login failed.", e1);
         }
         Assert.assertFalse(sessionActive);
     }

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2017 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -22,6 +22,7 @@ package integration.gateway;
 
 import integration.AbstractServerTest;
 import omero.gateway.Gateway;
+import omero.gateway.JoinSessionCredentials;
 import omero.gateway.LoginCredentials;
 import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.ExperimenterData;
@@ -69,6 +70,31 @@ public class GatewayUsageTest extends AbstractServerTest
         Gateway gw = new Gateway(new SimpleLogger());
         ExperimenterData root = gw.connect(c);
         Assert.assertNotNull(root);
+        gw.disconnect();
+    }
+    
+    @Test
+    public void testLoginWithSessionID() throws DSOutOfServiceException {
+        omero.client client = new omero.client();
+        String[] args = new String[4];
+        args[0] = "--omero.host=" + client.getProperty("omero.host");
+        args[1] = "--omero.port=" + client.getProperty("omero.port");
+        args[2] = "--omero.user=root";
+        args[3] = "--omero.pass=" + client.getProperty("omero.rootpass");
+        LoginCredentials c = new LoginCredentials(args);
+        Gateway gw = new Gateway(new SimpleLogger());
+        ExperimenterData root = gw.connect(c);
+        String sessionId = gw.getSessionId(root);
+
+        Gateway gw2 = new Gateway(new SimpleLogger());
+        JoinSessionCredentials c2 = new JoinSessionCredentials(sessionId,
+                client.getProperty("omero.host"), Integer.parseInt(client
+                        .getProperty("omero.port")));
+        ExperimenterData root2 = gw2.connect(c2);
+        Assert.assertNotNull(root2);
+        Assert.assertEquals(gw2.getSessionId(root2), sessionId);
+        gw2.disconnect();
+
         gw.disconnect();
     }
     


### PR DESCRIPTION
# What this PR does
- Guest login was used to determine if a username is actually a session id. With this PR a `joinSession` attempt is made, if the username matches UUID format.
- The `Facility.handleException()` method silently 'swallowed' exceptions caused by connection issues. With this PR a `DSOutofServiceException` is thrown in these cases.
- Adds `JoinSessionCredentials` to provide a specific class for session id logins.
- Automatically remove stale connectors from the groupConnectorMap. That way the Gateway can continue working after a server restart without explicit dis- and reconnect.
- Makes the `Gateway` `AutoCloseable` so that it can be used in try-with-resources blocks.
- In various Facility methods, check arguments and return immediately when arguments not reasonable (Ids not provided, etc.).

# Testing this PR

- Check Java gateway integration tests.
- Test that login via session id still works
- Test that reconnect after connection loss still works. E. g. open Insight. Disconnect network. Try to browse a dataset. A connection warning should appear after a while. Reconnect the network. Insight should reconnect again, too, without crashing.
- Continuously request some data from the server using the same Gateway connection (catch all exceptions). Stop and restart the server in between. While the server is not running you will get some exceptions. But when the server is ready again the Gateway should continue working as usual. See below for an example test client (*).

# Related reading

- https://trello.com/c/XKg3FisH/42-java-gateway
- https://trello.com/c/JF3VjeWk/694-refactor-logincredentials
- Context for `Facility.handleException()` and server restart issue:  https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8367

--

*) Example client to use for testing server restart
```
LoginCredentials l = new LoginCredentials( ... );
Gateway g = new Gateway(new SimpleLogger());

ExperimenterData exp = g.connect(l);
SecurityContext ctx = new SecurityContext(exp.getGroupId());

while (true) {
    try {
        IObject obj = g.getFacility(BrowseFacility.class).findIObject(
                ctx, Image.class.getSimpleName(), 1);
        System.out.println(obj.getClass().getSimpleName() + " "
                + obj.getId().getValue());
    } catch (Throwable e) {
        e.printStackTrace();
    } finally {
        try {
            Thread.sleep(5000);
        } catch (InterruptedException e) {
        }
    }
}
```