### PR TITLE
Search plugin

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/search.py
+++ b/components/tools/OmeroPy/src/omero/plugins/search.py
@@ -95,7 +95,7 @@ class SearchControl(HqlControl):
 
         if args.index:
             if not self.ctx.get_event_context().isAdmin:
-                raise Exception("Only admin can index object")
+                self.ctx.die(432, "Only admin can index object")
 
             try:
                 parts = args.type.split(":")

--- a/components/tools/OmeroPy/src/omero/plugins/search.py
+++ b/components/tools/OmeroPy/src/omero/plugins/search.py
@@ -94,6 +94,9 @@ class SearchControl(HqlControl):
         import omero.all
 
         if args.index:
+            if not self.ctx.get_event_context().isAdmin:
+                raise Exception("Only admin can index object")
+
             try:
                 parts = args.type.split(":")
                 kls = parts[0].strip()
@@ -157,6 +160,7 @@ class SearchControl(HqlControl):
 
             finally:
                 search.close()
+
 
 try:
     register("search", SearchControl, HELP)

--- a/components/tools/OmeroPy/test/integration/clitest/test_search.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_search.py
@@ -172,3 +172,10 @@ class TestSearch(CLITest):
         _to = "--to=%s" % self.days_ago(-1)
         args = ["Dataset", txt, _from, _to]
         self.assertSearch(args, name=self._uuid_ds)
+
+    def test_search_index_by_user(self):
+        self.mkimage()
+        short = self.short()
+        with pytest.raises(Exception) as exc:
+            self.assertSearch(("Image", short + "*", "--index"))
+        assert 'Only admin can index object' in str(exc.value)

--- a/components/tools/OmeroPy/test/integration/clitest/test_search.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_search.py
@@ -82,7 +82,6 @@ class TestSearch(CLITest):
         else:
             with pytest.raises(NonZeroReturnCode):
                 results = self.go()
-    
 
     def test_search_basic(self):
         self.mkimage()

--- a/components/tools/OmeroPy/test/integration/clitest/test_search.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_search.py
@@ -82,6 +82,7 @@ class TestSearch(CLITest):
         else:
             with pytest.raises(NonZeroReturnCode):
                 results = self.go()
+    
 
     def test_search_basic(self):
         self.mkimage()
@@ -173,9 +174,10 @@ class TestSearch(CLITest):
         args = ["Dataset", txt, _from, _to]
         self.assertSearch(args, name=self._uuid_ds)
 
-    def test_search_index_by_user(self):
+    def test_search_index_by_user(self, capsys):
         self.mkimage()
         short = self.short()
-        with pytest.raises(Exception) as exc:
-            self.assertSearch(("Image", short + "*", "--index"))
-        assert 'Only admin can index object' in str(exc.value)
+        self.args.extend(("Image", short + "*", "--index"))
+        self.cli.invoke(self.args, strict=False)
+        o, e = capsys.readouterr()
+        assert 'Only admin can index object' in str(e)


### PR DESCRIPTION
# What this PR does

Only admin can index object
This PR adds a check in the search method if ``index`` is true

# Testing this PR
Check that the new test is green

# Related reading
Noticed while working on https://trello.com/c/FjayBnvM/39-gateway-support-for-roles