### PR TITLE
deprecate Path object in OMERO model

### DIFF
--- a/components/model/resources/mappings/jobs.ome.xml
+++ b/components/model/resources/mappings/jobs.ome.xml
@@ -70,7 +70,7 @@
 		<properties>
 		</properties>
 	</type>
-        <!-- Deprecated -->
+	<!-- Warning: ImportJob is DEPRECATED and may be removed in OMERO 6.0. -->
 	<type id="ome.model.jobs.ImportJob" superclass="ome.model.jobs.Job">
 		<!-- Note: ImportJob is not in model-->
 		<properties>

--- a/components/model/resources/mappings/roi.ome.xml
+++ b/components/model/resources/mappings/roi.ome.xml
@@ -96,6 +96,7 @@
                         <optional name="textValue" type="text"/>
                 </properties>
         </type>
+        <!-- Warning: Path is DEPRECATED and may be removed in OMERO 6.0. -->
         <type id="ome.model.roi.Path" discriminator="path" superclass="ome.model.roi.Shape">
                 <properties>
                         <optional name="d" type="text"/><!-- e.g. "M 100 100 L 300 100 L 200 300 z" -->


### PR DESCRIPTION
# What this PR does

Schedules`ome.model.jobs.ImportJob` and `ome.model.roi.Path` for removal in OMERO 6.0. We may yet relent.

# Related reading

https://trello.com/c/ol6NTQLD/58-path-shapes-in-omero