### PR TITLE
model glossary generation

### DIFF
--- a/components/server/src/ome/services/graphs/GraphPathReport.java
+++ b/components/server/src/ome/services/graphs/GraphPathReport.java
@@ -46,7 +46,7 @@ import ome.tools.hibernate.ListAsSQLArrayUserType;
 
 /**
  * A standalone tool for producing a summary of the Hibernate object mapping for our Sphinx documentation. One may invoke it with
- * <code>java -cp lib/server/\* `bin/omero config get | awk '{print"-D"$1}'` ome.services.graphs.GraphPathReport EveryObject.txt</code>.
+ * <code>java -cp lib/server/\* `bin/omero config get | awk '{print"-D"$1}'` ome.services.graphs.GraphPathReport EveryObject.rst</code>.
  * If not using {@code |} prefixes then one may transform the output via {@code fold -sw72}.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0


### PR DESCRIPTION
# What this PR does

change extension to .rst

# Testing this PR

Nothing to test

During release prep it is convenient to copy the command
Extension is now ``.rst`` instead of ``.txt`` see https://github.com/openmicroscopy/ome-documentation/pull/1733


# Related reading
Noticed while updating the model glossary during m4 prep

cc @mtbc 