### PR TITLE
Rename restricted admins doc URL

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
@@ -398,7 +398,7 @@
     <div id="privilege_info"></div>
     <div id="privilege_list">
         <h1>Choose user privileges</h1>
-        <p>For more info see <a href="https://www.openmicroscopy.org/latest/omero/sysadmins/admins-with-restricted-privileges.html">administrator privileges</a>.</p>
+        <p>For more info see <a href="https://www.openmicroscopy.org/latest/omero/sysadmins/restricted-admins.html">administrator privileges</a>.</p>
         <div id="privileges">
 
         </div>

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
@@ -398,7 +398,7 @@
     <div id="privilege_info"></div>
     <div id="privilege_list">
         <h1>Choose user privileges</h1>
-        <p>For more info see <a href="https://www.openmicroscopy.org/latest/omero/sysadmins/restricted-admins.html">administrator privileges</a>.</p>
+        <p>For more info see <a href="https://docs.openmicroscopy.org/latest/omero/sysadmins/restricted-admins.html">administrator privileges</a>.</p>
         <div id="privileges">
 
         </div>


### PR DESCRIPTION
# What this PR does

Carries the change on https://github.com/openmicroscopy/ome-documentation/pull/1783/commits/347d7f5081f83c906dcb1cde68b1f10920873916 forward to update the URL in the webadmin interface to use the new doc URL


# Testing this PR

Got to the webadmin tool user tab and click add new User to get the screen with the link on it as per http://help.staging.openmicroscopy.org/facility-manager.html#lightadmin

Check the URL - it **won't** work just now because the latest redirect won't be live until the release but it should match the page location from https://ci.openmicroscopy.org/view/Docs/job/OMERO-DEV-merge-docs/ (when /latest/ is removed and the URL is written as /omero/5.4.0-DEV/sysadmins...)

# Related reading

https://github.com/openmicroscopy/ome-documentation/pull/1783/