### PR TITLE
Ignore unhandled annotation targets

### DIFF
--- a/components/blitz/src/ome/formats/model/ReferenceProcessor.java
+++ b/components/blitz/src/ome/formats/model/ReferenceProcessor.java
@@ -114,8 +114,8 @@ public class ReferenceProcessor implements ModelProcessor {
               indexes.put(Index.IMAGE_INDEX, indexArray[0]);
               indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
             } else {
-                log.warn("Ignoring target class " + target+", not handled yet.");
-                continue;
+              log.warn("Ignoring target class " + target + ", not handled yet.");
+              continue;
             }
             container = store.getIObjectContainer(targetClass, indexes);
           }

--- a/components/blitz/src/ome/formats/model/ReferenceProcessor.java
+++ b/components/blitz/src/ome/formats/model/ReferenceProcessor.java
@@ -114,16 +114,16 @@ public class ReferenceProcessor implements ModelProcessor {
               indexes.put(Index.IMAGE_INDEX, indexArray[0]);
               indexes.put(Index.CHANNEL_INDEX, indexArray[1]);
             } else {
-              throw new RuntimeException(
-                  String.format("Unable to synchronize reference %s --> %s",
-                                reference, target));
+                log.warn("Ignoring target class " + target+", not handled yet.");
+                continue;
             }
             container = store.getIObjectContainer(targetClass, indexes);
           }
           // Add our LSIDs to the string based reference cache.
           references.add(reference.toString());
         }
-        String lsid = targetClass == null? target.toString() : container.LSID;
+        String lsid = targetClass == null || container == null ? target.toString()
+                : container.LSID;
         // We don't want to overwrite any existing references that may
         // have come from other LSID mappings (such as a generated
         // LSID) so add any existing LSIDs to the list of references.


### PR DESCRIPTION
# What this PR does

If an ome.tiff contains annotations of e. g. PlaneInfo objects the import crashes with a RuntimeException. With this PR no exception will be thrown, just a warning logged (like it's already done if the annotation target is null, see line 83).

# Testing this PR

Import the file from https://www.openmicroscopy.org/qa2/qa/feedback/17938/ 

# Related reading

https://trello.com/c/1sX3tep3/62-bug-creating-annotations-on-plane

