### PR TITLE
stabilize integration tests

### DIFF
--- a/components/tools/OmeroJava/test/integration.testng.xml
+++ b/components/tools/OmeroJava/test/integration.testng.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suite SYSTEM "http://beust.com/testng/testng-1.0.dtd" >
 
-<suite name="OmeroJava.integration" time-out="120000">
+<suite name="OmeroJava.integration" time-out="120000" configfailurepolicy="continue">
   <test name="integration">
     <groups>
       <run>

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2369,7 +2369,17 @@ public class AbstractServerTest extends AbstractTest {
         return provideEveryBooleanCombination(4);
     }
 
+    /**
+     * Override the Ice implicit call context with a group ID.
+     * Removes the override upon closing.
+     * @author m.t.b.carroll@ixod.org
+     * @since 5.4.0
+     */
     protected class ImplicitGroupContext implements AutoCloseable {
+        /**
+         * Set the implicit group context to the given group.
+         * @param groupId a group ID
+         */
         ImplicitGroupContext(long groupId) {
             if (client.getImplicitContext().containsKey(Login.OMERO_GROUP)) {
                 throw new IllegalStateException("group context already set");
@@ -2377,8 +2387,12 @@ public class AbstractServerTest extends AbstractTest {
             client.getImplicitContext().put(Login.OMERO_GROUP, Long.toString(groupId));
         }
 
-        ImplicitGroupContext(RLong id) {
-            this(id.getValue());
+        /**
+         * Set the implicit group context.
+         * @param groupId a group ID
+         */
+        ImplicitGroupContext(RLong groupId) {
+            this(groupId.getValue());
         }
 
         @Override
@@ -2387,7 +2401,17 @@ public class AbstractServerTest extends AbstractTest {
         }
     }
 
+    /**
+     * Override the Ice implicit call context with all-groups.
+     * Removes the override upon closing.
+     * @author m.t.b.carroll@ixod.org
+     * @since 5.4.0
+     */
     protected class ImplicitAllGroupsContext extends ImplicitGroupContext {
+        /**
+         * Set the implicit group context to all-groups.
+         * @param groupId a group ID
+         */
         ImplicitAllGroupsContext() {
             super(-1);
         }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Map.Entry;
 
 import ome.formats.OMEROMetadataStoreClient;
 import ome.formats.importer.IObservable;
@@ -139,8 +138,6 @@ import org.testng.annotations.DataProvider;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-
-import Ice.ImplicitContext;
 
 /**
  * Base test for integration tests.
@@ -322,18 +319,6 @@ public class AbstractServerTest extends AbstractTest {
             }
         }
         return importer;
-    }
-
-    /**
-     * Cast the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
-     * into implicit context, which asks for {@code <String, String>}.
-     * @param implicitContext the implicit context to be changed
-     * @param newContext the map of strings (e.g. {@link #ALL_GROUPS_CONTEXT})
-     */
-    protected void mergeIntoContext(ImplicitContext implicitContext, Map<String, String> newContext) {
-        for (final Entry<String, String> entry : newContext.entrySet()) {
-            implicitContext.put(entry.getKey(), entry.getValue());
-        }
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -1351,7 +1351,7 @@ public class AbstractServerTest extends AbstractTest {
         };
         ImportCandidates candidates = new ImportCandidates(reader, paths, o);
 
-        ImportLibrary library = new ImportLibrary(createImporter(), reader);
+        ImportLibrary library = new ImportLibrary(importer, reader);
         library.addObserver(o);
 
         ImportContainer ic = candidates.getContainers().get(0);

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2368,4 +2368,25 @@ public class AbstractServerTest extends AbstractTest {
     public Object[][] provideFourBooleanArguments() {
         return provideEveryBooleanCombination(4);
     }
+
+    protected class ImplicitGroupContext implements AutoCloseable {
+        ImplicitGroupContext(long groupId) {
+            client.getImplicitContext().put(Login.OMERO_GROUP, Long.toString(groupId));
+        }
+
+        ImplicitGroupContext(RLong id) {
+            this(id.getValue());
+        }
+
+        @Override
+        public void close() {
+            client.getImplicitContext().remove(Login.OMERO_GROUP);
+        }
+    }
+
+    protected class ImplicitAllGroupsContext extends ImplicitGroupContext {
+        ImplicitAllGroupsContext() {
+            super(-1);
+        }
+    }
 }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -192,7 +192,7 @@ public class AbstractServerTest extends AbstractTest {
     protected Roles roles;
 
     /** Reference to the importer store. */
-    protected OMEROMetadataStoreClient importer;
+    private OMEROMetadataStoreClient importer;
 
     /** Helper class creating mock object. */
     protected ModelMockFactory mmFactory;
@@ -291,10 +291,20 @@ public class AbstractServerTest extends AbstractTest {
     @Override
     @AfterClass
     public void tearDown() throws Exception {
+        clean();
         for (omero.client c : clients) {
             if (c != null) {
                 c.__del__();
             }
+        }
+    }
+
+    protected OMEROMetadataStoreClient createImporter() 
+    {
+        try {
+            importer = new OMEROMetadataStoreClient();
+            importer.initialize(factory);
+        } catch (Exception e) {
         }
     }
 
@@ -939,8 +949,6 @@ public class AbstractServerTest extends AbstractTest {
             iPix = factory.getPixelsService();
             roles = iAdmin.getSecurityRoles();
             mmFactory = new ModelMockFactory(root.getSession().getTypesService());
-            importer = new OMEROMetadataStoreClient();
-            importer.initialize(factory);
             ctx = iAdmin.getEventContext();
         } catch (SecurityViolation sv) {
             mmFactory = null;
@@ -948,7 +956,6 @@ public class AbstractServerTest extends AbstractTest {
             iQuery = null;
             iUpdate = null;
             iPix = null;
-            importer = null;
         }
 
         return ctx;
@@ -1306,6 +1313,9 @@ public class AbstractServerTest extends AbstractTest {
     protected List<Pixels> importFile(OMEROMetadataStoreClient importer,
             File file, String format, boolean metadata, IObject target)
             throws Throwable {
+        if (importer == null) {
+            importer = createImporter();
+        }        
         String[] paths = new String[1];
         paths[0] = file.getAbsolutePath();
         ImportConfig config = new ImportConfig();
@@ -1324,7 +1334,7 @@ public class AbstractServerTest extends AbstractTest {
         };
         ImportCandidates candidates = new ImportCandidates(reader, paths, o);
 
-        ImportLibrary library = new ImportLibrary(importer, reader);
+        ImportLibrary library = new ImportLibrary(createImporter(), reader);
         library.addObserver(o);
 
         ImportContainer ic = candidates.getContainers().get(0);

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -301,9 +301,22 @@ public class AbstractServerTest extends AbstractTest {
 
     protected OMEROMetadataStoreClient createImporter() throws Exception
     {
+
         if (importer == null) {
-            importer = new OMEROMetadataStoreClient();
-            importer.initialize(factory);
+            try {
+                importer = new OMEROMetadataStoreClient();
+                importer.initialize(factory);
+            } catch (Exception e) {
+                if (importer != null) {
+                    try {
+                        importer.closeServices();
+                    } catch (Exception ex) {
+                        //the initial error will be thrown
+                    }
+                    importer = null;
+                }
+                throw e;
+            }
         }
         return importer;
     }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2371,6 +2371,9 @@ public class AbstractServerTest extends AbstractTest {
 
     protected class ImplicitGroupContext implements AutoCloseable {
         ImplicitGroupContext(long groupId) {
+            if (client.getImplicitContext().containsKey(Login.OMERO_GROUP)) {
+                throw new IllegalStateException("group context already set");
+            }
             client.getImplicitContext().put(Login.OMERO_GROUP, Long.toString(groupId));
         }
 

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -299,13 +299,13 @@ public class AbstractServerTest extends AbstractTest {
         }
     }
 
-    protected OMEROMetadataStoreClient createImporter() 
+    protected OMEROMetadataStoreClient createImporter() throws Exception
     {
-        try {
+        if (importer == null) {
             importer = new OMEROMetadataStoreClient();
             importer.initialize(factory);
-        } catch (Exception e) {
         }
+        return importer;
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -938,7 +938,7 @@ public class AbstractServerTest extends AbstractTest {
             iAdmin = factory.getAdminService();
             iPix = factory.getPixelsService();
             roles = iAdmin.getSecurityRoles();
-            mmFactory = new ModelMockFactory(factory.getTypesService());
+            mmFactory = new ModelMockFactory(root.getSession().getTypesService());
             importer = new OMEROMetadataStoreClient();
             importer.initialize(factory);
             ctx = iAdmin.getEventContext();

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -458,14 +458,15 @@ public class AbstractServerTest extends AbstractTest {
      * @param property property to examine the testedObjects for (can be GROUP or OWNER)
      * @throws ServerError if query fails
      */
-    protected void verifyObjectProperty(Collection<? extends IObject> testedObjects, long id, DetailsProperty property) throws ServerError {
+    protected void verifyObjectProperty(Collection<? extends IObject> testedObjects, long id, DetailsProperty property)
+            throws ServerError {
         if (testedObjects.isEmpty()) {
             throw new IllegalArgumentException("must assert about some objects");
         }
         for (final IObject testedObject : testedObjects) {
             final String testedObjectName = testedObject.getClass().getName() + '[' + testedObject.getId().getValue() + ']';
-            final String query = "SELECT details." + property + ".id FROM " + testedObject.getClass().getSuperclass().getSimpleName() +
-                    " WHERE id = :id";
+            final String query = "SELECT details." + property + ".id FROM " +
+                    testedObject.getClass().getSuperclass().getSimpleName() + " WHERE id = :id";
             final Parameters params = new ParametersI().addId(testedObject.getId());
             final List<List<RType>> results = root.getSession().getQueryService().projection(query, params, ALL_GROUPS_CONTEXT);
             final long actualId = ((RLong) results.get(0).get(0)).getValue();

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -299,6 +299,9 @@ public class AbstractServerTest extends AbstractTest {
         }
     }
 
+    /**
+     * Creates the import if not already initialized and returns it.
+     */
     protected OMEROMetadataStoreClient createImporter() throws Exception
     {
 

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2398,6 +2398,9 @@ public class AbstractServerTest extends AbstractTest {
 
         @Override
         public void close() {
+            if (!client.getImplicitContext().containsKey(Login.OMERO_GROUP)) {
+                throw new IllegalStateException("group context no longer set");
+            }
             client.getImplicitContext().remove(Login.OMERO_GROUP);
         }
     }

--- a/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
@@ -98,7 +98,7 @@ public class ImportLibraryTest extends AbstractServerTest {
         mmFactory.createImageFile(f, ModelMockFactory.FORMATS[0]);
         f.deleteOnExit();
         ImportConfig config = new ImportConfig();
-        ImportLibrary library = new ImportLibrary(importer, new OMEROWrapper(
+        ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
                 config));
         ImportContainer ic = getCandidates(f).getContainers().get(0);
         List<Pixels> pixels = library.importImage(ic, 0, 0, 1);
@@ -152,7 +152,7 @@ public class ImportLibraryTest extends AbstractServerTest {
         mmFactory.createImageFile(f, ModelMockFactory.FORMATS[0]);
         f.deleteOnExit();
         ImportConfig config = new ImportConfig();
-        ImportLibrary library = new ImportLibrary(importer, new OMEROWrapper(
+        ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
                 config));
         ImportContainer ic = getCandidates(f).getContainers().get(0);
 
@@ -188,7 +188,7 @@ public class ImportLibraryTest extends AbstractServerTest {
         mmFactory.createImageFile(f, ModelMockFactory.FORMATS[0]);
         f.deleteOnExit();
         ImportConfig config = new ImportConfig();
-        ImportLibrary library = new ImportLibrary(importer, new OMEROWrapper(
+        ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
                 config));
         ImportContainer ic = getCandidates(f).getContainers().get(0);
         ic = new ImportContainer(f, null, null, null, ic.getUsedFiles(), null);

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -1834,8 +1834,8 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 "SELECT id, hasher.value, hash FROM OriginalFile " +
                 "WHERE name = :name AND path = :path AND details.group.id = :group_id",
                 new ParametersI().add("name", omero.rtypes.rstring(fakeImageFile.getName()))
-                .add("path", omero.rtypes.rstring(repoPath))
-                .add("group_id", omero.rtypes.rlong(normalUser.groupId))).get(0);
+                                 .add("path", omero.rtypes.rstring(repoPath))
+                                 .add("group_id", omero.rtypes.rlong(normalUser.groupId))).get(0);
         final long imageFileId = ((RLong) results.get(0)).getValue();
         final String hasherOriginal = ((RString) results.get(1)).getValue();
         final String hashOriginal = ((RString) results.get(2)).getValue();

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -227,13 +227,13 @@ public class LightAdminPrivilegesTest extends RolesTests {
         Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null, isRestricted ? AdminPrivilegeChgrp.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(otherGroupId)) {
-        Assert.assertEquals(getCurrentPermissions(folder).canChgrp(), isExpectSuccess);
-        doChange(client, factory, Requests.chgrp().target(folder).toGroup(otherGroupId).build(), isExpectSuccess);
-        if (isExpectSuccess) {
-            folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
-            Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), normalUser.userId);
-            Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), otherGroupId);
-        }
+            Assert.assertEquals(getCurrentPermissions(folder).canChgrp(), isExpectSuccess);
+            doChange(client, factory, Requests.chgrp().target(folder).toGroup(otherGroupId).build(), isExpectSuccess);
+            if (isExpectSuccess) {
+                folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
+                Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), normalUser.userId);
+                Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), otherGroupId);
+            }
         }
     }
 
@@ -254,17 +254,17 @@ public class LightAdminPrivilegesTest extends RolesTests {
         Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null, isRestricted ? AdminPrivilegeChgrp.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(folder).canChgrp(), isExpectSuccess);
-        folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
-        folder.getDetails().setGroup(otherGroup);
-        try {
-            folder = (Folder) iUpdate.saveAndReturnObject(folder);
-            Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), normalUser.userId);
-            Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), otherGroup.getId().getValue());
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(folder).canChgrp(), isExpectSuccess);
+            folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
+            folder.getDetails().setGroup(otherGroup);
+            try {
+                folder = (Folder) iUpdate.saveAndReturnObject(folder);
+                Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), normalUser.userId);
+                Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), otherGroup.getId().getValue());
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -285,13 +285,13 @@ public class LightAdminPrivilegesTest extends RolesTests {
         final EventContext otherUser = newUserInGroup(normalUser);
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null, isRestricted ? AdminPrivilegeChown.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(folder).canChown(), isExpectSuccess);
-        doChange(client, factory, Requests.chown().target(folder).toUser(otherUser.userId).build(), isExpectSuccess);
-        if (isExpectSuccess) {
-            folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
-            Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), otherUser.userId);
-            Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
-        }
+            Assert.assertEquals(getCurrentPermissions(folder).canChown(), isExpectSuccess);
+            doChange(client, factory, Requests.chown().target(folder).toUser(otherUser.userId).build(), isExpectSuccess);
+            if (isExpectSuccess) {
+                folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
+                Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), otherUser.userId);
+                Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
+            }
         }
     }
 
@@ -312,17 +312,17 @@ public class LightAdminPrivilegesTest extends RolesTests {
         final EventContext otherUser = newUserInGroup(normalUser);
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null, isRestricted ? AdminPrivilegeChown.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(folder).canChown(), isExpectSuccess);
-        folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
-        folder.getDetails().setOwner(new ExperimenterI(otherUser.userId, false));
-        try {
-            folder = (Folder) iUpdate.saveAndReturnObject(folder);
-            Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), otherUser.userId);
-            Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(folder).canChown(), isExpectSuccess);
+            folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
+            folder.getDetails().setOwner(new ExperimenterI(otherUser.userId, false));
+            try {
+                folder = (Folder) iUpdate.saveAndReturnObject(folder);
+                Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), otherUser.userId);
+                Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -364,16 +364,16 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
-        repo = getRepository(Repository.OTHER);
-        try {
-            final HandlePrx handle = repo.deletePaths(new String[] {testScriptName}, false, false);
-            final CmdCallbackI callback = new CmdCallbackI(client, handle);
-            callback.loop(20, scalingFactor);
-            assertCmd(callback, isExpectSuccess);
-        } catch (Ice.LocalException ue) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
+            repo = getRepository(Repository.OTHER);
+            try {
+                final HandlePrx handle = repo.deletePaths(new String[] {testScriptName}, false, false);
+                final CmdCallbackI callback = new CmdCallbackI(client, handle);
+                callback.loop(20, scalingFactor);
+                assertCmd(callback, isExpectSuccess);
+            } catch (Ice.LocalException ue) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check the content of the script */
         loginUser(normalUser);
@@ -412,8 +412,8 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(file).canDelete(), isExpectSuccess);
-        doChange(client, factory, Requests.delete().target(file).build(), isExpectSuccess);
+            Assert.assertEquals(getCurrentPermissions(file).canDelete(), isExpectSuccess);
+            doChange(client, factory, Requests.delete().target(file).build(), isExpectSuccess);
         }
     }
 
@@ -455,14 +455,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
-        iScript = factory.getScriptService();
-        try {
-            iScript.deleteScript(testScriptId);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
+            iScript = factory.getScriptService();
+            try {
+                iScript.deleteScript(testScriptId);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check if the script was deleted or left intact */
         loginUser(normalUser);
@@ -516,17 +516,17 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteManagedRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(remoteFile).canDelete(), isExpectSuccess);
-        final RepositoryPrx repo = getRepository(Repository.MANAGED);
-        try {
-            final String remoteFilename = remoteFile.getPath().getValue() + remoteFile.getName().getValue();
-            final HandlePrx handle = repo.deletePaths(new String[] {remoteFilename}, false, false);
-            final CmdCallbackI callback = new CmdCallbackI(client, handle);
-            callback.loop(20, scalingFactor);
-            assertCmd(callback, isExpectSuccess);
-        } catch (Ice.LocalException ue) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(remoteFile).canDelete(), isExpectSuccess);
+            final RepositoryPrx repo = getRepository(Repository.MANAGED);
+            try {
+                final String remoteFilename = remoteFile.getPath().getValue() + remoteFile.getName().getValue();
+                final HandlePrx handle = repo.deletePaths(new String[] {remoteFilename}, false, false);
+                final CmdCallbackI callback = new CmdCallbackI(client, handle);
+                callback.loop(20, scalingFactor);
+                assertCmd(callback, isExpectSuccess);
+            } catch (Ice.LocalException ue) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check the existence of the file */
         loginUser(normalUser);
@@ -569,8 +569,8 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteManagedRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(remoteFile).canDelete(), isExpectSuccess);
-        doChange(client, factory, Requests.delete().target(remoteFile).build(), isExpectSuccess);
+            Assert.assertEquals(getCurrentPermissions(remoteFile).canDelete(), isExpectSuccess);
+            doChange(client, factory, Requests.delete().target(remoteFile).build(), isExpectSuccess);
         }
     }
 
@@ -590,8 +590,8 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteOwned.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(folder).canDelete(), isExpectSuccess);
-        doChange(client, factory, Requests.delete().target(folder).build(), isExpectSuccess);
+            Assert.assertEquals(getCurrentPermissions(folder).canDelete(), isExpectSuccess);
+            doChange(client, factory, Requests.delete().target(folder).build(), isExpectSuccess);
         }
     }
 
@@ -634,16 +634,16 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteScriptRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
-        repo = getRepository(Repository.SCRIPT);
-        try {
-            final HandlePrx handle = repo.deletePaths(new String[] {testScriptName}, false, false);
-            final CmdCallbackI callback = new CmdCallbackI(client, handle);
-            callback.loop(20, scalingFactor);
-            assertCmd(callback, isExpectSuccess);
-        } catch (Ice.LocalException ue) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
+            repo = getRepository(Repository.SCRIPT);
+            try {
+                final HandlePrx handle = repo.deletePaths(new String[] {testScriptName}, false, false);
+                final CmdCallbackI callback = new CmdCallbackI(client, handle);
+                callback.loop(20, scalingFactor);
+                assertCmd(callback, isExpectSuccess);
+            } catch (Ice.LocalException ue) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check the content of the script */
         loginUser(normalUser);
@@ -704,8 +704,8 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteScriptRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
-        doChange(client, factory, Requests.delete().target(testScript).build(), isExpectSuccess);
+            Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
+            doChange(client, factory, Requests.delete().target(testScript).build(), isExpectSuccess);
         }
         /* check the content of the script */
         loginUser(normalUser);
@@ -768,14 +768,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeDeleteScriptRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
-        iScript = factory.getScriptService();
-        try {
-            iScript.deleteScript(testScriptId);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(testScript).canDelete(), isExpectSuccess);
+            iScript = factory.getScriptService();
+            try {
+                iScript.deleteScript(testScriptId);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check if the script was deleted or left intact */
         loginUser(normalUser);
@@ -1415,14 +1415,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        repo = getRepository(Repository.OTHER);
-        final String filename = userDirectory + '/' + UUID.randomUUID();
-        try {
-            repo.makeDir(filename, false);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            repo = getRepository(Repository.OTHER);
+            final String filename = userDirectory + '/' + UUID.randomUUID();
+            try {
+                repo.makeDir(filename, false);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -1449,14 +1449,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        repo = getRepository(Repository.OTHER);
-        final String filename = userDirectory + '/' + UUID.randomUUID();
-        try {
-            factory.sharedResources().newTable(repo.root().getId().getValue(), filename).close();
-            Assert.assertTrue(isExpectSuccess);
-        } catch (Ice.LocalException se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            repo = getRepository(Repository.OTHER);
+            final String filename = userDirectory + '/' + UUID.randomUUID();
+            try {
+                factory.sharedResources().newTable(repo.root().getId().getValue(), filename).close();
+                Assert.assertTrue(isExpectSuccess);
+            } catch (Ice.LocalException se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -1480,14 +1480,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        repo = getRepository(Repository.OTHER);
-        final String filename = userDirectory + '/' + UUID.randomUUID();
-        try {
-            repo.register(filename, null);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            repo = getRepository(Repository.OTHER);
+            final String filename = userDirectory + '/' + UUID.randomUUID();
+            try {
+                repo.register(filename, null);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -1516,16 +1516,16 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         final long testScriptId;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        iScript = factory.getScriptService();
-        final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        try {
-            testScriptId = iScript.uploadScript(testScriptName, actualScript);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-            /* upload failed so finish here */
-            return;
-        }
+            iScript = factory.getScriptService();
+            final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
+            try {
+                testScriptId = iScript.uploadScript(testScriptName, actualScript);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+                /* upload failed so finish here */
+                return;
+            }
         }
         /* check that the new script exists */
         loginUser(normalUser);
@@ -1555,16 +1555,16 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        OriginalFile file = mmFactory.createOriginalFile();
-        file.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
-        try {
-            file = (OriginalFile) iUpdate.saveAndReturnObject(file);
-            Assert.assertEquals(file.getDetails().getOwner().getId().getValue(), normalUser.userId);
-            Assert.assertEquals(file.getDetails().getGroup().getId().getValue(), normalUser.groupId);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            OriginalFile file = mmFactory.createOriginalFile();
+            file.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
+            try {
+                file = (OriginalFile) iUpdate.saveAndReturnObject(file);
+                Assert.assertEquals(file.getDetails().getOwner().getId().getValue(), normalUser.userId);
+                Assert.assertEquals(file.getDetails().getGroup().getId().getValue(), normalUser.groupId);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -1601,22 +1601,22 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         final byte[] fileContentBlank;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(file).canEdit(), isExpectSuccess);
-        fileContentBlank = new byte[fileContentOriginal.length];
-        try {
-            rfs = factory.createRawFileStore();
-            rfs.setFileId(fileId);
-            rfs.write(fileContentBlank, 0, fileContentBlank.length);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        } finally {
+            Assert.assertEquals(getCurrentPermissions(file).canEdit(), isExpectSuccess);
+            fileContentBlank = new byte[fileContentOriginal.length];
             try {
-                rfs.close();
+                rfs = factory.createRawFileStore();
+                rfs.setFileId(fileId);
+                rfs.write(fileContentBlank, 0, fileContentBlank.length);
+                Assert.assertTrue(isExpectSuccess);
             } catch (ServerError se) {
-                /* cannot try to close */
+                Assert.assertFalse(isExpectSuccess);
+            } finally {
+                try {
+                    rfs.close();
+                } catch (ServerError se) {
+                    /* cannot try to close */
+                }
             }
-        }
         }
         /* check the resulting file content */
         loginUser(normalUser);
@@ -1667,22 +1667,22 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         final byte[] fileContentBlank;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
-        repo = getRepository(Repository.OTHER);
-        fileContentBlank = new byte[fileContentOriginal.length];
-        try {
-            rfs = repo.file(testScriptName, "rw");
-            rfs.write(fileContentBlank, 0, fileContentBlank.length);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        } finally {
+            Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
+            repo = getRepository(Repository.OTHER);
+            fileContentBlank = new byte[fileContentOriginal.length];
             try {
-                rfs.close();
-            } catch (Ice.CommunicatorDestroyedException cde) {
-                /* cannot try to close */
+                rfs = repo.file(testScriptName, "rw");
+                rfs.write(fileContentBlank, 0, fileContentBlank.length);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            } finally {
+                try {
+                    rfs.close();
+                } catch (Ice.CommunicatorDestroyedException cde) {
+                    /* cannot try to close */
+                }
             }
-        }
         }
         /* check the content of the script */
         loginUser(normalUser);
@@ -1724,15 +1724,15 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         final String newScript;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
-        iScript = factory.getScriptService();
-        newScript = originalScript + "\n# this script is a copy of another";
-        try {
-            iScript.editScript(new OriginalFileI(testScriptId, false), newScript);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
+            iScript = factory.getScriptService();
+            newScript = originalScript + "\n# this script is a copy of another";
+            try {
+                iScript.editScript(new OriginalFileI(testScriptId, false), newScript);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check the permissions on the script */
         loginUser(normalUser);
@@ -1764,17 +1764,17 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        file = (OriginalFile) iQuery.get("OriginalFile", file.getId().getValue());
-        Assert.assertEquals(getCurrentPermissions(file).canEdit(), isExpectSuccess);
-        final String newFilename = "Test_" + getClass().getName() + '_' + UUID.randomUUID();
-        file.setName(omero.rtypes.rstring(newFilename));
-        try {
-            file = (OriginalFile) iUpdate.saveAndReturnObject(file);
-            Assert.assertEquals(file.getName().getValue(), newFilename);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            file = (OriginalFile) iQuery.get("OriginalFile", file.getId().getValue());
+            Assert.assertEquals(getCurrentPermissions(file).canEdit(), isExpectSuccess);
+            final String newFilename = "Test_" + getClass().getName() + '_' + UUID.randomUUID();
+            file.setName(omero.rtypes.rstring(newFilename));
+            try {
+                file = (OriginalFile) iUpdate.saveAndReturnObject(file);
+                Assert.assertEquals(file.getName().getValue(), newFilename);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -1794,21 +1794,21 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteManagedRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        final ImportLocation importLocation;
-        try {
-            importLocation = importFileset(Collections.singletonList(fakeImageFile.getPath()));
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-            /* no file to check */
-            return;
-        }
-        final RString imagePath = omero.rtypes.rstring(importLocation.sharedPath + FsFile.separatorChar);
-        final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
-        final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
-                "FROM OriginalFile o WHERE o.path = :path AND o.name = :name AND o.details.group.id = :group_id",
-                new ParametersI().add("path", imagePath).add("name", imageName).addLong("group_id", normalUser.groupId));
-        Assert.assertNotNull(remoteFile);
+            final ImportLocation importLocation;
+            try {
+                importLocation = importFileset(Collections.singletonList(fakeImageFile.getPath()));
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+                /* no file to check */
+                return;
+            }
+            final RString imagePath = omero.rtypes.rstring(importLocation.sharedPath + FsFile.separatorChar);
+            final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
+            final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
+                    "FROM OriginalFile o WHERE o.path = :path AND o.name = :name AND o.details.group.id = :group_id",
+                    new ParametersI().add("path", imagePath).add("name", imageName).addLong("group_id", normalUser.groupId));
+            Assert.assertNotNull(remoteFile);
         }
     }
 
@@ -1834,8 +1834,8 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 "SELECT id, hasher.value, hash FROM OriginalFile " +
                 "WHERE name = :name AND path = :path AND details.group.id = :group_id",
                 new ParametersI().add("name", omero.rtypes.rstring(fakeImageFile.getName()))
-                                 .add("path", omero.rtypes.rstring(repoPath))
-                                 .add("group_id", omero.rtypes.rlong(normalUser.groupId))).get(0);
+                .add("path", omero.rtypes.rstring(repoPath))
+                .add("group_id", omero.rtypes.rlong(normalUser.groupId))).get(0);
         final long imageFileId = ((RLong) results.get(0)).getValue();
         final String hasherOriginal = ((RString) results.get(1)).getValue();
         final String hashOriginal = ((RString) results.get(2)).getValue();
@@ -1844,21 +1844,21 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 isRestricted ? AdminPrivilegeWriteManagedRepo.value : null);
         final String hasherChanged;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(new OriginalFileI(imageFileId, false)).canEdit(), isExpectSuccess);
-        final ManagedRepositoryPrx repo = ManagedRepositoryPrxHelper.checkedCast(getRepository(Repository.MANAGED));
-        if (ChecksumAlgorithmSHA1160.value.equals(hasherOriginal)) {
-            hasherChanged = ChecksumAlgorithmMurmur3128.value;
-        } else {
-            hasherChanged = ChecksumAlgorithmSHA1160.value;
-        }
-        try {
-            final ChecksumAlgorithm hasherAlgorithm = new ChecksumAlgorithmI();
-            hasherAlgorithm.setValue(omero.rtypes.rstring(hasherChanged));
-            repo.setChecksumAlgorithm(hasherAlgorithm, Collections.singletonList(imageFileId));
-            Assert.assertTrue(isExpectSuccess);
-        } catch (Ice.LocalException | ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Assert.assertEquals(getCurrentPermissions(new OriginalFileI(imageFileId, false)).canEdit(), isExpectSuccess);
+            final ManagedRepositoryPrx repo = ManagedRepositoryPrxHelper.checkedCast(getRepository(Repository.MANAGED));
+            if (ChecksumAlgorithmSHA1160.value.equals(hasherOriginal)) {
+                hasherChanged = ChecksumAlgorithmMurmur3128.value;
+            } else {
+                hasherChanged = ChecksumAlgorithmSHA1160.value;
+            }
+            try {
+                final ChecksumAlgorithm hasherAlgorithm = new ChecksumAlgorithmI();
+                hasherAlgorithm.setValue(omero.rtypes.rstring(hasherChanged));
+                repo.setChecksumAlgorithm(hasherAlgorithm, Collections.singletonList(imageFileId));
+                Assert.assertTrue(isExpectSuccess);
+            } catch (Ice.LocalException | ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check the effect on the image's hash and hasher */
         loginUser(normalUser);
@@ -1903,25 +1903,25 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 isRestricted ? AdminPrivilegeWriteManagedRepo.value : null);
         final byte[] fileContentBlank;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(remoteFile).canEdit(), isExpectSuccess);
-        final RepositoryPrx repo = getRepository(Repository.MANAGED);
-        fileContentBlank = new byte[(int) (fakeImageFile.length() + 16)];
-        RawFileStorePrx rfs = null;
-        try {
-            rfs = repo.file(remoteFile.getPath().getValue() + remoteFile.getName().getValue(), "rw");
-            rfs.write(fileContentBlank, 0, fileContentBlank.length);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        } finally {
+            Assert.assertEquals(getCurrentPermissions(remoteFile).canEdit(), isExpectSuccess);
+            final RepositoryPrx repo = getRepository(Repository.MANAGED);
+            fileContentBlank = new byte[(int) (fakeImageFile.length() + 16)];
+            RawFileStorePrx rfs = null;
             try {
-                if (rfs != null) {
-                    rfs.close();
+                rfs = repo.file(remoteFile.getPath().getValue() + remoteFile.getName().getValue(), "rw");
+                rfs.write(fileContentBlank, 0, fileContentBlank.length);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            } finally {
+                try {
+                    if (rfs != null) {
+                        rfs.close();
+                    }
+                } catch (Ice.CommunicatorDestroyedException cde) {
+                    /* cannot try to close */
                 }
-            } catch (Ice.CommunicatorDestroyedException cde) {
-                /* cannot try to close */
             }
-        }
         }
         /* check the resulting file size */
         loginUser(normalUser);
@@ -1944,16 +1944,16 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteOwned.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Folder folder = mmFactory.simpleFolder();
-        folder.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
-        try {
-            folder = (Folder) iUpdate.saveAndReturnObject(folder);
-            Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), normalUser.userId);
-            Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            Folder folder = mmFactory.simpleFolder();
+            folder.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
+            try {
+                folder = (Folder) iUpdate.saveAndReturnObject(folder);
+                Assert.assertEquals(folder.getDetails().getOwner().getId().getValue(), normalUser.userId);
+                Assert.assertEquals(folder.getDetails().getGroup().getId().getValue(), normalUser.groupId);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -1973,17 +1973,17 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteOwned.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
-        Assert.assertEquals(getCurrentPermissions(folder).canEdit(), isExpectSuccess);
-        final String newFolderName = "Test_" + getClass().getName() + '_' + UUID.randomUUID();
-        folder.setName(omero.rtypes.rstring(newFolderName));
-        try {
-            folder = (Folder) iUpdate.saveAndReturnObject(folder);
-            Assert.assertEquals(folder.getName().getValue(), newFolderName);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            folder = (Folder) iQuery.get("Folder", folder.getId().getValue());
+            Assert.assertEquals(getCurrentPermissions(folder).canEdit(), isExpectSuccess);
+            final String newFolderName = "Test_" + getClass().getName() + '_' + UUID.randomUUID();
+            folder.setName(omero.rtypes.rstring(newFolderName));
+            try {
+                folder = (Folder) iUpdate.saveAndReturnObject(folder);
+                Assert.assertEquals(folder.getName().getValue(), newFolderName);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -2007,14 +2007,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        repo = getRepository(Repository.SCRIPT);
-        final String filename = userDirectory + '/' + UUID.randomUUID();
-        try {
-            repo.makeDir(filename, false);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            repo = getRepository(Repository.SCRIPT);
+            final String filename = userDirectory + '/' + UUID.randomUUID();
+            try {
+                repo.makeDir(filename, false);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -2041,15 +2041,15 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        repo = getRepository(Repository.SCRIPT);
-        final String filename = userDirectory + '/' + UUID.randomUUID();
-        try {
-            // TODO: test is broken because SharedResources.newTable ignores its repo ID argument
-            factory.sharedResources().newTable(repo.root().getId().getValue(), filename).close();
-            Assert.assertTrue(isExpectSuccess);
-        } catch (Ice.LocalException se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            repo = getRepository(Repository.SCRIPT);
+            final String filename = userDirectory + '/' + UUID.randomUUID();
+            try {
+                // TODO: test is broken because SharedResources.newTable ignores its repo ID argument
+                factory.sharedResources().newTable(repo.root().getId().getValue(), filename).close();
+                Assert.assertTrue(isExpectSuccess);
+            } catch (Ice.LocalException se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -2073,14 +2073,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        repo = getRepository(Repository.SCRIPT);
-        final String filename = userDirectory + '/' + UUID.randomUUID();
-        try {
-            repo.register(filename, null);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            repo = getRepository(Repository.SCRIPT);
+            final String filename = userDirectory + '/' + UUID.randomUUID();
+            try {
+                repo.register(filename, null);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 
@@ -2173,22 +2173,22 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
         final byte[] fileContentBlank;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
-        repo = getRepository(Repository.SCRIPT);
-        fileContentBlank = new byte[fileContentOriginal.length];
-        try {
-            rfs = repo.file(testScriptName, "rw");
-            rfs.write(fileContentBlank, 0, fileContentBlank.length);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        } finally {
+            Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
+            repo = getRepository(Repository.SCRIPT);
+            fileContentBlank = new byte[fileContentOriginal.length];
             try {
-                rfs.close();
-            } catch (Ice.CommunicatorDestroyedException cde) {
-                /* cannot try to close */
+                rfs = repo.file(testScriptName, "rw");
+                rfs.write(fileContentBlank, 0, fileContentBlank.length);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            } finally {
+                try {
+                    rfs.close();
+                } catch (Ice.CommunicatorDestroyedException cde) {
+                    /* cannot try to close */
+                }
             }
-        }
         }
         /* check the content of the script */
         loginUser(normalUser);
@@ -2233,16 +2233,16 @@ public class LightAdminPrivilegesTest extends RolesTests {
         OriginalFile testScript;
         final String newScript;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        testScript = new OriginalFileI(testScriptId, false);
-        Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
-        iScript = factory.getScriptService();
-        newScript = originalScript + "\n# this script is a copy of another";
-        try {
-            iScript.editScript(testScript, newScript);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            testScript = new OriginalFileI(testScriptId, false);
+            Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
+            iScript = factory.getScriptService();
+            newScript = originalScript + "\n# this script is a copy of another";
+            try {
+                iScript.editScript(testScript, newScript);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
         /* check the permissions on the script */
         loginUser(normalUser);
@@ -2277,17 +2277,17 @@ public class LightAdminPrivilegesTest extends RolesTests {
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        file = (OriginalFile) iQuery.get("OriginalFile", file.getId().getValue());
-        Assert.assertEquals(getCurrentPermissions(file).canEdit(), isExpectSuccess);
-        final String newFilename = "Test_" + getClass().getName() + '_' + UUID.randomUUID();
-        file.setName(omero.rtypes.rstring(newFilename));
-        try {
-            file = (OriginalFile) iUpdate.saveAndReturnObject(file);
-            Assert.assertEquals(file.getName().getValue(), newFilename);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess);
-        }
+            file = (OriginalFile) iQuery.get("OriginalFile", file.getId().getValue());
+            Assert.assertEquals(getCurrentPermissions(file).canEdit(), isExpectSuccess);
+            final String newFilename = "Test_" + getClass().getName() + '_' + UUID.randomUUID();
+            file.setName(omero.rtypes.rstring(newFilename));
+            try {
+                file = (OriginalFile) iUpdate.saveAndReturnObject(file);
+                Assert.assertEquals(file.getName().getValue(), newFilename);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess);
+            }
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -115,7 +115,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
     @BeforeClass
     public void populateAllPrivileges() throws ServerError {
         final ImmutableSet.Builder<AdminPrivilege> privileges = ImmutableSet.builder();
-        for (final IObject privilege : factory.getTypesService().allEnumerations("AdminPrivilege")) {
+        for (final IObject privilege : root.getSession().getTypesService().allEnumerations("AdminPrivilege")) {
             privileges.add((AdminPrivilege) privilege);
         }
         allPrivileges = privileges.build();

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -230,68 +230,68 @@ public class LightAdminRolesTest extends RolesTests {
         /* lightAdmin tries to create Project and Dataset on behalf of the normalUser
          * in normalUser's group.*/
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Project proj = mmFactory.simpleProject();
-        Dataset dat = mmFactory.simpleDataset();
-        Project sentProj = null;
-        Dataset sentDat = null;
-        /* lightAdmin sets the normalUser as the owner of the newly created Project/Dataset but only
-         * in cases in which lightAdmin is not sudoing (if sudoing, the created Project/Dataset
-         * already belong to normalUser).*/
-        if (!isSudoing) {
-            proj.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
-            dat.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
-        }
-        /* Check lightAdmin can or cannot save the created Project and Dataset as appropriate
-         * (see definition of isExpectSuccessCreate above).*/
-        try {
-            sentProj = (Project) iUpdate.saveAndReturnObject(proj);
-            sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
-            Assert.assertTrue(isExpectSuccessCreate);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccessCreate);
-        }
-        /* Check the owner of the Project and Dataset (P/D) is the normalUser in all cases
-         * the P/D were created, in all other cases P/D should be null.*/
-        if (isExpectSuccessCreate) {
-            assertOwnedBy(sentProj, normalUser);
-            assertOwnedBy(sentDat, normalUser);
-        } else {
-            Assert.assertNull(sentProj);
-            Assert.assertNull(sentDat);
-        }
-        /* Finish the test if lightAdmin is not sudoing.
-         * Further tests of this test method deal with import and linking
-         * for normalUser by lightAdmin who sudoes on behalf of normalUser.
-         * Imports and linking for others while NOT using Sudo
-         * are covered in other test methods in this class.*/
-        if (!isSudoing) return;
+            Project proj = mmFactory.simpleProject();
+            Dataset dat = mmFactory.simpleDataset();
+            Project sentProj = null;
+            Dataset sentDat = null;
+            /* lightAdmin sets the normalUser as the owner of the newly created Project/Dataset but only
+             * in cases in which lightAdmin is not sudoing (if sudoing, the created Project/Dataset
+             * already belong to normalUser).*/
+            if (!isSudoing) {
+                proj.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
+                dat.getDetails().setOwner(new ExperimenterI(normalUser.userId, false));
+            }
+            /* Check lightAdmin can or cannot save the created Project and Dataset as appropriate
+             * (see definition of isExpectSuccessCreate above).*/
+            try {
+                sentProj = (Project) iUpdate.saveAndReturnObject(proj);
+                sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+                Assert.assertTrue(isExpectSuccessCreate);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccessCreate);
+            }
+            /* Check the owner of the Project and Dataset (P/D) is the normalUser in all cases
+             * the P/D were created, in all other cases P/D should be null.*/
+            if (isExpectSuccessCreate) {
+                assertOwnedBy(sentProj, normalUser);
+                assertOwnedBy(sentDat, normalUser);
+            } else {
+                Assert.assertNull(sentProj);
+                Assert.assertNull(sentDat);
+            }
+            /* Finish the test if lightAdmin is not sudoing.
+             * Further tests of this test method deal with import and linking
+             * for normalUser by lightAdmin who sudoes on behalf of normalUser.
+             * Imports and linking for others while NOT using Sudo
+             * are covered in other test methods in this class.*/
+            if (!isSudoing) return;
 
-        /* Check that after sudo, lightAdmin can import and write the originalFile
-         * of the imported image on behalf of the normalUser into the created Dataset.*/
-        List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
-        OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
-        Image image = (Image) originalFileAndImage.get(1);
+            /* Check that after sudo, lightAdmin can import and write the originalFile
+             * of the imported image on behalf of the normalUser into the created Dataset.*/
+            List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
+            OriginalFile originalFile = (OriginalFile) originalFileAndImage.get(0);
+            Image image = (Image) originalFileAndImage.get(1);
 
-        /* Check the canLink() boolean for both Dataset and Project.
-         * lightAdmin is always sudoing in this part of the test.
-         * Thus canLink() is always true, because lightAdmin is sudoed
-         * on behalf of the owner of the objects (normalUser).*/
-        Assert.assertTrue(getCurrentPermissions(sentProj).canLink());
-        Assert.assertTrue(getCurrentPermissions(sentDat).canLink());
-        /* Check that being sudoed, lightAdmin can link the Project and Dataset of normalUser.*/
-        ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
+            /* Check the canLink() boolean for both Dataset and Project.
+             * lightAdmin is always sudoing in this part of the test.
+             * Thus canLink() is always true, because lightAdmin is sudoed
+             * on behalf of the owner of the objects (normalUser).*/
+            Assert.assertTrue(getCurrentPermissions(sentProj).canLink());
+            Assert.assertTrue(getCurrentPermissions(sentDat).canLink());
+            /* Check that being sudoed, lightAdmin can link the Project and Dataset of normalUser.*/
+            ProjectDatasetLink projectDatasetLink = linkParentToChild(sentProj, sentDat);
 
-        /* Check the owner of the image, its originalFile, imageDatasetLink and projectDatasetLink
-         * is normalUser and the image and its originalFile are in normalUser's group.*/
-        final IObject imageDatasetLink = iQuery.findByQuery(
-                "FROM DatasetImageLink WHERE child.id = :id",
-                new ParametersI().addId(image.getId().getValue()));
-        assertInGroup(originalFile, normalUser.groupId);
-        assertOwnedBy(originalFile, normalUser);
-        assertInGroup(image, normalUser.groupId);
-        assertOwnedBy(image, normalUser);
-        assertOwnedBy(imageDatasetLink, normalUser);
-        assertOwnedBy(projectDatasetLink, normalUser);
+            /* Check the owner of the image, its originalFile, imageDatasetLink and projectDatasetLink
+             * is normalUser and the image and its originalFile are in normalUser's group.*/
+            final IObject imageDatasetLink = iQuery.findByQuery(
+                    "FROM DatasetImageLink WHERE child.id = :id",
+                    new ParametersI().addId(image.getId().getValue()));
+            assertInGroup(originalFile, normalUser.groupId);
+            assertOwnedBy(originalFile, normalUser);
+            assertInGroup(image, normalUser.groupId);
+            assertOwnedBy(image, normalUser);
+            assertOwnedBy(imageDatasetLink, normalUser);
+            assertOwnedBy(projectDatasetLink, normalUser);
         }
     }
 
@@ -330,61 +330,61 @@ public class LightAdminRolesTest extends RolesTests {
         final ProjectDatasetLink projectDatasetLink;
         final DatasetImageLink datasetImageLink;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        sentProj = (Project) iUpdate.saveAndReturnObject(mmFactory.simpleProject());
-        sentDat = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset());
-        /* Import an image for the normalUser into the normalUser's default group
-         * and target it into the created Dataset.*/
-        List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
-        originalFile = (OriginalFile) originalFileAndImage.get(0);
-        image = (Image) originalFileAndImage.get(1);
-        assertOwnedBy(image, normalUser);
-        /* Link the Project and the Dataset.*/
-        projectDatasetLink = linkParentToChild(sentProj, sentDat);
-        datasetImageLink = (DatasetImageLink) iQuery.findByQuery(
-                "FROM DatasetImageLink WHERE child.id = :id",
-                new ParametersI().addId(image.getId()));
+            sentProj = (Project) iUpdate.saveAndReturnObject(mmFactory.simpleProject());
+            sentDat = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset());
+            /* Import an image for the normalUser into the normalUser's default group
+             * and target it into the created Dataset.*/
+            List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
+            originalFile = (OriginalFile) originalFileAndImage.get(0);
+            image = (Image) originalFileAndImage.get(1);
+            assertOwnedBy(image, normalUser);
+            /* Link the Project and the Dataset.*/
+            projectDatasetLink = linkParentToChild(sentProj, sentDat);
+            datasetImageLink = (DatasetImageLink) iQuery.findByQuery(
+                    "FROM DatasetImageLink WHERE child.id = :id",
+                    new ParametersI().addId(image.getId()));
         }
         /* Take care of post-import workflows which do not use sudo.*/
         if (!isSudoing) {
             loginUser(lightAdmin);
         }
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        /* Check that lightAdmin can delete the objects
-         * created on behalf of normalUser only if lightAdmin has sufficient permissions.
-         * Note that deletion of the Project
-         * would delete the whole hierarchy, which was successfully tested
-         * during writing of this test. The order of the below delete() commands
-         * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
-         * tested in this way.
-         * Also check that the canDelete boolean on the object retrieved
-         * by the lightAdmin matches the deletePassing boolean.*/
-        Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
+            /* Check that lightAdmin can delete the objects
+             * created on behalf of normalUser only if lightAdmin has sufficient permissions.
+             * Note that deletion of the Project
+             * would delete the whole hierarchy, which was successfully tested
+             * during writing of this test. The order of the below delete() commands
+             * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
+             * tested in this way.
+             * Also check that the canDelete boolean on the object retrieved
+             * by the lightAdmin matches the deletePassing boolean.*/
+            Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
 
-        /* Check the existence/non-existence of the objects as appropriate.*/
-        if (deletePassing) {
-            assertDoesNotExist(originalFile);
-            assertDoesNotExist(image);
-            assertDoesNotExist(sentDat);
-            assertDoesNotExist(sentProj);
-            assertDoesNotExist(datasetImageLink);
-            assertDoesNotExist(projectDatasetLink);
-        } else {
-            assertExists(originalFile);
-            assertExists(image);
-            assertExists(sentDat);
-            assertExists(sentProj);
-            assertExists(datasetImageLink);
-            assertExists(projectDatasetLink);
-        }
+            /* Check the existence/non-existence of the objects as appropriate.*/
+            if (deletePassing) {
+                assertDoesNotExist(originalFile);
+                assertDoesNotExist(image);
+                assertDoesNotExist(sentDat);
+                assertDoesNotExist(sentProj);
+                assertDoesNotExist(datasetImageLink);
+                assertDoesNotExist(projectDatasetLink);
+            } else {
+                assertExists(originalFile);
+                assertExists(image);
+                assertExists(sentDat);
+                assertExists(sentProj);
+                assertExists(datasetImageLink);
+                assertExists(projectDatasetLink);
+            }
         }
     }
 
@@ -440,25 +440,25 @@ public class LightAdminRolesTest extends RolesTests {
             loginUser(otherUser);
         }
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        /* Check that lightAdmin or otherUser can delete the objects
-         * of normalUser only if lightAdmin has sufficient permissions or it is read-write group.
-         * Note that deletion of the Project
-         * would delete the whole hierarchy, which was successfully tested
-         * during writing of this test. The order of the below delete() commands
-         * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
-         * tested in this way.
-         * Also check that the canDelete boolean on the object retrieved by the lightAdmin
-         * or otherUser matches the deletePassing boolean.*/
-        Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
-        Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
-        doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
+            /* Check that lightAdmin or otherUser can delete the objects
+             * of normalUser only if lightAdmin has sufficient permissions or it is read-write group.
+             * Note that deletion of the Project
+             * would delete the whole hierarchy, which was successfully tested
+             * during writing of this test. The order of the below delete() commands
+             * is intentional, as the ability to delete the links and Project/Dataset/Image separately is
+             * tested in this way.
+             * Also check that the canDelete boolean on the object retrieved by the lightAdmin
+             * or otherUser matches the deletePassing boolean.*/
+            Assert.assertEquals(getCurrentPermissions(datasetImageLink).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(datasetImageLink).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(projectDatasetLink).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(projectDatasetLink).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(image).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(image).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(sentDat).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(sentDat).build(), deletePassing);
+            Assert.assertEquals(getCurrentPermissions(sentProj).canDelete(), deletePassing);
+            doChange(client, factory, Requests.delete().target(sentProj).build(), deletePassing);
         }
 
         /* Check the existence/non-existence of the objects as appropriate.*/
@@ -490,7 +490,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @param isPrivileged if to test a user who has the <tt>DeleteOwned</tt> privilege
      * @param groupPermissions to test the effect of group permission level
      * @throws Exception unexpected
-    */
+     */
     @Test(dataProvider = "isPrivileged cases")
     public void testDeleteGroupOwner(boolean isPrivileged,
             String groupPermissions) throws Exception {
@@ -525,19 +525,19 @@ public class LightAdminRolesTest extends RolesTests {
          * boolean.*/
         loginUser(lightAdmin);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(sentDataset).canDelete(), deletePassingOwnedGroup);
-        doChange(client, factory, Requests.delete().target(sentDataset).build(), deletePassingOwnedGroup);
+            Assert.assertEquals(getCurrentPermissions(sentDataset).canDelete(), deletePassingOwnedGroup);
+            doChange(client, factory, Requests.delete().target(sentDataset).build(), deletePassingOwnedGroup);
         }
         try (final AutoCloseable igc = new ImplicitGroupContext(otherUser.groupId)) {
-        Assert.assertEquals(getCurrentPermissions(sentOtherDataset).canDelete(), deletePassingNotOwnedGroup);
-        doChange(client, factory, Requests.delete().target(sentOtherDataset).build(), deletePassingNotOwnedGroup);
-        /* Check the existence/non-existence of the objects as appropriate.*/
-        assertDoesNotExist(sentDataset);
-        if (deletePassingNotOwnedGroup) {
-            assertDoesNotExist(sentOtherDataset);
-        } else {
-            assertExists(sentOtherDataset);
-        }
+            Assert.assertEquals(getCurrentPermissions(sentOtherDataset).canDelete(), deletePassingNotOwnedGroup);
+            doChange(client, factory, Requests.delete().target(sentOtherDataset).build(), deletePassingNotOwnedGroup);
+            /* Check the existence/non-existence of the objects as appropriate.*/
+            assertDoesNotExist(sentDataset);
+            if (deletePassingNotOwnedGroup) {
+                assertDoesNotExist(sentOtherDataset);
+            } else {
+                assertExists(sentOtherDataset);
+            }
         }
     }
 
@@ -577,17 +577,17 @@ public class LightAdminRolesTest extends RolesTests {
         /* Try to rename the Project.*/
         final String changedName = "ChangedNameOfLightAdmin";
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        long id = sentProj.getId().getValue();
-        final Project retrievedUnrenamedProject = (Project) iQuery.get("Project", id);
-        retrievedUnrenamedProject.setName(omero.rtypes.rstring(changedName));
-        /* Check that lightAdmin can edit the Project of normalUser only when
-         * lightAdmin is equipped with sufficient permissions, captured in boolean isExpectSuccess.*/
-        try {
-            sentProj = (Project) iUpdate.saveAndReturnObject(retrievedUnrenamedProject);
-            Assert.assertTrue(isExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccess, se.toString());
-        }
+            long id = sentProj.getId().getValue();
+            final Project retrievedUnrenamedProject = (Project) iQuery.get("Project", id);
+            retrievedUnrenamedProject.setName(omero.rtypes.rstring(changedName));
+            /* Check that lightAdmin can edit the Project of normalUser only when
+             * lightAdmin is equipped with sufficient permissions, captured in boolean isExpectSuccess.*/
+            try {
+                sentProj = (Project) iUpdate.saveAndReturnObject(retrievedUnrenamedProject);
+                Assert.assertTrue(isExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccess, se.toString());
+            }
         }
         String savedChangedName = sentProj.getName().getValue().toString();
         logRootIntoGroup(normalUser.groupId);
@@ -662,26 +662,26 @@ public class LightAdminRolesTest extends RolesTests {
         }
         /* In order to find the image in whatever group, get to all groups context.*/
         try (final AutoCloseable igc = new ImplicitAllGroupsContext()) {
-        /* lightAdmin tries to move the image into another group of the normalUser
-         * which should succeed if sudoing and also in case
-         * the light admin has Chgrp permissions
-         * (i.e. isExpectSuccessInMemberGroup is true). Also check that
-         * the canChgrp boolean matches the isExpectSuccessInMemberGroup boolean value */
-        Assert.assertEquals(getCurrentPermissions(image).canChgrp(), isExpectSuccessInMemberGroup);
-        doChange(client, factory, Requests.chgrp().target(image).toGroup(normalUsersOtherGroupId).build(), isExpectSuccessInMemberGroup);
-        if (isExpectSuccessInMemberGroup) {
-            assertInGroup(image, normalUsersOtherGroupId);
-            assertInGroup(originalFile, normalUsersOtherGroupId);
-            /* Annotations on the image changed the group with the image.*/
-            assertInGroup(annotOriginalFileAnnotationTagAndLinks, normalUsersOtherGroupId);
-        } else {
-            assertInGroup(image, normalUser.groupId);
-            assertInGroup(originalFile, normalUser.groupId);
-            /* The annotations were not moved.*/
-            assertInGroup(annotOriginalFileAnnotationTagAndLinks, normalUser.groupId);
-        }
-        /* In any case, the image should still belong to normalUser.*/
-        assertOwnedBy(image, normalUser);
+            /* lightAdmin tries to move the image into another group of the normalUser
+             * which should succeed if sudoing and also in case
+             * the light admin has Chgrp permissions
+             * (i.e. isExpectSuccessInMemberGroup is true). Also check that
+             * the canChgrp boolean matches the isExpectSuccessInMemberGroup boolean value */
+            Assert.assertEquals(getCurrentPermissions(image).canChgrp(), isExpectSuccessInMemberGroup);
+            doChange(client, factory, Requests.chgrp().target(image).toGroup(normalUsersOtherGroupId).build(), isExpectSuccessInMemberGroup);
+            if (isExpectSuccessInMemberGroup) {
+                assertInGroup(image, normalUsersOtherGroupId);
+                assertInGroup(originalFile, normalUsersOtherGroupId);
+                /* Annotations on the image changed the group with the image.*/
+                assertInGroup(annotOriginalFileAnnotationTagAndLinks, normalUsersOtherGroupId);
+            } else {
+                assertInGroup(image, normalUser.groupId);
+                assertInGroup(originalFile, normalUser.groupId);
+                /* The annotations were not moved.*/
+                assertInGroup(annotOriginalFileAnnotationTagAndLinks, normalUser.groupId);
+            }
+            /* In any case, the image should still belong to normalUser.*/
+            assertOwnedBy(image, normalUser);
         }
     }
 
@@ -749,29 +749,29 @@ public class LightAdminRolesTest extends RolesTests {
         /* In order to find the image in whatever group, get all groups context.*/
         try (final AutoCloseable igc = new ImplicitAllGroupsContext()) {
 
-        /* Try to move the image into anotherGroup the normalUser
-         * is not a member of, which should fail in all cases
-         * except the lightAdmin has Chgrp permission and is not sudoing
-         * (i.e. chgrpNoSudoExpectSuccessAnyGroup is true). Also check the
-         * the canChgrp boolean.*/
-        Assert.assertEquals(getCurrentPermissions(image).canChgrp(), canChgrpExpectedTrue);
-        doChange(client, factory, Requests.chgrp().target(image).toGroup(anotherGroupId).build(),
-                chgrpNonMemberExpectSuccess);
-        if (chgrpNonMemberExpectSuccess) {
-            /* Check that the image and its original file moved to another group.*/
-            assertInGroup(image, anotherGroupId);
-            assertInGroup(originalFile, anotherGroupId);
-            /* check the annotations on the image changed the group as expected */
-            assertInGroup(annotOriginalFileAnnotationTagAndLinks, anotherGroupId);
-        } else {
-            /* Check that the image is still in its original group (normalUser's group).*/
-            assertInGroup(image, normalUser.groupId);
-            assertInGroup(originalFile, normalUser.groupId);
-            /* The annotations stayed with the image in the normalUser's group.*/
-            assertInGroup(annotOriginalFileAnnotationTagAndLinks, normalUser.groupId);
-        }
-        /* In any case, the image should still belong to normalUser.*/
-        assertOwnedBy(image, normalUser);
+            /* Try to move the image into anotherGroup the normalUser
+             * is not a member of, which should fail in all cases
+             * except the lightAdmin has Chgrp permission and is not sudoing
+             * (i.e. chgrpNoSudoExpectSuccessAnyGroup is true). Also check the
+             * the canChgrp boolean.*/
+            Assert.assertEquals(getCurrentPermissions(image).canChgrp(), canChgrpExpectedTrue);
+            doChange(client, factory, Requests.chgrp().target(image).toGroup(anotherGroupId).build(),
+                    chgrpNonMemberExpectSuccess);
+            if (chgrpNonMemberExpectSuccess) {
+                /* Check that the image and its original file moved to another group.*/
+                assertInGroup(image, anotherGroupId);
+                assertInGroup(originalFile, anotherGroupId);
+                /* check the annotations on the image changed the group as expected */
+                assertInGroup(annotOriginalFileAnnotationTagAndLinks, anotherGroupId);
+            } else {
+                /* Check that the image is still in its original group (normalUser's group).*/
+                assertInGroup(image, normalUser.groupId);
+                assertInGroup(originalFile, normalUser.groupId);
+                /* The annotations stayed with the image in the normalUser's group.*/
+                assertInGroup(annotOriginalFileAnnotationTagAndLinks, normalUser.groupId);
+            }
+            /* In any case, the image should still belong to normalUser.*/
+            assertOwnedBy(image, normalUser);
         }
     }
 
@@ -833,39 +833,39 @@ public class LightAdminRolesTest extends RolesTests {
         Assert.assertEquals(getCurrentPermissions(image).canChown(), chownImagePassing);
         /* Get into correct group context and check all cases.*/
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        /* lightAdmin tries to chown the image.*/
-        doChange(client, factory, Requests.chown().target(image).toUser(anotherUser.userId).build(), chownImagePassing);
-        /* ChecK the results of the chown when lightAdmin is sudoed,
-         * which should fail in any case.*/
-        if (isSudoing) {
-            assertOwnedBy(image, normalUser);
-            assertOwnedBy(originalFile, normalUser);
-            assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, normalUser);
-        /* Check the chown was successful for both the image and the annotations
-         * when the permissions for chowning both
-         * the image as well as the annotations on it are sufficient.*/
-        } else if (chownImagePassing && annotationsChownExpectSuccess) {
-            assertOwnedBy(image, anotherUser);
-            assertOwnedBy(originalFile, anotherUser);
-            /* Annotations will be chowned because
-             * groupPermissions are private or read-only (captured in boolean
-             * annotationsChownExpectSuccess).*/
-            assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, anotherUser);
-        /* Check the chown was successful for the image but not the annotations
-         * in case the annotationsChownExpectSuccess is false, i.e. in read-only and private group.*/
-        } else if (chownImagePassing && !annotationsChownExpectSuccess){
-            assertOwnedBy(image, anotherUser);
-            assertOwnedBy(originalFile, anotherUser);
-            assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, normalUser);
-        } else {
-        /* In the remaining case, the chown will fail, as the chownPassingWhenNotSudoing
-         * is false because permChown was not given. All objects belong to normalUser.*/
-            assertOwnedBy(image, normalUser);
-            assertOwnedBy(originalFile, normalUser);
-            assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, normalUser);
-        }
-        /* In any case, the image must be in the right group.*/
-        assertInGroup(image, normalUser.groupId);
+            /* lightAdmin tries to chown the image.*/
+            doChange(client, factory, Requests.chown().target(image).toUser(anotherUser.userId).build(), chownImagePassing);
+            /* ChecK the results of the chown when lightAdmin is sudoed,
+             * which should fail in any case.*/
+            if (isSudoing) {
+                assertOwnedBy(image, normalUser);
+                assertOwnedBy(originalFile, normalUser);
+                assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, normalUser);
+                /* Check the chown was successful for both the image and the annotations
+                 * when the permissions for chowning both
+                 * the image as well as the annotations on it are sufficient.*/
+            } else if (chownImagePassing && annotationsChownExpectSuccess) {
+                assertOwnedBy(image, anotherUser);
+                assertOwnedBy(originalFile, anotherUser);
+                /* Annotations will be chowned because
+                 * groupPermissions are private or read-only (captured in boolean
+                 * annotationsChownExpectSuccess).*/
+                assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, anotherUser);
+                /* Check the chown was successful for the image but not the annotations
+                 * in case the annotationsChownExpectSuccess is false, i.e. in read-only and private group.*/
+            } else if (chownImagePassing && !annotationsChownExpectSuccess){
+                assertOwnedBy(image, anotherUser);
+                assertOwnedBy(originalFile, anotherUser);
+                assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, normalUser);
+            } else {
+                /* In the remaining case, the chown will fail, as the chownPassingWhenNotSudoing
+                 * is false because permChown was not given. All objects belong to normalUser.*/
+                assertOwnedBy(image, normalUser);
+                assertOwnedBy(originalFile, normalUser);
+                assertOwnedBy(annotOriginalFileAnnotationTagAndLinks, normalUser);
+            }
+            /* In any case, the image must be in the right group.*/
+            assertInGroup(image, normalUser.groupId);
         }
     }
 
@@ -911,72 +911,72 @@ public class LightAdminRolesTest extends RolesTests {
         /* lightAdmin creates Dataset in the normalUser's group
          * (lightAdmin is not member of that group).*/
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Dataset dat = mmFactory.simpleDataset();
-        Dataset sentDat = null;
-        /* Creation of Dataset success is governed by
-         * createDatasetExpectSuccess boolean (defined above).*/
-        try {
-            sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
-            Assert.assertTrue(createDatasetExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(createDatasetExpectSuccess, se.toString());
-        }
-        /* As lightAdmin, import an Image into the created Dataset.*/
-        OriginalFile originalFile = null;
-        Image image = null;
-        /* Import success is governed by importNotYourGroupExpectSuccess boolean (defined above).*/
-        try {
-            List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
-            originalFile = (OriginalFile) originalFileAndImage.get(0);
-            image = (Image) originalFileAndImage.get(1);
-            Assert.assertTrue(importNotYourGroupExpectSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(importNotYourGroupExpectSuccess, se.toString());
-        }
-        /* Check the ownership and group of the original file and the image.*/
-        if (importNotYourGroupExpectSuccess) {
-            assertOwnedBy(originalFile, lightAdmin);
-            assertInGroup(originalFile, normalUser.groupId);
-            assertOwnedBy(image, lightAdmin);
-            assertInGroup(image, normalUser.groupId);
-        /* In case the import was not successful, Image does not exist.
-         * Further testing is not interesting in such case.*/
-        } else {
-            Assert.assertNull(originalFile, "if import failed, the originalFile should be null");
-            Assert.assertNull(image, "if import failed, the image should be null");
-            return;
-        }
-        /* Check that the canChown value on the Dataset matches the boolean
-         * createDatasetImportNotYourGroupAndChownExpectSuccess.*/
-        Assert.assertEquals(getCurrentPermissions(sentDat).canChown(),
-                createDatasetImportNotYourGroupAndChownExpectSuccess);
-        /* lightAdmin tries to change the ownership of the Dataset to normalUser.*/
-        doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(),
-                createDatasetImportNotYourGroupAndChownExpectSuccess);
-        final DatasetImageLink link = (DatasetImageLink) iQuery.findByQuery(
-                "FROM DatasetImageLink WHERE parent.id = :id",
-                new ParametersI().addId(sentDat.getId()));
-        /* Check that image, dataset and link are in the normalUser's group
-         * and belong to normalUser in case the workflow succeeded.*/
-        if (createDatasetImportNotYourGroupAndChownExpectSuccess) {
-            assertOwnedBy(image, normalUser);
-            assertInGroup(image, normalUser.groupId);
-            assertOwnedBy(sentDat, normalUser);
-            assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy(link, normalUser);
-            assertInGroup(link, normalUser.groupId);
-            assertOwnedBy(originalFile, normalUser);
-            assertInGroup(originalFile, normalUser.groupId);
-        /* Check that the image, dataset and link still belong
-         * to lightAdmin as the chown failed, but are in the group of normalUser.*/
-        } else {
-            assertOwnedBy(image, lightAdmin);
-            assertInGroup(image, normalUser.groupId);
-            assertOwnedBy(sentDat, lightAdmin);
-            assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy(link, lightAdmin);
-            assertInGroup(link, normalUser.groupId);
-        }
+            Dataset dat = mmFactory.simpleDataset();
+            Dataset sentDat = null;
+            /* Creation of Dataset success is governed by
+             * createDatasetExpectSuccess boolean (defined above).*/
+            try {
+                sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+                Assert.assertTrue(createDatasetExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(createDatasetExpectSuccess, se.toString());
+            }
+            /* As lightAdmin, import an Image into the created Dataset.*/
+            OriginalFile originalFile = null;
+            Image image = null;
+            /* Import success is governed by importNotYourGroupExpectSuccess boolean (defined above).*/
+            try {
+                List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
+                originalFile = (OriginalFile) originalFileAndImage.get(0);
+                image = (Image) originalFileAndImage.get(1);
+                Assert.assertTrue(importNotYourGroupExpectSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(importNotYourGroupExpectSuccess, se.toString());
+            }
+            /* Check the ownership and group of the original file and the image.*/
+            if (importNotYourGroupExpectSuccess) {
+                assertOwnedBy(originalFile, lightAdmin);
+                assertInGroup(originalFile, normalUser.groupId);
+                assertOwnedBy(image, lightAdmin);
+                assertInGroup(image, normalUser.groupId);
+                /* In case the import was not successful, Image does not exist.
+                 * Further testing is not interesting in such case.*/
+            } else {
+                Assert.assertNull(originalFile, "if import failed, the originalFile should be null");
+                Assert.assertNull(image, "if import failed, the image should be null");
+                return;
+            }
+            /* Check that the canChown value on the Dataset matches the boolean
+             * createDatasetImportNotYourGroupAndChownExpectSuccess.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(),
+                    createDatasetImportNotYourGroupAndChownExpectSuccess);
+            /* lightAdmin tries to change the ownership of the Dataset to normalUser.*/
+            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(),
+                    createDatasetImportNotYourGroupAndChownExpectSuccess);
+            final DatasetImageLink link = (DatasetImageLink) iQuery.findByQuery(
+                    "FROM DatasetImageLink WHERE parent.id = :id",
+                    new ParametersI().addId(sentDat.getId()));
+            /* Check that image, dataset and link are in the normalUser's group
+             * and belong to normalUser in case the workflow succeeded.*/
+            if (createDatasetImportNotYourGroupAndChownExpectSuccess) {
+                assertOwnedBy(image, normalUser);
+                assertInGroup(image, normalUser.groupId);
+                assertOwnedBy(sentDat, normalUser);
+                assertInGroup(sentDat, normalUser.groupId);
+                assertOwnedBy(link, normalUser);
+                assertInGroup(link, normalUser.groupId);
+                assertOwnedBy(originalFile, normalUser);
+                assertInGroup(originalFile, normalUser.groupId);
+                /* Check that the image, dataset and link still belong
+                 * to lightAdmin as the chown failed, but are in the group of normalUser.*/
+            } else {
+                assertOwnedBy(image, lightAdmin);
+                assertInGroup(image, normalUser.groupId);
+                assertOwnedBy(sentDat, lightAdmin);
+                assertInGroup(sentDat, normalUser.groupId);
+                assertOwnedBy(link, lightAdmin);
+                assertInGroup(link, normalUser.groupId);
+            }
         }
     }
 
@@ -1015,68 +1015,68 @@ public class LightAdminRolesTest extends RolesTests {
         final Dataset sentDat;
         final Image sentImage;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Image image = mmFactory.createImage();
-        sentImage = (Image) iUpdate.saveAndReturnObject(image);
-        Dataset dat = mmFactory.simpleDataset();
-        sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
-        Project proj = mmFactory.simpleProject();
-        sentProj = (Project) iUpdate.saveAndReturnObject(proj);
+            Image image = mmFactory.createImage();
+            sentImage = (Image) iUpdate.saveAndReturnObject(image);
+            Dataset dat = mmFactory.simpleDataset();
+            sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+            Project proj = mmFactory.simpleProject();
+            sentProj = (Project) iUpdate.saveAndReturnObject(proj);
         }
         loginUser(lightAdmin);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        /* lightAdmin checks that the canLink value on all the objects to be linked
-         * matches the isExpectLinkingSuccess boolean.*/
-        Assert.assertEquals(getCurrentPermissions(sentImage).canLink(), isExpectLinkingSuccess);
-        Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), isExpectLinkingSuccess);
-        Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccess);
-        /* lightAdmin tries to create links between the image and Dataset
-         * and between Dataset and Project.
-         * If links could not be created, finish the test.*/
-        DatasetImageLink linkOfDatasetImage = new DatasetImageLinkI();
-        ProjectDatasetLink linkOfProjectDataset = new ProjectDatasetLinkI();
-        try {
-            linkOfDatasetImage = linkParentToChild(sentDat, sentImage);
-            linkOfProjectDataset = linkParentToChild(sentProj, sentDat);
-            Assert.assertTrue(isExpectLinkingSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectLinkingSuccess, se.toString());
-            return;
-        }
+            /* lightAdmin checks that the canLink value on all the objects to be linked
+             * matches the isExpectLinkingSuccess boolean.*/
+            Assert.assertEquals(getCurrentPermissions(sentImage).canLink(), isExpectLinkingSuccess);
+            Assert.assertEquals(getCurrentPermissions(sentDat).canLink(), isExpectLinkingSuccess);
+            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccess);
+            /* lightAdmin tries to create links between the image and Dataset
+             * and between Dataset and Project.
+             * If links could not be created, finish the test.*/
+            DatasetImageLink linkOfDatasetImage = new DatasetImageLinkI();
+            ProjectDatasetLink linkOfProjectDataset = new ProjectDatasetLinkI();
+            try {
+                linkOfDatasetImage = linkParentToChild(sentDat, sentImage);
+                linkOfProjectDataset = linkParentToChild(sentProj, sentDat);
+                Assert.assertTrue(isExpectLinkingSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectLinkingSuccess, se.toString());
+                return;
+            }
 
-        /* Check that the value of canChown boolean on the links is matching
-         * the isExpectSuccessLinkAndChown boolean.*/
-        Assert.assertEquals(getCurrentPermissions(linkOfDatasetImage).canChown(), isExpectSuccessLinkAndChown);
-        Assert.assertEquals(getCurrentPermissions(linkOfProjectDataset).canChown(), isExpectSuccessLinkAndChown);
+            /* Check that the value of canChown boolean on the links is matching
+             * the isExpectSuccessLinkAndChown boolean.*/
+            Assert.assertEquals(getCurrentPermissions(linkOfDatasetImage).canChown(), isExpectSuccessLinkAndChown);
+            Assert.assertEquals(getCurrentPermissions(linkOfProjectDataset).canChown(), isExpectSuccessLinkAndChown);
 
-        /* lightAdmin transfers the ownership of both links to normalUser.
-         * The success of the whole linking and chowning
-         * operation is captured in boolean isExpectSuccessLinkAndChown. Note that the
-         * ownership of the links must be transferred explicitly, as the Chown feature
-         * on the Project would not transfer ownership links owned by non-owners
-         * of the Project/Dataset/Image objects (chown on mixed ownership hierarchy does not chown objects
-         * owned by other users).*/
-        Chown2 chown = Requests.chown().target(linkOfDatasetImage).toUser(normalUser.userId).build();
-        doChange(client, factory, chown, isExpectSuccessLinkAndChown);
-        chown = Requests.chown().target(linkOfProjectDataset).toUser(normalUser.userId).build();
-        doChange(client, factory, chown, isExpectSuccessLinkAndChown);
+            /* lightAdmin transfers the ownership of both links to normalUser.
+             * The success of the whole linking and chowning
+             * operation is captured in boolean isExpectSuccessLinkAndChown. Note that the
+             * ownership of the links must be transferred explicitly, as the Chown feature
+             * on the Project would not transfer ownership links owned by non-owners
+             * of the Project/Dataset/Image objects (chown on mixed ownership hierarchy does not chown objects
+             * owned by other users).*/
+            Chown2 chown = Requests.chown().target(linkOfDatasetImage).toUser(normalUser.userId).build();
+            doChange(client, factory, chown, isExpectSuccessLinkAndChown);
+            chown = Requests.chown().target(linkOfProjectDataset).toUser(normalUser.userId).build();
+            doChange(client, factory, chown, isExpectSuccessLinkAndChown);
 
-        /* Check the ownership of the links, Image, Dataset and Project.*/
-        final long linkDatasetImageId = ((RLong) iQuery.projection(
-                "SELECT id FROM DatasetImageLink WHERE parent.id  = :id",
-                new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
-        final long linkProjectDatasetId = ((RLong) iQuery.projection(
-                "SELECT id FROM ProjectDatasetLink WHERE parent.id  = :id",
-                new ParametersI().addId(sentProj.getId())).get(0).get(0)).getValue();
-        assertOwnedBy(sentImage, normalUser);
-        assertOwnedBy(sentDat, normalUser);
-        assertOwnedBy(sentProj, normalUser);
-        if (isExpectSuccessLinkAndChown) {
-            assertOwnedBy((new DatasetImageLinkI(linkDatasetImageId, false)), normalUser);
-            assertOwnedBy((new ProjectDatasetLinkI(linkProjectDatasetId, false)), normalUser);
-        } else {
-            assertOwnedBy((new DatasetImageLinkI(linkDatasetImageId, false)), lightAdmin);
-            assertOwnedBy((new ProjectDatasetLinkI(linkProjectDatasetId, false)), lightAdmin);
-        }
+            /* Check the ownership of the links, Image, Dataset and Project.*/
+            final long linkDatasetImageId = ((RLong) iQuery.projection(
+                    "SELECT id FROM DatasetImageLink WHERE parent.id  = :id",
+                    new ParametersI().addId(sentDat.getId())).get(0).get(0)).getValue();
+            final long linkProjectDatasetId = ((RLong) iQuery.projection(
+                    "SELECT id FROM ProjectDatasetLink WHERE parent.id  = :id",
+                    new ParametersI().addId(sentProj.getId())).get(0).get(0)).getValue();
+            assertOwnedBy(sentImage, normalUser);
+            assertOwnedBy(sentDat, normalUser);
+            assertOwnedBy(sentProj, normalUser);
+            if (isExpectSuccessLinkAndChown) {
+                assertOwnedBy((new DatasetImageLinkI(linkDatasetImageId, false)), normalUser);
+                assertOwnedBy((new ProjectDatasetLinkI(linkProjectDatasetId, false)), normalUser);
+            } else {
+                assertOwnedBy((new DatasetImageLinkI(linkDatasetImageId, false)), lightAdmin);
+                assertOwnedBy((new ProjectDatasetLinkI(linkProjectDatasetId, false)), lightAdmin);
+            }
         }
     }
 
@@ -1130,24 +1130,24 @@ public class LightAdminRolesTest extends RolesTests {
             loginUser(otherUser);
         }
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Image ownImage = mmFactory.createImage();
-        Image sentOwnImage = (Image) iUpdate.saveAndReturnObject(ownImage);
-        Dataset ownDat = mmFactory.simpleDataset();
-        Dataset sentOwnDat = (Dataset) iUpdate.saveAndReturnObject(ownDat);
-        /* lightAdmin or otherUser checks that the canLink value on all the objects to be linked
-         * is true (for own image) and for other people's objects (sentProj, sentDat) the canLink
-         * are matching the expected behavior (see booleans isExpectLinkingSuccess... definitions).*/
-        Assert.assertTrue(getCurrentPermissions(sentOwnImage).canLink());
-        Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccess);
-        /* lightAdmin or otherUser try to create links between their own image and normalUser's Dataset
-         * and between their own Dataset and normalUser's Project.*/
-        try {
-            linkParentToChild(sentDat, sentOwnImage);
-            linkParentToChild(sentProj, sentOwnDat);
-            Assert.assertTrue(isExpectLinkingSuccess);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectLinkingSuccess, se.toString());
-        }
+            Image ownImage = mmFactory.createImage();
+            Image sentOwnImage = (Image) iUpdate.saveAndReturnObject(ownImage);
+            Dataset ownDat = mmFactory.simpleDataset();
+            Dataset sentOwnDat = (Dataset) iUpdate.saveAndReturnObject(ownDat);
+            /* lightAdmin or otherUser checks that the canLink value on all the objects to be linked
+             * is true (for own image) and for other people's objects (sentProj, sentDat) the canLink
+             * are matching the expected behavior (see booleans isExpectLinkingSuccess... definitions).*/
+            Assert.assertTrue(getCurrentPermissions(sentOwnImage).canLink());
+            Assert.assertEquals(getCurrentPermissions(sentProj).canLink(), isExpectLinkingSuccess);
+            /* lightAdmin or otherUser try to create links between their own image and normalUser's Dataset
+             * and between their own Dataset and normalUser's Project.*/
+            try {
+                linkParentToChild(sentDat, sentOwnImage);
+                linkParentToChild(sentProj, sentOwnDat);
+                Assert.assertTrue(isExpectLinkingSuccess);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectLinkingSuccess, se.toString());
+            }
         }
     }
 
@@ -1186,100 +1186,100 @@ public class LightAdminRolesTest extends RolesTests {
         final OriginalFile originalFile;
         final Image image;
         try (final AutoCloseable igc = new ImplicitGroupContext(lightAdmin.groupId)) {
-        Dataset dat = mmFactory.simpleDataset();
-        sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
-        /* Import an Image into the created Dataset.*/
-        List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
-        originalFile = (OriginalFile) originalFileAndImage.get(0);
-        image = (Image) originalFileAndImage.get(1);
-        /* Check that originalFile and the image
-         * corresponding to the originalFile are in the right group.*/
-        assertOwnedBy(originalFile, lightAdmin);
-        assertInGroup(originalFile, lightAdmin.groupId);
-        assertOwnedBy(image, lightAdmin);
-        assertInGroup(image, lightAdmin.groupId);
+            Dataset dat = mmFactory.simpleDataset();
+            sentDat = (Dataset) iUpdate.saveAndReturnObject(dat);
+            /* Import an Image into the created Dataset.*/
+            List<IObject> originalFileAndImage = importImageWithOriginalFile(sentDat);
+            originalFile = (OriginalFile) originalFileAndImage.get(0);
+            image = (Image) originalFileAndImage.get(1);
+            /* Check that originalFile and the image
+             * corresponding to the originalFile are in the right group.*/
+            assertOwnedBy(originalFile, lightAdmin);
+            assertInGroup(originalFile, lightAdmin.groupId);
+            assertOwnedBy(image, lightAdmin);
+            assertInGroup(image, lightAdmin.groupId);
         }
 
         /* In order to find the image in whatever group, get all groups context.*/
         try (final AutoCloseable igc = new ImplicitAllGroupsContext()) {
-        /* Check that the value of canChgrp on the dataset is true.
-         * Note that although the move into normalUser's group might fail,
-         * lightAdmin could be moving the dataset into some group where they are member,
-         * and thus the canChgrp must be "true".*/
-        Assert.assertTrue(getCurrentPermissions(sentDat).canChgrp());
-        /* lightAdmin tries to move the dataset (and with it the linked image)
-         * from lightAdmin's group to normalUser's group,
-         * which should succeed in case the light admin has Chgrp permissions.*/
-        doChange(client, factory, Requests.chgrp().target(sentDat).toGroup(normalUser.groupId).build(), permChgrp);
-        /* Check the group of the moved objects.*/
-        final DatasetImageLink datasetImageLink = (DatasetImageLink) iQuery.findByQuery(
-                "FROM DatasetImageLink WHERE parent.id = :id",
-                new ParametersI().addId(sentDat.getId()));
-        if (permChgrp) {
-            assertInGroup(originalFile, normalUser.groupId);
-            assertInGroup(image, normalUser.groupId);
-            assertInGroup(sentDat, normalUser.groupId);
-            assertInGroup(datasetImageLink, normalUser.groupId);
-        } else {
-            assertInGroup(originalFile, lightAdmin.groupId);
-            assertInGroup(image, lightAdmin.groupId);
-            assertInGroup(sentDat, lightAdmin.groupId);
-            assertInGroup(datasetImageLink, lightAdmin.groupId);
-        }
-        /* Check that the canChown boolean on Dataset is matching permChown boolean.*/
-        Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), permChown);
-        /* lightAdmin tries to transfer the ownership of Dataset to normalUser.
-         * Chowning the Dataset succeeds if lightAdmin has Chown privilege.
-         * Successful chowning of the dataset transfers the ownership of the linked image
-         * and the link too.*/
-        doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), permChown);
-        /* Boolean importYourGroupAndChgrpAndChownExpectSuccess
-         * captures permChown and permChgrp. Check the objects ownership and groups.*/
-        if (importYourGroupAndChgrpAndChownExpectSuccess) {
-            /* First case: The whole "import for others" workflow succeeds.
-             * Image, Dataset and link are in normalUser's group and belong to normalUser.*/
-            assertOwnedBy(originalFile, normalUser);
-            assertInGroup(originalFile, normalUser.groupId);
-            assertOwnedBy(image, normalUser);
-            assertInGroup(image, normalUser.groupId);
-            assertOwnedBy(sentDat, normalUser);
-            assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy(datasetImageLink, normalUser);
-            assertInGroup(datasetImageLink, normalUser.groupId);
-        } else if (permChown) {
-            /* Second case: Chown succeeds, but Chgrp fails.
-             * Image, Dataset and link belong to the normalUser, but are in lightAdmin's group */
-            assertOwnedBy(originalFile, normalUser);
-            assertInGroup(originalFile, lightAdmin.groupId);
-            assertOwnedBy(image, normalUser);
-            assertInGroup(image, lightAdmin.groupId);
-            assertOwnedBy(sentDat, normalUser);
-            assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy(datasetImageLink, normalUser);
-            assertInGroup(datasetImageLink, lightAdmin.groupId);
-        } else if (permChgrp) {
-            /* Third case: Chgrp succeeds, but Chown fails.
-             * Image, Dataset and link are in normalUser's group but belong to lightAdmin.*/
-            assertOwnedBy(originalFile, lightAdmin);
-            assertInGroup(originalFile, normalUser.groupId);
-            assertOwnedBy(image, lightAdmin);
-            assertInGroup(image, normalUser.groupId);
-            assertOwnedBy(sentDat, lightAdmin);
-            assertInGroup(sentDat, normalUser.groupId);
-            assertOwnedBy(datasetImageLink, lightAdmin);
-            assertInGroup(datasetImageLink, normalUser.groupId);
-        } else {
-            /* Fourth case: Ghgrp and Chown both fail.
-             * Image, Dataset and link are in lightAdmin's group and belong to lightAdmin.*/
-            assertOwnedBy(originalFile, lightAdmin);
-            assertInGroup(originalFile, lightAdmin.groupId);
-            assertOwnedBy(image, lightAdmin);
-            assertInGroup(image, lightAdmin.groupId);
-            assertOwnedBy(sentDat, lightAdmin);
-            assertInGroup(sentDat, lightAdmin.groupId);
-            assertOwnedBy(datasetImageLink, lightAdmin);
-            assertInGroup(datasetImageLink, lightAdmin.groupId);
-        }
+            /* Check that the value of canChgrp on the dataset is true.
+             * Note that although the move into normalUser's group might fail,
+             * lightAdmin could be moving the dataset into some group where they are member,
+             * and thus the canChgrp must be "true".*/
+            Assert.assertTrue(getCurrentPermissions(sentDat).canChgrp());
+            /* lightAdmin tries to move the dataset (and with it the linked image)
+             * from lightAdmin's group to normalUser's group,
+             * which should succeed in case the light admin has Chgrp permissions.*/
+            doChange(client, factory, Requests.chgrp().target(sentDat).toGroup(normalUser.groupId).build(), permChgrp);
+            /* Check the group of the moved objects.*/
+            final DatasetImageLink datasetImageLink = (DatasetImageLink) iQuery.findByQuery(
+                    "FROM DatasetImageLink WHERE parent.id = :id",
+                    new ParametersI().addId(sentDat.getId()));
+            if (permChgrp) {
+                assertInGroup(originalFile, normalUser.groupId);
+                assertInGroup(image, normalUser.groupId);
+                assertInGroup(sentDat, normalUser.groupId);
+                assertInGroup(datasetImageLink, normalUser.groupId);
+            } else {
+                assertInGroup(originalFile, lightAdmin.groupId);
+                assertInGroup(image, lightAdmin.groupId);
+                assertInGroup(sentDat, lightAdmin.groupId);
+                assertInGroup(datasetImageLink, lightAdmin.groupId);
+            }
+            /* Check that the canChown boolean on Dataset is matching permChown boolean.*/
+            Assert.assertEquals(getCurrentPermissions(sentDat).canChown(), permChown);
+            /* lightAdmin tries to transfer the ownership of Dataset to normalUser.
+             * Chowning the Dataset succeeds if lightAdmin has Chown privilege.
+             * Successful chowning of the dataset transfers the ownership of the linked image
+             * and the link too.*/
+            doChange(client, factory, Requests.chown().target(sentDat).toUser(normalUser.userId).build(), permChown);
+            /* Boolean importYourGroupAndChgrpAndChownExpectSuccess
+             * captures permChown and permChgrp. Check the objects ownership and groups.*/
+            if (importYourGroupAndChgrpAndChownExpectSuccess) {
+                /* First case: The whole "import for others" workflow succeeds.
+                 * Image, Dataset and link are in normalUser's group and belong to normalUser.*/
+                assertOwnedBy(originalFile, normalUser);
+                assertInGroup(originalFile, normalUser.groupId);
+                assertOwnedBy(image, normalUser);
+                assertInGroup(image, normalUser.groupId);
+                assertOwnedBy(sentDat, normalUser);
+                assertInGroup(sentDat, normalUser.groupId);
+                assertOwnedBy(datasetImageLink, normalUser);
+                assertInGroup(datasetImageLink, normalUser.groupId);
+            } else if (permChown) {
+                /* Second case: Chown succeeds, but Chgrp fails.
+                 * Image, Dataset and link belong to the normalUser, but are in lightAdmin's group */
+                assertOwnedBy(originalFile, normalUser);
+                assertInGroup(originalFile, lightAdmin.groupId);
+                assertOwnedBy(image, normalUser);
+                assertInGroup(image, lightAdmin.groupId);
+                assertOwnedBy(sentDat, normalUser);
+                assertInGroup(sentDat, lightAdmin.groupId);
+                assertOwnedBy(datasetImageLink, normalUser);
+                assertInGroup(datasetImageLink, lightAdmin.groupId);
+            } else if (permChgrp) {
+                /* Third case: Chgrp succeeds, but Chown fails.
+                 * Image, Dataset and link are in normalUser's group but belong to lightAdmin.*/
+                assertOwnedBy(originalFile, lightAdmin);
+                assertInGroup(originalFile, normalUser.groupId);
+                assertOwnedBy(image, lightAdmin);
+                assertInGroup(image, normalUser.groupId);
+                assertOwnedBy(sentDat, lightAdmin);
+                assertInGroup(sentDat, normalUser.groupId);
+                assertOwnedBy(datasetImageLink, lightAdmin);
+                assertInGroup(datasetImageLink, normalUser.groupId);
+            } else {
+                /* Fourth case: Ghgrp and Chown both fail.
+                 * Image, Dataset and link are in lightAdmin's group and belong to lightAdmin.*/
+                assertOwnedBy(originalFile, lightAdmin);
+                assertInGroup(originalFile, lightAdmin.groupId);
+                assertOwnedBy(image, lightAdmin);
+                assertInGroup(image, lightAdmin.groupId);
+                assertOwnedBy(sentDat, lightAdmin);
+                assertInGroup(sentDat, lightAdmin.groupId);
+                assertOwnedBy(datasetImageLink, lightAdmin);
+                assertInGroup(datasetImageLink, lightAdmin.groupId);
+            }
         }
     }
 
@@ -1313,22 +1313,22 @@ public class LightAdminRolesTest extends RolesTests {
         final DatasetImageLink linkOfDatasetImage1, linkOfDatasetImage2;
         final ProjectDatasetLink linkOfProjectDataset1, linkOfProjectDataset2;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        Image image1 = mmFactory.createImage();
-        Image image2 = mmFactory.createImage();
-        sentImage1 = (Image) iUpdate.saveAndReturnObject(image1);
-        sentImage2 = (Image) iUpdate.saveAndReturnObject(image2);
-        Dataset dat1 = mmFactory.simpleDataset();
-        Dataset dat2 = mmFactory.simpleDataset();
-        sentDat1 = (Dataset) iUpdate.saveAndReturnObject(dat1);
-        sentDat2 = (Dataset) iUpdate.saveAndReturnObject(dat2);
-        Project proj1 = mmFactory.simpleProject();
-        Project proj2 = mmFactory.simpleProject();
-        sentProj1 = (Project) iUpdate.saveAndReturnObject(proj1);
-        sentProj2 = (Project) iUpdate.saveAndReturnObject(proj2);
-        linkOfDatasetImage1 = linkParentToChild(sentDat1, sentImage1);
-        linkOfDatasetImage2 = linkParentToChild(sentDat2, sentImage2);
-        linkOfProjectDataset1 = linkParentToChild(sentProj1, sentDat1);
-        linkOfProjectDataset2 = linkParentToChild(sentProj2, sentDat2);
+            Image image1 = mmFactory.createImage();
+            Image image2 = mmFactory.createImage();
+            sentImage1 = (Image) iUpdate.saveAndReturnObject(image1);
+            sentImage2 = (Image) iUpdate.saveAndReturnObject(image2);
+            Dataset dat1 = mmFactory.simpleDataset();
+            Dataset dat2 = mmFactory.simpleDataset();
+            sentDat1 = (Dataset) iUpdate.saveAndReturnObject(dat1);
+            sentDat2 = (Dataset) iUpdate.saveAndReturnObject(dat2);
+            Project proj1 = mmFactory.simpleProject();
+            Project proj2 = mmFactory.simpleProject();
+            sentProj1 = (Project) iUpdate.saveAndReturnObject(proj1);
+            sentProj2 = (Project) iUpdate.saveAndReturnObject(proj2);
+            linkOfDatasetImage1 = linkParentToChild(sentDat1, sentImage1);
+            linkOfDatasetImage2 = linkParentToChild(sentDat2, sentImage2);
+            linkOfProjectDataset1 = linkParentToChild(sentProj1, sentDat1);
+            linkOfProjectDataset2 = linkParentToChild(sentProj2, sentDat2);
         }
 
         /* normalUser creates two sets of Project/Dataset?Image hierarchy in the other group (anotherGroup).*/
@@ -1338,62 +1338,62 @@ public class LightAdminRolesTest extends RolesTests {
         final DatasetImageLink linkOfDatasetImage1AnotherGroup, linkOfDatasetImage2AnotherGroup;
         final ProjectDatasetLink linkOfProjectDataset1AnotherGroup, linkOfProjectDataset2AnotherGroup;
         try (final AutoCloseable igc = new ImplicitGroupContext(anotherGroup.getId())) {
-        Image image1AnotherGroup = mmFactory.createImage();
-        Image image2AnotherGroup = mmFactory.createImage();
-        sentImage1AnotherGroup = (Image) iUpdate.saveAndReturnObject(image1AnotherGroup);
-        sentImage2AnotherGroup = (Image) iUpdate.saveAndReturnObject(image2AnotherGroup);
-        Dataset dat1AnotherGroup = mmFactory.simpleDataset();
-        Dataset dat2AnotherGroup = mmFactory.simpleDataset();
-        sentDat1AnotherGroup = (Dataset) iUpdate.saveAndReturnObject(dat1AnotherGroup);
-        sentDat2AnotherGroup = (Dataset) iUpdate.saveAndReturnObject(dat2AnotherGroup);
-        Project proj1AnotherGroup = mmFactory.simpleProject();
-        Project proj2AnotherGroup = mmFactory.simpleProject();
-        sentProj1AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj1AnotherGroup);
-        sentProj2AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj2AnotherGroup);
-        linkOfDatasetImage1AnotherGroup = linkParentToChild(sentDat1AnotherGroup, sentImage1AnotherGroup);
-        linkOfDatasetImage2AnotherGroup = linkParentToChild(sentDat2AnotherGroup, sentImage2AnotherGroup);
-        linkOfProjectDataset1AnotherGroup = linkParentToChild(sentProj1AnotherGroup, sentDat1AnotherGroup);
-        linkOfProjectDataset2AnotherGroup = linkParentToChild(sentProj2AnotherGroup, sentDat2AnotherGroup);
+            Image image1AnotherGroup = mmFactory.createImage();
+            Image image2AnotherGroup = mmFactory.createImage();
+            sentImage1AnotherGroup = (Image) iUpdate.saveAndReturnObject(image1AnotherGroup);
+            sentImage2AnotherGroup = (Image) iUpdate.saveAndReturnObject(image2AnotherGroup);
+            Dataset dat1AnotherGroup = mmFactory.simpleDataset();
+            Dataset dat2AnotherGroup = mmFactory.simpleDataset();
+            sentDat1AnotherGroup = (Dataset) iUpdate.saveAndReturnObject(dat1AnotherGroup);
+            sentDat2AnotherGroup = (Dataset) iUpdate.saveAndReturnObject(dat2AnotherGroup);
+            Project proj1AnotherGroup = mmFactory.simpleProject();
+            Project proj2AnotherGroup = mmFactory.simpleProject();
+            sentProj1AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj1AnotherGroup);
+            sentProj2AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj2AnotherGroup);
+            linkOfDatasetImage1AnotherGroup = linkParentToChild(sentDat1AnotherGroup, sentImage1AnotherGroup);
+            linkOfDatasetImage2AnotherGroup = linkParentToChild(sentDat2AnotherGroup, sentImage2AnotherGroup);
+            linkOfProjectDataset1AnotherGroup = linkParentToChild(sentProj1AnotherGroup, sentDat1AnotherGroup);
+            linkOfProjectDataset2AnotherGroup = linkParentToChild(sentProj2AnotherGroup, sentDat2AnotherGroup);
         }
         /* lightAdmin tries to transfers all normalUser's data to recipient.*/
         loginUser(lightAdmin);
         /* In order to be able to operate in both groups, get all groups context.*/
         try (final AutoCloseable igc = new ImplicitAllGroupsContext()) {
-        /* Check on one selected object only (sentProj1AnotherGroup) the value
-         * of canChown. The value must match the chownPassing boolean.*/
-        Assert.assertEquals(getCurrentPermissions(sentProj1AnotherGroup).canChown(), chownPassing);
-        /* Check that transfer proceeds only if chownPassing boolean is true.*/
-        doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), chownPassing);
-        if (!chownPassing) {
-            /* Finish the test if no transfer of data could proceed.*/
-            return;
-        }
-        /* Check the transfer of all the data in normalUser's group was successful,
-         * first checking ownership of the first hierarchy set.*/
-        assertOwnedBy(sentProj1, recipient);
-        assertOwnedBy(sentDat1, recipient);
-        assertOwnedBy(sentImage1, recipient);
-        assertOwnedBy(linkOfDatasetImage1, recipient);
-        assertOwnedBy(linkOfProjectDataset1, recipient);
-        /* Check ownership of the second hierarchy set.*/
-        assertOwnedBy(sentProj2, recipient);
-        assertOwnedBy(sentDat2, recipient);
-        assertOwnedBy(sentImage2, recipient);
-        assertOwnedBy(linkOfDatasetImage2, recipient);
-        assertOwnedBy(linkOfProjectDataset2, recipient);
-        /* Check ownership of the objects in anotherGroup,
-         * first checking ownership of the first hierarchy.*/
-        assertOwnedBy(sentProj1AnotherGroup, recipient);
-        assertOwnedBy(sentDat1AnotherGroup, recipient);
-        assertOwnedBy(sentImage1AnotherGroup, recipient);
-        assertOwnedBy(linkOfDatasetImage1AnotherGroup, recipient);
-        assertOwnedBy(linkOfProjectDataset1AnotherGroup, recipient);
-        /* Check ownership of the second hierarchy set in anotherGroup.*/
-        assertOwnedBy(sentProj2AnotherGroup, recipient);
-        assertOwnedBy(sentDat2AnotherGroup, recipient);
-        assertOwnedBy(sentImage1AnotherGroup, recipient);
-        assertOwnedBy(linkOfDatasetImage2AnotherGroup, recipient);
-        assertOwnedBy(linkOfProjectDataset2AnotherGroup, recipient);
+            /* Check on one selected object only (sentProj1AnotherGroup) the value
+             * of canChown. The value must match the chownPassing boolean.*/
+            Assert.assertEquals(getCurrentPermissions(sentProj1AnotherGroup).canChown(), chownPassing);
+            /* Check that transfer proceeds only if chownPassing boolean is true.*/
+            doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), chownPassing);
+            if (!chownPassing) {
+                /* Finish the test if no transfer of data could proceed.*/
+                return;
+            }
+            /* Check the transfer of all the data in normalUser's group was successful,
+             * first checking ownership of the first hierarchy set.*/
+            assertOwnedBy(sentProj1, recipient);
+            assertOwnedBy(sentDat1, recipient);
+            assertOwnedBy(sentImage1, recipient);
+            assertOwnedBy(linkOfDatasetImage1, recipient);
+            assertOwnedBy(linkOfProjectDataset1, recipient);
+            /* Check ownership of the second hierarchy set.*/
+            assertOwnedBy(sentProj2, recipient);
+            assertOwnedBy(sentDat2, recipient);
+            assertOwnedBy(sentImage2, recipient);
+            assertOwnedBy(linkOfDatasetImage2, recipient);
+            assertOwnedBy(linkOfProjectDataset2, recipient);
+            /* Check ownership of the objects in anotherGroup,
+             * first checking ownership of the first hierarchy.*/
+            assertOwnedBy(sentProj1AnotherGroup, recipient);
+            assertOwnedBy(sentDat1AnotherGroup, recipient);
+            assertOwnedBy(sentImage1AnotherGroup, recipient);
+            assertOwnedBy(linkOfDatasetImage1AnotherGroup, recipient);
+            assertOwnedBy(linkOfProjectDataset1AnotherGroup, recipient);
+            /* Check ownership of the second hierarchy set in anotherGroup.*/
+            assertOwnedBy(sentProj2AnotherGroup, recipient);
+            assertOwnedBy(sentDat2AnotherGroup, recipient);
+            assertOwnedBy(sentImage1AnotherGroup, recipient);
+            assertOwnedBy(linkOfDatasetImage2AnotherGroup, recipient);
+            assertOwnedBy(linkOfProjectDataset2AnotherGroup, recipient);
         }
     }
 
@@ -1427,14 +1427,14 @@ public class LightAdminRolesTest extends RolesTests {
         /* lightAdmin logs in and tries to delete the ROI.*/
         loginNewAdmin(true, permissions);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        doChange(client, factory, Requests.delete().target(roi).build(), isExpectSuccessDeleteROI);
-        /* Check the ROI was deleted, whereas the image exists.*/
-        if (isExpectSuccessDeleteROI) {
-            assertDoesNotExist(roi);
-        } else {
-            assertExists(roi);
-        }
-        assertExists(sentImage);
+            doChange(client, factory, Requests.delete().target(roi).build(), isExpectSuccessDeleteROI);
+            /* Check the ROI was deleted, whereas the image exists.*/
+            if (isExpectSuccessDeleteROI) {
+                assertDoesNotExist(roi);
+            } else {
+                assertExists(roi);
+            }
+            assertExists(sentImage);
         }
     }
 
@@ -1476,90 +1476,90 @@ public class LightAdminRolesTest extends RolesTests {
         lightAdmin = loginNewAdmin(true, permissions);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
 
-        /* lightAdmin tries to set ROI on normalUser's image.*/
-        Roi roi = new RoiI();
-        roi.addShape(new RectangleI());
-        roi.setImage((Image) sentImage.proxy());
-        try {
-            roi = (Roi) iUpdate.saveAndReturnObject(roi);
-            /* Check the value of canAnnotate on the sentImage.
-             * The value must be true as the ROI can be saved.*/
-            Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
-            Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
-        } catch (SecurityViolation sv) {
-            /* Check the value of canAnnotate on the sentImage.
-             * The value must be false as the ROI cannot be saved.*/
-            Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
-            Assert.assertFalse(isExpectSuccessCreateROIRndSettings);
-        }
+            /* lightAdmin tries to set ROI on normalUser's image.*/
+            Roi roi = new RoiI();
+            roi.addShape(new RectangleI());
+            roi.setImage((Image) sentImage.proxy());
+            try {
+                roi = (Roi) iUpdate.saveAndReturnObject(roi);
+                /* Check the value of canAnnotate on the sentImage.
+                 * The value must be true as the ROI can be saved.*/
+                Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
+                Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
+            } catch (SecurityViolation sv) {
+                /* Check the value of canAnnotate on the sentImage.
+                 * The value must be false as the ROI cannot be saved.*/
+                Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
+                Assert.assertFalse(isExpectSuccessCreateROIRndSettings);
+            }
 
-        /* lightAdmin tries to set rendering settings on normalUser's image
-         * using setOriginalSettingsInSet method.*/
-        IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
-        try {
-            prx.setOriginalSettingsInSet(Pixels.class.getName(),
-                    Arrays.asList(pixelsOfImage.getId().getValue()));
-            /* Check the value of canAnnotate on the sentImage.
-             * The value must be true as the Rnd settings can be saved.*/
-            Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
-            Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
-        } catch (SecurityViolation sv) {
-            /* Check the value of canAnnotate on the sentImage.
-             * The value must be false as the Rnd settings cannot be saved.*/
-            Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
-            Assert.assertFalse(isExpectSuccessCreateROIRndSettings, sv.toString());
-        }
-        /* Retrieve the image corresponding to the ROI and Rnd settings
-         * (if they could be set) and check the ROI and rendering settings
-         * belong to lightAdmin, whereas the image belongs to normalUser.*/
-        RenderingDef rDef = (RenderingDef) iQuery.findByQuery("FROM RenderingDef WHERE pixels.id = :id",
-                new ParametersI().addId(pixelsOfImage.getId()));
-        if (isExpectSuccessCreateROIRndSettings) {
-            long imageId = ((RLong) iQuery.projection(
-                    "SELECT rdef.pixels.image.id FROM RenderingDef rdef WHERE rdef.id = :id",
-                    new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();
-            assertOwnedBy(roi, lightAdmin);
-            assertOwnedBy(rDef, lightAdmin);
-            assertOwnedBy((new ImageI(imageId, false)), normalUser);
-        } else {
-            /* ROI and Rnd settings (rDef) must be null as they could not be set.*/
-            roi = (Roi) iQuery.findByQuery("FROM Roi WHERE image.id = :id",
-                    new ParametersI().addId(sentImage.getId()));
-            Assert.assertNull(roi);
-            Assert.assertNull(rDef);
-        }
-        /* lightAdmin tries to chown the ROI and the rendering settings (rDef) to normalUser.
-         * Only attempt the canChown check and the chown if the ROI and rendering settings exist.*/
-        if (isExpectSuccessCreateROIRndSettings) {
-            /* Check the value of canChown on the ROI and rendering settings (rDef) matches
-             * the boolean isExpectSuccessCreateAndChownRndSettings.*/
-            Assert.assertEquals(getCurrentPermissions(roi).canChown(), isExpectSuccessCreateAndChown);
-            Assert.assertEquals(getCurrentPermissions(rDef).canChown(), isExpectSuccessCreateAndChown);
-            /* Note that in read-only group, the chown of ROI would fail, see
-             * https://trello.com/c/7o4q2Tkt/745-fix-graphs-for-mixed-ownership-read-only.
-             * The workaround used here is to chown both the image and the ROI.*/
-            doChange(client, factory, Requests.chown().target(roi, sentImage).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChown);
-            doChange(client, factory, Requests.chown().target(rDef).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChown);
-            /* Retrieve the image corresponding to the ROI and Rnd settings.*/
-            long imageId = ((RLong) iQuery.projection(
-                    "SELECT rdef.pixels.image.id FROM RenderingDef rdef WHERE rdef.id = :id",
-                    new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();
-            if (isExpectSuccessCreateAndChown) {
-                /* First case: Workflow succeeded for creation and chown, all belongs to normalUser.*/
-                assertOwnedBy(roi, normalUser);
-                assertOwnedBy(rDef, normalUser);
-                assertOwnedBy((new ImageI (imageId, false)), normalUser);
-            } else {
-                /* Second case: Creation succeeded, but the chown failed.*/
+            /* lightAdmin tries to set rendering settings on normalUser's image
+             * using setOriginalSettingsInSet method.*/
+            IRenderingSettingsPrx prx = factory.getRenderingSettingsService();
+            try {
+                prx.setOriginalSettingsInSet(Pixels.class.getName(),
+                        Arrays.asList(pixelsOfImage.getId().getValue()));
+                /* Check the value of canAnnotate on the sentImage.
+                 * The value must be true as the Rnd settings can be saved.*/
+                Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
+                Assert.assertTrue(isExpectSuccessCreateROIRndSettings);
+            } catch (SecurityViolation sv) {
+                /* Check the value of canAnnotate on the sentImage.
+                 * The value must be false as the Rnd settings cannot be saved.*/
+                Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
+                Assert.assertFalse(isExpectSuccessCreateROIRndSettings, sv.toString());
+            }
+            /* Retrieve the image corresponding to the ROI and Rnd settings
+             * (if they could be set) and check the ROI and rendering settings
+             * belong to lightAdmin, whereas the image belongs to normalUser.*/
+            RenderingDef rDef = (RenderingDef) iQuery.findByQuery("FROM RenderingDef WHERE pixels.id = :id",
+                    new ParametersI().addId(pixelsOfImage.getId()));
+            if (isExpectSuccessCreateROIRndSettings) {
+                long imageId = ((RLong) iQuery.projection(
+                        "SELECT rdef.pixels.image.id FROM RenderingDef rdef WHERE rdef.id = :id",
+                        new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();
                 assertOwnedBy(roi, lightAdmin);
                 assertOwnedBy(rDef, lightAdmin);
                 assertOwnedBy((new ImageI(imageId, false)), normalUser);
+            } else {
+                /* ROI and Rnd settings (rDef) must be null as they could not be set.*/
+                roi = (Roi) iQuery.findByQuery("FROM Roi WHERE image.id = :id",
+                        new ParametersI().addId(sentImage.getId()));
+                Assert.assertNull(roi);
+                Assert.assertNull(rDef);
             }
-        } else {
-            /* Third case: Creation did not succeed, and chown was not attempted.*/
-            Assert.assertNull(roi);
-            Assert.assertNull(rDef);
-        }
+            /* lightAdmin tries to chown the ROI and the rendering settings (rDef) to normalUser.
+             * Only attempt the canChown check and the chown if the ROI and rendering settings exist.*/
+            if (isExpectSuccessCreateROIRndSettings) {
+                /* Check the value of canChown on the ROI and rendering settings (rDef) matches
+                 * the boolean isExpectSuccessCreateAndChownRndSettings.*/
+                Assert.assertEquals(getCurrentPermissions(roi).canChown(), isExpectSuccessCreateAndChown);
+                Assert.assertEquals(getCurrentPermissions(rDef).canChown(), isExpectSuccessCreateAndChown);
+                /* Note that in read-only group, the chown of ROI would fail, see
+                 * https://trello.com/c/7o4q2Tkt/745-fix-graphs-for-mixed-ownership-read-only.
+                 * The workaround used here is to chown both the image and the ROI.*/
+                doChange(client, factory, Requests.chown().target(roi, sentImage).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChown);
+                doChange(client, factory, Requests.chown().target(rDef).toUser(normalUser.userId).build(), isExpectSuccessCreateAndChown);
+                /* Retrieve the image corresponding to the ROI and Rnd settings.*/
+                long imageId = ((RLong) iQuery.projection(
+                        "SELECT rdef.pixels.image.id FROM RenderingDef rdef WHERE rdef.id = :id",
+                        new ParametersI().addId(rDef.getId())).get(0).get(0)).getValue();
+                if (isExpectSuccessCreateAndChown) {
+                    /* First case: Workflow succeeded for creation and chown, all belongs to normalUser.*/
+                    assertOwnedBy(roi, normalUser);
+                    assertOwnedBy(rDef, normalUser);
+                    assertOwnedBy((new ImageI (imageId, false)), normalUser);
+                } else {
+                    /* Second case: Creation succeeded, but the chown failed.*/
+                    assertOwnedBy(roi, lightAdmin);
+                    assertOwnedBy(rDef, lightAdmin);
+                    assertOwnedBy((new ImageI(imageId, false)), normalUser);
+                }
+            } else {
+                /* Third case: Creation did not succeed, and chown was not attempted.*/
+                Assert.assertNull(roi);
+                Assert.assertNull(rDef);
+            }
         }
     }
 
@@ -1603,72 +1603,72 @@ public class LightAdminRolesTest extends RolesTests {
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        /* lightAdmin tries to create a fileAttachment in normalUser's group.*/
-        FileAnnotation fileAnnotation = mmFactory.createFileAnnotation();
-        OriginalFile originalFile;
-        try {
-            fileAnnotation = (FileAnnotation) iUpdate.saveAndReturnObject(fileAnnotation);
-            originalFile = (OriginalFile) fileAnnotation.getFile();
-            Assert.assertTrue(isExpectSuccessCreateFileAttachment);
-        } catch (SecurityViolation sv) {
-            Assert.assertFalse(isExpectSuccessCreateFileAttachment);
-            /* Finish the test in case fileAttachment could not be created.*/
-            return;
-        }
-        /* Check that the value of canChown on the fileAnnotation is matching the boolean
-         * isExpectSuccessCreateFileAttAndChown.*/
-        Assert.assertEquals(getCurrentPermissions(fileAnnotation).canChown(), isExpectSuccessCreateFileAttAndChown);
-        /* lightAdmin tries to link the fileAnnotation to the normalUser's image.
-         * This will not work in private group. See definition of the boolean
-         * isExpectSuccessLinkFileAttachment.*/
-        ImageAnnotationLink link = null;
-        try {
-            link = (ImageAnnotationLink) linkParentToChild(sentImage, fileAnnotation);
-            /* Check the value of canAnnotate on the image is true in successful linking case.*/
-            Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
-            Assert.assertTrue(isExpectSuccessLinkFileAttachemnt);
-        } catch (SecurityViolation sv) {
-            /* Check the value of canAnnotate on the image is false in case linking fails.*/
-            Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
-            Assert.assertFalse(isExpectSuccessLinkFileAttachemnt);
-            /* Finish the test in case no link could be created.*/
-            return;
-        }
-        /* lightAdmin tries to transfer the ownership of fileAnnotation to normalUser.
-         * The test was terminated (see above) in all cases
-         * in which the fileAnnotation was not created.*/
-        doChange(client, factory, Requests.chown().target(fileAnnotation).toUser(normalUser.userId).build(), isExpectSuccessCreateFileAttAndChown);
-        if (isExpectSuccessCreateFileAttAndChown) {
-            /* First case: fileAnnotation creation and chowning succeeded.*/
-            assertOwnedBy(fileAnnotation, normalUser);
-            assertOwnedBy(originalFile, normalUser);
-        } else {
-            /* Second case: creation of fileAnnotation succeeded, but the chown failed.*/
-            assertOwnedBy(fileAnnotation, lightAdmin);
-            assertOwnedBy(originalFile, lightAdmin);
-        }
-        /* Check the value of canChown on the link is matching the boolean
-         * isExpectSuccessCreateLinkAndChown.*/
-        Assert.assertEquals(getCurrentPermissions(link).canChown(), isExpectSuccessCreateLinkAndChown);
-        /* lightAdmin tries to transfer the ownership of link to normalUser.
-         * The test was terminated (see above) in all cases
-         * in which the link was not created.*/
-        doChange(client, factory, Requests.chown().target(link).toUser(normalUser.userId).build(), isExpectSuccessCreateLinkAndChown);
-        if (isExpectSuccessCreateLinkAndChown) {
-            /* First case: link was created and chowned, the whole workflow succeeded.*/
-            link = (ImageAnnotationLink) iQuery.findByQuery("FROM ImageAnnotationLink l JOIN FETCH"
-                    + " l.child JOIN FETCH l.parent WHERE l.child.id = :id",
-                    new ParametersI().addId(fileAnnotation.getId()));
-            assertOwnedBy(link, normalUser);
-            assertOwnedBy(fileAnnotation, normalUser);
-            assertOwnedBy(originalFile, normalUser);
-        } else {
-            /* Second case: link was created but could not be chowned.*/
-            link = (ImageAnnotationLink) iQuery.findByQuery("FROM ImageAnnotationLink l JOIN FETCH"
-                    + " l.child JOIN FETCH l.parent WHERE l.child.id = :id",
-                    new ParametersI().addId(fileAnnotation.getId()));
-            assertOwnedBy(link, lightAdmin);
-        }
+            /* lightAdmin tries to create a fileAttachment in normalUser's group.*/
+            FileAnnotation fileAnnotation = mmFactory.createFileAnnotation();
+            OriginalFile originalFile;
+            try {
+                fileAnnotation = (FileAnnotation) iUpdate.saveAndReturnObject(fileAnnotation);
+                originalFile = (OriginalFile) fileAnnotation.getFile();
+                Assert.assertTrue(isExpectSuccessCreateFileAttachment);
+            } catch (SecurityViolation sv) {
+                Assert.assertFalse(isExpectSuccessCreateFileAttachment);
+                /* Finish the test in case fileAttachment could not be created.*/
+                return;
+            }
+            /* Check that the value of canChown on the fileAnnotation is matching the boolean
+             * isExpectSuccessCreateFileAttAndChown.*/
+            Assert.assertEquals(getCurrentPermissions(fileAnnotation).canChown(), isExpectSuccessCreateFileAttAndChown);
+            /* lightAdmin tries to link the fileAnnotation to the normalUser's image.
+             * This will not work in private group. See definition of the boolean
+             * isExpectSuccessLinkFileAttachment.*/
+            ImageAnnotationLink link = null;
+            try {
+                link = (ImageAnnotationLink) linkParentToChild(sentImage, fileAnnotation);
+                /* Check the value of canAnnotate on the image is true in successful linking case.*/
+                Assert.assertTrue(getCurrentPermissions(sentImage).canAnnotate());
+                Assert.assertTrue(isExpectSuccessLinkFileAttachemnt);
+            } catch (SecurityViolation sv) {
+                /* Check the value of canAnnotate on the image is false in case linking fails.*/
+                Assert.assertFalse(getCurrentPermissions(sentImage).canAnnotate());
+                Assert.assertFalse(isExpectSuccessLinkFileAttachemnt);
+                /* Finish the test in case no link could be created.*/
+                return;
+            }
+            /* lightAdmin tries to transfer the ownership of fileAnnotation to normalUser.
+             * The test was terminated (see above) in all cases
+             * in which the fileAnnotation was not created.*/
+            doChange(client, factory, Requests.chown().target(fileAnnotation).toUser(normalUser.userId).build(), isExpectSuccessCreateFileAttAndChown);
+            if (isExpectSuccessCreateFileAttAndChown) {
+                /* First case: fileAnnotation creation and chowning succeeded.*/
+                assertOwnedBy(fileAnnotation, normalUser);
+                assertOwnedBy(originalFile, normalUser);
+            } else {
+                /* Second case: creation of fileAnnotation succeeded, but the chown failed.*/
+                assertOwnedBy(fileAnnotation, lightAdmin);
+                assertOwnedBy(originalFile, lightAdmin);
+            }
+            /* Check the value of canChown on the link is matching the boolean
+             * isExpectSuccessCreateLinkAndChown.*/
+            Assert.assertEquals(getCurrentPermissions(link).canChown(), isExpectSuccessCreateLinkAndChown);
+            /* lightAdmin tries to transfer the ownership of link to normalUser.
+             * The test was terminated (see above) in all cases
+             * in which the link was not created.*/
+            doChange(client, factory, Requests.chown().target(link).toUser(normalUser.userId).build(), isExpectSuccessCreateLinkAndChown);
+            if (isExpectSuccessCreateLinkAndChown) {
+                /* First case: link was created and chowned, the whole workflow succeeded.*/
+                link = (ImageAnnotationLink) iQuery.findByQuery("FROM ImageAnnotationLink l JOIN FETCH"
+                        + " l.child JOIN FETCH l.parent WHERE l.child.id = :id",
+                        new ParametersI().addId(fileAnnotation.getId()));
+                assertOwnedBy(link, normalUser);
+                assertOwnedBy(fileAnnotation, normalUser);
+                assertOwnedBy(originalFile, normalUser);
+            } else {
+                /* Second case: link was created but could not be chowned.*/
+                link = (ImageAnnotationLink) iQuery.findByQuery("FROM ImageAnnotationLink l JOIN FETCH"
+                        + " l.child JOIN FETCH l.parent WHERE l.child.id = :id",
+                        new ParametersI().addId(fileAnnotation.getId()));
+                assertOwnedBy(link, lightAdmin);
+            }
         }
     }
 
@@ -1691,28 +1691,28 @@ public class LightAdminRolesTest extends RolesTests {
         final String actualScript;
         final long testScriptId;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        IScriptPrx iScript = factory.getScriptService();
-        /* lightAdmin fetches a script from the server.*/
-        OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = null;
-        try {
-            rfs = factory.createRawFileStore();
-            rfs.setFileId(scriptFile.getId().getValue());
-            actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        } finally {
-            if (rfs != null) rfs.close();
-        }
-        /* lightAdmin tries uploading the script as a new script in normalUser's group.*/
-        iScript = factory.getScriptService();
-        final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        try {
-            testScriptId = iScript.uploadOfficialScript(testScriptName, actualScript);
-            Assert.assertTrue(isExpectSuccessUploadOfficialScript);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccessUploadOfficialScript);
-            /* Upload failed so finish the test.*/
-            return;
-        }
+            IScriptPrx iScript = factory.getScriptService();
+            /* lightAdmin fetches a script from the server.*/
+            OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
+            RawFileStorePrx rfs = null;
+            try {
+                rfs = factory.createRawFileStore();
+                rfs.setFileId(scriptFile.getId().getValue());
+                actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
+            } finally {
+                if (rfs != null) rfs.close();
+            }
+            /* lightAdmin tries uploading the script as a new script in normalUser's group.*/
+            iScript = factory.getScriptService();
+            final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
+            try {
+                testScriptId = iScript.uploadOfficialScript(testScriptName, actualScript);
+                Assert.assertTrue(isExpectSuccessUploadOfficialScript);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccessUploadOfficialScript);
+                /* Upload failed so finish the test.*/
+                return;
+            }
         }
         /* Check that the new script exists in the "user" group.*/
         loginUser(normalUser);
@@ -1749,17 +1749,17 @@ public class LightAdminRolesTest extends RolesTests {
         lightAdmin = loginNewAdmin(true, permissions);
         final String actualScript;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        IScriptPrx iScript = factory.getScriptService();
-        /* lightAdmin fetches a script from the server.*/
-        OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = null;
-        try {
-            rfs = factory.createRawFileStore();
-            rfs.setFileId(scriptFile.getId().getValue());
-            actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        } finally {
-            if (rfs != null) rfs.close();
-        }
+            IScriptPrx iScript = factory.getScriptService();
+            /* lightAdmin fetches a script from the server.*/
+            OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
+            RawFileStorePrx rfs = null;
+            try {
+                rfs = factory.createRawFileStore();
+                rfs.setFileId(scriptFile.getId().getValue());
+                actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
+            } finally {
+                if (rfs != null) rfs.close();
+            }
         }
         /* Another light admin (anotherLightAdmin) with appropriate permissions
          * uploads the script as a new script.*/
@@ -1781,13 +1781,13 @@ public class LightAdminRolesTest extends RolesTests {
         /* lightAdmin tries deleting the script.*/
         loginUser(lightAdmin);
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-        iScript = factory.getScriptService();
-        try {
-            iScript.deleteScript(testScriptId);
-            Assert.assertTrue(isExpectSuccessDeleteOfficialScript);
-        } catch (ServerError se) {
-            Assert.assertFalse(isExpectSuccessDeleteOfficialScript);
-        }
+            iScript = factory.getScriptService();
+            try {
+                iScript.deleteScript(testScriptId);
+                Assert.assertTrue(isExpectSuccessDeleteOfficialScript);
+            } catch (ServerError se) {
+                Assert.assertFalse(isExpectSuccessDeleteOfficialScript);
+            }
         }
         /* normalUser checks if the script was deleted or left intact.*/
         loginUser(normalUser);
@@ -2126,21 +2126,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean permChown : booleanCases) {
-                for (final boolean permWriteOwned : booleanCases) {
-                    for (final boolean permWriteFile : booleanCases) {
-                        for (final String groupPerms : permsCases) {
-                            final Object[] testCase = new Object[index];
-                            testCase[PERM_CHOWN] = permChown;
-                            testCase[PERM_WRITEOWNED] = permWriteOwned;
-                            testCase[PERM_WRITEFILE] = permWriteFile;
-                            testCase[GROUP_PERMS] = groupPerms;
-                            //DEBUG if (permChown == true && permWriteOwned == true && permWriteFile == true && groupPerms.equals("rwr---"))
-                            testCases.add(testCase);
-                        }
+        for (final boolean permChown : booleanCases) {
+            for (final boolean permWriteOwned : booleanCases) {
+                for (final boolean permWriteFile : booleanCases) {
+                    for (final String groupPerms : permsCases) {
+                        final Object[] testCase = new Object[index];
+                        testCase[PERM_CHOWN] = permChown;
+                        testCase[PERM_WRITEOWNED] = permWriteOwned;
+                        testCase[PERM_WRITEFILE] = permWriteFile;
+                        testCase[GROUP_PERMS] = groupPerms;
+                        //DEBUG if (permChown == true && permWriteOwned == true && permWriteFile == true && groupPerms.equals("rwr---"))
+                        testCases.add(testCase);
                     }
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2158,21 +2158,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permWriteOwned : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        if (isSudoing && permWriteOwned)
-                            /* not an interesting case */
-                            continue;
-                        testCase[IS_SUDOING] = isSudoing;
-                        testCase[PERM_WRITEOWNED] = permWriteOwned;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isSudoing == true && permWriteOwned == true && groupPerms.equals("rwr---")))
-                        testCases.add(testCase);
-                    }
+        for (final boolean isSudoing : booleanCases) {
+            for (final boolean permWriteOwned : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    if (isSudoing && permWriteOwned)
+                        /* not an interesting case */
+                        continue;
+                    testCase[IS_SUDOING] = isSudoing;
+                    testCase[PERM_WRITEOWNED] = permWriteOwned;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG if (isSudoing == true && permWriteOwned == true && groupPerms.equals("rwr---")))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2190,21 +2190,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permDeleteOwned : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        if (isSudoing && permDeleteOwned)
-                            /* not an interesting case */
-                            continue;
-                        testCase[IS_SUDOING] = isSudoing;
-                        testCase[PERM_DELETEOWNED] = permDeleteOwned;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isSudoing == true && permDeleteOwned == true && groupPerms.equals("rwr---"))
-                        testCases.add(testCase);
-                    }
+        for (final boolean isSudoing : booleanCases) {
+            for (final boolean permDeleteOwned : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    if (isSudoing && permDeleteOwned)
+                        /* not an interesting case */
+                        continue;
+                    testCase[IS_SUDOING] = isSudoing;
+                    testCase[PERM_DELETEOWNED] = permDeleteOwned;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG if (isSudoing == true && permDeleteOwned == true && groupPerms.equals("rwr---"))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2222,21 +2222,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean isAdmin : booleanCases) {
-                for (final boolean permDeleteOwned : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        if (!isAdmin && permDeleteOwned)
-                            /* not an interesting case */
-                            continue;
-                        testCase[IS_ADMIN] = isAdmin;
-                        testCase[PERM_DELETEOWNED] = permDeleteOwned;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (isAdmin == true && permDeleteOwned == true && groupPerms.equals("rwr---"))
-                        testCases.add(testCase);
-                    }
+        for (final boolean isAdmin : booleanCases) {
+            for (final boolean permDeleteOwned : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    if (!isAdmin && permDeleteOwned)
+                        /* not an interesting case */
+                        continue;
+                    testCase[IS_ADMIN] = isAdmin;
+                    testCase[PERM_DELETEOWNED] = permDeleteOwned;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG if (isAdmin == true && permDeleteOwned == true && groupPerms.equals("rwr---"))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2254,21 +2254,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permChgrp : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        /* No test cases are excluded here, because isSudoing
-                         * is in a sense acting to annule Chgrp permission
-                         * which is tested in the testChgrp and is an interesting case.*/
-                        testCase[IS_SUDOING] = isSudoing;
-                        testCase[PERM_CHGRP] = permChgrp;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isSudoing == true && permChgrp == true && groupPerms.equals("rwr---"))
-                        testCases.add(testCase);
-                    }
+        for (final boolean isSudoing : booleanCases) {
+            for (final boolean permChgrp : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    /* No test cases are excluded here, because isSudoing
+                     * is in a sense acting to annule Chgrp permission
+                     * which is tested in the testChgrp and is an interesting case.*/
+                    testCase[IS_SUDOING] = isSudoing;
+                    testCase[PERM_CHGRP] = permChgrp;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG  if (isSudoing == true && permChgrp == true && groupPerms.equals("rwr---"))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2286,21 +2286,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean isSudoing : booleanCases) {
-                for (final boolean permChown : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        /* No test cases are excluded here, because isSudoing
-                         * is in a sense acting to annule Chown permission
-                         * which is tested in the testChown and is an interesting case.*/
-                        testCase[IS_SUDOING] = isSudoing;
-                        testCase[PERM_CHOWN] = permChown;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG  if (isSudoing == true && permChown == true && groupPerms.equals("rwr---"))
-                        testCases.add(testCase);
-                    }
+        for (final boolean isSudoing : booleanCases) {
+            for (final boolean permChown : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    /* No test cases are excluded here, because isSudoing
+                     * is in a sense acting to annule Chown permission
+                     * which is tested in the testChown and is an interesting case.*/
+                    testCase[IS_SUDOING] = isSudoing;
+                    testCase[PERM_CHOWN] = permChown;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG  if (isSudoing == true && permChown == true && groupPerms.equals("rwr---"))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2321,34 +2321,34 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean permWriteOwned : booleanCases) {
-                for (final boolean permWriteFile : booleanCases) {
-                    for (final boolean permWriteManagedRepo : booleanCases) {
-                        for (final boolean permChown : booleanCases) {
-                            for (final String groupPerms : permsCases) {
-                                final Object[] testCase = new Object[index];
-                                if (!permWriteOwned && !permWriteFile)
-                                    /* not an interesting case */
-                                    continue;
-                                if (!permWriteOwned && !permWriteManagedRepo)
-                                    /* not an interesting case */
-                                    continue;
-                                if (!permWriteOwned && !permWriteFile && !permWriteManagedRepo)
-                                    /* not an interesting case */
-                                    continue;
-                                testCase[PERM_WRITEOWNED] = permWriteOwned;
-                                testCase[PERM_WRITEFILE] = permWriteFile;
-                                testCase[PERM_WRITEMANAGEDREPO] = permWriteManagedRepo;
-                                testCase[PERM_CHOWN] = permChown;
-                                testCase[GROUP_PERMS] = groupPerms;
-                                // DEBUG if (permWriteOwned == true && permWriteFile == true && permWriteManagedRepo == true
-                                // && permChown == true && groupPerms.equals("rwr---"))
-                                testCases.add(testCase);
-                            }
+        for (final boolean permWriteOwned : booleanCases) {
+            for (final boolean permWriteFile : booleanCases) {
+                for (final boolean permWriteManagedRepo : booleanCases) {
+                    for (final boolean permChown : booleanCases) {
+                        for (final String groupPerms : permsCases) {
+                            final Object[] testCase = new Object[index];
+                            if (!permWriteOwned && !permWriteFile)
+                                /* not an interesting case */
+                                continue;
+                            if (!permWriteOwned && !permWriteManagedRepo)
+                                /* not an interesting case */
+                                continue;
+                            if (!permWriteOwned && !permWriteFile && !permWriteManagedRepo)
+                                /* not an interesting case */
+                                continue;
+                            testCase[PERM_WRITEOWNED] = permWriteOwned;
+                            testCase[PERM_WRITEFILE] = permWriteFile;
+                            testCase[PERM_WRITEMANAGEDREPO] = permWriteManagedRepo;
+                            testCase[PERM_CHOWN] = permChown;
+                            testCase[GROUP_PERMS] = groupPerms;
+                            // DEBUG if (permWriteOwned == true && permWriteFile == true && permWriteManagedRepo == true
+                            // && permChown == true && groupPerms.equals("rwr---"))
+                            testCases.add(testCase);
                         }
                     }
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2367,21 +2367,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean permWriteOwned : booleanCases) {
-                for (final boolean permChown : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        if (!permWriteOwned && !permChown)
-                            /* not an interesting case */
-                            continue;
-                        testCase[PERM_WRITEOWNED] = permWriteOwned;
-                        testCase[PERM_CHOWN] = permChown;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (permWriteOwned == true && permChown == true && groupPerms.equals("rwr---"))
-                        testCases.add(testCase);
-                    }
+        for (final boolean permWriteOwned : booleanCases) {
+            for (final boolean permChown : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    if (!permWriteOwned && !permChown)
+                        /* not an interesting case */
+                        continue;
+                    testCase[PERM_WRITEOWNED] = permWriteOwned;
+                    testCase[PERM_CHOWN] = permChown;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG if (permWriteOwned == true && permChown == true && groupPerms.equals("rwr---"))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2400,21 +2400,21 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean permWriteOwned : booleanCases) {
-                for (final boolean isAdmin : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        if (!permWriteOwned && !isAdmin)
-                            /* not an interesting case */
-                            continue;
-                        testCase[PERM_WRITEOWNED] = permWriteOwned;
-                        testCase[IS_ADMIN] = isAdmin;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (permWriteOwned == true && isAdmin == true && groupPerms.equals("rwr---"))
-                        testCases.add(testCase);
-                    }
+        for (final boolean permWriteOwned : booleanCases) {
+            for (final boolean isAdmin : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    if (!permWriteOwned && !isAdmin)
+                        /* not an interesting case */
+                        continue;
+                    testCase[PERM_WRITEOWNED] = permWriteOwned;
+                    testCase[IS_ADMIN] = isAdmin;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG if (permWriteOwned == true && isAdmin == true && groupPerms.equals("rwr---"))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2432,22 +2432,22 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean permChgrp : booleanCases) {
-                for (final boolean permChown : booleanCases) {
-                    for (final String groupPerms : permsCases) {
-                        final Object[] testCase = new Object[index];
-                        /* No test cases are excluded here, because Chgrp
-                         * and Chown are two separate steps which can work
-                         * independently on each other and both are tested
-                         * in the test.*/
-                        testCase[PERM_CHGRP] = permChgrp;
-                        testCase[PERM_CHOWN] = permChown;
-                        testCase[GROUP_PERMS] = groupPerms;
-                        // DEBUG if (permChgrp == true && permChown == true && groupPerms.equals("rwr---"))
-                        testCases.add(testCase);
-                    }
+        for (final boolean permChgrp : booleanCases) {
+            for (final boolean permChown : booleanCases) {
+                for (final String groupPerms : permsCases) {
+                    final Object[] testCase = new Object[index];
+                    /* No test cases are excluded here, because Chgrp
+                     * and Chown are two separate steps which can work
+                     * independently on each other and both are tested
+                     * in the test.*/
+                    testCase[PERM_CHGRP] = permChgrp;
+                    testCase[PERM_CHOWN] = permChown;
+                    testCase[GROUP_PERMS] = groupPerms;
+                    // DEBUG if (permChgrp == true && permChown == true && groupPerms.equals("rwr---"))
+                    testCases.add(testCase);
                 }
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2466,15 +2466,15 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"rw----", "rwr---", "rwra--", "rwrw--"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean isPrivileged : booleanCases) {
-                for (final String groupPerms : permsCases) {
-                    final Object[] testCase = new Object[index];
-                    testCase[IS_PRIVILEGED] = isPrivileged;
-                    testCase[GROUP_PERMS] = groupPerms;
-                    // DEBUG if (isPrivileged == true && groupPerms.equals("rwr---"))
-                    testCases.add(testCase);
-                }
+        for (final boolean isPrivileged : booleanCases) {
+            for (final String groupPerms : permsCases) {
+                final Object[] testCase = new Object[index];
+                testCase[IS_PRIVILEGED] = isPrivileged;
+                testCase[GROUP_PERMS] = groupPerms;
+                // DEBUG if (isPrivileged == true && groupPerms.equals("rwr---"))
+                testCases.add(testCase);
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 
@@ -2491,15 +2491,15 @@ public class LightAdminRolesTest extends RolesTests {
         final String[] permsCases = new String[]{"DataViewer", "Importer", "Analyst", "Organizer"};
         final List<Object[]> testCases = new ArrayList<Object[]>();
 
-            for (final boolean permModifyUser : booleanCases) {
-                for (final String lightAdminType : permsCases) {
-                    final Object[] testCase = new Object[index];
-                    testCase[PERM_MODIFYUSER] = permModifyUser;
-                    testCase[LIGHT_ADMIN_TYPES] = lightAdminType;
-                    // DEBUG if (permModifyUser == true && createdAdminType.equals("DataViewer"))
-                    testCases.add(testCase);
-                }
+        for (final boolean permModifyUser : booleanCases) {
+            for (final String lightAdminType : permsCases) {
+                final Object[] testCase = new Object[index];
+                testCase[PERM_MODIFYUSER] = permModifyUser;
+                testCase[LIGHT_ADMIN_TYPES] = lightAdminType;
+                // DEBUG if (permModifyUser == true && createdAdminType.equals("DataViewer"))
+                testCases.add(testCase);
             }
+        }
         return testCases.toArray(new Object[testCases.size()][]);
     }
 

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1332,15 +1332,15 @@ public class LightAdminRolesTest extends RolesTests {
         }
 
         /* normalUser creates two sets of Project/Dataset?Image hierarchy in the other group (anotherGroup).*/
-        final Image sentImage1AnootherGroup, sentImage2AnotherGroup;
+        final Image sentImage1AnotherGroup, sentImage2AnotherGroup;
         final Dataset sentDat1AnotherGroup, sentDat2AnotherGroup;
-        final Project sentProj1AnootherGroup, sentProj2AnotherGroup;
+        final Project sentProj1AnotherGroup, sentProj2AnotherGroup;
         final DatasetImageLink linkOfDatasetImage1AnotherGroup, linkOfDatasetImage2AnotherGroup;
         final ProjectDatasetLink linkOfProjectDataset1AnotherGroup, linkOfProjectDataset2AnotherGroup;
         try (final AutoCloseable igc = new ImplicitGroupContext(anotherGroup.getId())) {
         Image image1AnotherGroup = mmFactory.createImage();
         Image image2AnotherGroup = mmFactory.createImage();
-        sentImage1AnootherGroup = (Image) iUpdate.saveAndReturnObject(image1AnotherGroup);
+        sentImage1AnotherGroup = (Image) iUpdate.saveAndReturnObject(image1AnotherGroup);
         sentImage2AnotherGroup = (Image) iUpdate.saveAndReturnObject(image2AnotherGroup);
         Dataset dat1AnotherGroup = mmFactory.simpleDataset();
         Dataset dat2AnotherGroup = mmFactory.simpleDataset();
@@ -1348,11 +1348,11 @@ public class LightAdminRolesTest extends RolesTests {
         sentDat2AnotherGroup = (Dataset) iUpdate.saveAndReturnObject(dat2AnotherGroup);
         Project proj1AnotherGroup = mmFactory.simpleProject();
         Project proj2AnotherGroup = mmFactory.simpleProject();
-        sentProj1AnootherGroup = (Project) iUpdate.saveAndReturnObject(proj1AnotherGroup);
+        sentProj1AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj1AnotherGroup);
         sentProj2AnotherGroup = (Project) iUpdate.saveAndReturnObject(proj2AnotherGroup);
-        linkOfDatasetImage1AnotherGroup = linkParentToChild(sentDat1AnotherGroup, sentImage1AnootherGroup);
+        linkOfDatasetImage1AnotherGroup = linkParentToChild(sentDat1AnotherGroup, sentImage1AnotherGroup);
         linkOfDatasetImage2AnotherGroup = linkParentToChild(sentDat2AnotherGroup, sentImage2AnotherGroup);
-        linkOfProjectDataset1AnotherGroup = linkParentToChild(sentProj1AnootherGroup, sentDat1AnotherGroup);
+        linkOfProjectDataset1AnotherGroup = linkParentToChild(sentProj1AnotherGroup, sentDat1AnotherGroup);
         linkOfProjectDataset2AnotherGroup = linkParentToChild(sentProj2AnotherGroup, sentDat2AnotherGroup);
         }
         /* lightAdmin tries to transfers all normalUser's data to recipient.*/
@@ -1361,7 +1361,7 @@ public class LightAdminRolesTest extends RolesTests {
         try (final AutoCloseable igc = new ImplicitAllGroupsContext()) {
         /* Check on one selected object only (sentProj1AnotherGroup) the value
          * of canChown. The value must match the chownPassing boolean.*/
-        Assert.assertEquals(getCurrentPermissions(sentProj1AnootherGroup).canChown(), chownPassing);
+        Assert.assertEquals(getCurrentPermissions(sentProj1AnotherGroup).canChown(), chownPassing);
         /* Check that transfer proceeds only if chownPassing boolean is true.*/
         doChange(client, factory, Requests.chown().targetUsers(normalUser.userId).toUser(recipient.userId).build(), chownPassing);
         if (!chownPassing) {
@@ -1383,15 +1383,15 @@ public class LightAdminRolesTest extends RolesTests {
         assertOwnedBy(linkOfProjectDataset2, recipient);
         /* Check ownership of the objects in anotherGroup,
          * first checking ownership of the first hierarchy.*/
-        assertOwnedBy(sentProj1AnootherGroup, recipient);
+        assertOwnedBy(sentProj1AnotherGroup, recipient);
         assertOwnedBy(sentDat1AnotherGroup, recipient);
-        assertOwnedBy(sentImage1AnootherGroup, recipient);
+        assertOwnedBy(sentImage1AnotherGroup, recipient);
         assertOwnedBy(linkOfDatasetImage1AnotherGroup, recipient);
         assertOwnedBy(linkOfProjectDataset1AnotherGroup, recipient);
         /* Check ownership of the second hierarchy set in anotherGroup.*/
         assertOwnedBy(sentProj2AnotherGroup, recipient);
         assertOwnedBy(sentDat2AnotherGroup, recipient);
-        assertOwnedBy(sentImage1AnootherGroup, recipient);
+        assertOwnedBy(sentImage1AnotherGroup, recipient);
         assertOwnedBy(linkOfDatasetImage2AnotherGroup, recipient);
         assertOwnedBy(linkOfProjectDataset2AnotherGroup, recipient);
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -118,8 +118,8 @@ public class LightAdminRolesTest extends RolesTests {
      * @throws Exception if the light administrator could not be created
      */
     private EventContext loginNewAdmin(boolean isAdmin, List <String> permissions) throws Exception {
-        final EventContext ctx = isAdmin ? newUserInGroup(iAdmin.lookupGroup(roles.systemGroupName), false) : newUserAndGroup("rwr-r-");
         final ServiceFactoryPrx rootSession = root.getSession();
+        final EventContext ctx = isAdmin ? newUserInGroup(rootSession.getAdminService().lookupGroup(roles.systemGroupName), false) : newUserAndGroup("rwr-r-");
         Experimenter user = new ExperimenterI(ctx.userId, false);
         user = (Experimenter) rootSession.getQueryService().get("Experimenter", ctx.userId);
         final List<AdminPrivilege> privileges = Utils.toEnum(AdminPrivilege.class, AdminPrivilegeI.class, permissions);

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -588,8 +588,8 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
         /* prepare as admin to import into another group */
         final long targetGroup = iAdmin.getEventContext().groupId;
         newUserInGroup(new ExperimenterGroupI(roles.systemGroupId, false), false);
-        client.getImplicitContext().put("omero.group", Long.toString(targetGroup));
 
+        try (final AutoCloseable igc = new ImplicitGroupContext(targetGroup)) {
         /* create and import a fake image */
         final File localPath = tempFileManager.createPath(UUID.randomUUID().toString(), null, true);
         final File localFile = ensureFileExists(localPath, UUID.randomUUID().toString() + ".fake");
@@ -598,6 +598,7 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
         /* check that the import was into the intended group */
         final OriginalFile remoteFile = (OriginalFile) iQuery.findByString("OriginalFile", "name", localFile.getName());
         Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), targetGroup);
+        }
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -95,7 +95,6 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
 
     @BeforeMethod
     public void setupNewUser() throws Exception {
-        newUserAndGroup("rw----");
         setRepo();
     }
 
@@ -917,7 +916,9 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
      * @throws ServerError expected directory creation error
      */
     @Test(expectedExceptions = ValidationException.class)
-    public void testMakeArbitraryDirectoryNormalUser() throws ServerError {
+    public void testMakeArbitraryDirectoryNormalUser() throws Exception {
+        newUserAndGroup("rw----");
+        setRepo();
         repo.makeDir(UUID.randomUUID().toString(), false);
     }
 

--- a/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
+++ b/components/tools/OmeroJava/test/integration/ManagedRepositoryTest.java
@@ -590,14 +590,14 @@ public class ManagedRepositoryTest extends AbstractServerImportTest {
         newUserInGroup(new ExperimenterGroupI(roles.systemGroupId, false), false);
 
         try (final AutoCloseable igc = new ImplicitGroupContext(targetGroup)) {
-        /* create and import a fake image */
-        final File localPath = tempFileManager.createPath(UUID.randomUUID().toString(), null, true);
-        final File localFile = ensureFileExists(localPath, UUID.randomUUID().toString() + ".fake");
-        importFileset(Collections.singletonList(localFile.toString()));
+            /* create and import a fake image */
+            final File localPath = tempFileManager.createPath(UUID.randomUUID().toString(), null, true);
+            final File localFile = ensureFileExists(localPath, UUID.randomUUID().toString() + ".fake");
+            importFileset(Collections.singletonList(localFile.toString()));
 
-        /* check that the import was into the intended group */
-        final OriginalFile remoteFile = (OriginalFile) iQuery.findByString("OriginalFile", "name", localFile.getName());
-        Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), targetGroup);
+            /* check that the import was into the intended group */
+            final OriginalFile remoteFile = (OriginalFile) iQuery.findByString("OriginalFile", "name", localFile.getName());
+            Assert.assertEquals(remoteFile.getDetails().getGroup().getId().getValue(), targetGroup);
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
@@ -103,9 +103,6 @@ public class PermissionsTestAll extends AbstractServerTest {
             "rwrw--", "Read-Write-" + uuid + "-"
             );
 
-    /** The security roles for that server. **/
-    private Roles securityRoles;
-
     /** The password used for user. **/
     private final static String PASSWORD = "ome";
 
@@ -123,12 +120,8 @@ public class PermissionsTestAll extends AbstractServerTest {
      * @throws Exception Thrown if an error occurred.
      */
     void setupGroups() throws Exception {
-        omero.client client = newRootOmeroClient();
-        client.enableKeepAlive(60);
-        factory = client.getSession();
-        IAdminPrx svc = factory.getAdminService();
+        IAdminPrx svc = root.getSession().getAdminService();
 
-        securityRoles = svc.getSecurityRoles();
         List<ExperimenterGroup> groups = new ArrayList<ExperimenterGroup>();
         List<ExperimenterGroup> groupCopies = new ArrayList<ExperimenterGroup>();
 
@@ -159,7 +152,6 @@ public class PermissionsTestAll extends AbstractServerTest {
         String admin = testUserNames[3];
         String owner = testUserNames[2];
 
-        Roles roles = factory.getAdminService().getSecurityRoles();
         ExperimenterGroup userGroup = new ExperimenterGroupI(roles.userGroupId,
                 false);
         ExperimenterGroup systemGroup = new ExperimenterGroupI(
@@ -189,7 +181,7 @@ public class PermissionsTestAll extends AbstractServerTest {
                 targetGroups.add(groupCopies.get(cntr));
                 cntr++;
             }
-            factory.getAdminService().createExperimenterWithPassword(
+            svc.createExperimenterWithPassword(
                     experimenter, omeroPassword, defaultGroup, targetGroups);
 
             // Make user : owner + uuid , owner of all the groups
@@ -202,8 +194,6 @@ public class PermissionsTestAll extends AbstractServerTest {
                 }
             }
         }
-
-        client.closeSession();
     }
 
     /**
@@ -481,12 +471,9 @@ public class PermissionsTestAll extends AbstractServerTest {
      * Implemented as specified by {@link AdminService}.
      */
     private boolean isSecuritySystemGroup(long groupID) {
-        if (securityRoles == null) {
-            return false;
-        }
-        return (securityRoles.guestGroupId == groupID
-                || securityRoles.systemGroupId == groupID
-                || securityRoles.userGroupId == groupID);
+        return (roles.guestGroupId == groupID
+                || roles.systemGroupId == groupID
+                || roles.userGroupId == groupID);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
@@ -235,7 +235,7 @@ public class PermissionsTestAll extends AbstractServerTest {
                 }
             }
 
-            client.closeSession();
+            client.__del__();
         }
     }
 

--- a/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
+++ b/components/tools/OmeroJava/test/integration/chgrp/MultiImageFilesetMoveTest.java
@@ -106,7 +106,7 @@ public class MultiImageFilesetMoveTest extends AbstractServerTest {
     protected List<Image> importMIF(int seriesCount) throws Throwable {
         File fake = TempFileManager.create_path("importMIF",
                 String.format("&series=%d.fake", seriesCount));
-        List<Pixels> pixels = importFile(importer, fake, null, false, null);
+        List<Pixels> pixels = importFile(createImporter(), fake, null, false, null);
         Assert.assertEquals(seriesCount, pixels.size());
         List<Image> images = new ArrayList<Image>();
         for (Pixels pixel : pixels) {


### PR DESCRIPTION
# What this PR does

Rewrites Java integration tests to behave the same but without creating so many users and service proxies. Also adjusts usage of Ice implicit context.

# Testing this PR

[OMERO-DEV-merge-integration-java](https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/) should pass. Code changes should not invalidate any tests. Specifically, while a `ImplicitGroupContext` is open then `this.client` should not change session/login. It may be easiest to ignore whitespace changes via https://github.com/openmicroscopy/openmicroscopy/pull/5524/files?w=1.