### PR TITLE
Insight Java 9 compatibility 

### DIFF
--- a/components/insight/build/Importer_template.exe4j
+++ b/components/insight/build/Importer_template.exe4j
@@ -27,7 +27,7 @@
         fontSize="8" fontColor="0,0,0" fontWeight="500" />
     </text>
   </splashScreen>
-  <java mainClass="@MAIN_CLASS@" vmParameters="@VM_PARAMETERS@"
+  <java mainClass="@MAIN_CLASS@"
     arguments="containerImporter.xml" allowVMPassthroughParameters="true" preferredVM=""
     minVersion="1.7" maxVersion="" allowBetaVM="false" jdkOnly="false">
     <searchSequence>
@@ -42,6 +42,10 @@
     <nativeLibraryDirectories>
       <directory name="libs" />
     </nativeLibraryDirectories>
+    <vmOptions>
+      <options version="1" line="-Xms256M -Xmx1024M"/>
+      <options version="9" line="-Xms256M -Xmx1024M --add-modules java.activation" />
+    </vmOptions>
   </java>
   <includedFiles />
   <unextractableFiles />

--- a/components/insight/build/Insight_template.exe4j
+++ b/components/insight/build/Insight_template.exe4j
@@ -27,7 +27,7 @@
         fontSize="8" fontColor="0,0,0" fontWeight="500" />
     </text>
   </splashScreen>
-  <java mainClass="@MAIN_CLASS@" vmParameters="@VM_PARAMETERS@"
+  <java mainClass="@MAIN_CLASS@"
     arguments="" allowVMPassthroughParameters="true" preferredVM="" 
     minVersion="1.7" maxVersion="" allowBetaVM="false" jdkOnly="false">
     <searchSequence>
@@ -42,6 +42,10 @@
     <nativeLibraryDirectories>
       <directory name="libs" />
     </nativeLibraryDirectories>
+    <vmOptions>
+      <options version="1" line="-Xms256M -Xmx1024M"/>
+      <options version="9" line="-Xms256M -Xmx1024M --add-modules java.activation" />
+    </vmOptions>
   </java>
   <includedFiles />
   <unextractableFiles />

--- a/components/insight/build/dist.xml
+++ b/components/insight/build/dist.xml
@@ -326,7 +326,6 @@
               <filter token="EXE_NAME" value="app/${dist@{type}.win.exename}"/>
               <filter token="APP_NAME" value="${dist@{type}.name}"/>
               <filter token="ICON_FILE" value="${dist@{type}.win.icon}"/>
-              <filter token="VM_PARAMETERS" value="${app.vmparameters}"/>
             </filterset>
           </copy>
           <exe4j projectfile="${build.dir}/@{type}.exe4j"/>
@@ -348,7 +347,6 @@
               <filter token="EXE_NAME" value="app/${dist@{type}.win64.exename}"/>
               <filter token="APP_NAME" value="${dist@{type}.name}"/>
               <filter token="ICON_FILE" value="${dist@{type}.win.icon}"/>
-              <filter token="VM_PARAMETERS" value="${app.vmparameters}"/>
             </filterset>
           </copy>
           <exe4j projectfile="${build.dir}/@{type}_64.exe4j"/>

--- a/components/insight/launch/OMEROimporter_unix.sh
+++ b/components/insight/launch/OMEROimporter_unix.sh
@@ -39,5 +39,11 @@ if [ -z "$CLIENTS_HOME" ]; then
 fi
 CLIENTS_HOME="$(dirname "$CLIENTS_HOME")"
 
+MODULE_ARGS=""
+JAVA_VERSION=`java -version 2>&1`
+if [ -z "${JAVA_VERSION##*build 9*}" ]
+then
+        MODULE_ARGS="--add-modules java.activation"
+fi
 cd "$CLIENTS_HOME"
-java -Xms256000000 -Xmx1024000000 -jar omero.insight.jar containerImporter.xml
+java -Xms256000000 -Xmx1024000000 $MODULE_ARGS -jar omero.insight.jar containerImporter.xml

--- a/components/insight/launch/OMEROinsight_unix.sh
+++ b/components/insight/launch/OMEROinsight_unix.sh
@@ -38,5 +38,12 @@ if [ -z "$CLIENTS_HOME" ]; then
 fi
 CLIENTS_HOME="$(dirname "$CLIENTS_HOME")"
 
+MODULE_ARGS=""
+JAVA_VERSION=`java -version 2>&1`
+if [ -z "${JAVA_VERSION##*build 9*}" ]
+then
+        MODULE_ARGS="--add-modules java.activation"
+fi
+
 cd "$CLIENTS_HOME"
-java -Xms256000000 -Xmx1024000000 -jar omero.insight.jar
+java -Xms256000000 -Xmx1024000000 $MODULE_ARGS -jar omero.insight.jar


### PR DESCRIPTION
--exclude not for 5.4.0 and not ready yet anyway (OSX build still has to be adjusted)

# What this PR does

For Java 9 Insight has to be launched with `--add-modules java.activation` argument.
This PR modifies the Linux launch scripts, as well as Windows and Mac builds accordingly.

Note: This might need an `exe4j` update on the build system. I had to update my local `exe4j` because the `<vmoptions>` attribute wasn't supported by the version I had before (no exception, just ignored).

# Testing this PR

A bit tricky to test: Ideally test that Importer and Insight still work with Java 1.8, then test again if both still work with Java 9, on Linux, OSX and Windows.

# Related reading

https://trello.com/c/Eh7p5387/57-to-watch-java-19

