### PR TITLE
remove password from guest user

### DIFF
--- a/sql/psql/OMERO5.4__0/allow-guest-user-without-password.sql
+++ b/sql/psql/OMERO5.4__0/allow-guest-user-without-password.sql
@@ -1,0 +1,6 @@
+-- Removes password protection from user with ID 1 and name "guest".
+
+UPDATE password SET hash = ''
+ WHERE experimenter_id = 1 AND
+       EXISTS (SELECT FROM experimenter
+                WHERE id = 1 AND omename = 'guest');


### PR DESCRIPTION
# What this PR does

Provides a utility script for removing any password for the guest user.

# Testing this PR

1. Check that you can log in as the guest user with any password.

1. Use `bin/omero user password guest` to set a password on the guest user.

1. Check that you *cannot* log in as the guest user with any password but the one you set.

1. Use `psql` with the `allow-guest-user-without-password.sql` script to remove the password from the guest user.

1. Check that you can log in as the guest user with any password.

1. Check that you still need the correct password to log in as other users.