### PR TITLE
Fix 2017-SV4

### DIFF
--- a/components/blitz/src/omero/cmd/admin/ResetPasswordRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/ResetPasswordRequestI.java
@@ -1,7 +1,5 @@
 /*
- *  $Id$
- *  
- *   Copyright 2014 University of Dundee. All rights reserved.
+ *   Copyright 2014-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -84,6 +82,7 @@ public class ResetPasswordRequestI extends ResetPasswordRequest implements
         if (email == null)
             throw helper.cancel(new ERR(), null, "no-email");
 
+        helper.allowGuests();
         this.helper.setSteps(1);
     }
 

--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -291,7 +291,9 @@ public class BasicACLVoter implements ACLVoter {
         if (tokenHolder.hasPrivilegedToken(iObject)) {
             return true;
         } else if (!sysType) {
-            if (iObject instanceof OriginalFile) {
+            if (ec.getCurrentUserId() == roles.getGuestId()) {
+                return false;
+            } else if (iObject instanceof OriginalFile) {
                 final OriginalFile file = (OriginalFile) iObject;
                 if (file.getRepo() != null && !file.getName().startsWith(fileRepoSecretKey)) {
                     /* Cannot yet set OriginalFile.repo except via secret key stored in database.
@@ -498,7 +500,9 @@ public class BasicACLVoter implements ACLVoter {
 
             boolean hasLightAdminPrivilege = false;
             if (!sysType) {
-                if (iObject instanceof OriginalFile) {
+                if (c.getCurrentUserId() == roles.getGuestId()) {
+                    return 0;
+                } else if (iObject instanceof OriginalFile) {
                     final String repo = ((OriginalFile) iObject).getRepo();
                     if (repo != null) {
                         if (managedRepoUuids.contains(repo)) {

--- a/components/server/src/ome/security/basic/CurrentDetails.java
+++ b/components/server/src/ome/security/basic/CurrentDetails.java
@@ -529,6 +529,13 @@ public class CurrentDetails implements PrincipalHolder {
         current().setEvent(event);
     }
 
+    /**
+     * @return if the current user is the system's <q>guest</q> user
+     */
+    public boolean isCurrentUserGuest() {
+        return current().getCurrentUserId() == roles.getGuestId();
+    }
+
     // ~ Cleanups
     // =========================================================================
 
@@ -627,5 +634,4 @@ public class CurrentDetails implements PrincipalHolder {
         }
 
     }
-
 }

--- a/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/AbstractBasicSecuritySystemTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractBasicSecuritySystemTest extends
         sec.login(p);
 
         // context
-        user = new Experimenter(1L, true);
+        user = new Experimenter(2L, true);
         group = new ExperimenterGroup(2L, true); // first non-"user" group
         group.getDetails().setPermissions(perms);
         type = new EventType(1L, true);
@@ -159,7 +159,7 @@ public abstract class AbstractBasicSecuritySystemTest extends
         mockEc.expects(atLeastOnce()).method("getCurrentSessionId").will(
                 returnValue(1L));
         mockEc.expects(atLeastOnce()).method("getCurrentUserId").will(
-                returnValue(1L));
+                returnValue(2L));
         mockEc.expects(atLeastOnce()).method("getCurrentUserName").will(
                 returnValue("some-user"));
         mockEc.expects(atLeastOnce()).method("getCurrentSudoerId").will(

--- a/components/server/test/ome/server/utests/sec/SecuritySystemTest.java
+++ b/components/server/test/ome/server/utests/sec/SecuritySystemTest.java
@@ -517,7 +517,7 @@ public class SecuritySystemTest extends AbstractBasicSecuritySystemTest {
         sec.loadEventContext(false);
 
         Details d = Details.create();
-        d.setOwner(new Experimenter(2L, false));
+        d.setOwner(new Experimenter(3L, false));
         d.setGroup(new ExperimenterGroup(2L, false)); // in same group
         d.setPermissions(new Permissions());
 
@@ -542,7 +542,7 @@ public class SecuritySystemTest extends AbstractBasicSecuritySystemTest {
         Image i = new Image();
 
         // setting permissions
-        i.getDetails().setOwner(new Experimenter(1L, false));
+        i.getDetails().setOwner(new Experimenter(2L, false));
         i.getDetails().setPermissions(p);
         Details test = sec.newTransientDetails(i);
         assertEquals(p, test.getPermissions());
@@ -580,7 +580,7 @@ public class SecuritySystemTest extends AbstractBasicSecuritySystemTest {
         oldDetails.setPermissions(new Permissions());
 
         // setting permissions
-        i.getDetails().setOwner(new Experimenter(1L, false));
+        i.getDetails().setOwner(new Experimenter(2L, false));
         i.getDetails().setGroup(new ExperimenterGroup(2L, false));
         i.getDetails().setCreationEvent(new Event(1L, false));
         i.getDetails().setPermissions(p);


### PR DESCRIPTION
Summary of the changes:

- the first commit is a forward port of the security fix in 5.3.5
- the second commit adjusts the server unit tests to prevent the usage of `userId` 1 (guest) for the tests
- the third commit is a cherry-pick of https://github.com/openmicroscopy/openmicroscopy/pull/5529 to restore the guest usage of `ResetPassword`

/cc @jburel @mtbc 