### PR TITLE
remove forgotten password link

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -119,8 +119,6 @@
 			</div>
 
         	<input type="submit" value="Login" />
-
-            <div><p><a href="{% url 'waforgottenpassword' %}">Forgot your password?</a></p></div>
     </form>
     {% endblock %}
 </div>


### PR DESCRIPTION
# What this PR does

Removes "forgotten password" link.
See https://trello.com/c/XMvAyTXe/163-forgotten-password-reset-functionality-in-omeroweb-disabled


# Testing this PR

1. Login screen - Forgotten password no longer visible.
