### PR TITLE
Update remaining old website URLs

### DIFF
--- a/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
+++ b/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
@@ -152,7 +152,7 @@ public class IniFileLoader {
      */
     public String getHomeUrl()
     {
-        return staticPref("General", "url", "https://www.openmicroscopy.org/site/products/omero/feature-list");
+        return staticPref("General", "url", "https://www.openmicroscopy.org/omero/new/");
     }
 
     /**

--- a/components/tools/OmeroPy/bin/omero
+++ b/components/tools/OmeroPy/bin/omero
@@ -103,7 +103,7 @@ try:
         This means that your installation is incomplete. Contact
         the OME mailing lists for more information:
 
-        https://www.openmicroscopy.org/site/community
+        https://www.openmicroscopy.org/support/
 
         If you are building from source, please supply the build log
         as well as which version you are building from. If you

--- a/components/tools/OmeroPy/src/omero/__init__.py
+++ b/components/tools/OmeroPy/src/omero/__init__.py
@@ -32,7 +32,7 @@ try:
         help understanding this issue, please send this error message
         to the OME community:
 
-        https://www.openmicroscopy.org/site/community
+        https://www.openmicroscopy.org/support/
 
         Debugging Info:
         --------------


### PR DESCRIPTION
# What this PR does

Updates the remaining /site URLs to point to the new website, found when grepping to check URLs for #5521 after Seb spotted that both I & Petr had missed an incorrect docs URL.

Both the links redirect to the correct place so this isn't essential but it would be nice to have all of them updated, especially as this is a major release.

# Testing this PR

Check the URLs


# Related reading

None.
