### PR TITLE
fix regression in IRoi.getTable

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/RoiI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RoiI.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2009 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */

--- a/components/blitz/src/ome/services/blitz/impl/RoiI.java
+++ b/components/blitz/src/ome/services/blitz/impl/RoiI.java
@@ -385,15 +385,16 @@ public class RoiI extends AbstractAmdServant implements _IRoiOperations,
                     throw new ome.conditions.ApiUsageException("No such file annotation: " + annotationId);
                 }
 
-                try {
-                    return factory.sharedResources(__current).openTable(
-                            new OriginalFileI(file.getId(), false));
-                } catch (ServerError e) {
-                    throw new RuntimeException(e);
-                }
+                return file.getId();
 
             }
-        }));
+        }) {
+            /* transforms the file annotation ID to a handle to an open table */
+            @Override
+            protected Object postProcess(Object rv) throws ServerError {
+                return factory.sharedResources(__current).openTable(new OriginalFileI((Long) rv, false));
+            }
+        });
     }
 
     class MaskClass

--- a/components/blitz/src/ome/services/throttling/Task.java
+++ b/components/blitz/src/ome/services/throttling/Task.java
@@ -1,9 +1,6 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
- *
  */
 
 package ome.services.throttling;

--- a/components/blitz/src/ome/services/throttling/Task.java
+++ b/components/blitz/src/ome/services/throttling/Task.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Method;
 
 import ome.system.OmeroContext;
 import omero.InternalException;
+import omero.ServerError;
 import omero.util.IceMapper;
 
 import org.slf4j.Logger;
@@ -60,7 +61,7 @@ public abstract class Task {
             if (isVoid) {
                 response.invoke(cb);
             } else {
-                response.invoke(cb, rv);
+                response.invoke(cb, postProcess(rv));
             }
         } catch (Exception e) {
             InternalException ie = new InternalException();
@@ -69,6 +70,17 @@ public abstract class Task {
             log.error(ie.message, e);
             exception(ie, ctx);
         }
+    }
+
+    /**
+     * Can be overridden to transform the return value from the async method.
+     * This implementation leaves the return value unchanged.
+     * @param rv a return value
+     * @return the return value transformed
+     * @throws ServerError if the transformation failed
+     */
+    protected Object postProcess(Object rv) throws ServerError {
+        return rv;
     }
 
     protected void exception(Throwable ex, OmeroContext ctx) {


### PR DESCRIPTION
# What this PR does

Fixes the executor's `IllegalStateException` upon use of the ROI service's `getTable` method.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/RoiServiceTest/ should pass.