### PR TITLE
Add javax.activation dependency

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -61,6 +61,8 @@
     <dependency org="net.java.dev.jna" name="platform" rev="${versions.platform}"/>
     <dependency org="edu.ucar" name="grib" rev="${versions.grib}" transitive="false"/>
     <dependency org="edu.ucar" name="bufr" rev="${versions.bufr}" transitive="false"/>
+    <!-- from Java 9 on javax.activation is not included any longer -->
+    <dependency org="javax.activation" name="activation" rev="1.1.1"/>
     <!-- Bioformats -->
     <dependency org="ome" name="formats-bsd" rev="${versions.bioformats}">
         <exclude org="com.jgoodies"/>

--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -62,7 +62,7 @@
     <dependency org="edu.ucar" name="grib" rev="${versions.grib}" transitive="false"/>
     <dependency org="edu.ucar" name="bufr" rev="${versions.bufr}" transitive="false"/>
     <!-- from Java 9 on javax.activation is not included any longer -->
-    <dependency org="javax.activation" name="activation" rev="1.1.1"/>
+    <dependency org="javax.activation" name="activation" rev="${versions.activation}"/>
     <!-- Bioformats -->
     <dependency org="ome" name="formats-bsd" rev="${versions.bioformats}">
         <exclude org="com.jgoodies"/>

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -924,6 +924,7 @@ versions.ant=1.8.0
 versions.antlr=2.7.6
 versions.appbundler=1.0.0
 versions.asm=1.5.3
+versions.activation=1.1.1
 versions.axis=1.4
 versions.backport=3.1
 versions.batik=1.8pre-jdk6


### PR DESCRIPTION
# What this PR does

Adds `javax.activation` to Insights ivy dependencies. 
With Java 9 modules system `javax.activation` is not part of JRE core any longer and will throw a `java.lang.NoClassDefFoundError: javax/activation/ActivationDataFlavor` error on login. 

# Testing this PR

Check that Insight still works with Java 9 (ideally reproduce the error with latest build first). It's enough when you see the main Insight window after login, no further testing needed.

# Related reading

https://trello.com/c/Eh7p5387/57-to-watch-java-19

