### PR TITLE
allow setting OMERO_PASSWORD for CLI login

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -406,7 +406,7 @@ ENV_HELP = """Environment variables:
   OMERO_TMPDIR      Set the base directory containing temporary files.
                     Default: $OMERO_USERDIR/tmp
   OMERO_PASSWORD    Set the user's password for creating new sessions.
-                    Suppresses interactive prompt. Ignored if -w is used.
+                    Ignored if -w or --password is used.
 """
 
 SUDO_HELP = """

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -405,6 +405,8 @@ ENV_HELP = """Environment variables:
                     Default: $OMERO_USERDIR/sessions
   OMERO_TMPDIR      Set the base directory containing temporary files.
                     Default: $OMERO_USERDIR/tmp
+  OMERO_PASSWORD    Set the user's password for creating new sessions.
+                    Suppresses interactive prompt. Ignored if -w is used.
 """
 
 SUDO_HELP = """

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -450,6 +450,9 @@ class SessionsControl(BaseControl):
         if not rv:
 
             if not pasw:
+                pasw = os.getenv("OMERO_PASSWORD")
+
+            if not pasw:
                 # Note: duplicating the `not pasw` check here
                 # for an overall nicer error message.
                 self._require_tty("cannot request password")


### PR DESCRIPTION
# What this PR does

Simple enhancement to OMERO.cli that allows setting the `OMERO_PASSWORD` environment variable instead of using the `-w` command-line option.

# Testing this PR

Check the behavior of OMERO.cli commands with and without `-w`. Set a password instead using the `OMERO_PASSWORD` environment variable and check that it is as if `-w` had been used.

# Related reading

https://trello.com/c/EKMzInAG/45-add-password-envvar-for-bin-omero-login