### PR TITLE
add a % sign to percentage in server log warning

### DIFF
--- a/components/blitz/src/omero/util/ServantHolder.java
+++ b/components/blitz/src/omero/util/ServantHolder.java
@@ -176,7 +176,7 @@ public class ServantHolder {
 
         double percent = (100.0 * size / servantsPerSession);
         if (percent > 0 && (percent % 10) == 0) {
-            log.warn(String.format("%s of servants used for session %s",
+            log.warn(String.format("%s%% of servants used for session %s",
                 (int) percent, session));
         }
         put(id.name, servant);


### PR DESCRIPTION
# What this PR does

Fixes the "servants used for session" log messages reported by @kennethgillen.

# Testing this PR

Search the Blitz log's warnings. If it is too hard to trigger the warning then it is probably easiest to comment out the preceding "if" condition then do a local build.

# Related reading

https://trello.com/c/KSZ8Q2Rc/53-logging-of-servants