### PR TITLE
Prevent 'endless' countTiles loop

### DIFF
--- a/components/romio/src/ome/io/nio/SimpleBackOff.java
+++ b/components/romio/src/ome/io/nio/SimpleBackOff.java
@@ -56,6 +56,10 @@ public class SimpleBackOff implements BackOff {
         this(new ConfiguredTileSizes(), 1000, 1000000);
     }
 
+    public SimpleBackOff(TileSizes sizes) {
+        this(sizes, 1000, 1000000);
+    }
+
     public SimpleBackOff(TileSizes sizes, long defaultValue, long maxPixels) {
         this.sizes = sizes;
         this.count = 10;

--- a/components/romio/src/ome/io/nio/SimpleBackOff.java
+++ b/components/romio/src/ome/io/nio/SimpleBackOff.java
@@ -48,13 +48,19 @@ public class SimpleBackOff implements BackOff {
 
     protected final TileSizes sizes;
 
+    protected final long maxPixels;
+    
+    protected final long defaultValue;
+    
     public SimpleBackOff() {
-        this(new ConfiguredTileSizes());
+        this(new ConfiguredTileSizes(), 1000, 1000000);
     }
 
-    public SimpleBackOff(TileSizes sizes) {
+    public SimpleBackOff(TileSizes sizes, long defaultValue, long maxPixels) {
         this.sizes = sizes;
         this.count = 10;
+        this.defaultValue = defaultValue;
+        this.maxPixels = maxPixels;
         try {
             ServiceFactory sf = new ServiceFactory();
             service = sf.getInstance(JAIIIOService.class);
@@ -85,10 +91,9 @@ public class SimpleBackOff implements BackOff {
 
     protected long calculate(Pixels pixels) {
         // only count tiles if pixels report reasonable size values
-        final long cutOff = 1000000;
-        return (pixels.getSizeC() > cutOff || pixels.getSizeT() > cutOff
-                || pixels.getSizeX() > cutOff || pixels.getSizeY() > cutOff || pixels
-                .getSizeZ() > cutOff) ? 1000
+        return (pixels.getSizeC() > maxPixels || pixels.getSizeT() > maxPixels
+                || pixels.getSizeX() > maxPixels || pixels.getSizeY() > maxPixels || pixels
+                .getSizeZ() > maxPixels) ? defaultValue
                 : (long) (scalingFactor * countTiles(pixels));
     }
 

--- a/components/romio/src/ome/io/nio/SimpleBackOff.java
+++ b/components/romio/src/ome/io/nio/SimpleBackOff.java
@@ -84,7 +84,12 @@ public class SimpleBackOff implements BackOff {
     }
 
     protected long calculate(Pixels pixels) {
-        return (long) (scalingFactor * countTiles(pixels));
+        // only count tiles if pixels report reasonable size values
+        final long cutOff = 1000000;
+        return (pixels.getSizeC() > cutOff || pixels.getSizeT() > cutOff
+                || pixels.getSizeX() > cutOff || pixels.getSizeY() > cutOff || pixels
+                .getSizeZ() > cutOff) ? 1000
+                : (long) (scalingFactor * countTiles(pixels));
     }
 
     protected int countTiles(Pixels pixels) {

--- a/components/server/resources/ome/services/service-ome.io.nio.PixelsService.xml
+++ b/components/server/resources/ome/services/service-ome.io.nio.PixelsService.xml
@@ -41,7 +41,9 @@
   </bean>
 
   <bean id="backOff" class="${omero.pixeldata.backoff}">
-    <constructor-arg ref="tileSizes"/>
+    <constructor-arg index="0" ref="tileSizes"/>
+    <constructor-arg index="1" value="${omero.pixeldata.backoff.default}"/>
+    <constructor-arg index="2" value="${omero.pixeldata.backoff.maxpixels}"/>
   </bean>
 
   <bean id="configuredTileSizes" class="ome.io.nio.ConfiguredTileSizes">

--- a/components/tools/OmeroJava/test/integration/ImporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ImporterTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2006-2016 University of Dundee. All rights reserved.
+ *   Copyright 2006-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package integration;
@@ -636,6 +636,27 @@ public class ImporterTest extends AbstractServerTest {
             Assert.fail("Cannot import the following formats:" + s);
         }
         Assert.assertEquals(0, failures.size());
+    }
+
+    @Test(timeOut = 5000)
+    public void testImportInsaneImage() throws Exception {
+        // Simulates QA 17685 (an image with unreasonably huge pixel sizes stuck the import process
+        // in a basically endless loop when trying to throw an exception)
+        File f = new File(
+                System.getProperty("java.io.tmpdir"),
+                "testImportInsaneImage&pixelType=uint8&sizeX=892411973&sizeY=1684497696&sizeZ=25971.fake");
+        f.deleteOnExit();
+        f.createNewFile();
+        List<Pixels> pixels = null;
+        try {
+            pixels = importFile(f, OME_FORMAT);
+        } catch (Throwable e) {
+            throw new Exception("cannot import image", e);
+        }
+        Pixels p = pixels.get(0);
+        Assert.assertEquals(p.getSizeX().getValue(), 892411973);
+        Assert.assertEquals(p.getSizeY().getValue(), 1684497696);
+        Assert.assertEquals(p.getSizeZ().getValue(), 25971);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ImporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ImporterTest.java
@@ -638,7 +638,7 @@ public class ImporterTest extends AbstractServerTest {
         Assert.assertEquals(0, failures.size());
     }
 
-    @Test(timeOut = 5000)
+    @Test(timeOut = 15000)
     public void testImportFinishTooLargePixelsImage() throws Exception {
         // Simulates QA 17685 (an image with unreasonably huge pixel sizes stuck the import process
         // in a basically endless loop when trying to throw an exception); purpose is to

--- a/components/tools/OmeroJava/test/integration/ImporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ImporterTest.java
@@ -639,9 +639,10 @@ public class ImporterTest extends AbstractServerTest {
     }
 
     @Test(timeOut = 5000)
-    public void testImportInsaneImage() throws Exception {
+    public void testImportFinishTooLargePixelsImage() throws Exception {
         // Simulates QA 17685 (an image with unreasonably huge pixel sizes stuck the import process
-        // in a basically endless loop when trying to throw an exception)
+        // in a basically endless loop when trying to throw an exception); purpose is to
+        // check that the import process finishes within a certain amount of time.
         File f = new File(
                 System.getProperty("java.io.tmpdir"),
                 "testImportInsaneImage&pixelType=uint8&sizeX=892411973&sizeY=1684497696&sizeZ=25971.fake");

--- a/components/tools/OmeroJava/test/integration/ImporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ImporterTest.java
@@ -25,6 +25,8 @@ import omero.api.IAdminPrx;
 import omero.api.IRoiPrx;
 import omero.api.RoiOptions;
 import omero.api.RoiResult;
+import omero.cmd.Delete2;
+import omero.gateway.util.Requests;
 import omero.model.Annotation;
 import omero.model.Arc;
 import omero.model.BooleanAnnotation;
@@ -638,7 +640,7 @@ public class ImporterTest extends AbstractServerTest {
         Assert.assertEquals(0, failures.size());
     }
 
-    @Test(timeOut = 15000)
+    @Test(timeOut = 20000)
     public void testImportFinishTooLargePixelsImage() throws Exception {
         // Simulates QA 17685 (an image with unreasonably huge pixel sizes stuck the import process
         // in a basically endless loop when trying to throw an exception); purpose is to
@@ -658,6 +660,9 @@ public class ImporterTest extends AbstractServerTest {
         Assert.assertEquals(p.getSizeX().getValue(), 892411973);
         Assert.assertEquals(p.getSizeY().getValue(), 1684497696);
         Assert.assertEquals(p.getSizeZ().getValue(), 25971);
+        
+        Delete2 dc = Requests.delete().target(p.getImage()).build();
+        callback(true, root, dc);
     }
 
     /**

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -390,6 +390,11 @@ omero.pixeldata.repetitions=1
 # to calculate the backoff (in ms) that users
 # should wait for an image to be ready to view.
 omero.pixeldata.backoff=ome.io.nio.SimpleBackOff
+# A default value for the backoff time
+omero.pixeldata.backoff.default=1000
+# The maximum number of pixels (in any dimension),
+# if exceeded the default value will be used.
+omero.pixeldata.backoff.maxpixels=1000000
 
 # Maximum time in milliseconds that file parsing
 # can take without the parsed metadata being

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -390,7 +390,7 @@ omero.pixeldata.repetitions=1
 # to calculate the backoff (in ms) that users
 # should wait for an image to be ready to view.
 omero.pixeldata.backoff=ome.io.nio.SimpleBackOff
-# A default value for the backoff time
+# A default value for the backoff time.
 omero.pixeldata.backoff.default=1000
 # The maximum number of pixels (in any dimension),
 # if exceeded the default value will be used.


### PR DESCRIPTION
# What this PR does

When an image reports ridiculous pixel sizes the `countTiles` method basically goes into an endless loop, which hangs the import process and creates unnecessary high server load. With this PR the pixel size is checked beforehand and if unreasonable high values are reported a default 'backoff' value is returned. This method is only used for constructing an Exception object anyway, therefore general implications of this PR should be very limited.

# Testing this PR

- Import the image from https://www.openmicroscopy.org/qa2/qa/feedback/17685 . You need to import the zipped file. Import of the file directly will be rejected. Make sure the import process finishes and the server load goes back to normal. Note: A thumbnail won't be generated, as this flawed image claims to have a size x,y,z of 892411973 x 1684497696 x 25971 pixels.
Alternatively you can also try to import something like `crazytestfile&pixelType=uint8&sizeX=892411973&sizeY=1684497696&sizeZ=25971.fake` instead.
- Check that `ImporterTest` integration test passes.

# Related reading

https://trello.com/c/GpPJ1Kcu/187-image-with-invalid-metadata-kills-server

