### PR TITLE
clear context after CallContext invocation

### DIFF
--- a/components/blitz/src/omero/cmd/CallContext.java
+++ b/components/blitz/src/omero/cmd/CallContext.java
@@ -77,6 +77,7 @@ public class CallContext implements MethodInterceptor {
         try {
             return arg0.proceed();
         } finally {
+            cd.setContext(null);
             MDC.clear();
         }
     }


### PR DESCRIPTION
# What this PR does

Has `CallContext` always clean up any context left in the thread's `CurrentDetails`.

# Testing this PR

Flakiness in integration tests may be reduced.

# Related reading

https://trello.com/c/qUkOm9ld/59-group-membership-flakiness