### PR TITLE
abort pyramid-making when tile fails

### DIFF
--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -439,7 +439,7 @@ public class PixelsService extends AbstractFileSystemService
                         log.warn("Error clearing empty or incomplete pixel " +
                                  "buffer.", e2);
                     }
-                    throw new Utils.FailedTileLoopException();
+                    throw new FailedTileLoopException();
                 }
             }
             }, source, (int) tileSize.getWidth(), (int) tileSize.getHeight());

--- a/components/romio/src/ome/io/nio/SimpleBackOff.java
+++ b/components/romio/src/ome/io/nio/SimpleBackOff.java
@@ -14,6 +14,7 @@ import loci.common.services.ServiceFactory;
 import loci.formats.codec.JPEG2000CodecOptions;
 import loci.formats.services.JAIIIOService;
 import ome.conditions.MissingPyramidException;
+import ome.io.nio.Utils.FailedTileLoopException;
 import ome.model.core.Pixels;
 
 import org.slf4j.Logger;
@@ -89,15 +90,19 @@ public class SimpleBackOff implements BackOff {
 
     protected int countTiles(Pixels pixels) {
         final int[] count = new int[] { 0 };
-        ome.io.nio.Utils.forEachTile(new TileLoopIteration() {
+        try {
+            ome.io.nio.Utils.forEachTile(new TileLoopIteration() {
 
-            public void run(int z, int c, int t, int x, int y, int tileWidth,
-                    int tileHeight, int tileCount) {
-                count[0]++;
-            }
-        }, pixels.getSizeX(), pixels.getSizeY(), pixels.getSizeZ(),
-           pixels.getSizeC(), pixels.getSizeT(),
-           sizes.getTileWidth(), sizes.getTileHeight());
+                public void run(int z, int c, int t, int x, int y, int tileWidth,
+                        int tileHeight, int tileCount) {
+                    count[0]++;
+                }
+            }, pixels.getSizeX(), pixels.getSizeY(), pixels.getSizeZ(),
+               pixels.getSizeC(), pixels.getSizeT(),
+               sizes.getTileWidth(), sizes.getTileHeight());
+        } catch (FailedTileLoopException ftle) {
+            // impossible, never thrown by run method
+        }
         return count[0];
     }
 

--- a/components/romio/src/ome/io/nio/TileLoopIteration.java
+++ b/components/romio/src/ome/io/nio/TileLoopIteration.java
@@ -1,11 +1,13 @@
 /*
  * ome.io.nio.TileLoopIteration
  *
- *   Copyright 2011 University of Dundee. All rights reserved.
+ *   Copyright 2011-2017 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
 package ome.io.nio;
+
+import ome.io.nio.Utils.FailedTileLoopException;
 
 /**
  * A single iteration of a tile for each loop.
@@ -29,7 +31,8 @@ public interface TileLoopIteration
      * @param tileHeight Height of the tile requested. The tile request
      * itself may be smaller if <code>y + tileHeight > sizeY</code>.
      * @param tileCount Counter of the tile since the beginning of the loop.
+     * @throws FailedTileLoopException if the loop should be aborted with no more tiles processed
      */
     void run(int z, int c, int t, int x, int y, int tileWidth,
-             int tileHeight, int tileCount);
+             int tileHeight, int tileCount) throws FailedTileLoopException;
 }

--- a/components/romio/src/ome/io/nio/Utils.java
+++ b/components/romio/src/ome/io/nio/Utils.java
@@ -103,9 +103,10 @@ public class Utils
 
     /**
      * The processing of a tile failed so abort the loop.
+     * <strong>Warning:</strong> Will become a checked exception after OMERO 5.4.x.
      */
     @SuppressWarnings("serial")
-    public static class FailedTileLoopException extends Exception {
+    public static class FailedTileLoopException extends RuntimeException {
 
         private Integer tileCount = null;
 

--- a/components/romio/test/ome/io/nio/utests/AbstractPyramidPixelBufferUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/AbstractPyramidPixelBufferUnitTest.java
@@ -17,6 +17,7 @@ import ome.io.nio.PixelBuffer;
 import ome.io.nio.PixelsService;
 import ome.io.nio.TileLoopIteration;
 import ome.io.nio.Utils;
+import ome.io.nio.Utils.FailedTileLoopException;
 import ome.model.core.Pixels;
 import ome.model.enums.PixelsType;
 import ome.util.checksum.ChecksumProviderFactory;
@@ -85,7 +86,7 @@ public abstract class AbstractPyramidPixelBufferUnitTest {
         FileUtils.deleteDirectory(new File(root));
     }
 
-    protected short writeTiles(final List<String> hashDigests) {
+    protected short writeTiles(final List<String> hashDigests) throws FailedTileLoopException {
         return writeTiles(hashDigests, new Runnable(){
             public void run() {
                 // Do nothing.
@@ -95,12 +96,8 @@ public abstract class AbstractPyramidPixelBufferUnitTest {
     /**
      * Calls {@link Runnable#run()} after each successful call to
      * {@link PixelBuffer#setTile(byte[], Integer, Integer, Integer, Integer, Integer, Integer, Integer)}.
-     *
-     * @param hashDigests
-     * @param run
-     * @return
      */
-    protected short writeTiles(final List<String> hashDigests, final Runnable run) {
+    protected short writeTiles(final List<String> hashDigests, final Runnable run) throws FailedTileLoopException {
         short tileCount = (short) Utils.forEachTile(new TileLoopIteration() {
             public void run(int z, int c, int t, int x, int y, int tileWidth,
                             int tileHeight, int tileCount) {

--- a/components/romio/test/ome/io/nio/utests/PyramidWriteLockUnitTest.java
+++ b/components/romio/test/ome/io/nio/utests/PyramidWriteLockUnitTest.java
@@ -12,7 +12,9 @@ import java.util.concurrent.TimeUnit;
 
 import ome.conditions.LockTimeout;
 import ome.io.bioformats.BfPyramidPixelBuffer;
+import ome.io.nio.Utils.FailedTileLoopException;
 
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -61,7 +63,11 @@ public class PyramidWriteLockUnitTest extends AbstractPyramidPixelBufferUnitTest
 
         Thread t = new Thread() {
             public void run() {
-                writeTiles(new ArrayList<String>(), run);
+                try {
+                    writeTiles(new ArrayList<String>(), run);
+                } catch (FailedTileLoopException ftle) {
+                    Assert.fail("unexpected exception", ftle);
+                }
             };
         };
         t.start();


### PR DESCRIPTION
# What this PR does

Prevents filling logs with "Error during tile population" by having `PixelsService.performWrite` abort further tiles when building a pyramid from one throws an exception.

# Testing this PR

Review code and logs. There should still be *some* error reported for any failing cases of making pyramids for imported big images, just not crazily many.

# Related reading

https://trello.com/c/xUMP9iuF/54-tile-loop-logging-bug