### PR TITLE
Gateway methods

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1551,6 +1551,7 @@ class _BlitzGateway (object):
         self._user = None
         self._userid = None
         self._proxies = NoProxies()
+        self._tracked_services = dict()
         if self.c is None:
             self._resetOmeroClient()
         else:
@@ -1567,6 +1568,51 @@ class _BlitzGateway (object):
 
         # The properties we are setting through the interface
         self.setIdentity(username, passwd, not clone)
+
+    def _register_service(self, service_string, stack):
+        """
+        Register the results of traceback.extract_stack() at the time
+        that a service was created.
+        """
+        service_string = str(service_string)
+        self._tracked_services[service_string] = stack
+        logger.info("Registered %s" % service_string)
+
+    def _unregister_service(self, service_string):
+        """
+        Called on close of a service.
+        """
+        service_string = str(service_string)
+        if service_string in self._tracked_services:
+            del self._tracked_services[service_string]
+            logger.info("Unregistered %s" % service_string)
+        else:
+            logger.warn("Cannot find registered service %s" % service_string)
+
+    def _assert_unregistered(self, prefix="Service left open!"):
+        """
+        Log an ERROR for every stateful service that is open
+        and was registered by this BlitzGateway instance.
+
+        Return the number of unclosed services found.
+        """
+
+        try:
+            stateful_services = self.c.getStatefulServices()
+        except Exception, e:
+            logger.warn("No services could be found.", e)
+            stateful_services = []
+
+        count = 0
+        for s in stateful_services:
+            service_string = str(s)
+            stack_list = self._tracked_services.get(service_string, [])
+            if stack_list:
+                count += 1
+                stack_msg = "".join(traceback.format_list(stack_list))
+                logger.error("%s - %s\n%s" % (
+                    prefix, service_string, stack_msg))
+        return count
 
     def createServiceOptsDict(self):
         serviceOpts = ServiceOptsDict(self.c.getImplicitContext().getContext())
@@ -1875,8 +1921,9 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-#    def __del__ (self):
-#        logger.debug("##GARBAGE COLLECTOR KICK IN")
+    def __del__ (self):
+        logger.debug("##GARBAGE COLLECTOR KICK IN")
+        self._assert_unregistered()
 
     def _createProxies(self):
         """
@@ -4726,6 +4773,7 @@ class ProxyObjectWrapper (object):
 
         if self._obj and isinstance(
                 self._obj, omero.api.StatefulServiceInterfacePrx):
+            self._conn._unregister_service(str(self._obj))
             self._obj.close(*args, **kwargs)
         self._obj = None
 
@@ -4746,7 +4794,10 @@ class ProxyObjectWrapper (object):
             if self._func_str is None:
                 return self._cast_to(self._sf.getByName(self._service_name))
             else:
-                return getattr(self._sf, self._func_str)()
+                obj = getattr(self._sf, self._func_str)()
+                if isinstance(obj, omero.api.StatefulServiceInterfacePrx):
+                    conn._register_service(str(obj), traceback.extract_stack())
+                return obj
         self._create_func = cf
         if self._obj is not None:
             try:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7892,7 +7892,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 self._re = self._prepareRE(rdid=rdid)
             except omero.ValidationException:
                 logger.debug('on _prepareRE()', exc_info=True)
-                self._re = None
+                self._closeRE()
         return self._re is not None
 
     def resetRDefs(self):
@@ -8461,8 +8461,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             rv[i] = float(level)/sizeXList[0]
         return rv
 
+    @assert_re()
     def setActiveChannels(self, channels, windows=None, colors=None,
-                          invertMaps=None, reverseMaps=None):
+                          invertMaps=None, reverseMaps=None, noRE=False):
         """
         Sets the active channels on the rendering engine.
         Also sets rendering windows and channel colors
@@ -8498,7 +8499,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 invertMaps = reverseMaps
         abs_channels = [abs(c) for c in channels]
         idx = 0     # index of windows/colors args above
-        for c in range(len(self.getChannels())):
+        for c in range(len(self.getChannels(noRE=noRE))):
             self._re.setActive(c, (c+1) in channels, self._conn.SERVICE_OPTS)
             if (c+1) in channels:
                 if (invertMaps is not None and
@@ -8948,43 +8949,46 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
         # Prepare the rendering engine parameters on the ImageWrapper.
         re = self._prepareRE()
-        z = re.getDefaultZ()
-        t = re.getDefaultT()
-        x = 0
-        y = 0
-        size_x = self.getSizeX()
-        size_y = self.getSizeY()
-        tile_width, tile_height = re.getTileSize()
-        tiles_wide = math.ceil(float(size_x) / tile_width)
-        tiles_high = math.ceil(float(size_y) / tile_height)
-        # Since the JPEG 2000 algorithm is iterative and rounds pixel counts
-        # at each resolution level we're doing the resulting tile size
-        # calculations in a loop. Also, since the image is physically tiled
-        # the resulting size is a multiple of the tile size and not the
-        # iterative quotient of a 2**(resolutionLevels - 1).
-        for i in range(1, re.getResolutionLevels()):
-            tile_width = round(tile_width / 2.0)
-            tile_height = round(tile_height / 2.0)
-        width = int(tiles_wide * tile_width)
-        height = int(tiles_high * tile_height)
-        jpeg_data = self.renderJpegRegion(z, t, x, y, width, height, level=0)
-        if size is None:
-            return jpeg_data
-        # We've been asked to scale the image by its longest side so we'll
-        # perform that operation until the server has the capability of
-        # doing so.
-        ratio = float(size) / max(width, height)
-        if width > height:
-            size = (int(size), int(height * ratio))
-        else:
-            size = (int(width * ratio), int(size))
-        jpeg_data = Image.open(StringIO(jpeg_data))
-        jpeg_data.thumbnail(size, Image.ANTIALIAS)
-        ImageDraw.Draw(jpeg_data)
-        f = StringIO()
-        jpeg_data.save(f, "JPEG")
-        f.seek(0)
-        return f.read()
+        try:
+            z = re.getDefaultZ()
+            t = re.getDefaultT()
+            x = 0
+            y = 0
+            size_x = self.getSizeX()
+            size_y = self.getSizeY()
+            tile_width, tile_height = re.getTileSize()
+            tiles_wide = math.ceil(float(size_x) / tile_width)
+            tiles_high = math.ceil(float(size_y) / tile_height)
+            # Since the JPEG 2000 algorithm is iterative and rounds pixel counts
+            # at each resolution level we're doing the resulting tile size
+            # calculations in a loop. Also, since the image is physically tiled
+            # the resulting size is a multiple of the tile size and not the
+            # iterative quotient of a 2**(resolutionLevels - 1).
+            for i in range(1, re.getResolutionLevels()):
+                tile_width = round(tile_width / 2.0)
+                tile_height = round(tile_height / 2.0)
+            width = int(tiles_wide * tile_width)
+            height = int(tiles_high * tile_height)
+            jpeg_data = self.renderJpegRegion(z, t, x, y, width, height, level=0)
+            if size is None:
+                return jpeg_data
+            # We've been asked to scale the image by its longest side so we'll
+            # perform that operation until the server has the capability of
+            # doing so.
+            ratio = float(size) / max(width, height)
+            if width > height:
+                size = (int(size), int(height * ratio))
+            else:
+                size = (int(width * ratio), int(size))
+            jpeg_data = Image.open(StringIO(jpeg_data))
+            jpeg_data.thumbnail(size, Image.ANTIALIAS)
+            ImageDraw.Draw(jpeg_data)
+            f = StringIO()
+            jpeg_data.save(f, "JPEG")
+            f.seek(0)
+            return f.read()
+        finally:
+            re.close()
 
     @assert_re()
     def renderJpegRegion(self, z, t, x, y, width, height, level=None,
@@ -9021,7 +9025,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 except omero.SecurityViolation:  # pragma: no cover
                     self._obj.clearPixels()
                     self._obj.pixelsLoaded = False
-                    self._re = None
+                    self._closeRE()
                     return self.renderJpeg(z, t, None)
             rv = self._re.renderCompressed(self._pd, self._conn.SERVICE_OPTS)
             return rv
@@ -9034,8 +9038,17 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             # hangs
             self._obj.clearPixels()
             self._obj.pixelsLoaded = False
-            self._re = None
+            self._closeRE()
             raise
+
+    def _closeRE(self):
+        try:
+            if self._re:
+                self._re.close()
+        except Exception, e:
+            logger.warn("Failed to close " + self._re)
+        finally:
+            self._re = None  # This should be the ONLY location to null _re!
 
     @assert_re()
     def renderJpeg(self, z=None, t=None, compression=0.9):
@@ -9064,7 +9077,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 except omero.SecurityViolation:  # pragma: no cover
                     self._obj.clearPixels()
                     self._obj.pixelsLoaded = False
-                    self._re = None
+                    self._closeRE()
                     return self.renderJpeg(z, t, None)
             projection = self.PROJECTIONS.get(self._pr, -1)
             if not isinstance(
@@ -9090,7 +9103,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             # hangs
             self._obj.clearPixels()
             self._obj.pixelsLoaded = False
-            self._re = None
+            self._closeRE()
             raise
 
     def exportOmeTiff(self, bufsize=0):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8462,8 +8462,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         return rv
 
     @assert_re()
-    def setActiveChannels(self, channels, windows=None, colors=None,
-                          invertMaps=None, reverseMaps=None, noRE=False):
+    def set_active_channels(self, channels, windows=None, colors=None,
+                            invertMaps=None, reverseMaps=None, noRE=False):
         """
         Sets the active channels on the rendering engine.
         Also sets rendering windows and channel colors
@@ -8524,6 +8524,16 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             if (c+1 in abs_channels):
                 idx += 1
         return True
+
+    @assert_re()
+    def setActiveChannels(self, channels, windows=None, colors=None,
+                          invertMaps=None, reverseMaps=None):
+        warnings.warn(
+                "setActiveChannels() is"
+                "deprecated in OMERO 5.4.0. Use set_active_channels",
+                DeprecationWarning)
+        return self.set_active_channels(channels, windows, colors,
+                                        invertMaps, reverseMaps, False)
 
     def getProjections(self):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8489,6 +8489,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                             Must be item for each channel
         :param invertMaps:  List of boolean (or None). If True/False then
                             set/remove reverseIntensityMap on channel
+        :param noRE:        If True Channels will not have rendering engine
+                            enabled. In this case, calling channel.getColor()
+                            or getWindowStart() etc. will return None.
         """
         if reverseMaps is not None:
             warnings.warn(

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8531,10 +8531,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     @assert_re()
     def setActiveChannels(self, channels, windows=None, colors=None,
                           invertMaps=None, reverseMaps=None):
-        warnings.warn(
-                "setActiveChannels() is"
-                "deprecated in OMERO 5.4.0. Use set_active_channels",
-                DeprecationWarning)
+        warnings.warn("setActiveChannels() is deprecated in OMERO 5.4.0."
+                      "Use set_active_channels", DeprecationWarning)
         return self.set_active_channels(channels, windows, colors,
                                         invertMaps, reverseMaps, False)
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1921,7 +1921,7 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-    def __del__ (self):
+    def __del__(self):
         logger.debug("##GARBAGE COLLECTOR KICK IN")
         self._assert_unregistered()
 
@@ -8959,17 +8959,18 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             tile_width, tile_height = re.getTileSize()
             tiles_wide = math.ceil(float(size_x) / tile_width)
             tiles_high = math.ceil(float(size_y) / tile_height)
-            # Since the JPEG 2000 algorithm is iterative and rounds pixel counts
-            # at each resolution level we're doing the resulting tile size
-            # calculations in a loop. Also, since the image is physically tiled
-            # the resulting size is a multiple of the tile size and not the
-            # iterative quotient of a 2**(resolutionLevels - 1).
+            # Since the JPEG 2000 algorithm is iterative and rounds pixel
+            # counts at each resolution level we're doing the resulting tile
+            # size calculations in a loop. Also, since the image is physically
+            # tiled the resulting size is a multiple of the tile size and not
+            # the iterative quotient of a 2**(resolutionLevels - 1).
             for i in range(1, re.getResolutionLevels()):
                 tile_width = round(tile_width / 2.0)
                 tile_height = round(tile_height / 2.0)
             width = int(tiles_wide * tile_width)
             height = int(tiles_high * tile_height)
-            jpeg_data = self.renderJpegRegion(z, t, x, y, width, height, level=0)
+            jpeg_data = self.renderJpegRegion(
+                z, t, x, y, width, height, level=0)
             if size is None:
                 return jpeg_data
             # We've been asked to scale the image by its longest side so we'll
@@ -9034,8 +9035,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             logger.debug(traceback.format_exc())
             return None
         except Ice.MemoryLimitException:  # pragma: no cover
-            # Make sure renderCompressed isn't called again on this re, as it
-            # hangs
+            # Make sure renderCompressed isn't called again on this re,
+            # as it hangs
             self._obj.clearPixels()
             self._obj.pixelsLoaded = False
             self._closeRE()
@@ -9043,10 +9044,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
     def _closeRE(self):
         try:
-            if self._re:
+            if self._re is not None:
                 self._re.close()
         except Exception, e:
             logger.warn("Failed to close " + self._re)
+            logger.debug(e)
         finally:
             self._re = None  # This should be the ONLY location to null _re!
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -452,3 +452,61 @@ class TestRDefs (object):
             "family": channels[1].getFamily().getValue(),
             "coefficient": channels[1].getCoefficient()
         }
+
+    def testGetChannelsNoRE(self, gatewaywrapper):
+        """
+        Tests that the color, window start are not available
+        if noRE is True
+        """
+        self.image = gatewaywrapper.getTestImage()
+        channels = self.image.getChannels(noRE=True)
+        for c in channels:
+            assert c.getColor() is None
+            assert c.getWindowStart() is None
+
+    def testSetActiveChannelsNoRE(self, gatewaywrapper):
+        """
+        Tests set_active_channels method without rendering engine
+        """
+        # Clean potentially customized default
+        self.image.clearDefaults()
+        self.image = gatewaywrapper.getTestImage()
+        c0wmin = self.image.getChannels()[0].getWindowMin()
+        # Change the color for the rendering defs
+        # For #126, also verify channels, and specifically setting min to 0
+        self.channels = self.image.getChannels()
+        assert self.c0color != 'F0F000'
+        assert self.c1color != '000F0F'
+        assert c0wmin != 0
+        self.image.set_active_channels(
+            [1, 2], [[0.0, 1631.0], [409.0, 5015.0]], [u'F0F000', u'000F0F'],
+            noRE=True)
+        self.channels = self.image.getChannels()
+        assert len(self.channels) == 2, 'bad channel count on image #%d' \
+            % self.TESTIMG_ID
+        assert self.channels[0].getColor().getHtml() == 'F0F000'
+        assert self.channels[1].getColor().getHtml() == '000F0F'
+        assert self.channels[0].getWindowStart() == 0
+
+    def testSetActiveChannelsWithRE(self, gatewaywrapper):
+        """
+        Tests set_active_channels method with rendering engine
+        """
+        # Clean potentially customized default
+        self.image.clearDefaults()
+        self.image = gatewaywrapper.getTestImage()
+        c0wmin = self.image.getChannels()[0].getWindowMin()
+        # Change the color for the rendering defs
+        # For #126, also verify channels, and specifically setting min to 0
+        self.channels = self.image.getChannels()
+        assert self.c0color != 'F0F000'
+        assert self.c1color != '000F0F'
+        assert c0wmin != 0
+        self.image.set_active_channels(
+            [1, 2], [[0.0, 1631.0], [409.0, 5015.0]], [u'F0F000', u'000F0F'])
+        self.channels = self.image.getChannels()
+        assert len(self.channels) == 2, 'bad channel count on image #%d' \
+            % self.TESTIMG_ID
+        assert self.channels[0].getColor().getHtml() == 'F0F000'
+        assert self.channels[1].getColor().getHtml() == '000F0F'
+        assert self.channels[0].getWindowStart() == 0

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -512,6 +512,10 @@ class TestRDefs (object):
         assert self.channels[0].getWindowStart() == 0
 
     def testUnregisterService(self, gatewaywrapper):
+        """
+        Tests if the service is unregistered after closing the
+        rendering engine
+        """
         image = gatewaywrapper.getTestImage()
         self.channels = image.getChannels()
         g = gatewaywrapper.gateway
@@ -521,6 +525,10 @@ class TestRDefs (object):
         assert count_close == (count - 1)
 
     def testRegisterService(self, gatewaywrapper):
+        """
+        Tests if the service is registered when opening the
+        rendering engine
+        """
         g = gatewaywrapper.gateway
         image = gatewaywrapper.getTestImage()
         count = g._assert_unregistered("testUnregisteredService")
@@ -528,8 +536,11 @@ class TestRDefs (object):
         count_after = g._assert_unregistered("testUnregisteredService")
         assert count_after == (count + 1)
         image._closeRE()
-        
+
     def testCloseRE(self, gatewaywrapper):
+        """
+        Tests if the rendering engine is closed
+        """
         image = gatewaywrapper.getTestImage()
         image._closeRE()
         assert image._re is None

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -510,3 +510,22 @@ class TestRDefs (object):
         assert self.channels[0].getColor().getHtml() == 'F0F000'
         assert self.channels[1].getColor().getHtml() == '000F0F'
         assert self.channels[0].getWindowStart() == 0
+
+    def testUnregisterService(self, gatewaywrapper):
+        image = gatewaywrapper.getTestImage()
+        self.channels = image.getChannels()
+        g = gatewaywrapper.gateway
+        count = g._assert_unregistered("testUnregisteredService")
+        image._closeRE()
+        count_close = g._assert_unregistered("testUnregisteredService")
+        assert count_close == (count - 1)
+
+    def testRegisterService(self, gatewaywrapper):
+        g = gatewaywrapper.gateway
+        image = gatewaywrapper.getTestImage()
+        count = g._assert_unregistered("testUnregisteredService")
+        self.channels = image.getChannels()
+        count_after = g._assert_unregistered("testUnregisteredService")
+        assert count_after == (count + 1)
+        image._closeRE()
+        

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -31,10 +31,12 @@ class TestRDefs (object):
             % self.TESTIMG_ID
         self.c0color = self.channels[0].getColor().getHtml()
         self.c1color = self.channels[1].getColor().getHtml()
+        self.image._closeRE()
 
     def testDefault(self, gatewaywrapper):
         # Clean potentially customized default
         self.image.clearDefaults()
+        self.image._closeRE()
         self.image = gatewaywrapper.getTestImage()
         c0wmin = self.image.getChannels()[0].getWindowMin()
         # Change the color for the rendering defs
@@ -54,7 +56,7 @@ class TestRDefs (object):
         # Save it as default
         assert self.image.saveDefaults(), 'Failed saveDefaults'
         # Verify that it comes back as default
-        self.image._re = None
+
         self.channels = self.image.getChannels()
         assert len(self.channels) == 2, 'bad channel count on image #%d' \
             % self.TESTIMG_ID
@@ -62,6 +64,7 @@ class TestRDefs (object):
         assert self.channels[1].getColor().getHtml() == '000F0F'
         assert self.channels[0].getWindowStart() == 0
         self.image.clearDefaults()
+        self.image._closeRE()
         self.image = gatewaywrapper.getTestImage()
         self.image.clearDefaults()
         self.channels = self.image.getChannels()
@@ -81,8 +84,11 @@ class TestRDefs (object):
             "Channel 1 should be Inactive"
         assert self.channels[1].isActive() is True, \
             "Channel 2 should be Active"
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testDefault")
 
-    def testCustomized(self):
+    def testCustomized(self, gatewaywrapper):
         self.image.setActiveChannels(
             [1, 2], [[292.0, 1631.0], [409.0, 5015.0]],
             [u'FF0000', u'0000FF'])
@@ -100,9 +106,13 @@ class TestRDefs (object):
             % self.TESTIMG_ID
         assert self.channels[0].getColor().getHtml() == 'F0F000'
         assert self.channels[1].getColor().getHtml() == '000F0F'
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testCustomized")
 
-    def testChannelWindows(self):
+    def testChannelWindows(self, gatewaywrapper):
         """ Verify getters and setter related to channel window settings """
+        self.channels = self.image.getChannels()
         for channel in self.channels:
             max = channel.getWindowMax()
             min = channel.getWindowMin()
@@ -116,15 +126,21 @@ class TestRDefs (object):
             channel.setWindow(start, end)
             assert channel.getWindowStart() == start
             assert channel.getWindowEnd() == end
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testChannelWindows")
 
-    def testFloatDefaultMinMax(self, author_testimg_32float):
+    def testFloatDefaultMinMax(self, gatewaywrapper, author_testimg_32float):
         """ Test the default min/max values for 32bit float images """
         channels = author_testimg_32float.getChannels()
         for channel in channels:
             assert channel.getWindowMin() == -2147483648
             assert channel.getWindowMax() == 2147483647
+        author_testimg_32float._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testFloatDefaultMinMax")
 
-    def testEmissionWave(self, author_testimg_tiny):
+    def testEmissionWave(self, gatewaywrapper, author_testimg_tiny):
         """ """
         assert self.channels[0].getEmissionWave() == 457
         assert self.channels[1].getEmissionWave() == 528
@@ -134,6 +150,9 @@ class TestRDefs (object):
         # 500)
         tiny = author_testimg_tiny.getChannels()
         assert tiny[0].getEmissionWave() == 500
+        author_testimg_tiny._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testEmissionWave")
 
     def testBatchCopy(self, gatewaywrapper, author_testimg_tiny,
                       author_testimg_tiny2):
@@ -154,6 +173,7 @@ class TestRDefs (object):
             i1c[0].setWindowStart(t+1)
             assert i1c[0].getWindowStart() != i2c[0].getWindowStart()
             i1.saveDefaults()
+            i1._closeRE()
             i1 = gatewaywrapper.getTinyTestImage()
             i1c = i1.getChannels()
             assert i1c[0].getWindowStart() == t+1
@@ -165,6 +185,7 @@ class TestRDefs (object):
             err = "FAIL: rsettings.applySettingsToImages(%i, (%i,)) -> %s" \
                 % (i1.getId(), i2.getId(), rv)
             assert rv[True] == [i2.getId()], err
+            i2._closeRE()
             i2 = gatewaywrapper.getTinyTestImage2()
             i2c = i2.getChannels()
             assert i2c[0].getWindowStart() == t+1
@@ -175,6 +196,7 @@ class TestRDefs (object):
             i1 = gatewaywrapper.getTinyTestImage()
             i1c = i1.getChannels()
             assert i1c[0].getWindowStart() == t
+            i1._closeRE()
             # Try the propagation as admin
             gatewaywrapper.loginAsAdmin()
             rsettings = gatewaywrapper.gateway.getRenderingSettingsService()
@@ -182,13 +204,14 @@ class TestRDefs (object):
             gatewaywrapper.gateway.SERVICE_OPTS.setOmeroUser(str(i1oid))
             rv = rsettings.applySettingsToImages(
                 frompid, list(toids), gatewaywrapper.gateway.SERVICE_OPTS)
+
             err = "FAIL: rsettings.applySettingsToImages(%i, (%i,)) -> %s" \
                 % (i1.getId(), i2.getId(), rv)
             assert rv[True] == [i2id], err
             i2 = gatewaywrapper.getTinyTestImage2()
             i2c = i2.getChannels()
             assert i2c[0].getWindowStart() == t
-
+            i2._closeRE()
         finally:
             gatewaywrapper.loginAsAuthor()
             i1 = gatewaywrapper.getTinyTestImage()
@@ -199,6 +222,10 @@ class TestRDefs (object):
             i1.saveDefaults()
             i2c[0].setWindowStart(t)
             i2.saveDefaults()
+            i1._closeRE()
+            i2._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testBatchCopy")
 
     def testGroupBasedPermissions(self, gatewaywrapper):
         """
@@ -218,6 +245,7 @@ class TestRDefs (object):
         admin = gatewaywrapper.gateway.getAdminService()
         admin.setGroupOwner(self.image.getDetails().getGroup()._obj, aobj)
         gatewaywrapper.loginAsAuthor()
+
         try:
             gatewaywrapper.gateway.CONFIG.IMG_RDEFNS = \
                 'omeropy.gatewaytest.img_rdefns'
@@ -232,6 +260,9 @@ class TestRDefs (object):
             self.image = gatewaywrapper.getTestImage()
             admin.unsetGroupOwner(self.image.getDetails().getGroup()._obj,
                                   aobj)
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testGroupBasedPermissions")
 
     def testGetRdefs(self, gatewaywrapper):
         """
@@ -246,7 +277,7 @@ class TestRDefs (object):
         self.image.setGreyscaleRenderingModel()
         self.image.setActiveChannels([1], colors=['cool.lut'])
         self.image.saveDefaults()
-
+        self.image._closeRE()
         # Author saves Rdef (color)
         gatewaywrapper.loginAsAuthor()
         authorId = gatewaywrapper.gateway.getUserId()
@@ -254,7 +285,7 @@ class TestRDefs (object):
         self.image.setColorRenderingModel()
         self.image.setActiveChannels([1], colors=['FF0000'])
         self.image.saveDefaults()
-
+        self.image._closeRE()
         rdefs = self.image.getAllRenderingDefs()
         assert len(rdefs) == 2
 
@@ -273,11 +304,11 @@ class TestRDefs (object):
 
         assert adminRdefId is not None
         assert authorRdefId is not None
-
         # Test getting different thumbnails
         defaultThumb = self.image.getThumbnail()
         authorThumb = self.image.getThumbnail(rdefId=authorRdefId)
         adminThumb = self.image.getThumbnail(rdefId=adminRdefId)
+
         # convert to PIL images
         defaultThumb = Image.open(StringIO(defaultThumb))
         authorThumb = Image.open(StringIO(authorThumb))
@@ -295,9 +326,13 @@ class TestRDefs (object):
         # Test thumbnail store init
         tb = self.image._prepareTB(rdefId=adminRdefId)
         assert tb.getRenderingDefId() == adminRdefId
+        tb.close()
         # Test thumbnail store init
         tb = self.image._prepareTB(rdefId=authorRdefId)
         assert tb.getRenderingDefId() == authorRdefId
+        tb.close()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testGetRdefs")
 
     def testResetDefaults(self, gatewaywrapper):
         """
@@ -334,14 +369,13 @@ class TestRDefs (object):
         assert not image.isGreyscaleRenderingModel()
         # Then reset and Save
         image.resetDefaults()
-
         # retrieve the image again... Should be greyscale
         image = gatewaywrapper.gateway.getObject("Image", iid)
         assert image.isGreyscaleRenderingModel()
         # Finally save as Color again, so Admin can test reset
         image.setColorRenderingModel()
         image.saveDefaults()
-
+        image._closeRE()
         # Login as Admin and try resetting...
         gatewaywrapper.loginAsAdmin()
         gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup('-1')
@@ -353,6 +387,9 @@ class TestRDefs (object):
         # Try resetting (save=True will be ignored, but reset will work)
         i.resetDefaults(save=True)
         assert i.isGreyscaleRenderingModel()
+        i._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testResetDefaults")
 
     def testQuantizationSettings(self, gatewaywrapper):
         """
@@ -401,6 +438,9 @@ class TestRDefs (object):
                 assert c.getFamily().getValue() == fam.getValue()
                 assert c.getCoefficient() == 0.5
                 i += 1
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testQuantizationSettings")
 
     def testQuantizationSettingsBulk(self, gatewaywrapper):
         """
@@ -452,6 +492,9 @@ class TestRDefs (object):
             "family": channels[1].getFamily().getValue(),
             "coefficient": channels[1].getCoefficient()
         }
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testQuantizationSettingsBulk")
 
     def testGetChannelsNoRE(self, gatewaywrapper):
         """
@@ -463,6 +506,8 @@ class TestRDefs (object):
         for c in channels:
             assert c.getColor() is None
             assert c.getWindowStart() is None
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testGetChannelsNoRE")
 
     def testSetActiveChannelsNoRE(self, gatewaywrapper):
         """
@@ -470,6 +515,7 @@ class TestRDefs (object):
         """
         # Clean potentially customized default
         self.image.clearDefaults()
+        self.image._closeRE()
         self.image = gatewaywrapper.getTestImage()
         c0wmin = self.image.getChannels()[0].getWindowMin()
         # Change the color for the rendering defs
@@ -478,6 +524,7 @@ class TestRDefs (object):
         assert self.c0color != 'F0F000'
         assert self.c1color != '000F0F'
         assert c0wmin != 0
+        self.image._closeRE()
         self.image.set_active_channels(
             [1, 2], [[0.0, 1631.0], [409.0, 5015.0]], [u'F0F000', u'000F0F'],
             noRE=True)
@@ -487,6 +534,9 @@ class TestRDefs (object):
         assert self.channels[0].getColor().getHtml() == 'F0F000'
         assert self.channels[1].getColor().getHtml() == '000F0F'
         assert self.channels[0].getWindowStart() == 0
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testSetActiveChannelsNoRE")
 
     def testSetActiveChannelsWithRE(self, gatewaywrapper):
         """
@@ -494,6 +544,7 @@ class TestRDefs (object):
         """
         # Clean potentially customized default
         self.image.clearDefaults()
+        self.image._closeRE()
         self.image = gatewaywrapper.getTestImage()
         c0wmin = self.image.getChannels()[0].getWindowMin()
         # Change the color for the rendering defs
@@ -510,6 +561,9 @@ class TestRDefs (object):
         assert self.channels[0].getColor().getHtml() == 'F0F000'
         assert self.channels[1].getColor().getHtml() == '000F0F'
         assert self.channels[0].getWindowStart() == 0
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testSetActiveChannelsWithRE")
 
     def testUnregisterService(self, gatewaywrapper):
         """
@@ -523,6 +577,8 @@ class TestRDefs (object):
         image._closeRE()
         count_close = g._assert_unregistered("testUnregisteredService")
         assert count_close == (count - 1)
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testUnregisterService")
 
     def testRegisterService(self, gatewaywrapper):
         """
@@ -531,16 +587,21 @@ class TestRDefs (object):
         """
         g = gatewaywrapper.gateway
         image = gatewaywrapper.getTestImage()
-        count = g._assert_unregistered("testUnregisteredService")
+        count = g._assert_unregistered("testRegisterService")
         self.channels = image.getChannels()
-        count_after = g._assert_unregistered("testUnregisteredService")
+        count_after = g._assert_unregistered("testRegisterService")
         assert count_after == (count + 1)
         image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testRegisterService")
 
     def testCloseRE(self, gatewaywrapper):
         """
         Tests if the rendering engine is closed
         """
         image = gatewaywrapper.getTestImage()
+        image.getChannels()
         image._closeRE()
         assert image._re is None
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testCloseRE")

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -529,3 +529,7 @@ class TestRDefs (object):
         assert count_after == (count + 1)
         image._closeRE()
         
+    def testCloseRE(self, gatewaywrapper):
+        image = gatewaywrapper.getTestImage()
+        image._closeRE()
+        assert image._re is None


### PR DESCRIPTION
# What this PR does

* Port commits currently in metadata 53. The Commits were used by the cli plugin render
* Add tests for new methodss
* Introduce ``set_active_channels`` and deprecate ``setActiveChannels``
* Review tests and make sure that all services are closed

# Related reading

see https://github.com/ome/omero-cli-render/pull/1

# To test
* Check that the tests are green

cc @joshmoore 