### PR TITLE
in codegen add checks for legal property values

### DIFF
--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -1286,6 +1286,16 @@ implements java.io.Serializable, IObject
 
     public void set${prop.nameCapped}(${prop.fieldType} ${prop.name}) {
         $errorIfUnloaded
+## See table column type alterations in psql-footer.vm.
+#if(($type.shortname == "Laser" && ($prop.name == "wavelength")) || ($type.shortname == "LightSettings" && ($prop.name == "wavelength")) || ($type.shortname == "LogicalChannel" && ($prop.name == "emissionWave" || $prop.name == "excitationWave")) || ($type.shortname == "Pixels" && ($prop.name == "physicalSizeX" || $prop.name == "physicalSizeY" || $prop.name == "physicalSizeZ")) || ($type.shortname == "TransmittanceRange" && ($prop.name == "cutIn" || $prop.name == "cutOut")))
+        if (${prop.name} != null && ${prop.name}.getValue() <= 0) {
+            throw new IllegalArgumentException("values of ${type.shortname}.${prop.name} must be strictly positive");
+        }
+#elseif(($type.shortname == "TransmittanceRange" && ($prop.name == "cutInTolerance" || $prop.name == "cutOutTolerance")))
+        if (${prop.name} != null && ${prop.name}.getValue() < 0) {
+            throw new IllegalArgumentException("values of ${type.shortname}.${prop.name} must not be negative");
+        }
+#end
         this.${prop.name} = ${prop.name};
     }
 
@@ -1353,6 +1363,20 @@ implements java.io.Serializable, IObject
 
     public void set${prop.nameCapped}(${prop.fieldType} ${prop.name}) {
         $errorIfUnloaded
+## See domain definitions in psql-header.vm.
+#if($prop.dbType == "positive_int" || $prop.dbType == "positive_float")
+        if (${prop.name} != null && ${prop.name} <= 0) {
+            throw new IllegalArgumentException("values of ${type.shortname}.${prop.name} must be strictly positive");
+        }
+#elseif($prop.dbType == "nonnegative_int" || $prop.dbType == "nonnegative_float")
+        if (${prop.name} != null && ${prop.name} < 0) {
+            throw new IllegalArgumentException("values of ${type.shortname}.${prop.name} must not be negative");
+        }
+#elseif($prop.dbType == "percent_fraction")
+        if (${prop.name} != null && (${prop.name} < 0 || ${prop.name} > 1)) {
+            throw new IllegalArgumentException("values of ${type.shortname}.${prop.name} may range from zero to one only");
+        }
+#end
         this.${prop.name} = (${prop.type}) ${prop.name};
     }
 #end######################################################################TYPE

--- a/components/dsl/resources/ome/dsl/psql-footer.vm
+++ b/components/dsl/resources/ome/dsl/psql-footer.vm
@@ -1034,6 +1034,9 @@ create trigger _fs_log_delete
 after delete on originalfile
     for each row execute procedure _fs_log_delete();
 
+-- Compare IllegalArgumentException cases in object.vm
+-- and unit testing in PropertyConstraintTest methods.
+
 ALTER TABLE laser
     ALTER COLUMN wavelength TYPE positive_float;
 

--- a/components/dsl/resources/ome/dsl/psql-header.vm
+++ b/components/dsl/resources/ome/dsl/psql-header.vm
@@ -57,6 +57,7 @@ SELECT assert_db_server_prerequisites(90300);
 DROP FUNCTION assert_db_server_prerequisites(INTEGER);
 DROP FUNCTION db_pretty_version(INTEGER);
 
+-- Compare IllegalArgumentException cases in object.vm.
 
 CREATE DOMAIN nonnegative_int AS INTEGER CHECK (VALUE >= 0);
 CREATE DOMAIN nonnegative_float AS DOUBLE PRECISION CHECK (VALUE >= 0);

--- a/components/model/test/ome/model/utests/PropertyConstraintTest.java
+++ b/components/model/test/ome/model/utests/PropertyConstraintTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.model.utests;
+
+import org.testng.annotations.Test;
+
+import ome.model.acquisition.Laser;
+import ome.model.acquisition.LightSettings;
+import ome.model.acquisition.TransmittanceRange;
+import ome.model.core.LogicalChannel;
+import ome.model.core.Pixels;
+import ome.model.enums.UnitsLength;
+import ome.model.units.Length;
+
+/**
+ * Test that client-side code enforces the special cases of column domain constraints enumerated in <tt>psql-footer.vm</tt>.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.4.1
+ */
+public class PropertyConstraintTest {
+
+    /* Laser.wavelength is a positive float */
+
+    @Test
+    public void testPositiveLaserWavelength() {
+        new Laser().setWavelength(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroLaserWavelength() {
+        new Laser().setWavelength(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeLaserWavelength() {
+        new Laser().setWavelength(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* LightSettings.wavelength is a positive float */
+
+    @Test
+    public void testPositiveLightSettingsWavelength() {
+        new LightSettings().setWavelength(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroLightSettingsWavelength() {
+        new LightSettings().setWavelength(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeLightSettingsWavelength() {
+        new LightSettings().setWavelength(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* LogicalChannel.emissionWave is a positive float */
+
+    @Test
+    public void testPositiveLogicalChannelEmissionWave() {
+        new LogicalChannel().setEmissionWave(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroLogicalChannelEmissionWave() {
+        new LogicalChannel().setEmissionWave(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeLogicalChannelEmissionWave() {
+        new LogicalChannel().setEmissionWave(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* LogicalChannel.excitationWave is a positive float */
+
+    @Test
+    public void testPositiveLogicalChannelExcitationWave() {
+        new LogicalChannel().setExcitationWave(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroLogicalChannelExcitationWave() {
+        new LogicalChannel().setExcitationWave(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeLogicalChannelExcitationWave() {
+        new LogicalChannel().setExcitationWave(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* Pixels.physicalSizeX is a positive float */
+
+    @Test
+    public void testPositivePixelsPhysicalSizeX() {
+        new Pixels().setPhysicalSizeX(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroPixelsPhysicalSizeX() {
+        new Pixels().setPhysicalSizeX(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativePixelsPhysicalSizeX() {
+        new Pixels().setPhysicalSizeX(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* Pixels.physicalSizeY is a positive float */
+
+    @Test
+    public void testPositivePixelsPhysicalSizeY() {
+        new Pixels().setPhysicalSizeY(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroPixelsPhysicalSizeY() {
+        new Pixels().setPhysicalSizeY(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativePixelsPhysicalSizeY() {
+        new Pixels().setPhysicalSizeY(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* Pixels.physicalSizeZ is a positive float */
+
+    @Test
+    public void testPositivePixelsPhysicalSizeZ() {
+        new Pixels().setPhysicalSizeZ(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroPixelsPhysicalSizeZ() {
+        new Pixels().setPhysicalSizeZ(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativePixelsPhysicalSizeZ() {
+        new Pixels().setPhysicalSizeZ(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* TransmittanceRange.cutIn is a positive float */
+
+    @Test
+    public void testPositiveTransmittanceRangeCutIn() {
+        new TransmittanceRange().setCutIn(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroTransmittanceRangeCutIn() {
+        new TransmittanceRange().setCutIn(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeTransmittanceRangeCutIn() {
+        new TransmittanceRange().setCutIn(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* TransmittanceRange.cutOut is a positive float */
+
+    @Test
+    public void testPositiveTransmittanceRangeCutOut() {
+        new TransmittanceRange().setCutOut(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testZeroTransmittanceRangeCutOut() {
+        new TransmittanceRange().setCutOut(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeTransmittanceRangeCutOut() {
+        new TransmittanceRange().setCutOut(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* TransmittanceRange.cutInTolerance is a nonnegative float */
+
+    @Test
+    public void testPositiveTransmittanceRangeCutInTolerance() {
+        new TransmittanceRange().setCutInTolerance(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test
+    public void testZeroTransmittanceRangeCutInTolerance() {
+        new TransmittanceRange().setCutInTolerance(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeTransmittanceRangeCutInTolerance() {
+        new TransmittanceRange().setCutInTolerance(new Length(-1, UnitsLength.CENTIMETER));
+    }
+
+    /* TransmittanceRange.cutOutTolerance is a nonnegative float */
+
+    @Test
+    public void testPositiveTransmittanceRangeCutOutTolerance() {
+        new TransmittanceRange().setCutOutTolerance(new Length(1, UnitsLength.CENTIMETER));
+    }
+
+    @Test
+    public void testZeroTransmittanceRangeCutOutTolerance() {
+        new TransmittanceRange().setCutOutTolerance(new Length(0, UnitsLength.CENTIMETER));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNegativeTransmittanceRangeCutOutTolerance() {
+        new TransmittanceRange().setCutOutTolerance(new Length(-1, UnitsLength.CENTIMETER));
+    }
+}

--- a/sql/psql/OMERO5.4__0/psql-footer.sql
+++ b/sql/psql/OMERO5.4__0/psql-footer.sql
@@ -2942,6 +2942,9 @@ create trigger _fs_log_delete
 after delete on originalfile
     for each row execute procedure _fs_log_delete();
 
+-- Compare IllegalArgumentException cases in object.vm
+-- and unit testing in PropertyConstraintTest methods.
+
 ALTER TABLE laser
     ALTER COLUMN wavelength TYPE positive_float;
 

--- a/sql/psql/OMERO5.4__0/psql-header.sql
+++ b/sql/psql/OMERO5.4__0/psql-header.sql
@@ -57,6 +57,7 @@ SELECT assert_db_server_prerequisites(90300);
 DROP FUNCTION assert_db_server_prerequisites(INTEGER);
 DROP FUNCTION db_pretty_version(INTEGER);
 
+-- Compare IllegalArgumentException cases in object.vm.
 
 CREATE DOMAIN nonnegative_int AS INTEGER CHECK (VALUE >= 0);
 CREATE DOMAIN nonnegative_float AS DOUBLE PRECISION CHECK (VALUE >= 0);


### PR DESCRIPTION
# What this PR does

For server-side model objects adds checks for legal property values for types from `psql-types.properties`:

```ini
PositiveInteger=positive_int
NonNegativeInteger=nonnegative_int
PositiveFloat=positive_float
PercentFraction=percent_fraction
```

This enables errors to be more promptly detected: in the code that sets the value, rather than later on when we save the objects and hit the constraints from `psql-header.sql`:

```sql
CREATE DOMAIN nonnegative_int AS INTEGER CHECK (VALUE >= 0);
CREATE DOMAIN nonnegative_float AS DOUBLE PRECISION CHECK (VALUE >= 0);
CREATE DOMAIN positive_int AS INTEGER CHECK (VALUE > 0);
CREATE DOMAIN positive_float AS DOUBLE PRECISION CHECK (VALUE > 0);
CREATE DOMAIN percent_fraction AS DOUBLE PRECISION CHECK (VALUE >= 0 AND VALUE <= 1);
```

which causes an undesirable PostgreSQL error in the server log.

Prompt detection of the violation means that the stack trace points more directly at the actual culprit rather than something rather later in the code path.

Also adds some related comments to our SQL scripts.

# Testing this PR

`PropertyConstraintTest` does some testing of this PR via Travis. You could try writing code to create `ome.model` objects (*not* `omero.model`) and set bad values in them according to the corresponding constraints from http://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome.html (see the "simple types" and look for property values that use them): you should get an immediate exception without needing to try to save to the database. It might also be interesting to find one of these images for which somebody got a related "ConstraintViolationException: could not insert" upon importing to see how the stack trace is now changed. I could try to hack a suitable fake together with OME-XML if desired.

# Related reading

https://trello.com/c/oqiU0S38/73-check-constraints-in-model-property-setters