### PR TITLE
increase graphs logging level to DEBUG

### DIFF
--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -87,8 +87,8 @@
   <logger name="ome.services.blitz.util.ShutdownSafeEhcacheManagerFactoryBean" level="WARN"/>
   <!-- Often useful to change to DEBUG -->
   <logger name="omero.cmd" level="INFO"/>
-  <logger name="omero.cmd.graphs" level="INFO"/>
-  <logger name="ome.services.graphs" level="INFO"/>
+  <logger name="omero.cmd.graphs" level="DEBUG"/>
+  <logger name="ome.services.graphs" level="DEBUG"/>
   <logger name="ome.services.delete" level="INFO"/>
   <!-- Adapters are also too so is a bit verbose -->
   <logger name="ome.adapters" level="ERROR"/>


### PR DESCRIPTION
Causes DEBUG-level logging for graphs code. Assists investigation of https://trello.com/c/DaJKgLoY/82-chown-all-scriptjob-failures. *Not* for merging.