### PR TITLE
enforce canonical path representation for repositories

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
+++ b/components/blitz/src/ome/services/blitz/repo/CheckedPath.java
@@ -316,7 +316,11 @@ public class CheckedPath {
      * slash.
      */
     protected String getDirname() {
-        return this.fsFile.toString() + FsFile.separatorChar;
+        if (FsFile.emptyPath.equals(this.fsFile)) {
+            return Character.toString(FsFile.separatorChar);
+        } else {
+            return FsFile.separatorChar + this.fsFile.toString() + FsFile.separatorChar;
+        }
     }
 
     /**
@@ -336,7 +340,11 @@ public class CheckedPath {
      * with separators including a trailing {@link FsFile#separatorChar}.
      */
     protected String getRelativePath() {
-        return this.parentDir + FsFile.separatorChar;
+        if (parentDir.isEmpty()) {
+            return Character.toString(FsFile.separatorChar);
+        } else {
+            return FsFile.separatorChar + this.parentDir + FsFile.separatorChar;
+        }
     }
 
     /**

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -482,10 +482,20 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
             file = photos.get(0);
         }
 
+        final String pathComponent, nameComponent;
+        final int lastSeparator = filename.lastIndexOf('/');
+        if (lastSeparator < 0) {
+            pathComponent = "/";
+            nameComponent = filename;
+        } else {
+            pathComponent = filename.substring(0, lastSeparator + 1);
+            nameComponent = filename.substring(lastSeparator + 1);
+        }
+
         if (file == null) {
             file = new OriginalFile();
-            file.setName(filename);
-            file.setPath(filename); // FIXME this should be something like /users/<name>/photo
+            file.setName(nameComponent);
+            file.setPath(pathComponent); // FIXME this should be something like /users/<name>/photo
             file.setSize((long) data.length);
             file.setHasher(new ChecksumAlgorithm(ChecksumAlgorithm.VALUE_SHA1_160));
             file.setHash(cpf.getProvider(ChecksumType.SHA1).putBytes(data)
@@ -503,8 +513,8 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
             internalMoveToCommonSpace(fa);
             internalMoveToCommonSpace(link);
         } else {
-            file.setName(filename);
-            file.setPath(filename);
+            file.setName(nameComponent);
+            file.setPath(pathComponent);
             file.setMimetype(mimetype);
             file = iUpdate.saveAndReturnObject(file);
         }

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -554,7 +554,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
         final ImportLocation importLocation = importFileset(Collections.singletonList(fakeImageFile.getPath()));
-        final RString imagePath = omero.rtypes.rstring(importLocation.sharedPath + FsFile.separatorChar);
+        final RString imagePath = omero.rtypes.rstring(FsFile.separatorChar + importLocation.sharedPath + FsFile.separatorChar);
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
         final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
                 "FROM OriginalFile o WHERE o.path = :path AND o.name = :name AND o.details.group.id = :group_id",

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -501,7 +501,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
         final ImportLocation importLocation = importFileset(Collections.singletonList(fakeImageFile.getPath()));
-        final RString imagePath = omero.rtypes.rstring(importLocation.sharedPath + FsFile.separatorChar);
+        final RString imagePath = omero.rtypes.rstring(FsFile.separatorChar + importLocation.sharedPath + FsFile.separatorChar);
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
         final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
                 "FROM OriginalFile o WHERE o.path = :path AND o.name = :name AND o.details.group.id = :group_id",
@@ -1803,7 +1803,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
                 /* no file to check */
                 return;
             }
-            final RString imagePath = omero.rtypes.rstring(importLocation.sharedPath + FsFile.separatorChar);
+            final RString imagePath = omero.rtypes.rstring(FsFile.separatorChar + importLocation.sharedPath + FsFile.separatorChar);
             final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
             final OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
                     "FROM OriginalFile o WHERE o.path = :path AND o.name = :name AND o.details.group.id = :group_id",
@@ -1829,7 +1829,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         final EventContext normalUser = newUserAndGroup("rwr-r-");
         /* import a fake image and determine its hash and hasher */
         final List<String> imageFilenames = Collections.singletonList(fakeImageFile.getPath());
-        final String repoPath = importFileset(imageFilenames).sharedPath + FsFile.separatorChar;
+        final String repoPath = FsFile.separatorChar + importFileset(imageFilenames).sharedPath + FsFile.separatorChar;
         List<RType> results = iQuery.projection(
                 "SELECT id, hasher.value, hash FROM OriginalFile " +
                 "WHERE name = :name AND path = :path AND details.group.id = :group_id",
@@ -1893,7 +1893,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
         final ImportLocation importLocation = importFileset(Collections.singletonList(fakeImageFile.getPath()));
-        final RString imagePath = omero.rtypes.rstring(importLocation.sharedPath + FsFile.separatorChar);
+        final RString imagePath = omero.rtypes.rstring(FsFile.separatorChar + importLocation.sharedPath + FsFile.separatorChar);
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
         OriginalFile remoteFile = (OriginalFile) iQuery.findByQuery(
                 "FROM OriginalFile o WHERE o.path = :path AND o.name = :name AND o.details.group.id = :group_id",

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -116,7 +116,7 @@ public class RolesTests extends AbstractServerImportTest {
         final String omeroGroup = client.getImplicitContext().get(omero.constants.GROUP.value);
         final long currentGroupId = StringUtils.isBlank(omeroGroup) ? iAdmin.getEventContext().groupId : Long.parseLong(omeroGroup);
         final ImportLocation importLocation = importFileset(Collections.singletonList(fakeImageFile.getPath()), 1, dataset);
-        final RString imagePath = omero.rtypes.rstring(importLocation.sharedPath + FsFile.separatorChar);
+        final RString imagePath = omero.rtypes.rstring(FsFile.separatorChar + importLocation.sharedPath + FsFile.separatorChar);
         final RString imageName = omero.rtypes.rstring(fakeImageFile.getName());
         String hql = "FROM OriginalFile o WHERE o.path = :path AND o.name = :name";
         final ParametersI params = new ParametersI().add("path", imagePath).add("name", imageName);

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -215,7 +215,7 @@ def rename_fileset(client, mrepo, fileset, new_dir, ctx=None):
         target = new_parpath + new_logname
         source = orig_parpath + orig_logname
         tomove.append((source, target))
-        log.path = rstring(new_parpath)
+        log.path = rstring("/" + new_parpath)
         log.name = rstring(new_logname)
         tosave.append(log)
 

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -152,8 +152,8 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         mrepo1 = self.get_managed_repo(client1)
         mrepo2 = self.get_managed_repo(client2)
 
-        testdir1 = self.test_dir(client1)
-        testdir2 = self.test_dir(client2)
+        testdir1 = '/' + self.test_dir(client1)
+        testdir2 = '/' + self.test_dir(client2)
 
         return self.Fixture(client1, mrepo1, testdir1), \
             self.Fixture(client2, mrepo2, testdir2)
@@ -359,9 +359,11 @@ class TestDbSync(AbstractRepoTest):
         self.create_file(mrepo, filename)
 
         # foo.txt is created on the backend but doesn't show up.
-        assert ['%s/file.txt' % self.unique_dir] == mrepo.list(self.unique_dir)
+        assert ['/%s/file.txt' % self.unique_dir] == \
+            mrepo.list(self.unique_dir)
         self.assert_passes(self.raw("touch", [fooname], client=self.root))
-        assert ['%s/file.txt' % self.unique_dir] == mrepo.list(self.unique_dir)
+        assert ['/%s/file.txt' % self.unique_dir] == \
+            mrepo.list(self.unique_dir)
 
         # If we try to create such a file, we should receive an exception
         try:


### PR DESCRIPTION
# What this PR does

Complementing the current expression index `originalfile_repo_path_index` in the database this PR adds checks in Java code for how file paths in repositories should be represented. If the server catches these errors earlier then fewer PostgreSQL errors are logged.

# Testing this PR

CI should remain green.