### PR TITLE
testtables_initialize_columns

### DIFF
--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -146,7 +146,7 @@ do
   bin/omero import $TINY_IMAGE_NAME --debug ERROR
 done
 
-# Uplodad files and create FileAnnotations
+# Upload files and create FileAnnotations
 ofile=$(bin/omero upload $FILE_ANNOTATION)
 bin/omero obj new FileAnnotation file=$ofile
 ofile2=$(bin/omero upload $FILE_ANNOTATION2)

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -112,7 +112,8 @@ plateid=$(sed -n -e 's/^Plate://p' plate_import.log)
 bin/omero obj update Plate:$plateid name=spwTests
 # Use populate_metadata to upload and attach bulk annotation csv
 # We use testtables to only try populate if tables are working
-OMERO_DEV_PLUGINS=1 bin/omero metadata testtables && bin/omero metadata populate Plate:$plateid --file $BULK_ANNOTATION_CSV
+export OMERO_DEV_PLUGINS=1      # required to enable 'metadata' CLI
+bin/omero metadata testtables && bin/omero metadata populate Plate:$plateid --file $BULK_ANNOTATION_CSV
 
 # Run script to populate WellSamples with posX and posY values
 PYTHONPATH=./lib/python python $WELLSCRIPT $HOSTNAME $PORT $key $plateid

--- a/components/tests/ui/robot_setup.sh
+++ b/components/tests/ui/robot_setup.sh
@@ -25,6 +25,7 @@ PLATE_NAME=${PLATE_NAME:-test&plates=1&plateAcqs=2&plateRows=2&plateCols=3&field
 TINY_PLATE_NAME=${TINY_PLATE_NAME:-test&plates=1&plateAcqs=1&plateRows=1&plateCols=1&fields=1&screens=0.fake}
 BULK_ANNOTATION_CSV=${BULK_ANNOTATION_CSV:-bulk_annotation.csv}
 FILE_ANNOTATION=${FILE_ANNOTATION:-robot_file_annotation.txt}
+FILE_ANNOTATION2=${FILE_ANNOTATION2:-robot_file_annotation2.txt}
 
 # Create robot user and group
 bin/omero login root@$HOSTNAME:$PORT -w $ROOT_PASSWORD
@@ -52,8 +53,9 @@ echo "Well,Well Type,Concentration" > "$BULK_ANNOTATION_CSV"
 echo "A1,Control,0" >> "$BULK_ANNOTATION_CSV"
 echo "A2,Treatment,10" >> "$BULK_ANNOTATION_CSV"
 
-# Create file for upload as File Annotation
+# Create files for upload as File Annotation
 echo "Robot test file annotations" > "$FILE_ANNOTATION"
+echo "Another test file annotation" > "$FILE_ANNOTATION2"
 
 # Create robot setup
 bin/omero login $USER_NAME@$HOSTNAME:$PORT -w $USER_PASSWORD
@@ -143,9 +145,11 @@ do
   bin/omero import $TINY_IMAGE_NAME --debug ERROR
 done
 
-# Uplodad file and create FileAnnotation
+# Uplodad files and create FileAnnotations
 ofile=$(bin/omero upload $FILE_ANNOTATION)
 bin/omero obj new FileAnnotation file=$ofile
+ofile2=$(bin/omero upload $FILE_ANNOTATION2)
+bin/omero obj new FileAnnotation file=$ofile2
 
 # Logout
 bin/omero logout

--- a/components/tests/ui/testcases/web/annotate_test.txt
+++ b/components/tests/ui/testcases/web/annotate_test.txt
@@ -14,7 +14,7 @@ ${commentTextTwo}       A second comment added by Robot test
 ${commentTextThree}     This will be added to Two Datasets
 ${commentTextFour}      I (Robot) just love adding comments!
 ${fileName}             robot_file_annotation.txt
-${fileNameTwo}          bulk_annotations
+${fileNameTwo}          robot_file_annotation2.txt
 ${SEARCH URL}           ${WELCOME URL}search/
 
 

--- a/components/tests/ui/testcases/web/annotate_test.txt
+++ b/components/tests/ui/testcases/web/annotate_test.txt
@@ -283,15 +283,16 @@ Test Search Results File Annotations
     ${sId_One}=                                 Create Screen       robot file annotations_1
 
     # Annotate single Screen
+    Click Element                               xpath=//h1[@data-name='attachments']
     Add File Annotation                         ${fileNameTwo}
 
     Input Text  id=id_search_query              ${fileNameTwo}
     Submit Form
     Location Should Be                          ${SEARCH URL}?search_query=${fileNameTwo}
 
-    Wait Until Page Contains Element            xpath=//img[contains(@alt, 'plate')]
-    Click Element                               xpath=//img[contains(@alt, 'plate')]
-    Wait Until Page Contains Element            //*[@id="general_tab"]//th[contains(text(), 'Plate ID:')]
+    Wait Until Page Contains Element            xpath=//img[contains(@alt, 'screen')]
+    Click Element                               xpath=//img[contains(@alt, 'screen')]
+    Wait Until Page Contains Element            //*[@id="general_tab"]//th[contains(text(), 'Screen ID:')]
 
     #Minimal checking to check if you can add Annotations on the search result page
     Click Element                               xpath=//h1[@data-name='attachments']

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -23,6 +23,7 @@ from omero.gateway import BlitzGateway
 from omero.util import populate_metadata, populate_roi, pydict_text_io
 from omero.util.metadata_utils import NSBULKANNOTATIONSCONFIG
 from omero.util.metadata_utils import NSBULKANNOTATIONSRAW
+from omero.grid import LongColumn
 
 
 HELP = """Metadata utilities
@@ -409,7 +410,7 @@ class MetadataControl(BaseControl):
         # If we have a table...
         initialized = False
         try:
-            table.initialize([])
+            table.initialize([LongColumn('ID', '', [])])
             initialized = True
         except:
             pass


### PR DESCRIPTION
# What this PR does

Fixes the CLI  ```metadata tablestest``` plugin to not use an empty list of Columns when testing
```table.initialize([])``` since this now fails with
```
ApiUsageException: exception ::omero::ApiUsageException
{
    serverStackTrace = 
    serverExceptionClass = 
    message = No columns provided
}
```
Instead we provide a single column, so this should work if tables are functioning correctly.
Robot framework setup.py uses ```$ bin/omero metadata tablestest``` to only attempt populate_metadata if it passes.

Also, we were using ```bulk_annotations``` (created by populate metadata) as a second File Annotation in some tests that were not testing Tables functionality. These were failing when that file was missing. Now we create a second file annotation so these tests no-longer rely on ```bulk_annotations```.

# Testing
 - Recently several tests of "Bulk Annotations" were failing because populate_metadata was not getting run (even though tables were working on that machine). https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/739/robot/

 - These tests should now be passing (if tables are working).

 - Other tests such as https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/739/robot/Web%20&%20Web/Web_1/Annotate%20Test/Test%20File%20Annotations/ should no longer fail with e.g. ```NoSuchElementException: Message: Could not locate element with visible text: bulk_annotations```
