### PR TITLE
make CLI help for graphs include/exclude less misleading

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1848,10 +1848,10 @@ class GraphControl(CmdControl):
         self._add_wait(parser, default=-1)
         parser.add_argument(
             "--include",
-            help="Modifies the given option by including a list of objects")
+            help="Modifies the given option by including a list of classes")
         parser.add_argument(
             "--exclude",
-            help="Modifies the given option by excluding a list of objects")
+            help="Modifies the given option by excluding a list of classes")
         parser.add_argument(
             "--ordered", action="store_true",
             help=("Pass multiple objects to commands strictly in the order "


### PR DESCRIPTION
# What this PR does

Adjusts the CLI help output for graphs commands to make it clearer that `--include` and `--exclude` expect class names not object IDs.

# Testing this PR

Check the help for a graphs command, e.g., `bin/omero delete --help`.

# Related reading

http://downloads.openmicroscopy.org/omero/5.4.0/api/slice2html/omero/cmd/graphs/ChildOption.html