### PR TITLE
fix_guest_username_check

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2262,7 +2262,7 @@ class ExperimenterWrapper(OmeroWebObjectWrapper,
             self.annotation_counter = kwargs['ldapUser']
 
     def isEditable(self):
-        return self.omeName.lower() is not 'guest'
+        return self.omeName.lower() != 'guest'
 
     def isLdapUser(self):
         """

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -2262,7 +2262,7 @@ class ExperimenterWrapper(OmeroWebObjectWrapper,
             self.annotation_counter = kwargs['ldapUser']
 
     def isEditable(self):
-        return self.omeName.lower() not in ('guest')
+        return self.omeName.lower() is not 'guest'
 
     def isLdapUser(self):
         """


### PR DESCRIPTION
# What this PR does

Fixes checking of "guest" user, e.g. in webadmin Users table.
See https://trello.com/c/U47AiD1R/48-weird-guest-login

To test, check that a user with e.g. username "g" is still editable at /webadmin/experimenters/ (and "guest" user is not).