### PR TITLE
zoom slider labels

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2388,7 +2388,7 @@ div.paging input.button_pagination {
     overflow: auto;
 }
 .zoomLabel {
-	font-size: 12px;
+    font-size: 12px;
     margin-top: 6px;
     margin-left: 9px;
     display: block;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2387,6 +2387,13 @@ div.paging input.button_pagination {
     right: 0px;
     overflow: auto;
 }
+.zoomLabel {
+	font-size: 12px;
+    margin-top: 6px;
+    margin-left: 9px;
+    display: block;
+    opacity: 0.8;
+}
 .wellImages {
     border-top: solid 1px #bbb;
 }

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_header_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_header_underscore.html
@@ -34,6 +34,9 @@
     </form>
 </div>
 <div style="position:absolute; bottom:0px; left:0px; right:0px; height: 25px; border-right:0px" class="toolbar">
-    <div id="thumb_size_slider" class="thumb_size_slider" title="Zoom Thumbnails"></div>
+    <div style="position: absolute; right: 10px; bottom: 0; width: 200px; height: 25px">
+        <span class="zoomLabel">Zoom:</span>
+        <div id="thumb_size_slider" class="thumb_size_slider" title="Zoom Thumbnails"></div>
+    </div>
 </div>
 <div id="icon_table" style="position:absolute; bottom:25px; left:0px; top:29px; overflow:auto; margin-top:0px; right:0px"></div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/plate.html
@@ -319,6 +319,7 @@
     <div class='fillSpace' style='bottom: 0; height: 25px; border-top: solid 1px #ddd; background: #EFF1F4' >
         <!-- Slider -->
         <div style="position: absolute; right: 10px; bottom: 0; width: 200px; height: 25px">
+            <span class="zoomLabel">Zoom:</span>
             <div id="thumb_size_slider" class="thumb_size_slider" title="Zoom Plate"></div>
         </div>
     </div>
@@ -346,6 +347,7 @@
     <div class='fillSpace' style='bottom: 0; height: 25px; border-top: solid 1px #ddd; background: #EFF1F4' >
         <!-- Slider -->
         <div style="position: absolute; right: 10px; bottom: 0px; width: 200px; height: 25px">
+            <span class="zoomLabel">Zoom:</span>
             <div id="wellImages_size_slider" class="thumb_size_slider" title="Zoom Plate"></div>
         </div>
     </div>


### PR DESCRIPTION
# What this PR does

Add "Zoom" labels next to zoom sliders to avoid confusion.
https://trello.com/c/ykDQD752/25-rfe-write-zoom-by-slider-bar
NB: I was aware of another long-term user who was unaware that you could zoom Dataset thumbnails.

To test:
 - See labels for Plates and Well thumbnails
 - Also for Dataset Thumbnails

![screen shot 2017-10-19 at 14 57 23](https://user-images.githubusercontent.com/900055/31774577-0e307fde-b4de-11e7-97cd-98066886d284.png)
