### PR TITLE
Fix filter_by_name refresh

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_header_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/icon_header_underscore.html
@@ -3,7 +3,7 @@
     <div id="layout_chooser">
         <button id="icon_layout" title="View as Thumbnails" class="<% if (layout === 'icon') print('checked') %>" /><button id="table_layout" title="View as List" class="<% if (layout === 'table') print('checked') %>" />
     </div>
-    <form class="search filtersearch" id="filtersearch" action="#" style="top:8px; width:90%">
+    <div class="search filtersearch" id="filtersearch" style="top:8px; width:90%">
         <div style="float:left; font-size: 16px">Filter:</div>
         <div id="filtersContainer" style="float:left">
             <div id="filterrating" class="imagefilter">
@@ -31,7 +31,7 @@
             <option disabled>──────────</option>
             <option value="removeAll">Remove all filters</option>
         </select>
-    </form>
+    </div>
 </div>
 <div style="position:absolute; bottom:0px; left:0px; right:0px; height: 25px; border-right:0px" class="toolbar">
     <div id="thumb_size_slider" class="thumb_size_slider" title="Zoom Thumbnails"></div>


### PR DESCRIPTION
# What this PR does

Fixes the page refresh when you "submit" the thumbnail filter form.
See https://trello.com/c/Znp0U4Mw/32-web-client-filter-by-name-bug
We don't use the ```<form>``` element here at-all, but the default form behaviour of "submit" when you hit enter in the form was causing page to refresh.
We now just use a ```<div>``` instead.
See https://trello.com/c/Znp0U4Mw/32-web-client-filter-by-name-bug

# Testing this PR

1. Browse to Dataset of thumbnails
1. Filter by name
2. In the filter field, hit enter (and wait)
3. Page should not refresh (go to /webclient/?#)