### PR TITLE
flyweight permissions in server

### DIFF
--- a/components/blitz/src/omero/model/PermissionsI.java
+++ b/components/blitz/src/omero/model/PermissionsI.java
@@ -124,7 +124,7 @@ public class PermissionsI extends Permissions implements ome.model.ModelBased {
 
     public PermissionsI(ome.model.internal.Permissions sourceP) {
         setPerm1((Long) ome.util.Utils.internalForm(sourceP));
-        this.restrictions = sourceP.copyRestrictions();
+        this.restrictions = sourceP.getRestrictions();
         String[] extRestr = sourceP.copyExtendedRestrictions();
         this.extendedRestrictions = extRestr == null ? null :
                 Arrays.<String>asList(extRestr);

--- a/components/model/ivy.xml
+++ b/components/model/ivy.xml
@@ -43,6 +43,8 @@
     <dependency org="org.apache.lucene" name="lucene-highlighter" rev="${versions.lucene}" conf="build,server->default"/>
     <dependency org="org.apache.lucene" name="lucene-spellchecker" rev="${versions.lucene}" conf="build,server->default"/>
     <dependency org="org.apache.lucene" name="lucene-misc" rev="${versions.lucene}" conf="build,server->default"/>
+    <!-- Apache Commons -->
+    <dependency org="commons-lang" name="commons-lang" rev="${versions.commons-lang}"/>
     <!-- build only -->
     <dependency org="org.hibernate" name="hibernate-tools" rev="${versions.hibernate-tools}" conf="build->default"/>
     <dependency org="freemarker" name="freemarker" rev="${versions.freemarker}" conf="build->default"/>

--- a/components/model/src/ome/model/internal/BooleanArrayCache.java
+++ b/components/model/src/ome/model/internal/BooleanArrayCache.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.model.internal;
+
+import java.lang.ref.SoftReference;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang.ArrayUtils;
+
+/**
+ * Thread-safe memory-sensitive cache of Boolean arrays. They are expected to be <em>immutable</em>.
+ * Shorter arrays are considered identical to longer arrays with the higher indices set to {@code false}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.4.1
+ */
+class BooleanArrayCache {
+
+    /* can be resurrected by getArrayFor */
+    private SoftReference<? extends Map<Long, boolean[]>> cacheRef = new SoftReference<>(new ConcurrentHashMap<Long, boolean[]>());
+
+    /**
+     * Calculate a {@code long} that corresponds to the bit pattern of the array.
+     * <code>numberForArray(new boolean[] {false, true, false, false}) == 2</code>
+     * @param array the array for which to calculate a number
+     * @return the number for the array's bit pattern
+     */
+    private static long numberForArray(boolean[] array) {
+        if (array.length > Long.SIZE) {
+            throw new IllegalArgumentException("array may have no more elements than " + Long.SIZE);
+        }
+        long number = 0;
+        long nextBit = 1;
+        for (final boolean bit : array) {
+            if (bit) {
+                number |= nextBit;
+            }
+            nextBit <<= 1;
+        }
+        return number;
+    }
+
+    /**
+     * Return an array with the same {@code true} indices as the given array.
+     * If passed {@code null} then returns an empty array.
+     * @param array an array
+     * @return a corresponding cached array, may be the same as given
+     */
+    boolean[] getArrayFor(boolean[] array) {
+        if (array == null) {
+            array = ArrayUtils.EMPTY_BOOLEAN_ARRAY;
+        }
+        final long number = numberForArray(array);
+        Map<Long, boolean[]> cache = cacheRef.get();
+        if (cache == null) {
+            /* if the old cache grew too large then the garbage collector must have needed the space */
+            cache = new ConcurrentHashMap<Long, boolean[]>();
+            cacheRef = new SoftReference<>(cache);
+        }
+        boolean[] cached = cache.get(number);
+        if (cached == null) {
+            cache.put(number, array);
+            return array;
+        } else {
+            if (numberForArray(cached) != number) {
+                throw new IllegalStateException("cache violation");
+            }
+            return cached;
+        }
+    }
+
+    /**
+     * Provides a method for transforming a Boolean array.
+     * @author m.t.b.carroll@dundee.ac.uk
+     * @since 5.4.1
+     */
+    interface Transformer {
+        boolean[] transform(boolean[] array);
+    }
+
+    /**
+     * Transforms the given array using the given transformer.
+     * If passed {@code null} then passes the transformer an empty array.
+     * The transformed array is passed through {@link #getArrayFor(boolean[])} before being returned.
+     * @param transformer an array transform
+     * @param array an array to transform
+     * @return the transformed array
+     */
+    public boolean[] transform(Transformer transformer, boolean[] array) {
+        if (array == null) {
+            array = ArrayUtils.EMPTY_BOOLEAN_ARRAY;
+        } else if (array.length > 0) {
+            array = Arrays.copyOf(array, array.length);
+        }
+        return getArrayFor(transformer.transform(array));
+    }
+}

--- a/components/model/src/ome/model/internal/BooleanArrayCache.java
+++ b/components/model/src/ome/model/internal/BooleanArrayCache.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang.ArrayUtils;
  * Thread-safe memory-sensitive cache of Boolean arrays. They are expected to be <em>immutable</em>.
  * Shorter arrays are considered identical to longer arrays with the higher indices set to {@code false}.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since 5.4.1
+ * @since 5.4.2
  */
 class BooleanArrayCache {
 
@@ -90,7 +90,7 @@ class BooleanArrayCache {
     /**
      * Provides a method for transforming a Boolean array.
      * @author m.t.b.carroll@dundee.ac.uk
-     * @since 5.4.1
+     * @since 5.4.2
      */
     interface Transformer {
         boolean[] transform(boolean[] array);

--- a/components/model/src/ome/model/internal/BooleanArrayCache.java
+++ b/components/model/src/ome/model/internal/BooleanArrayCache.java
@@ -21,21 +21,22 @@ package ome.model.internal;
 
 import java.lang.ref.SoftReference;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.ArrayUtils;
 
 /**
- * Thread-safe memory-sensitive cache of Boolean arrays. They are expected to be <em>immutable</em>.
+ * Memory-sensitive cache of Boolean arrays. They are expected to be <em>immutable</em>.
  * Shorter arrays are considered identical to longer arrays with the higher indices set to {@code false}.
+ * This class is <em>not</em> thread-safe.
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.4.2
  */
 class BooleanArrayCache {
 
     /* can be resurrected by getArrayFor */
-    private SoftReference<? extends Map<Long, boolean[]>> cacheRef = new SoftReference<>(new ConcurrentHashMap<Long, boolean[]>());
+    private SoftReference<? extends Map<Long, boolean[]>> cacheRef = new SoftReference<>(new HashMap<Long, boolean[]>());
 
     /**
      * Calculate a {@code long} that corresponds to the bit pattern of the array.
@@ -72,7 +73,7 @@ class BooleanArrayCache {
         Map<Long, boolean[]> cache = cacheRef.get();
         if (cache == null) {
             /* if the old cache grew too large then the garbage collector must have needed the space */
-            cache = new ConcurrentHashMap<Long, boolean[]>();
+            cache = new HashMap<Long, boolean[]>();
             cacheRef = new SoftReference<>(cache);
         }
         boolean[] cached = cache.get(number);

--- a/components/model/src/ome/model/internal/Permissions.java
+++ b/components/model/src/ome/model/internal/Permissions.java
@@ -136,7 +136,12 @@ public class Permissions implements Serializable {
         }
     }
 
-    private static final BooleanArrayCache CACHE = new BooleanArrayCache();
+    private static final ThreadLocal<BooleanArrayCache> CACHE = new ThreadLocal<BooleanArrayCache>() {
+        @Override
+        protected BooleanArrayCache initialValue() {
+            return new BooleanArrayCache();
+        }
+    };
 
     // ~ Constructors
     // =========================================================================
@@ -417,7 +422,7 @@ public class Permissions implements Serializable {
         this.restrictions[ANNOTATERESTRICTION] |= (0 == (allow & (1 << ANNOTATERESTRICTION)));
         this.restrictions[CHGRPRESTRICTION] |= (0 == (allow & (1 << CHGRPRESTRICTION)));
         this.restrictions[CHOWNRESTRICTION] |= (0 == (allow & (1 << CHOWNRESTRICTION)));
-        restrictions = CACHE.getArrayFor(restrictions);
+        restrictions = CACHE.get().getArrayFor(restrictions);
     }
 
     private static boolean noTrues(boolean[] source) {
@@ -558,10 +563,10 @@ public class Permissions implements Serializable {
                 /* the bit is clear implicitly */
                 restrictions = Arrays.copyOf(restrictions, restriction + 1);
                 restrictions[restriction] = true;
-                restrictions = CACHE.getArrayFor(restrictions);
+                restrictions = CACHE.get().getArrayFor(restrictions);
             } else if (!restrictions[restriction]) {
                 /* the bit is clear explicitly */
-                restrictions = CACHE.transform(new BooleanArrayCache.Transformer() {
+                restrictions = CACHE.get().transform(new BooleanArrayCache.Transformer() {
                     @Override
                     public boolean[] transform(boolean[] restrictions) {
                         restrictions[restriction] = true;
@@ -573,7 +578,7 @@ public class Permissions implements Serializable {
             /* must clear the bit */
             if (restrictions != null && restrictions.length > restriction && restrictions[restriction]) {
                 /* the bit is set */
-                restrictions = CACHE.transform(new BooleanArrayCache.Transformer() {
+                restrictions = CACHE.get().transform(new BooleanArrayCache.Transformer() {
                     @Override
                     public boolean[] transform(boolean[] restrictions) {
                         restrictions[restriction] = false;

--- a/components/model/src/ome/util/Counter.java
+++ b/components/model/src/ome/util/Counter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.util;
+
+import java.math.BigInteger;
+
+import org.apache.commons.lang.ArrayUtils;
+
+/**
+ * A simple integral counter that can be incremented. Its properties include,
+ * <ul>
+ * <li><em>unbounded</em></li>
+ * <li>{@link #increment()} typically does <em>not</em> require a heap allocation</li>
+ * <li><em>not</em> thread-safe.</li>
+ * </ul>
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.4.2
+ */
+public class Counter {
+
+    private byte[] count;
+
+    /**
+     * Create a new counter starting at zero.
+     */
+    public Counter() {
+        reset();
+    }
+
+    /**
+     * Increment the value of this counter by one.
+     */
+    public void increment() {
+        for (int index = count.length; index > 0;) {
+            if (++count[--index] != 0) {
+                return;
+            }
+        }
+        count = new byte[count.length + 1];
+        count[0] = 1;
+    }
+
+    /**
+     * Reset this counter to zero.
+     */
+    public void reset() {
+        count = ArrayUtils.EMPTY_BYTE_ARRAY;
+    }
+
+    /**
+     * @return the integer value of this counter
+     */
+    public BigInteger asBigInteger() {
+        return new BigInteger(1, count);
+    }
+}

--- a/components/model/test/ome/model/internal/BooleanArrayCacheTest.java
+++ b/components/model/test/ome/model/internal/BooleanArrayCacheTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * Unit tests for the the {@link BooleanArrayCache}.
  * Setup and teardown provide each test method with a fresh cache.
  * @author m.t.b.carroll@dundee.ac.uk
- * @since 5.4.1
+ * @since 5.4.2
  */
 public class BooleanArrayCacheTest {
 

--- a/components/model/test/ome/model/internal/BooleanArrayCacheTest.java
+++ b/components/model/test/ome/model/internal/BooleanArrayCacheTest.java
@@ -20,6 +20,7 @@
 package ome.model.internal;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.testng.Assert;
@@ -151,6 +152,27 @@ public class BooleanArrayCacheTest {
         cache.getArrayFor(array);
         array[0] = true;
         array = new boolean[] {false, true, false, true};
+        cache.getArrayFor(array);
+    }
+
+    /**
+     * Test that an array can be cached even when it uses all the bits of a {@code long}.
+     */
+    @Test
+    public void testMaximumBooleans() {
+        final boolean[] initialArray = new boolean[64];
+        Arrays.fill(initialArray, true);
+        final boolean[] cachedArray = cache.getArrayFor(initialArray);
+        Assert.assertEquals(cachedArray.length, initialArray.length);
+    }
+
+    /**
+     * Test that an array cannot be cached when it uses more bits than a {@code long} affords.
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testTooManyBooleans() {
+        final boolean[] array = new boolean[65];
+        Arrays.fill(array, true);
         cache.getArrayFor(array);
     }
 }

--- a/components/model/test/ome/model/internal/BooleanArrayCacheTest.java
+++ b/components/model/test/ome/model/internal/BooleanArrayCacheTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.model.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for the the {@link BooleanArrayCache}.
+ * Setup and teardown provide each test method with a fresh cache.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.4.1
+ */
+public class BooleanArrayCacheTest {
+
+    private BooleanArrayCache cache = null;
+
+    /**
+     * Set up a cache for each test method.
+     */
+    @BeforeMethod
+    public void setupNewCache() {
+        cache = new BooleanArrayCache();
+    }
+
+    /**
+     * Retire the cache after each test method.
+     */
+    @AfterClass
+    public void teardownCache() {
+        cache = null;
+    }
+
+    /**
+     * Generate a Boolean array from a string. The <em>last</em> character of the string corresponds to the array's zero index.
+     * If passed {@code null} then also returns {@code null}.
+     * @param bits a bit string
+     * @return the corresponding Boolean array
+     */
+    private static boolean[] fromString(String bits) {
+        if (bits == null) {
+            return null;
+        }
+        bits = new StringBuilder(bits).reverse().toString();
+        final boolean[] rv = new boolean[bits.length()];
+        for (int index = 0; index < rv.length; index++) {
+            rv[index] = bits.charAt(index) != '0';
+        }
+        return rv;
+    }
+
+    /**
+     * Test for cache hits with bit-strings that differ only in how much {@code false}-padding they have at higher indices.
+     * @param x one array
+     * @param y another array
+     */
+    @Test(dataProvider = "similar arrays")
+    public void testSimilar(String x, String y) {
+        final boolean[] cachedX = cache.getArrayFor(fromString(x));
+        final boolean[] cachedY = cache.getArrayFor(fromString(y));
+        Assert.assertTrue(cachedX == cachedY);
+    }
+
+    /**
+     * Test for cache misses with bit-strings that differ in ways beyond how much {@code false}-padding they have at higher indices.
+     * @param x one array
+     * @param y another array
+     */
+    @Test(dataProvider = "differing arrays")
+    public void testDifferent(String x, String y) {
+        final boolean[] cachedX = cache.getArrayFor(fromString(x));
+        final boolean[] cachedY = cache.getArrayFor(fromString(y));
+        Assert.assertFalse(cachedX == cachedY);
+    }
+
+    /**
+     * Turn sets of bit-strings into ordered pairs of different bit-strings.
+     * @param sets of bit-strings
+     * @return ordered pairs of bit-strings
+     */
+    private static Object[][] providePairs(Object[][] sets) {
+        final List<Object[]> pairs = new ArrayList<Object[]>();
+        for (final Object[] set : sets) {
+            for (int index1 = 0; index1 < set.length; index1++) {
+                for (int index2 = 0; index2 < set.length; index2++) {
+                    if (index1 != index2) {
+                        pairs.add(new Object[] {set[index1], set[index2]});
+                    }
+                }
+            }
+        }
+        return pairs.toArray(new Object[pairs.size()][]);
+    }
+
+    /**
+     * @return test cases for {@link #testSimilar(String, String)}
+     */
+    @DataProvider(name = "similar arrays")
+    public Object[][] provideSimilar() {
+        final String[][] sets = new String[][] {
+                {null, "", "0", "00"},
+                {"1", "01", "001"},
+                {"10", "010"},
+                {"101", "0101"},
+                {"110", "0110"}};
+        return providePairs(sets);
+    }
+
+    /**
+     * @return test cases for {@link #testDifferent(String, String)}
+     */
+    @DataProvider(name = "differing arrays")
+    public Object[][] provideDifferent() {
+        final String[][] sets = new String[][] {
+                {"0", "1", "10", "100"},
+                {"01", "10", "11"},
+                {"101", "010"},
+                {"10", "01", "1010", "0101"}};
+        return providePairs(sets);
+    }
+
+    /**
+     * Test that array mutation is detected by the cache.
+     */
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testCacheViolation() {
+        boolean[] array = new boolean[] {false, true, false, true};
+        cache.getArrayFor(array);
+        array[0] = true;
+        array = new boolean[] {false, true, false, true};
+        cache.getArrayFor(array);
+    }
+}

--- a/components/model/test/ome/util/CounterTest.java
+++ b/components/model/test/ome/util/CounterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.util;
+
+import java.math.BigInteger;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test of the behavior of {@link Counter}.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.4.2
+ */
+public class CounterTest {
+
+    /**
+     * Test that the count stays in step as expected.
+     * Given the {@code byte[]}-based implementation, crosses a couple of byte overflow boundaries in testing.
+     */
+    @Test
+    public void testCounting() {
+        final Counter actual = new Counter();
+        for (int expected = 0; expected < 75000; expected++, actual.increment()) {
+            Assert.assertEquals(actual.asBigInteger(), BigInteger.valueOf(expected));
+        }
+    }
+
+    /**
+     * Test the reset behavior of counters.
+     */
+    @Test
+    public void testReset() {
+        final Counter actual = new Counter();
+        Assert.assertEquals(actual.asBigInteger(), BigInteger.ZERO);
+        actual.increment();
+        Assert.assertEquals(actual.asBigInteger(), BigInteger.ONE);
+        actual.reset();
+        Assert.assertEquals(actual.asBigInteger(), BigInteger.ZERO);
+        actual.increment();
+        Assert.assertEquals(actual.asBigInteger(), BigInteger.ONE);
+    }
+}


### PR DESCRIPTION
# What this PR does

Introduces a cache for the Boolean arrays associated with permissions restrictions. Then, the server should not hold on for long to many different arrays that represent the same permissions.

# Testing this PR

There should be no CI regressions. Watch for differences in server speed, e.g., running time of integration tests. With #5586 reports from each thread's `BooleanArrayCache` every fifty minutes can be seen on eel in `/opt/hudson/workspace/OMERO-DEV-merge-{deploy,integration}/src/dist/var/log/Blitz-0.log`.

# Related reading

https://trello.com/c/SXxKgAC3/8-flyweight-permissions-in-server