### PR TITLE
public redirect to login

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -370,6 +370,15 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     # Actual api_paths_to_object() is retrieved by jsTree once loaded
     initially_open_owner = show.initially_open_owner
 
+    # If we failed to find 'show'...
+    if request.GET.get('show', None) is not None and first_sel is None:
+        # and we're logged in as PUBLIC user...
+        if settings.PUBLIC_USER == conn.getUser().getOmeName():
+            # this is likely a regular user who needs to log in as themselves.
+            # Login then redirect to current url
+            return HttpResponseRedirect(
+                "%s?url=%s" % (reverse("weblogin"), url))
+
     # need to be sure that tree will be correct omero.group
     if first_sel is not None:
         switch_active_group(request, first_sel.details.group.id.val)


### PR DESCRIPTION
# What this PR does

Exploring options to deal with issue at https://trello.com/c/iqNzex9h/60-schleicher-et-al-open-biology-group-link.
OMERO.web with PUBLIC user enabled for "webclient" urls, if a regular user tries to go to their own data, e.g. ```/webclient/?show=project-123``` without logging in, they will be auto-logged in as Public user and their data will not be found.

This PR handles that scenario by redirecting to /webclient/login/ (and then back to the current page) if
 - show is set in url query string AND
 - show object is not found AND
 - currently logged-in user is Public user

# Testing this PR

1. Need to enable Public user (see docs)

2. As a regular user, get a URL to one of your objects, e.g. /webclient/?show=image-345 then log out.

3. Go to /webclient/ - should be auto-logged in as Public user.

4. Go to e.g. webclient/?show=image-345 - should be directed to login page. 

5. On login, should be redirected to your URL and see your data.

cc @kennethgillen @pwalczysko @joshmoore 