### PR TITLE
Login as public user option when webindex is made public

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -123,7 +123,7 @@
             {% if public_enabled %}
                 <hr class="login-divider"/>
                 <div class="login-link">
-                    <a class="login-link-text" href="{{ public_login_redirect }}">Login as public user</a>
+                    <a class="login-link-text" href="{{ public_login_redirect }}">Log in as public user</a>
                 </div>
             {% endif %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -70,8 +70,6 @@
 <div id="login">
     {% block login %}
     <form class="standard_form inlined" action="{% url 'weblogin' %}{% if url %}?{{url}}{% endif %}" method="post">{% csrf_token %}
-        
-			
             {% if error %}
 				<span class="error">{% trans "Error:" %} {{ error }}</span>
 			{% endif %}
@@ -91,9 +89,7 @@
 	                 {% endfor %}
 				{% endif %}
 		   </div>
-		   
-		   
-            
+
 			<div>
 				{% trans form.username.label_tag %}
 				<!--{% if form.username.field.required %}*{% endif %} -->
@@ -120,14 +116,23 @@
 
         	<input type="submit" value="Login" />
 
-            <div><p><a href="{% url 'waforgottenpassword' %}">Forgot your password?</a></p></div>
+            <div>
+                <p><a href="{% url 'waforgottenpassword' %}">Forgot your password?</a></p>
+            </div>
+
+            {% if public_enabled %}
+                <hr class="login-divider"/>
+                <div class="login-link">
+                    <a class="login-link-text" href="{{ public_login_redirect }}">Login as public user</a>
+                </div>
+            {% endif %}
+
     </form>
+
     {% endblock %}
 </div>
 
 <div id="login-footer">
-	
-	
 	<p>
 		OMERO.web {{ version }}.<br/>
 		&copy; 2007-{{ build_year }} University of Dundee &amp; Open Microscopy Environment<br/>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -242,13 +242,20 @@ class WebclientLoginView(LoginView):
             'version': omero_version,
             'build_year': build_year,
             'error': error,
-            'form': form}
+            'form': form
+        }
         url = request.GET.get("url")
         if url is not None and len(url) != 0:
             context['url'] = urlencode({'url': url})
 
         if hasattr(settings, 'LOGIN_LOGO'):
             context['LOGIN_LOGO'] = settings.LOGIN_LOGO
+
+        if settings.PUBLIC_ENABLED:
+            redirect = reverse('webindex')
+            if settings.PUBLIC_URL_FILTER.search(redirect):
+                context['public_enabled'] = True
+                context['public_login_redirect'] = redirect
 
         t = template_loader.get_template(self.template)
         c = Context(request, context)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.login.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.login.css
@@ -255,3 +255,24 @@ body {
 	color:hsl(210,10%,65%);
 	text-shadow: 0 1px 0 rgba(255,255,255,.5);
 }
+
+.login-divider {
+    display: block;
+    height: 1px;
+    border: 0;
+    border-top: 1px solid #ccc;
+    margin: 1em 0;
+    padding: 0;
+}
+
+.login-link {
+    position: relative;
+    width: 100%;
+    height: auto;
+    text-align: right;
+	padding: 0;
+}
+
+.login-link-text {
+    font-size: 1.5em;
+}


### PR DESCRIPTION
This PR adds the option for a public user to login to _webclient_.

This login route is only available when the `omero.web.public.enabled` is set to `true` and `omero.web.public.url_filter` allows a user to navigate to _(host)/webindex_.

### Testing this PR

Enable public user:
1. As an admin, create 'read-only' group
2. Create, or add, a user to the 'read-only' group
3. In terminal run: 
`$ omero config set omero.web.public.enabled True`
`$ omero config set omero.web.public.password {public password}`
`$ omero config set omero.web.public.user {public username}` 
`$ omero config set omero.web.public.url_filter '^/*'`
4. Start OmeroWeb and navigate to login page

### Result

You should see an option to "Login as public user" underneath the usual username / password login section.

![screen shot 2017-10-27 at 11 29 34](https://user-images.githubusercontent.com/3717090/32099906-21f92d9a-bb0a-11e7-9fb5-224c33e17861.png)

https://trello.com/c/sEhHlVdI/97-display-public-user-login-option-on-login-screen