### PR TITLE
stabilize light admin scripts tests

### DIFF
--- a/components/antlib/resources/global.xml
+++ b/components/antlib/resources/global.xml
@@ -177,6 +177,7 @@
             <fileset dir="@{fromdir}">
                 <include name="**/*.properties"/>
                 <include name="**/*.vm"/>
+                <include name="**/minimal-script.py"/>
                 <include name="**/*.dv"/>
                 <include name="**/*.bmp"/>
                 <include name="**/*.jpg"/>

--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -278,7 +278,7 @@ omero.version=${omero.version}
             <src path="${test.dir}"/>
         </myjavac>
         <jar destfile="${target.dir}/${ivy.module}.jar">
-            <fileset dir="${testclasses.dir}" includes="**/*.class,**/*.xml,**/*.txt,**/*.properties,**/*.dv,**/*.bmp,**/*.jpg,**/*.png"/>
+            <fileset dir="${testclasses.dir}" includes="**/*.class,**/*.xml,**/*.txt,**/*.properties,**/*.py,**/*.dv,**/*.bmp,**/*.jpg,**/*.png"/>
         </jar>
         <delete file="${target.dir}/${ivy.module}.xml"/> <!-- delete last produced ivy file to be sure a new one will be generated -->
         <ivy:publish artifactspattern="${target.dir}/[module].[ext]" resolver="test-resolver" settingsRef="ivy.${ant.project.name}"

--- a/components/common/test/minimal-script.py
+++ b/components/common/test/minimal-script.py
@@ -1,6 +1,6 @@
-import omero, omero.scripts as s
+import omero.scripts as s
 import uuid
 
 uuid = str(uuid.uuid4())
-print "I am the script named %s." % uuid
+print("I am the script named %s." % uuid)
 client = s.client(uuid, "simple script")

--- a/components/common/test/minimal-script.py
+++ b/components/common/test/minimal-script.py
@@ -1,0 +1,6 @@
+import omero, omero.scripts as s
+import uuid
+
+uuid = str(uuid.uuid4())
+print "I am the script named %s." % uuid
+client = s.client(uuid, "simple script")

--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -129,6 +129,7 @@
                 <include name="test.bmp"/>
                 <include name="test.jpg"/>
                 <include name="test.txt"/>
+                <include name="minimal-script.py"/>
             </patternset>
         </unjar>
     </target>

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -339,18 +339,13 @@ public class LightAdminPrivilegesTest extends RolesTests {
     public void testDeleteFilePrivilegeDeletionViaRepo(boolean isAdmin, boolean isRestricted, boolean isSudo) throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        /* fetch a script from the server */
-        final List<OriginalFile> scripts = factory.getScriptService().getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scripts.get(0).getId().getValue());
-        final byte[] fileContentOriginal = rfs.read(0, (int) rfs.size());
-        rfs.close();
-        /* upload the script as a new script */
+        /* upload the test script as a new script */
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         RepositoryPrx repo = getRepository(Repository.OTHER);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        rfs = repo.file(testScriptName, "rw");
+        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
         /* check that script is readable */
@@ -430,16 +425,10 @@ public class LightAdminPrivilegesTest extends RolesTests {
     public void testDeleteFilePrivilegeDeletionViaScripts(boolean isAdmin, boolean isRestricted, boolean isSudo) throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
+        /* upload the test script as a new script */
         IScriptPrx iScript = factory.getScriptService();
-        /* fetch a script from the server */
-        final OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scriptFile.getId().getValue());
-        final String actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
-        /* upload the script as a new script */
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadScript(testScriptName, actualScript);
+        final long testScriptId = iScript.uploadScript(testScriptName, pythonScript);
         /* delete any jobs associated with the script */
         final Delete2Builder delete = Requests.delete().option(Requests.option().excludeType("OriginalFile").build());
         for (final IObject scriptJob : iQuery.findAllByQuery(
@@ -471,11 +460,11 @@ public class LightAdminPrivilegesTest extends RolesTests {
         } else {
             assertExists(testScript);
         }
-        rfs = factory.createRawFileStore();
+        final RawFileStorePrx rfs = factory.createRawFileStore();
         try {
             rfs.setFileId(testScriptId);
             final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            Assert.assertEquals(currentScript, actualScript);
+            Assert.assertEquals(currentScript, pythonScript);
             Assert.assertFalse(isExpectSuccess);
         } catch (Ice.LocalException | ServerError se) {
             /* can catch only ServerError once RawFileStoreTest.testBadFileId is fixed */
@@ -609,18 +598,13 @@ public class LightAdminPrivilegesTest extends RolesTests {
             throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        /* fetch a script from the server */
-        final List<OriginalFile> scripts = factory.getScriptService().getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scripts.get(0).getId().getValue());
-        final byte[] fileContentOriginal = rfs.read(0, (int) rfs.size());
-        rfs.close();
-        /* upload the script as a new script */
+        /* upload the test script as a new script */
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         RepositoryPrx repo = getRepository(Repository.SCRIPT);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        rfs = repo.file(testScriptName, "rw");
+        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
         /* check that script is readable */
@@ -679,18 +663,13 @@ public class LightAdminPrivilegesTest extends RolesTests {
             throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        /* fetch a script from the server */
-        final List<OriginalFile> scripts = factory.getScriptService().getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scripts.get(0).getId().getValue());
-        final byte[] fileContentOriginal = rfs.read(0, (int) rfs.size());
-        rfs.close();
-        /* upload the script as a new script */
+        /* upload the test script as a new script */
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         RepositoryPrx repo = getRepository(Repository.SCRIPT);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        rfs = repo.file(testScriptName, "rw");
+        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
         /* check that script is readable */
@@ -741,18 +720,11 @@ public class LightAdminPrivilegesTest extends RolesTests {
             throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        IScriptPrx iScript = factory.getScriptService();
-        /* fetch a script from the server */
-        final OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scriptFile.getId().getValue());
-        final String actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
-        /* upload the script as a new script */
         loginNewAdmin(true, null);
-        iScript = factory.getScriptService();
+        /* upload the test script as a new script */
+        IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadOfficialScript(testScriptName, actualScript);
+        final long testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
         /* delete any jobs associated with the script */
         final Delete2Builder delete = Requests.delete().option(Requests.option().excludeType("OriginalFile").build());
         for (final IObject scriptJob : iQuery.findAllByQuery(
@@ -784,11 +756,11 @@ public class LightAdminPrivilegesTest extends RolesTests {
         } else {
             assertExists(testScript);
         }
-        rfs = factory.createRawFileStore();
+        final RawFileStorePrx rfs = factory.createRawFileStore();
         try {
             rfs.setFileId(testScriptId);
             final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            Assert.assertEquals(currentScript, actualScript);
+            Assert.assertEquals(currentScript, pythonScript);
             Assert.assertFalse(isExpectSuccess);
         } catch (Ice.LocalException | ServerError se) {
             /* can catch only ServerError once RawFileStoreTest.testBadFileId is fixed */
@@ -1504,22 +1476,15 @@ public class LightAdminPrivilegesTest extends RolesTests {
     public void testWriteFilePrivilegeCreationViaScripts(boolean isAdmin, boolean isRestricted, boolean isSudo) throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        IScriptPrx iScript = factory.getScriptService();
-        /* fetch a script from the server */
-        OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scriptFile.getId().getValue());
-        final String actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
-        /* try uploading the script as a new script in the normal user's group */
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteFile.value : null);
+        /* try uploading the test script as a new script in the normal user's group */
         final long testScriptId;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-            iScript = factory.getScriptService();
+            final IScriptPrx iScript = factory.getScriptService();
             final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
             try {
-                testScriptId = iScript.uploadScript(testScriptName, actualScript);
+                testScriptId = iScript.uploadScript(testScriptName, pythonScript);
                 Assert.assertTrue(isExpectSuccess);
             } catch (ServerError se) {
                 Assert.assertFalse(isExpectSuccess);
@@ -1529,14 +1494,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
         }
         /* check that the new script exists */
         loginUser(normalUser);
-        scriptFile = (OriginalFile) iQuery.get("OriginalFile", testScriptId);
+        final OriginalFile scriptFile = (OriginalFile) iQuery.get("OriginalFile", testScriptId);
         Assert.assertEquals(scriptFile.getDetails().getGroup().getId().getValue(), normalUser.groupId);
         /* check if the script is correctly uploaded */
-        rfs = factory.createRawFileStore();
+        final RawFileStorePrx rfs = factory.createRawFileStore();
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, actualScript);
+        Assert.assertEquals(currentScript, pythonScript);
     }
 
     /**
@@ -1641,18 +1606,13 @@ public class LightAdminPrivilegesTest extends RolesTests {
     public void testWriteFilePrivilegeEditingViaRepoFile(boolean isAdmin, boolean isRestricted, boolean isSudo) throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        /* fetch a script from the server */
-        final List<OriginalFile> scripts = factory.getScriptService().getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scripts.get(0).getId().getValue());
-        final byte[] fileContentOriginal = rfs.read(0, (int) rfs.size());
-        rfs.close();
-        /* upload the script as a new script */
+        /* upload the test script as a new script */
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         RepositoryPrx repo = getRepository(Repository.OTHER);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        rfs = repo.file(testScriptName, "rw");
+        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
         /* check that script is readable */
@@ -1708,16 +1668,10 @@ public class LightAdminPrivilegesTest extends RolesTests {
     public void testWriteFilePrivilegeEditingViaScripts(boolean isAdmin, boolean isRestricted, boolean isSudo) throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
+        /* upload the test script as a new script */
         IScriptPrx iScript = factory.getScriptService();
-        final List<OriginalFile> scripts = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE);
-        /* fetch a script from the server */
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scripts.get(0).getId().getValue());
-        final String originalScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
-        /* upload the script as a new script */
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadScript(testScriptName, originalScript);
+        final long testScriptId = iScript.uploadScript(testScriptName, pythonScript);
         OriginalFile testScript = new OriginalFileI(testScriptId, false);
         /* try replacing the content of the normal user's script */
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
@@ -1726,7 +1680,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
             Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
             iScript = factory.getScriptService();
-            newScript = originalScript + "\n# this script is a copy of another";
+            newScript = pythonScript + "\n# this script is a copy of another";
             try {
                 iScript.editScript(new OriginalFileI(testScriptId, false), newScript);
                 Assert.assertTrue(isExpectSuccess);
@@ -1740,11 +1694,11 @@ public class LightAdminPrivilegesTest extends RolesTests {
         Assert.assertEquals(testScript.getDetails().getOwner().getId().getValue(), normalUser.userId);
         Assert.assertEquals(testScript.getDetails().getGroup().getId().getValue(), normalUser.groupId);
         /* check the content of the script */
-        rfs = factory.createRawFileStore();
+        final RawFileStorePrx rfs = factory.createRawFileStore();
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : originalScript);
+        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : pythonScript);
     }
 
     /**
@@ -2098,21 +2052,14 @@ public class LightAdminPrivilegesTest extends RolesTests {
             throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        IScriptPrx iScript = factory.getScriptService();
-        /* fetch a script from the server */
-        OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scriptFile.getId().getValue());
-        final String actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
-        /* try uploading the script as a new script */
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
-        iScript = factory.getScriptService();
+        /* try uploading the test script as a new script */
+        final IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         long testScriptId = -1;
         try {
-            testScriptId = iScript.uploadOfficialScript(testScriptName, actualScript);
+            testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
             Assert.assertTrue(isExpectSuccess);
         } catch (ServerError se) {
             Assert.assertFalse(isExpectSuccess);
@@ -2121,15 +2068,15 @@ public class LightAdminPrivilegesTest extends RolesTests {
         }
         /* check that the new script exists in the "user" group */
         loginUser(normalUser);
-        scriptFile = (OriginalFile) iQuery.get("OriginalFile", testScriptId);
+        final OriginalFile scriptFile = (OriginalFile) iQuery.get("OriginalFile", testScriptId);
         Assert.assertEquals(scriptFile.getDetails().getOwner().getId().getValue(), roles.rootId);
         Assert.assertEquals(scriptFile.getDetails().getGroup().getId().getValue(), roles.userGroupId);
         /* check if the script is correctly uploaded */
-        rfs = factory.createRawFileStore();
+        final RawFileStorePrx rfs = factory.createRawFileStore();
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, actualScript);
+        Assert.assertEquals(currentScript, pythonScript);
     }
 
     /**
@@ -2147,18 +2094,13 @@ public class LightAdminPrivilegesTest extends RolesTests {
             throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        /* fetch a script from the server */
-        final List<OriginalFile> scripts = factory.getScriptService().getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE);
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scripts.get(0).getId().getValue());
-        final byte[] fileContentOriginal = rfs.read(0, (int) rfs.size());
-        rfs.close();
-        /* upload the script as a new script */
+        /* upload the test script as a new script */
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         RepositoryPrx repo = getRepository(Repository.SCRIPT);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        rfs = repo.file(testScriptName, "rw");
+        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
         /* check that script is readable */
@@ -2215,18 +2157,11 @@ public class LightAdminPrivilegesTest extends RolesTests {
             throws Exception {
         final boolean isExpectSuccess = isAdmin && !isRestricted;
         final EventContext normalUser = newUserAndGroup("rwr-r-");
-        IScriptPrx iScript = factory.getScriptService();
-        final List<OriginalFile> scripts = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE);
-        /* fetch a script from the server */
-        RawFileStorePrx rfs = factory.createRawFileStore();
-        rfs.setFileId(scripts.get(0).getId().getValue());
-        final String originalScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        rfs.close();
-        /* upload the script as a new script */
         loginNewAdmin(true, null);
-        iScript = factory.getScriptService();
+        /* upload the test script as a new script */
+        IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadOfficialScript(testScriptName, originalScript);
+        final long testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
         /* try replacing the content of the normal user's script */
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
@@ -2236,7 +2171,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
             testScript = new OriginalFileI(testScriptId, false);
             Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
             iScript = factory.getScriptService();
-            newScript = originalScript + "\n# this script is a copy of another";
+            newScript = pythonScript + "\n# this script is a copy of another";
             try {
                 iScript.editScript(testScript, newScript);
                 Assert.assertTrue(isExpectSuccess);
@@ -2250,11 +2185,11 @@ public class LightAdminPrivilegesTest extends RolesTests {
         Assert.assertEquals(testScript.getDetails().getOwner().getId().getValue(), roles.rootId);
         Assert.assertEquals(testScript.getDetails().getGroup().getId().getValue(), roles.userGroupId);
         /* check the content of the script */
-        rfs = factory.createRawFileStore();
+        final RawFileStorePrx rfs = factory.createRawFileStore();
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : originalScript);
+        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : pythonScript);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1696,25 +1696,13 @@ public class LightAdminRolesTest extends RolesTests {
         List<String> permissions = new ArrayList<String>();
         if (isPrivileged) permissions.add(AdminPrivilegeWriteScriptRepo.value);
         loginNewAdmin(true, permissions);
-        final String actualScript;
         final long testScriptId;
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-            IScriptPrx iScript = factory.getScriptService();
-            /* lightAdmin fetches a script from the server.*/
-            OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-            RawFileStorePrx rfs = null;
-            try {
-                rfs = factory.createRawFileStore();
-                rfs.setFileId(scriptFile.getId().getValue());
-                actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            } finally {
-                if (rfs != null) rfs.close();
-            }
-            /* lightAdmin tries uploading the script as a new script in normalUser's group.*/
-            iScript = factory.getScriptService();
+            /* lightAdmin tries uploading the test script as a new script in normalUser's group.*/
+            final IScriptPrx iScript = factory.getScriptService();
             final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
             try {
-                testScriptId = iScript.uploadOfficialScript(testScriptName, actualScript);
+                testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
                 Assert.assertTrue(isExpectSuccessUploadOfficialScript);
             } catch (ServerError se) {
                 Assert.assertFalse(isExpectSuccessUploadOfficialScript);
@@ -1737,7 +1725,7 @@ public class LightAdminRolesTest extends RolesTests {
         } finally {
             if (rfs != null) rfs.close();
         }
-        Assert.assertEquals(currentScript, actualScript);
+        Assert.assertEquals(currentScript, pythonScript);
     }
 
     /**
@@ -1755,26 +1743,12 @@ public class LightAdminRolesTest extends RolesTests {
         if (isPrivileged) permissions.add(AdminPrivilegeDeleteScriptRepo.value);
         final EventContext lightAdmin;
         lightAdmin = loginNewAdmin(true, permissions);
-        final String actualScript;
-        try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
-            IScriptPrx iScript = factory.getScriptService();
-            /* lightAdmin fetches a script from the server.*/
-            OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-            RawFileStorePrx rfs = null;
-            try {
-                rfs = factory.createRawFileStore();
-                rfs.setFileId(scriptFile.getId().getValue());
-                actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            } finally {
-                if (rfs != null) rfs.close();
-            }
-        }
         /* Another light admin (anotherLightAdmin) with appropriate permissions
          * uploads the script as a new script.*/
         loginNewAdmin(true, AdminPrivilegeWriteScriptRepo.value);
         IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadOfficialScript(testScriptName, actualScript);
+        final long testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
         /* Delete any jobs associated with the script.*/
         final Delete2Builder delete = Requests.delete().option(Requests.option().excludeType("OriginalFile").build());
         for (final IObject scriptJob : iQuery.findAllByQuery(
@@ -1809,7 +1783,7 @@ public class LightAdminRolesTest extends RolesTests {
             rfs = factory.createRawFileStore();
             rfs.setFileId(testScriptId);
             final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            Assert.assertEquals(currentScript, actualScript);
+            Assert.assertEquals(currentScript, pythonScript);
             Assert.assertFalse(isExpectSuccessDeleteOfficialScript);
         } catch (Ice.LocalException | ServerError se) {
             /* Have to catch both types of exceptions because
@@ -2647,25 +2621,18 @@ public class LightAdminRolesTest extends RolesTests {
      */
     @Test(expectedExceptions = omero.SecurityViolation.class)
     public void testModifyScriptUsingUploadFromClientbyRestrictedSystemUser() throws Exception {
-        logNewAdminWithoutPrivileges();
-        IScriptPrx iScript = factory.getScriptService();
-        /* lightAdmin fetches a script from the server.*/
-        OriginalFile scriptFile = iScript.getScriptsByMimetype(ScriptServiceTest.PYTHON_MIMETYPE).get(0);
-        String actualScript;
-        RawFileStorePrx rfs = null;
-        try {
-            rfs = factory.createRawFileStore();
-            rfs.setFileId(scriptFile.getId().getValue());
-            actualScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-        } finally {
-            if (rfs != null) rfs.close();
-        }
+        /* root uploads an official script to the server.*/
+        IScriptPrx iScript = root.getSession().getScriptService();
+        String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
+        final long scriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
         /* lightAdmin tries uploading the script as a new script in normalUser's group.*/
+        logNewAdminWithoutPrivileges();
         iScript = factory.getScriptService();
-        final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
+        testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         File file = new File(testScriptName);
         file.deleteOnExit();
-        FileUtils.writeStringToFile(file, actualScript);
+        FileUtils.writeStringToFile(file, pythonScript);
+        final OriginalFile scriptFile = (OriginalFile) iQuery.get("OriginalFile", scriptId);
         client.upload(file, scriptFile);
     }
 

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -21,13 +21,17 @@ package integration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.springframework.util.ResourceUtils;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.Files;
 
 import ome.services.blitz.repo.path.FsFile;
 import omero.RString;
@@ -59,6 +63,8 @@ public class RolesTests extends AbstractServerImportTest {
 
     protected File fakeImageFile = null;
 
+    protected String pythonScript = null;
+
     /**
      * Create a fake image file for use in import tests.
      * @throws IOException unexpected
@@ -68,6 +74,25 @@ public class RolesTests extends AbstractServerImportTest {
         final File temporaryDirectory = TEMPORARY_FILE_MANAGER.createPath("images", null, true);
         fakeImageFile = new File(temporaryDirectory, "image.fake");
         fakeImageFile.createNewFile();
+    }
+
+    /**
+     * Note the contents of an uploadable Python script.
+     * @throws IOException unexpected
+     */
+    @BeforeClass
+    public void notePythonScriptContent() throws IOException {
+        final File scriptFile = ResourceUtils.getFile("classpath:minimal-script.py");
+        pythonScript = Files.toString(scriptFile, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Clear the instance fields that were set before running this class' tests.
+     */
+    @AfterClass
+    public void teardown() {
+        fakeImageFile = null;
+        pythonScript = null;
     }
 
     /* These permissions do not permit anything.*/


### PR DESCRIPTION
# What this PR does

Has the light admin scripts tests use their own safe minimal Python script for testing instead of relying on a randomly selected official script already in the server.

# Testing this PR

Expect passes in:

- https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/LightAdminPrivilegesTest/
- https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/LightAdminRolesTest/

# Related reading

https://trello.com/c/HsKwJHSk/96-fix-integration-tests