### PR TITLE
null-protect interceptor setting admin privs in database

### DIFF
--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ObjectUtils;
 import org.hibernate.CallbackException;
 import org.hibernate.EmptyInterceptor;
@@ -360,7 +361,9 @@ public class OmeroInterceptor implements Interceptor {
             debug("updating current light administrator privileges");
             final Set<AdminPrivilege> privileges = currentUser.current().getCurrentAdminPrivileges();
             sqlAction.deleteCurrentAdminPrivileges();
-            sqlAction.insertCurrentAdminPrivileges(privileges);
+            if (CollectionUtils.isNotEmpty(privileges)) {
+                sqlAction.insertCurrentAdminPrivileges(privileges);
+            }
         }
     }
 


### PR DESCRIPTION
# What this PR does

Adds a null check around OMERO interceptor's post-flush activity noting current administrator privileges in the database.

# Testing this PR

CI should show no regressions. Small code diff should make sense.

# Related reading

https://trello.com/c/kSKvNpjw/101-bug-ns-errors-null-pointer-on-session-close