### PR TITLE
CLI - Hide passwords by default

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -26,6 +26,7 @@ from omero.util import edit_path, get_omero_userdir
 from omero.util.decorators import wraps
 from omero.util.upgrade_check import UpgradeCheck
 from omero_ext import portalocker
+from omero_ext.argparse import SUPPRESS
 
 import omero.java
 
@@ -148,14 +149,13 @@ class PrefsControl(WriteableConfigControl):
         get.set_defaults(func=self.get)
         get.add_argument(
             "KEY", nargs="*", help="Names of keys in the current profile")
-        get.add_argument(
-            "--hide-password", action="store_true",
-            help="[Deprecated; this is the default now] Hide values of "
-                 "password keys in the current profile")
-        get.add_argument(
-            "--show-secrets", action="store_true",
-            help="Show values of sensitive keys (passwords, tokens, etc.) "
-                 "in the current profile")
+
+        secrets = get.add_mutually_exclusive_group()
+        secrets.add_argument("--show-secrets", action="store_true",
+                             help="Show values of sensitive keys (passwords, tokens, "
+                                  "etc.) in the current profile")
+        secrets.add_argument("--hide-password", action="store_false", dest="show_secrets",
+                             help=SUPPRESS)
 
         set = parser.add(
             sub, self.set,
@@ -289,7 +289,6 @@ class PrefsControl(WriteableConfigControl):
             for k in config.IGNORE:
                 k in keys and keys.remove(k)
 
-        show_secrets = 'show_secrets' in args and args.show_secrets
         is_password = (lambda x: x.lower().endswith('pass') or
                        x.lower().endswith('password'))
         for k in keys:
@@ -298,7 +297,7 @@ class PrefsControl(WriteableConfigControl):
             if args.KEY and len(args.KEY) == 1:
                 self.ctx.out(config[k])
             else:
-                if is_password(k) and not show_secrets:
+                if is_password(k) and not args.show_secrets:
                     self.ctx.out("%s=%s" % (k, '*' * 8 if config[k] else ''))
                 else:
                     self.ctx.out("%s=%s" % (k, config[k]))

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -152,10 +152,10 @@ class PrefsControl(WriteableConfigControl):
 
         secrets = get.add_mutually_exclusive_group()
         secrets.add_argument("--show-secrets", action="store_true",
-                             help="Show values of sensitive keys (passwords, tokens, "
-                                  "etc.) in the current profile")
-        secrets.add_argument("--hide-password", action="store_false", dest="show_secrets",
-                             help=SUPPRESS)
+                             help="Show values of sensitive keys (passwords, "
+                                  "tokens, etc.) in the current profile")
+        secrets.add_argument("--hide-password", action="store_false",
+                             dest="show_secrets", help=SUPPRESS)
 
         set = parser.add(
             sub, self.set,

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -153,8 +153,9 @@ class PrefsControl(WriteableConfigControl):
             help="[Deprecated; this is the default now] Hide values of "
                  "password keys in the current profile")
         get.add_argument(
-            "--show-password", action="store_true",
-            help="Show values of password keys in the current profile")
+            "--show-secrets", action="store_true",
+            help="Show values of sensitive keys (passwords, tokens, etc.) "
+                 "in the current profile")
 
         set = parser.add(
             sub, self.set,
@@ -288,7 +289,7 @@ class PrefsControl(WriteableConfigControl):
             for k in config.IGNORE:
                 k in keys and keys.remove(k)
 
-        show_password = 'show_password' in args and args.show_password
+        show_secrets = 'show_secrets' in args and args.show_secrets
         is_password = (lambda x: x.lower().endswith('pass') or
                        x.lower().endswith('password'))
         for k in keys:
@@ -297,7 +298,7 @@ class PrefsControl(WriteableConfigControl):
             if args.KEY and len(args.KEY) == 1:
                 self.ctx.out(config[k])
             else:
-                if is_password(k) and not show_password:
+                if is_password(k) and not show_secrets:
                     self.ctx.out("%s=%s" % (k, '*' * 8 if config[k] else ''))
                 else:
                     self.ctx.out("%s=%s" % (k, config[k]))

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -150,7 +150,11 @@ class PrefsControl(WriteableConfigControl):
             "KEY", nargs="*", help="Names of keys in the current profile")
         get.add_argument(
             "--hide-password", action="store_true",
-            help="Hide values of password keys in the current profile")
+            help="[Deprecated; this is the default now] Hide values of "
+                 "password keys in the current profile")
+        get.add_argument(
+            "--show-password", action="store_true",
+            help="Show values of password keys in the current profile")
 
         set = parser.add(
             sub, self.set,
@@ -284,7 +288,7 @@ class PrefsControl(WriteableConfigControl):
             for k in config.IGNORE:
                 k in keys and keys.remove(k)
 
-        hide_password = 'hide_password' in args and args.hide_password
+        show_password = 'show_password' in args and args.show_password
         is_password = (lambda x: x.lower().endswith('pass') or
                        x.lower().endswith('password'))
         for k in keys:
@@ -293,7 +297,7 @@ class PrefsControl(WriteableConfigControl):
             if args.KEY and len(args.KEY) == 1:
                 self.ctx.out(config[k])
             else:
-                if (hide_password and is_password(k)):
+                if is_password(k) and not show_password:
                     self.ctx.out("%s=%s" % (k, '*' * 8 if config[k] else ''))
                 else:
                     self.ctx.out("%s=%s" % (k, config[k]))

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -151,11 +151,11 @@ class PrefsControl(WriteableConfigControl):
             "KEY", nargs="*", help="Names of keys in the current profile")
 
         secrets = get.add_mutually_exclusive_group()
-        secrets.add_argument("--show-secrets", action="store_true",
+        secrets.add_argument("--show-password", action="store_true",
                              help="Show values of sensitive keys (passwords, "
                                   "tokens, etc.) in the current profile")
         secrets.add_argument("--hide-password", action="store_false",
-                             dest="show_secrets", help=SUPPRESS)
+                             dest="show_password", help=SUPPRESS)
 
         set = parser.add(
             sub, self.set,
@@ -297,7 +297,7 @@ class PrefsControl(WriteableConfigControl):
             if args.KEY and len(args.KEY) == 1:
                 self.ctx.out(config[k])
             else:
-                if is_password(k) and not args.show_secrets:
+                if is_password(k) and not args.show_password:
                     self.ctx.out("%s=%s" % (k, '*' * 8 if config[k] else ''))
                 else:
                     self.ctx.out("%s=%s" % (k, config[k]))

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -121,7 +121,7 @@ class TestPrefs(object):
             'omero.Z.mypassword=\n'
             'omero.Z.pass=\n'
             'omero.Z.password='))
-        self.invoke("get --show-password")
+        self.invoke("get --show-secrets")
         self.assertStdoutStderr(capsys, out=(
             'omero.X.mypassword=long_password\n'
             'omero.X.pass=shortpass\n'

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -121,7 +121,7 @@ class TestPrefs(object):
             'omero.Z.mypassword=\n'
             'omero.Z.pass=\n'
             'omero.Z.password='))
-        self.invoke("get --show-secrets")
+        self.invoke("get --show-password")
         self.assertStdoutStderr(capsys, out=(
             'omero.X.mypassword=long_password\n'
             'omero.X.pass=shortpass\n'

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -111,18 +111,6 @@ class TestPrefs(object):
             self.cli.invoke(self.args + ["set", k, v], strict=True)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out=(
-            'omero.X.mypassword=long_password\n'
-            'omero.X.pass=shortpass\n'
-            'omero.X.password=medium_password\n'
-            'omero.X.regular=value\n'
-            'omero.Y.MyPassword=long_password\n'
-            'omero.Y.Pass=shortpass\n'
-            'omero.Y.Password=medium_password\n'
-            'omero.Z.mypassword=\n'
-            'omero.Z.pass=\n'
-            'omero.Z.password='))
-        self.invoke("get --hide-password")
-        self.assertStdoutStderr(capsys, out=(
             'omero.X.mypassword=********\n'
             'omero.X.pass=********\n'
             'omero.X.password=********\n'
@@ -130,6 +118,18 @@ class TestPrefs(object):
             'omero.Y.MyPassword=********\n'
             'omero.Y.Pass=********\n'
             'omero.Y.Password=********\n'
+            'omero.Z.mypassword=\n'
+            'omero.Z.pass=\n'
+            'omero.Z.password='))
+        self.invoke("get --show-password")
+        self.assertStdoutStderr(capsys, out=(
+            'omero.X.mypassword=long_password\n'
+            'omero.X.pass=shortpass\n'
+            'omero.X.password=medium_password\n'
+            'omero.X.regular=value\n'
+            'omero.Y.MyPassword=long_password\n'
+            'omero.Y.Pass=shortpass\n'
+            'omero.Y.Password=medium_password\n'
             'omero.Z.mypassword=\n'
             'omero.Z.pass=\n'
             'omero.Z.password='))


### PR DESCRIPTION
# What this PR does

Hide passwords by default when running `./omero config get`. Deprecate `--hide-password` option and replace with `--show-password`.

# Testing this PR

- Run `./omero config get` and check that passwords are replaced by `********`.
- Run `./omero config get --hide-password` and check you get the same output.
- Run `./omero config get --show-password` and check that passwords are displayed.

# Related reading

https://trello.com/c/9rHSC7aB/54-hide-passwords-in-config-get

Is there a certain format to use when deprecating arguments? I just added `[Deprecated ...]` in front of the argument's help text for now.

