### PR TITLE
Histogram example - Java

### DIFF
--- a/components/blitz/src/omero/util/IceMapper.java
+++ b/components/blitz/src/omero/util/IceMapper.java
@@ -597,6 +597,10 @@ public class IceMapper extends ome.util.ModelMapper implements
      */
     public static PlaneDef convert(omero.romio.PlaneDef def)
             throws omero.ApiUsageException {
+        if (def == null) {
+            return null;
+        }
+        
         PlaneDef pd = new PlaneDef(def.slice, def.t);
         pd.setStride(def.stride);
         omero.romio.RegionDef r = def.region;

--- a/examples/Training/java/src/training/RawDataAccess.java
+++ b/examples/Training/java/src/training/RawDataAccess.java
@@ -223,23 +223,14 @@ public class RawDataAccess
      * Retrieve the histogram
      */
     private void retrieveHistogram() throws Exception {
-        PixelsData pixels = image.getDefaultPixels();
-        long pixelsId = pixels.getId();
-        RawPixelsStorePrx store = null;
-        try {
-            store = gateway.getPixelsStore(ctx);
-            store.setPixelsId(pixelsId, false);
+        try (RawDataFacility rdf = gateway.getFacility(RawDataFacility.class)) {
+            PixelsData pixels = image.getDefaultPixels();
             int[] channels = new int[] { 0 };
             int binCount = 256;
-            Map<Integer, int[]> histdata = store.getHistogram(channels,
-                    binCount, false, null);
+            Map<Integer, int[]> histdata = rdf.getHistogram(ctx, pixels,
+                    channels, binCount, false, null);
             int[] histogram = histdata.get(0);
             printHistogram(histogram);
-        } catch (Exception e) {
-            throw new Exception("Cannot get the histogram data", e);
-        } finally {
-            if (store != null)
-                store.close();
         }
     }
      


### PR DESCRIPTION
# What this PR does

Adds an example for getting the histogram data for an image to the training examples.

While testing the example I noticed that when you pass `null` as PlaneDef parameter the blitz IceMapper throws a NPE. I also addressed that in the first commit.

# Testing this PR

Check the training job passes.

# Related reading

- Docs PR: - Docs PR: https://github.com/openmicroscopy/ome-documentation/pull/1803
- https://trello.com/c/5SjwyaM4/112-histogram-api
