### PR TITLE
Histogram example - Python

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7189,6 +7189,38 @@ class _PixelsWrapper (BlitzObjectWrapper):
         tileList = list(self.getTiles([(theZ, theC, theT, tile)]))
         return tileList[0]
 
+    def getHistogram(self, theZ=0, theC=0, theT=0, binCount=256,
+                     globalRange=False):
+        """
+        Get a histogram of the specified plane
+        :param binCount:     The number of bins to use for the histogram
+        """
+
+        try:
+            rawPixelsStore = self._prepareRawPixelsStore()
+            plane = omero.romio.PlaneDef()
+            plane.z = theZ
+            plane.t = theT
+            data = rawPixelsStore.getHistogram([theC], binCount, globalRange,
+                                               plane)
+            if len(data) == 1:
+                return data[theC]
+            return None
+
+        except Exception, e:
+            logger.error(
+                "Failed to getHistogram() from rawPixelsStore",
+                exc_info=True)
+            exc = e
+        try:
+            rawPixelsStore.close()
+        except Exception, e:
+            logger.error("Failed to close rawPixelsStore", exc_info=True)
+            if exc is None:
+                exc = e
+        if exc is not None:
+            raise exc
+
 PixelsWrapper = _PixelsWrapper
 
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7189,38 +7189,6 @@ class _PixelsWrapper (BlitzObjectWrapper):
         tileList = list(self.getTiles([(theZ, theC, theT, tile)]))
         return tileList[0]
 
-    def getHistogram(self, theZ=0, theC=0, theT=0, binCount=256,
-                     globalRange=False):
-        """
-        Get a histogram of the specified plane
-        :param binCount:     The number of bins to use for the histogram
-        """
-
-        try:
-            rawPixelsStore = self._prepareRawPixelsStore()
-            plane = omero.romio.PlaneDef()
-            plane.z = theZ
-            plane.t = theT
-            data = rawPixelsStore.getHistogram([theC], binCount, globalRange,
-                                               plane)
-            if len(data) == 1:
-                return data[theC]
-            return None
-
-        except Exception, e:
-            logger.error(
-                "Failed to getHistogram() from rawPixelsStore",
-                exc_info=True)
-            exc = e
-        try:
-            rawPixelsStore.close()
-        except Exception, e:
-            logger.error("Failed to close rawPixelsStore", exc_info=True)
-            if exc is None:
-                exc = e
-        if exc is not None:
-            raise exc
-
 PixelsWrapper = _PixelsWrapper
 
 

--- a/examples/Training/python/Raw_Data_Access.py
+++ b/examples/Training/python/Raw_Data_Access.py
@@ -81,7 +81,7 @@ for i, p in enumerate(planes):
 # Retrieve a histogram
 # ====================
 # Get a 256 bin histogram for channel 0 and plane z=0/t=0:
-hist = pixels.getHistogram(0, 0, 0, 256)
+hist = image.getHistogram([0], 256, False, 0, 0)
 print hist
 
 # Close connection

--- a/examples/Training/python/Raw_Data_Access.py
+++ b/examples/Training/python/Raw_Data_Access.py
@@ -78,6 +78,11 @@ planes = pixels.getPlanes(zct_list)
 for i, p in enumerate(planes):
     print "plane zct:", zct_list[i], " min:", p.min(), " max:", p.max()
 
+# Retrieve a histogram
+# ====================
+# Get a 256 bin histogram for channel 0 and plane z=0/t=0:
+hist = pixels.getHistogram(0, 0, 0, 256)
+print hist
 
 # Close connection
 # ================


### PR DESCRIPTION
# What this PR does

- Adds `getHistogram` method to the gateway
- Adds an example to the Python training examples.

# Testing this PR

Check that the training jobs passes.

# Related reading

- Docs PR: https://github.com/openmicroscopy/ome-documentation/pull/1804
- https://trello.com/c/5SjwyaM4/112-histogram-api
