### PR TITLE
Added wait for page load in robot test login

### DIFF
--- a/components/tests/ui/resources/web/login.txt
+++ b/components/tests/ui/resources/web/login.txt
@@ -25,7 +25,7 @@ Page Should Be Open
 
 Welcome Page Should Be Open
     [Arguments]             ${welcome url}=${WELCOME URL}   ${title}=Webclient
-    Page Should Be Open     ${WELCOME URL}       ${title}
+    Wait Until Keyword Succeeds             ${TIMEOUT}   ${INTERVAL}   Page Should Be Open     ${WELCOME URL}       ${title} 
 
 Login Page Should Be Open
     [Arguments]             ${login url}=${LOGIN URL}   ${title}=OMERO.web - Login


### PR DESCRIPTION
### What this PR does

Fixes an issue were running a local robot test fails due to timing out before login to omero web completes.

# Testing this PR

Run a robot framework test, such as `./build.py -f components/tests/ui/build.xml web-firefox -DTEST=forms_test.txt`

Login portion of tests should succeed. 
