### PR TITLE
fix script service integration test failures

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -5,6 +5,8 @@
 package integration;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -131,6 +133,7 @@ import omero.sys.Roles;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.springframework.util.ResourceUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -138,6 +141,7 @@ import org.testng.annotations.DataProvider;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 
 /**
  * Base test for integration tests.
@@ -210,6 +214,9 @@ public class AbstractServerTest extends AbstractTest {
      * @see #newUserInGroup(ExperimenterGroup)
      */
     private final Set<omero.client> clients = new HashSet<omero.client>();
+
+    /* a simple valid Python script */
+    private String pythonScript = null;
 
     protected AbstractServerTest() {
         final ome.system.Roles defaultRoles = new ome.system.Roles();
@@ -1121,6 +1128,19 @@ public class AbstractServerTest extends AbstractTest {
             }
         }
         throw new RuntimeException("no managed repository");
+    }
+
+    /**
+     * Provides a simple Python script with valid syntax.
+     * @return the content of an uploadable Python script
+     * @throws IOException if the simple script cannot be read
+     */
+    protected String getPythonScript() throws IOException {
+        if (pythonScript == null) {
+            final File scriptFile = ResourceUtils.getFile("classpath:minimal-script.py");
+            pythonScript = Files.toString(scriptFile, StandardCharsets.UTF_8);
+        }
+        return pythonScript;
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminPrivilegesTest.java
@@ -344,7 +344,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         RepositoryPrx repo = getRepository(Repository.OTHER);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        final byte[] fileContentOriginal = getPythonScript().getBytes(StandardCharsets.UTF_8);
         RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
@@ -428,7 +428,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         /* upload the test script as a new script */
         IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadScript(testScriptName, pythonScript);
+        final long testScriptId = iScript.uploadScript(testScriptName, getPythonScript());
         /* delete any jobs associated with the script */
         final Delete2Builder delete = Requests.delete().option(Requests.option().excludeType("OriginalFile").build());
         for (final IObject scriptJob : iQuery.findAllByQuery(
@@ -464,7 +464,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         try {
             rfs.setFileId(testScriptId);
             final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            Assert.assertEquals(currentScript, pythonScript);
+            Assert.assertEquals(currentScript, getPythonScript());
             Assert.assertFalse(isExpectSuccess);
         } catch (Ice.LocalException | ServerError se) {
             /* can catch only ServerError once RawFileStoreTest.testBadFileId is fixed */
@@ -603,7 +603,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         RepositoryPrx repo = getRepository(Repository.SCRIPT);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        final byte[] fileContentOriginal = getPythonScript().getBytes(StandardCharsets.UTF_8);
         RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
@@ -668,7 +668,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         RepositoryPrx repo = getRepository(Repository.SCRIPT);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        final byte[] fileContentOriginal = getPythonScript().getBytes(StandardCharsets.UTF_8);
         RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
@@ -724,7 +724,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         /* upload the test script as a new script */
         IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
+        final long testScriptId = iScript.uploadOfficialScript(testScriptName, getPythonScript());
         /* delete any jobs associated with the script */
         final Delete2Builder delete = Requests.delete().option(Requests.option().excludeType("OriginalFile").build());
         for (final IObject scriptJob : iQuery.findAllByQuery(
@@ -760,7 +760,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         try {
             rfs.setFileId(testScriptId);
             final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            Assert.assertEquals(currentScript, pythonScript);
+            Assert.assertEquals(currentScript, getPythonScript());
             Assert.assertFalse(isExpectSuccess);
         } catch (Ice.LocalException | ServerError se) {
             /* can catch only ServerError once RawFileStoreTest.testBadFileId is fixed */
@@ -1484,7 +1484,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
             final IScriptPrx iScript = factory.getScriptService();
             final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
             try {
-                testScriptId = iScript.uploadScript(testScriptName, pythonScript);
+                testScriptId = iScript.uploadScript(testScriptName, getPythonScript());
                 Assert.assertTrue(isExpectSuccess);
             } catch (ServerError se) {
                 Assert.assertFalse(isExpectSuccess);
@@ -1501,7 +1501,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, pythonScript);
+        Assert.assertEquals(currentScript, getPythonScript());
     }
 
     /**
@@ -1611,7 +1611,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         RepositoryPrx repo = getRepository(Repository.OTHER);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        final byte[] fileContentOriginal = getPythonScript().getBytes(StandardCharsets.UTF_8);
         RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
@@ -1671,7 +1671,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         /* upload the test script as a new script */
         IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadScript(testScriptName, pythonScript);
+        final long testScriptId = iScript.uploadScript(testScriptName, getPythonScript());
         OriginalFile testScript = new OriginalFileI(testScriptId, false);
         /* try replacing the content of the normal user's script */
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
@@ -1680,7 +1680,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         try (final AutoCloseable igc = new ImplicitGroupContext(normalUser.groupId)) {
             Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
             iScript = factory.getScriptService();
-            newScript = pythonScript + "\n# this script is a copy of another";
+            newScript = getPythonScript() + "\n# this script is a copy of another";
             try {
                 iScript.editScript(new OriginalFileI(testScriptId, false), newScript);
                 Assert.assertTrue(isExpectSuccess);
@@ -1698,7 +1698,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : pythonScript);
+        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : getPythonScript());
     }
 
     /**
@@ -2059,7 +2059,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         long testScriptId = -1;
         try {
-            testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
+            testScriptId = iScript.uploadOfficialScript(testScriptName, getPythonScript());
             Assert.assertTrue(isExpectSuccess);
         } catch (ServerError se) {
             Assert.assertFalse(isExpectSuccess);
@@ -2076,7 +2076,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, pythonScript);
+        Assert.assertEquals(currentScript, getPythonScript());
     }
 
     /**
@@ -2099,7 +2099,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         RepositoryPrx repo = getRepository(Repository.SCRIPT);
         final OriginalFile testScript = repo.register(testScriptName, omero.rtypes.rstring(ScriptServiceTest.PYTHON_MIMETYPE));
         final long testScriptId = testScript.getId().getValue();
-        final byte[] fileContentOriginal = pythonScript.getBytes(StandardCharsets.UTF_8);
+        final byte[] fileContentOriginal = getPythonScript().getBytes(StandardCharsets.UTF_8);
         RawFileStorePrx rfs = repo.file(testScriptName, "rw");
         rfs.write(fileContentOriginal, 0, fileContentOriginal.length);
         rfs.close();
@@ -2161,7 +2161,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         /* upload the test script as a new script */
         IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
+        final long testScriptId = iScript.uploadOfficialScript(testScriptName, getPythonScript());
         /* try replacing the content of the normal user's script */
         loginNewActor(isAdmin, isSudo ? loginNewAdmin(true, null).userName : null,
                 isRestricted ? AdminPrivilegeWriteScriptRepo.value : null);
@@ -2171,7 +2171,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
             testScript = new OriginalFileI(testScriptId, false);
             Assert.assertEquals(getCurrentPermissions(testScript).canEdit(), isExpectSuccess);
             iScript = factory.getScriptService();
-            newScript = pythonScript + "\n# this script is a copy of another";
+            newScript = getPythonScript() + "\n# this script is a copy of another";
             try {
                 iScript.editScript(testScript, newScript);
                 Assert.assertTrue(isExpectSuccess);
@@ -2189,7 +2189,7 @@ public class LightAdminPrivilegesTest extends RolesTests {
         rfs.setFileId(testScriptId);
         final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
         rfs.close();
-        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : pythonScript);
+        Assert.assertEquals(currentScript, isExpectSuccess ? newScript : getPythonScript());
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1702,7 +1702,7 @@ public class LightAdminRolesTest extends RolesTests {
             final IScriptPrx iScript = factory.getScriptService();
             final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
             try {
-                testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
+                testScriptId = iScript.uploadOfficialScript(testScriptName, getPythonScript());
                 Assert.assertTrue(isExpectSuccessUploadOfficialScript);
             } catch (ServerError se) {
                 Assert.assertFalse(isExpectSuccessUploadOfficialScript);
@@ -1725,7 +1725,7 @@ public class LightAdminRolesTest extends RolesTests {
         } finally {
             if (rfs != null) rfs.close();
         }
-        Assert.assertEquals(currentScript, pythonScript);
+        Assert.assertEquals(currentScript, getPythonScript());
     }
 
     /**
@@ -1748,7 +1748,7 @@ public class LightAdminRolesTest extends RolesTests {
         loginNewAdmin(true, AdminPrivilegeWriteScriptRepo.value);
         IScriptPrx iScript = factory.getScriptService();
         final String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long testScriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
+        final long testScriptId = iScript.uploadOfficialScript(testScriptName, getPythonScript());
         /* Delete any jobs associated with the script.*/
         final Delete2Builder delete = Requests.delete().option(Requests.option().excludeType("OriginalFile").build());
         for (final IObject scriptJob : iQuery.findAllByQuery(
@@ -1783,7 +1783,7 @@ public class LightAdminRolesTest extends RolesTests {
             rfs = factory.createRawFileStore();
             rfs.setFileId(testScriptId);
             final String currentScript = new String(rfs.read(0, (int) rfs.size()), StandardCharsets.UTF_8);
-            Assert.assertEquals(currentScript, pythonScript);
+            Assert.assertEquals(currentScript, getPythonScript());
             Assert.assertFalse(isExpectSuccessDeleteOfficialScript);
         } catch (Ice.LocalException | ServerError se) {
             /* Have to catch both types of exceptions because
@@ -2624,14 +2624,14 @@ public class LightAdminRolesTest extends RolesTests {
         /* root uploads an official script to the server.*/
         IScriptPrx iScript = root.getSession().getScriptService();
         String testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
-        final long scriptId = iScript.uploadOfficialScript(testScriptName, pythonScript);
+        final long scriptId = iScript.uploadOfficialScript(testScriptName, getPythonScript());
         /* lightAdmin tries uploading the script as a new script in normalUser's group.*/
         logNewAdminWithoutPrivileges();
         iScript = factory.getScriptService();
         testScriptName = "Test_" + getClass().getName() + '_' + UUID.randomUUID() + ".py";
         File file = new File(testScriptName);
         file.deleteOnExit();
-        FileUtils.writeStringToFile(file, pythonScript);
+        FileUtils.writeStringToFile(file, getPythonScript());
         final OriginalFile scriptFile = (OriginalFile) iQuery.get("OriginalFile", scriptId);
         client.upload(file, scriptFile);
     }

--- a/components/tools/OmeroJava/test/integration/RolesTests.java
+++ b/components/tools/OmeroJava/test/integration/RolesTests.java
@@ -21,19 +21,17 @@ package integration;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.springframework.util.ResourceUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Files;
 
 import ome.services.blitz.repo.path.FsFile;
+
 import omero.RString;
 import omero.SecurityViolation;
 import omero.ServerError;
@@ -63,8 +61,6 @@ public class RolesTests extends AbstractServerImportTest {
 
     protected File fakeImageFile = null;
 
-    protected String pythonScript = null;
-
     /**
      * Create a fake image file for use in import tests.
      * @throws IOException unexpected
@@ -77,22 +73,11 @@ public class RolesTests extends AbstractServerImportTest {
     }
 
     /**
-     * Note the contents of an uploadable Python script.
-     * @throws IOException unexpected
-     */
-    @BeforeClass
-    public void notePythonScriptContent() throws IOException {
-        final File scriptFile = ResourceUtils.getFile("classpath:minimal-script.py");
-        pythonScript = Files.toString(scriptFile, StandardCharsets.UTF_8);
-    }
-
-    /**
      * Clear the instance fields that were set before running this class' tests.
      */
     @AfterClass
     public void teardown() {
         fakeImageFile = null;
-        pythonScript = null;
     }
 
     /* These permissions do not permit anything.*/


### PR DESCRIPTION
# What this PR does

Adjusts the scripts service integration tests to use a known-valid Python script for uploads.

Also makes testGetParams keep trying until it finds a valid Python script.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/ScriptServiceTest/ should pass.

# Related reading

https://trello.com/c/HsKwJHSk/96-fix-integration-tests