### PR TITLE
Gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,11 +46,14 @@ temp-testng-customsuite.xml
 .settings
 .springBeans
 /components/tools/OmeroWeb/omeroweb/media/webtest
+/components/tools/OmeroWeb/omeroweb/static/
+/components/var
 # Scons output files
 .sconsign.dblite
 *.dylib
 *.egg
 *.os
+*.iml
 omero_version.py
 eclipse.log
 velocity.log*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.gitignore
 .classpath
 .hg
 .hgignore

--- a/components/tests/ui/.gitignore
+++ b/components/tests/ui/.gitignore
@@ -1,0 +1,2 @@
+resources/config.txt
+resources/robot_ice.config


### PR DESCRIPTION
### What this PR does
Adds files extensions (.iml) to root project .gitignore file and removes restriction of preventing other .gitignore files from being added to subfolders of the project.

No testing required, just your opinion.