### PR TITLE
robot_fix_cannot_get_automation_extension

### DIFF
--- a/components/tests/ui/testcases/web/annotate_test.txt
+++ b/components/tests/ui/testcases/web/annotate_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Variables ***

--- a/components/tests/ui/testcases/web/center_right_panel_tests.txt
+++ b/components/tests/ui/testcases/web/center_right_panel_tests.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Variables ***

--- a/components/tests/ui/testcases/web/create_scenario.txt
+++ b/components/tests/ui/testcases/web/create_scenario.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Variables ***

--- a/components/tests/ui/testcases/web/delete_test.txt
+++ b/components/tests/ui/testcases/web/delete_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 

--- a/components/tests/ui/testcases/web/forms_test.txt
+++ b/components/tests/ui/testcases/web/forms_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Test Cases ***

--- a/components/tests/ui/testcases/web/map_annotations_test.txt
+++ b/components/tests/ui/testcases/web/map_annotations_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Test Cases ***

--- a/components/tests/ui/testcases/web/post_test.txt
+++ b/components/tests/ui/testcases/web/post_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Test Cases ***

--- a/components/tests/ui/testcases/web/rdef_test.txt
+++ b/components/tests/ui/testcases/web/rdef_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Variables ***

--- a/components/tests/ui/testcases/web/search.txt
+++ b/components/tests/ui/testcases/web/search.txt
@@ -7,7 +7,7 @@ Resource          ../../resources/web/login.txt
 
 Library           DateTime
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Variables ***

--- a/components/tests/ui/testcases/web/show_test.txt
+++ b/components/tests/ui/testcases/web/show_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Variables ***

--- a/components/tests/ui/testcases/web/spw_test.txt
+++ b/components/tests/ui/testcases/web/spw_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 

--- a/components/tests/ui/testcases/web/tagging_test.txt
+++ b/components/tests/ui/testcases/web/tagging_test.txt
@@ -5,7 +5,7 @@ Resource          ../../resources/config.txt
 Resource          ../../resources/web/login.txt
 Resource          ../../resources/web/tree.txt
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 *** Keywords ***

--- a/components/tests/ui/testcases/web/view_image.txt
+++ b/components/tests/ui/testcases/web/view_image.txt
@@ -7,7 +7,7 @@ Resource          ../../resources/web/tree.txt
 
 Library           Collections
 
-Suite Setup         Run Keywords  User "${USERNAME}" logs in with password "${PASSWORD}"  Maximize Browser Window
+Suite Setup         User "${USERNAME}" logs in with password "${PASSWORD}"
 Suite Teardown      Close all browsers
 
 

--- a/components/tests/ui/testcases/web/webadmin_user_settings.txt
+++ b/components/tests/ui/testcases/web/webadmin_user_settings.txt
@@ -9,7 +9,7 @@ Resource            ../../resources/web/webadmin.txt
 Resource            ../../resources/web/tree.txt
 Resource            ../../resources/config.txt
 
-Suite Setup         Run Keywords    Open Browser And Log In As User     Maximize Browser Window
+Suite Setup         Open Browser And Log In As User
 Suite Teardown      Logout and Teardown
 
 


### PR DESCRIPTION
# What this PR does

Tries to fix lots of this error, recently seen on ci and locally:
(90 failed at https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/764/robot/)
```
Message: | Parent suite setup failed: WebDriverException: Message: unknown error: cannot get automation extension from unknown error: page could not be found: chrome-extension://aapnijgdinlhnhlmodcfapnahmbfebeb/_generated_background_page.html   (Session info: chrome=62.0.3202.94)   (Driver info: chromedriver=2.29.461585 (0be2cd95f834e9ee7c46bcc7cf405b483f5ae83b),platform=Mac OS X 10.9.5 x86_64)
```

E.g. https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/764/robot/Web%20&%20Web/Web/Create%20Scenario/Test%20Container%20Creation%20Enabled/

