### PR TITLE
Error message change on OMERO import

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
@@ -855,7 +855,7 @@ public class PublicRepositoryI implements _RepositoryOperations, ApplicationCont
         if (null == repositoryDao.findRepoFile(sf, sql, repoUuid, checked, null)) {
             omero.ResourceError re = new omero.ResourceError();
             IceMapper.fillServerError(re, new RuntimeException(
-                    "Directory exists but is not registered: " + checked));
+                    "OMERO data directory and database out of sync. Please re-create your OMERO data directory."));
             throw re;
         }
     }


### PR DESCRIPTION
Changed error message from `Directory exists but is not registered` to `OMERO data directory and database out of sync. Please re-create your OMERO data directory` when a user attempts to import data into OMERO but hasn't re-created their data directory.