### PR TITLE
Debug "Cannot retrieve default value for property" message

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -348,9 +348,11 @@ class PrefsControl(WriteableConfigControl):
             from omeroweb import settings
             setting = settings.CUSTOM_SETTINGS_MAPPINGS.get(key)
             default = setting[2](setting[1]) if setting else []
-        except:
-            self.ctx.die(514, "Cannot retrieve default value for property %s" %
-                         key)
+        except Exception, e:
+            self.ctx.dbg(traceback.format_exc())
+            self.ctx.die(514,
+                         "Cannot retrieve default value for property %s: %s" %
+                         (key, e))
         if not isinstance(default, list):
             self.ctx.die(515, "Property %s is not a list" % key)
         return default


### PR DESCRIPTION
This can happen, for example, when using the system Python
rather than a virtualenv Python where Django has been installed.

# What this PR does

Print the reason for failing to get the property:

```
Cannot retrieve default value for property omero.web.apps: No module named django.utils.http
```

or if `OMERO_DEBUG=1`, then show a stacktrace.


# Testing this PR

1. Pick an installation method which *only* installs Django in a virtual (e.g. omero-web docker)
2. Run: `bin/omero config append omero.web.apps "omero_mapr"` _without_ enabling the local virtualenv
3. Check that the error message is: `Cannot retrieve default value for property omero.web.apps`
4. Try the same with this PR (perhaps `openmicroscopy/omero-web:dev-merge`)
5. Check that the error message includes "No module named django" as above
