### PR TITLE
Re-raise exception from integration tests

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -121,8 +121,9 @@ class ITest(object):
             cls.root.setAgent("OMERO.py.root_test")
             cls.root.createSession("root", rootpass)
             cls.root.getSession().keepAlive(None)
-        except:
-            raise Exception("Could not initiate a root connection")
+        except Exception:
+            cls.log.error("Could not initiate a root connection")
+            raise
 
         cls.group = cls.new_group(perms=cls.DEFAULT_PERMS)
         cls.user = cls.new_user(group=cls.group,


### PR DESCRIPTION
Without this change, only the fact that a connection cannot
be established is raised, hiding the original cause. In this
case, that was use of "localhost" rather than "omero" from
etc/ice.config

# Testing this PR
1. Run integration tests with a bad hostname
2. Ensure that a useful error message is printed
3. On ci-master, all tests should remain green
