### PR TITLE
TEMP disable saving changes to User and Group

### DIFF
--- a/components/tests/ui/testcases/web/webadmin_user_settings.txt
+++ b/components/tests/ui/testcases/web/webadmin_user_settings.txt
@@ -24,29 +24,29 @@ User Settings
     ${orig_middle_name}=    Get Element Attribute     xpath=//input[@id='id_middle_name']@value
     ${middle_name}=         Unique name         middle_name
     Input Text              id_middle_name      ${middle_name}
-    Click Button            Save
-    Page Should Contain Element   xpath=//input[@id='id_middle_name'][@value='${middle_name}']
-    # reset
-    Input Text              id_middle_name      ${orig_middle_name}
-    Click Button            Save
+    # Click Button            Save
+    # Page Should Contain Element   xpath=//input[@id='id_middle_name'][@value='${middle_name}']
+    # # reset
+    # Input Text              id_middle_name      ${orig_middle_name}
+    # Click Button            Save
 
-    # Edit Password
-    ${temp_password}=       Set Variable        tempPassword
-    Click Element           id=change_password
-    Input Text              id_old_password     ${PASSWORD}
-    Input Text              id_password         ${temp_password}
-    Input Text              id_confirmation     ${temp_password}
-    Click Dialog Button     OK
-    Wait Until Page Contains  Password reset OK
+    # # Edit Password
+    # ${temp_password}=       Set Variable        tempPassword
+    # Click Element           id=change_password
+    # Input Text              id_old_password     ${PASSWORD}
+    # Input Text              id_password         ${temp_password}
+    # Input Text              id_confirmation     ${temp_password}
+    # Click Dialog Button     OK
+    # Wait Until Page Contains  Password reset OK
 
-    # Reset Password back to original
-    Reload Page             # clears 'OK'
-    Click Element           id=change_password
-    Input Text              id_old_password     ${temp_password}
-    Input Text              id_password         ${PASSWORD}
-    Input Text              id_confirmation     ${PASSWORD}
-    Click Dialog Button     OK
-    Wait Until Page Contains  Password reset OK
+    # # Reset Password back to original
+    # Reload Page             # clears 'OK'
+    # Click Element           id=change_password
+    # Input Text              id_old_password     ${temp_password}
+    # Input Text              id_password         ${PASSWORD}
+    # Input Text              id_confirmation     ${PASSWORD}
+    # Click Dialog Button     OK
+    # Wait Until Page Contains  Password reset OK
 
 
 Owner Group Edit
@@ -61,13 +61,13 @@ Owner Group Edit
     # Edit permissions
     Radio Button Should Be Set To   permissions     2       # we should start off as 'read-annotate'
     Select Radio Button             permissions     1
-    Submit Form                     css=form.settings_form
+    # Submit Form                     css=form.settings_form
 
-    # Return to edit group, to check permissions were saved and reset
-    Location Should Be          ${WEBADMIN WELCOME URL}myaccount/
-    Click Element               css=#group_settings_tab a
-    Click Element               xpath=//table[@id='dataTable']//a/span[contains(text(), "Edit")]
-    Radio Button Should Be Set To   permissions     1
-    Select Radio Button             permissions     2
-    Submit Form                     css=form.settings_form
+    # # Return to edit group, to check permissions were saved and reset
+    # Location Should Be          ${WEBADMIN WELCOME URL}myaccount/
+    # Click Element               css=#group_settings_tab a
+    # Click Element               xpath=//table[@id='dataTable']//a/span[contains(text(), "Edit")]
+    # Radio Button Should Be Set To   permissions     1
+    # Select Radio Button             permissions     2
+    # Submit Form                     css=form.settings_form
 

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -121,8 +121,9 @@ class ITest(object):
             cls.root.setAgent("OMERO.py.root_test")
             cls.root.createSession("root", rootpass)
             cls.root.getSession().keepAlive(None)
-        except:
-            raise Exception("Could not initiate a root connection")
+        except Exception:
+            cls.log.error("Could not initiate a root connection")
+            raise
 
         cls.group = cls.new_group(perms=cls.DEFAULT_PERMS)
         cls.user = cls.new_user(group=cls.group,

--- a/history.txt
+++ b/history.txt
@@ -12,7 +12,7 @@ This is a bug-fix release.
 
 Improvements include:
 
--  labelled zoom slider bars in the UI to differentiate from horizontal
+-  labeled zoom slider bars in the UI to differentiate from horizontal
    scrollbars and make clear thumbnails can be zoomed (including Plate and
    Well thumbnails)
 -  fixes for installation walkthrough documentation - installation of script
@@ -36,7 +36,7 @@ Improvements include:
    * fixed the CLI metadata tablestest plugin to not use an empty list of
      Columns
 
-This release also upgrades the version of Bio-Formats which OMERO uses to
+This release also upgrades the version of Bio-Formats that OMERO uses to
 5.7.2.
 
 5.4.0 (October 2017)


### PR DESCRIPTION
# What this PR does

This is an investigation into failing robot tests.
I noticed from e.g. https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-robotframework/773/console that after the last test run on Firefox, where the user edits themselves and group, ALL login attempts fail for that user in the subsequent Chrome tests.
I can't reproduce this locally (edit user doesn't break login) so I'm not sure whether this will have any effect on the CI job, but it's worth a try...
