### PR TITLE
Update swingx to 1.6.1

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/treetable/OMETreeTable.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.util.ui.treetable.TreeTable 
  *
   *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -29,6 +29,7 @@ import java.awt.event.MouseListener;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+
 import javax.swing.DefaultCellEditor;
 import javax.swing.Icon;
 import javax.swing.JCheckBox;
@@ -39,11 +40,11 @@ import javax.swing.event.TreeExpansionListener;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.tree.TreePath;
 
+
 //Third-party libraries
 import org.jdesktop.swingx.JXTreeTable;
 import org.jdesktop.swingx.decorator.Highlighter;
 import org.jdesktop.swingx.decorator.HighlighterFactory;
-import org.jdesktop.swingx.table.ColumnHeaderRenderer;
 import org.jdesktop.swingx.treetable.MutableTreeTableNode;
 import org.jdesktop.swingx.treetable.TreeTableModel;
 
@@ -108,22 +109,10 @@ public class OMETreeTable
 	/** Tree expansion listener. */
 	protected TreeExpansionListener	treeExpansionListener;
 
-	/** The mouse listener. */
-	//protected MouseListener			mouseListener;
-	
-	/** Initializes the table. */
-	private void initialize()
-	{
-		ColumnHeaderRenderer l = 
-			(ColumnHeaderRenderer) getTableHeader().getDefaultRenderer();
-		l.setHorizontalAlignment(SwingConstants.CENTER);
-	}
-	
 	/** Creates a new instance. */
 	public OMETreeTable()
 	{
 		super();
-		initialize();
 	}
 	
 	/**
@@ -135,7 +124,6 @@ public class OMETreeTable
 	{
 		super(model);
 		setTableModel(model);
-		initialize();
 	}
 	
 	/**

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -996,7 +996,7 @@ versions.spring=3.0.1.RELEASE
 versions.spring-ldap=1.3.0.RELEASE
 versions.spring-security=3.0.2.RELEASE
 versions.subethasmtp=3.1.7
-versions.swingx=0.9.4
+versions.swingx=1.6.1
 versions.robotframework.swinglibrary=1.9.6
 # Costello's version matches SwingLibrary's dependency
 versions.abbot.costello=1.4.0


### PR DESCRIPTION
# What this PR does

Update the version of the swingx library which Insight uses to 1.6.1. This version doesn't have the
`ColumnHeaderRenderer` any longer, so I just removed its usage. The `OMETreeTable` is actually the only place where the `swingx` lib is used. The only implication of this is, that the table headers in Insight are now left aligned instead of centred. In my opinion that's not a big deal. But on the other hand will make the plugin compatible with Fiji again.

# Testing this PR

Replicate the error:
In **Fiji** (must be Fiji, ImageJ works) open OMERO plugin, open a dataset and in the centre panel choose the table view (or open a dataset with more than 100 images, then the table view will be the default). Plugin will crash with ClassCastException.

Replace the OMERO plugin in Fiji with the the merge build. Repeat the workflow. Plugin should work as expected.

Briefly check some other tables in Insight and/or plugin, e. g. the ROI/Folder table and make sure they still work as before.

# Related reading

https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8412
https://trello.com/c/YDyYAUIO/153-outstanding-insight-bugs - Inbox checklist

/cc @pwalczysko @jburel 
