### PR TITLE
Quantization follow up

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8875,6 +8875,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     # 'reverseIntensity' is deprecated. Use 'inverted'
                     'inverted': reverse,
                     'reverseIntensity': reverse,
+                    'family': unwrap(w.getFamily().getValue()),
+                    'coefficient': unwrap(w.getCoefficient()),
                     'rgb': {'red': w.getRed().val,
                             'green': w.getGreen().val,
                             'blue': w.getBlue().val}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -74,6 +74,8 @@ def channelMarshal(channel):
             # 'reverseIntensity' is deprecated. Use 'inverted'
             'inverted': channel.isInverted(),
             'reverseIntensity': channel.isInverted(),
+            'family': unwrap(channel.getFamily()),
+            'coefficient': unwrap(channel.getCoefficient()),
             'window': {'min': channel.getWindowMin(),
                        'max': channel.getWindowMax(),
                        'start': channel.getWindowStart(),

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2181,7 +2181,11 @@ def get_image_rdef_json(request, conn=None, **kwargs):
                 color = ch.get('lut') or ch['color']
                 chs.append("%s|%s:%s$%s" % (act, ch['window']['start'],
                                             ch['window']['end'], color))
-                maps.append({'inverted': {'enabled': ch['inverted']}})
+                maps.append({
+                    'inverted': {'enabled': ch['inverted']},
+                    'quantization': {
+                        'coefficient': ch['coefficient'],
+                        'family': ch['family']}})
             rdef = {'c': (",".join(chs)),
                     'm': rv['rdefs']['model'],
                     'pixel_range': "%s:%s" % (rv['pixel_range'][0],

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -65,6 +65,8 @@ class TestImgDetail(IWebTest):
                 'start': 88,
                 'min': 88
             },
+            'family': 'linear',
+            'coefficient': 1,
             'reverseIntensity': False,
             'inverted': False,
             'emissionWave': 500,

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -48,6 +48,7 @@ class TestRendering(IWebTest):
         image1 = conn.getObject("Image", iid1)
         image1.resetDefaults()
         image1.setColorRenderingModel()
+        image1.setQuantizationMap(0, "logarithmic", 0.5)
         image1.saveDefaults()
         image1 = conn.getObject("Image", iid1)
 
@@ -59,6 +60,13 @@ class TestRendering(IWebTest):
 
         assert image1.isGreyscaleRenderingModel() is False
         assert image2.isGreyscaleRenderingModel() is True
+
+        img1_chan = image1.getChannels()[0]
+        assert img1_chan.getFamily().getValue() == 'logarithmic'
+        assert img1_chan.getCoefficient() == 0.5
+        img2_chan = image2.getChannels()[0]
+        assert img2_chan.getFamily().getValue() == 'linear'
+        assert img2_chan.getCoefficient() == 1.0
 
         # copy rendering settings from image1 via ID
         request_url = reverse('webgateway.views.copy_image_rdef_json')
@@ -76,6 +84,9 @@ class TestRendering(IWebTest):
 
         image2 = conn.getObject("Image", iid2)
         assert image2.isGreyscaleRenderingModel() is False
+        img2_chan = image2.getChannels()[0]
+        assert img2_chan.getFamily().getValue() == 'logarithmic'
+        assert img2_chan.getCoefficient() == 0.5
 
     def test_copy_past_rendering_settings_from_url(self):
         # Create 2 images with 2 channels each
@@ -90,6 +101,7 @@ class TestRendering(IWebTest):
         image1.setColorRenderingModel()
         image1.setActiveChannels([1, 2], [[20, 300], [50, 100]],
                                  ['00FF00', 'FF0000'], [True, False])
+        image1.setQuantizationMap(0, "exponential", 0.8)
         image1.saveDefaults()
         image1 = conn.getObject("Image", iid1)
 
@@ -104,20 +116,30 @@ class TestRendering(IWebTest):
 
         def buildParamC(im):
             chs = []
+            maps = []
             for i, ch in enumerate(im.getChannels()):
                 act = "" if ch.isActive() else "-"
                 start = int(ch.getWindowStart())
                 end = int(ch.getWindowEnd())
                 rev = 'r' if ch.isInverted() else '-r'
                 color = ch.getColor().getHtml()
+                map = '{"quantization":' \
+                    '{"family":"%s","coefficient":%s}}' % \
+                    (ch.getFamily().getValue(),
+                        str(ch.getCoefficient()))
+                maps.append(map)
                 chs.append("%s%s|%s:%s%s$%s" % (act, i+1, start, end,
                                                 rev, color))
-            return ",".join(chs)
+            return ",".join(chs) + "&maps=[" + ",".join(maps) + "]"
 
         # build channel parameter e.g. 1|0:15$FF0000...
         old_c1 = buildParamC(image1)
         # Check it is what we expect
-        assert old_c1 == "1|20:300r$00FF00,2|50:100-r$FF0000"
+        exp_map1 = '{"quantization":' \
+            '{"family":"exponential","coefficient":0.8}}'
+        exp_map2 = '{"quantization":{"family":"linear","coefficient":1.0}}'
+        assert old_c1 == '1|20:300r$00FF00,2|50:100-r$FF0000' \
+            '&maps=[' + exp_map1 + ',' + exp_map2 + ']'
 
         # copy rendering settings from image1 via URL
         request_url = reverse('webgateway.views.copy_image_rdef_json')
@@ -157,6 +179,9 @@ class TestRendering(IWebTest):
         assert old_c1 == new_c2
         # check if image2 rendering model changed from greyscale to color
         assert image2.isGreyscaleRenderingModel() is False
+        newChan = image2.getChannels()[0]
+        assert newChan.getFamily().getValue() == 'exponential'
+        assert newChan.getCoefficient() == 0.8
 
     """
     Tests retrieving all rendering defs for an image (given id)
@@ -171,6 +196,8 @@ class TestRendering(IWebTest):
         image.resetDefaults()
         image.setColorRenderingModel()
         image.setChannelInverted(0, True)
+        image.setQuantizationMap(0, "logarithmic", 0.45)
+        image.setQuantizationMap(1, "exponential", 0.9)
         image.saveDefaults()
         image = conn.getObject("Image", iid)
 
@@ -198,13 +225,16 @@ class TestRendering(IWebTest):
         # channel info is supposed to match
         expChannels = image.getChannels()
         inverted = [True, False, False]    # expected reverse intensity flags
+        expFamilies = ['logarithmic', 'exponential', 'linear']
+        expCoefficients = [0.45, 0.9, 1.0]
         for i, c in enumerate(channels):
             assert c['active'] == expChannels[i].isActive()
             assert c['start'] == expChannels[i].getWindowStart()
             assert c['end'] == expChannels[i].getWindowEnd()
             assert c['color'] == expChannels[i].getColor().getHtml()
             assert c['reverseIntensity'] == inverted[i]
-            assert c['inverted'] == inverted[i]
+            assert c['family'] == expFamilies[i]
+            assert c['coefficient'] == expCoefficients[i]
 
         # id and owner check
         assert rdefs[0].get("id") is not None


### PR DESCRIPTION
# What this PR does

Follow-up for: https://github.com/openmicroscopy/openmicroscopy/pull/5501
Having looked into using the above PR in iviewer I noticed that some bits were missing to integrate it seamlessly with the other rendering settings that are already used:
- image_marshal does not include the quantization info, hence the information is missing in the json that's requested
- copy and paste, as well as the rendering settings request did also not include quantization in its logic

# Testing this PR
Check that the tests are green:
- https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-Python27/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_marshal/TestImgDetail/
- https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-Python27/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_rendering/TestRendering/
