### PR TITLE
tables: retry repo_uuid lookup

### DIFF
--- a/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
@@ -24,6 +24,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 # Don't retry since we expect errors
 omero.tables.RETRIES = 1
+omero.tables.SECONDS_SLEEP = 1
 
 
 class communicator_provider(object):


### PR DESCRIPTION
This adds on to 12646428a3f44908ae5451c88db710bebe32de94 (gh-5481)
but not just adding a wait to the .omero/repository lookup but as
well to the .omero/repository/*/repo_uuid lookup, so that the 20
REPEATS don't progress within 2-3 seconds but instead take long
enough for the integration server has time to configure itself

cF. https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-training/811/

# Testing this PR

1. table tables (incl. merge-training) should be green for an extended period
2. setting `omero.repo.wait` to a longer period (in MT) should help alleviate any issues

