### PR TITLE
fix syntax of ["deprecate"] metadata directive in Slice files

### DIFF
--- a/components/blitz/resources/omero/Constants.ice
+++ b/components/blitz/resources/omero/Constants.ice
@@ -211,7 +211,7 @@ module omero {
      **/
     module analysis {
         /** namespaces related to the FLIM analysis. **/
-        ["deprecated: It will be removed in 5.4"]
+        ["deprecate: It will be removed in 5.4"]
         module flim {
             const string NSFLIM = "openmicroscopy.org/omero/analysis/flim";
 

--- a/components/blitz/resources/omero/System.ice
+++ b/components/blitz/resources/omero/System.ice
@@ -103,7 +103,7 @@ module omero {
       omero::RBool  leaves;
       omero::RBool  orphan;
       omero::RBool  acquisitionData;
-      ["deprecated:experimental: may be wholly removed in next major version"]
+      ["deprecate:experimental: may be wholly removed in next major version"]
       omero::RBool  cacheable;
     };
 

--- a/components/blitz/resources/omero/api/IAdmin.ice
+++ b/components/blitz/resources/omero/api/IAdmin.ice
@@ -502,13 +502,13 @@ module omero {
                  */
                 idempotent void deleteGroup(omero::model::ExperimenterGroup group) throws ServerError;
 
-                ["deprecated:changeOwner() is deprecated. use omero::cmd::Chown2() instead."]
+                ["deprecate:changeOwner() is deprecated. use omero::cmd::Chown2() instead."]
                 idempotent void changeOwner(omero::model::IObject obj, string omeName) throws ServerError;
 
-                ["deprecated:changeGroup() is deprecated. use omero::cmd::Chgrp2() instead."]
+                ["deprecate:changeGroup() is deprecated. use omero::cmd::Chgrp2() instead."]
                 idempotent void changeGroup(omero::model::IObject obj, string omeName) throws ServerError;
 
-                ["deprecated:changePermissions() is deprecated. use omero::cmd::Chmod2() instead."]
+                ["deprecate:changePermissions() is deprecated. use omero::cmd::Chmod2() instead."]
                 idempotent void changePermissions(omero::model::IObject obj, omero::model::Permissions perms) throws ServerError;
 
                 /**
@@ -586,7 +586,7 @@ module omero {
                  */
                 void changeExpiredCredentials(string name, string oldCred, string newCred) throws ServerError;
 
-                ["deprecated:reportForgottenPassword() is deprecated. use omero::cmd::ResetPasswordRequest() instead."]
+                ["deprecate:reportForgottenPassword() is deprecated. use omero::cmd::ResetPasswordRequest() instead."]
                 void reportForgottenPassword(string name, string email) throws ServerError;
 
                 // Security Context

--- a/components/blitz/resources/omero/api/ILdap.ice
+++ b/components/blitz/resources/omero/api/ILdap.ice
@@ -137,7 +137,7 @@ module omero {
                  */
                 idempotent omero::model::ExperimenterGroup findGroup(string groupname) throws ServerError;
 
-                ["deprecated:setDN() is deprecated. Set the LDAP flag on model objects instead."]
+                ["deprecate:setDN() is deprecated. Set the LDAP flag on model objects instead."]
                 idempotent void setDN(omero::RLong experimenterID, string dn) throws ServerError;
 
                 /**

--- a/components/blitz/resources/omero/api/IPixels.ice
+++ b/components/blitz/resources/omero/api/IPixels.ice
@@ -145,7 +145,7 @@ module omero {
                  * @param value Enumeration string value.
                  * @return Enumeration object.
                  **/
-                 ["deprecated:Use ITypes#getEnumeration(string, string) instead."]
+                 ["deprecate:Use ITypes#getEnumeration(string, string) instead."]
                 idempotent omero::model::IObject getEnumeration(string enumClass, string value) throws ServerError;
 
                 /**
@@ -156,7 +156,7 @@ module omero {
                  * @return List of all enumeration objects for the
                  *         <i>enumClass</i>.
                  **/
-                 ["deprecated:Use ITypes#allEnumerations(string) instead."]
+                 ["deprecate:Use ITypes#allEnumerations(string) instead."]
                 idempotent IObjectList getAllEnumerations(string enumClass) throws ServerError;
 
                 /**

--- a/components/blitz/resources/omero/api/IRoi.ice
+++ b/components/blitz/resources/omero/api/IRoi.ice
@@ -16,7 +16,7 @@
 // -----------------------------
 // Histograms
 // Volumes, Velocities, Diffusions
-["deprecated:IROI is deprecated."]
+["deprecate:IROI is deprecated."]
 module omero {
 
     module api {
@@ -127,7 +127,7 @@ module omero {
                  * All Shapes are loaded, as is the Pixels and Image object.
                  * TODO: Annotations?
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult findByRoi(long roiId, RoiOptions opts) throws omero::ServerError;
 
@@ -136,7 +136,7 @@ module omero {
                  *
                  * Loads Rois as findByRoi.
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult findByImage(long imageId, RoiOptions opts) throws omero::ServerError;
 
@@ -145,35 +145,35 @@ module omero {
                  *
                  * Loads Rois as findByRoi.
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult findByPlane(long imageId, int z, int t, RoiOptions opts) throws omero::ServerError;
 
                 /**
                  * Calculate the points contained within a given shape
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapePoints getPoints(long shapeId) throws omero::ServerError;
 
                 /**
                  * Calculate stats for all the shapes within the given Roi.
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiStats getRoiStats(long roiId) throws omero::ServerError;
 
                 /**
                  * Calculate the stats for the points within the given Shape.
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapeStats getShapeStats(long shapeId) throws omero::ServerError;
 
                 /**
                  * Calculate the stats for the points within the given Shapes.
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapeStatsList getShapeStatsList(LongList shapeIdList) throws omero::ServerError;
 
@@ -187,7 +187,7 @@ module omero {
                  * - if channel list is given, only the channels in that list are iterated over
                  * - does not request data from reader on each iteration 
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapeStatsList getShapeStatsRestricted(
                     LongList shapeIdList, int zForUnattached, int tForUnattached, IntegerArray channels) throws omero::ServerError;
@@ -207,7 +207,7 @@ module omero {
                  * @param opts, userId and groupId are respected based on the
                  *        ownership of the annotation.
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 AnnotationList getRoiMeasurements(long imageId, RoiOptions opts) throws omero::ServerError;
 
@@ -217,7 +217,7 @@ module omero {
                  *
                  * @param annotationId if -1, logic is identical to findByImage(imageId, opts)
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult getMeasuredRois(long imageId, long annotationId, RoiOptions opts) throws omero::ServerError;
 
@@ -227,7 +227,7 @@ module omero {
                  * Logic is identical to getMeasuredRois, but Roi data will not be duplicated. (i.e.
                  * the objects are referentially identical)
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 LongRoiResultMap getMeasuredRoisMap(long imageId, LongList annotationIds, RoiOptions opts) throws omero::ServerError;
 
@@ -236,11 +236,11 @@ module omero {
                  * {@link omero.model.FileAnnotation} id returned
                  * by {@link #getImageMeasurements}.
                  **/
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 idempotent
                 omero::grid::Table* getTable(long annotationId) throws omero::ServerError;
 
-                ["deprecated:IROI is deprecated."]
+                ["deprecate:IROI is deprecated."]
                 void uploadMask(long roiId, int z, int t, Ice::ByteSeq bytes) throws omero::ServerError;
 
             };

--- a/components/blitz/resources/omero/api/IShare.ice
+++ b/components/blitz/resources/omero/api/IShare.ice
@@ -12,7 +12,7 @@
 #include <omero/ModelF.ice>
 #include <omero/ServicesF.ice>
 #include <omero/Collections.ice>
-["deprecated:IShare is deprecated."]
+["deprecate:IShare is deprecated."]
 module omero {
 
     module api {

--- a/components/blitz/resources/omero/api/IUpdate.ice
+++ b/components/blitz/resources/omero/api/IUpdate.ice
@@ -56,7 +56,7 @@ module omero {
                 void saveArray(IObjectList graph) throws ServerError;
                 IObjectList saveAndReturnArray(IObjectList graph) throws ServerError;
                 omero::sys::LongList saveAndReturnIds(IObjectList graph) throws ServerError;
-                ["deprecated:use omero::cmd::Delete2 instead"]
+                ["deprecate:use omero::cmd::Delete2 instead"]
                 void deleteObject(omero::model::IObject row) throws ServerError;
 
                 /**

--- a/components/blitz/resources/omero/api/RenderingEngine.ice
+++ b/components/blitz/resources/omero/api/RenderingEngine.ice
@@ -203,7 +203,7 @@ module omero {
                  * binary masks.
                  * @param overlays Binary mask to color map.
                  */
-                ["deprecated: use omero::romio::PlaneDefWithMasks instead"] idempotent void setOverlays(omero::RLong tablesId, omero::RLong imageId, LongIntMap rowColorMap) throws ServerError;
+                ["deprecate: use omero::romio::PlaneDefWithMasks instead"] idempotent void setOverlays(omero::RLong tablesId, omero::RLong imageId, LongIntMap rowColorMap) throws ServerError;
 
                 /** Creates an instance of the rendering engine. */
                 idempotent void load() throws ServerError;
@@ -421,7 +421,7 @@ module omero {
                  * @see #updateCodomainMap
                  * @see #removeCodomainMap
                  */
-                 ["deprecated:addCodomainMap() is deprecated. use addCodomainMapToChannel instead."]
+                 ["deprecate:addCodomainMap() is deprecated. use addCodomainMapToChannel instead."]
                 void addCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
 
                 /**
@@ -433,7 +433,7 @@ module omero {
                  * @see #addCodomainMap
                  * @see #removeCodomainMap
                  */
-                 ["deprecated:removeCodomainMap() is deprecated."]
+                 ["deprecate:removeCodomainMap() is deprecated."]
                 void updateCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
 
                 /**
@@ -444,7 +444,7 @@ module omero {
                  * @see #addCodomainMap
                  * @see #updateCodomainMap
                  */
-                 ["deprecated:removeCodomainMap() is deprecated. use removeCodomainMapFromChannel instead."]
+                 ["deprecate:removeCodomainMap() is deprecated. use removeCodomainMapFromChannel instead."]
                 void removeCodomainMap(omero::romio::CodomainMapContext mapCtx) throws ServerError;
 
                 /**

--- a/components/blitz/resources/omero/cmd/FS.ice
+++ b/components/blitz/resources/omero/cmd/FS.ice
@@ -196,7 +196,7 @@ module omero {
          *   Folder, Screen, Plate, Well, WellSample,
          *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
          **/
-        ["deprecated:use omero::cmd::DiskUsage2 instead"]
+        ["deprecate:use omero::cmd::DiskUsage2 instead"]
         class DiskUsage extends Request {
             omero::api::StringSet classes;
             omero::api::StringLongListMap objects;
@@ -214,7 +214,7 @@ module omero {
          *   Thumbnail for the image thumbnails
          * The above map values are broken down by owner-group keys.
          **/
-        ["deprecated:use omero::cmd::DiskUsage2Response instead"]
+        ["deprecate:use omero::cmd::DiskUsage2Response instead"]
         class DiskUsageResponse extends Response {
             omero::api::LongPairToStringIntMap fileCountByReferer;
             omero::api::LongPairToStringLongMap bytesUsedByReferer;

--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -205,7 +205,7 @@ module omero {
                 /**
                  * Ignore in the operation all objects of these types.
                  **/
-                ["deprecated:experimental: may be wholly removed in next major version"]
+                ["deprecate:experimental: may be wholly removed in next major version"]
                 omero::api::StringSet typesToIgnore;
         };
 


### PR DESCRIPTION
# What this PR does

Extends our Slice docs documentation at http://downloads.openmicroscopy.org/latest/omero5.4/api/slice2html/ with the intended informative messages about instances of API deprecation.

# Testing this PR

I don't know where the docs are staged but locally can try something like `ant release-slice2html` then explore HTML in `docs/api/slice2html/` to see how the default messages like "This member is deprecated." on pages like http://downloads.openmicroscopy.org/omero/5.4.1/api/slice2html/omero/sys/Options.html are now fixed.

# Related reading

https://doc.zeroc.com/display/Ice36/Deprecating+Slice+Definitions