### PR TITLE
Bump omero-marshal to 0.5.2

### DIFF
--- a/components/tools/OmeroWeb/requirements-py27-ice35.txt
+++ b/components/tools/OmeroWeb/requirements-py27-ice35.txt
@@ -8,5 +8,5 @@ Django>=1.8,<1.9
 django-pipeline==1.3.20
 gunicorn>=19.3
 
-omero-marshal==0.5.1
+omero-marshal==0.5.2
 django-redis>=4.4

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -9,5 +9,5 @@ Django>=1.8,<1.9
 django-pipeline==1.3.20
 gunicorn>=19.3
 
-omero-marshal==0.5.1
+omero-marshal==0.5.2
 django-redis>=4.4

--- a/components/tools/OmeroWeb/test/integration/test_api_rois.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_rois.py
@@ -30,6 +30,7 @@ from omero.model import EllipseI, \
     ImageI, \
     LengthI, \
     LineI, \
+    MaskI, \
     PointI, \
     PolygonI, \
     RectangleI, \
@@ -116,7 +117,18 @@ class TestContainers(IWebTest):
         points = "10,20, 50,150, 200,200, 250,75"
         polygon.points = rstring(points)
 
-        return [rect, ellipse, line, point, polygon]
+        mask = MaskI()
+        mask.setTheC(rint(0))
+        mask.setTheZ(rint(0))
+        mask.setTheT(rint(0))
+        mask.setX(rdouble(100))
+        mask.setY(rdouble(100))
+        mask.setWidth(rdouble(500))
+        mask.setHeight(rdouble(500))
+        mask.setTextValue(rstring("test-Mask"))
+        mask.setBytes(None)
+
+        return [rect, ellipse, line, point, polygon, mask]
 
     @pytest.fixture()
     def image_rois(self, user1, shapes):


### PR DESCRIPTION
This release adds support for Masks - see https://github.com/openmicroscopy/omero-marshal/blob/v0.5.2/CHANGELOG.md

To test this PR:
- import a file with masks into a server, e.g `test&masks=15fake` and use the JSON API to confirm the associate mask shapes are encoded
- check the expanded JSON API integration test is still passing