### PR TITLE
 Projection save

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ProjectionProjectAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ProjectionProjectAction.java
@@ -63,9 +63,10 @@ public class ProjectionProjectAction
     	if (model.getState() == ImViewer.READY && !model.isBigImage()) {
     		if (model.getSelectedIndex() != ImViewer.PROJECTION_INDEX)
     			setEnabled(false);
-    		else setEnabled(model.canAnnotate());
+    		else setEnabled(model.canEdit());
     	} else setEnabled(false);
     }
+
     /**
      * Reacts to state changes.
      * @see ViewerAction#onStateChange(ChangeEvent)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -1191,7 +1191,15 @@ public interface ImViewer
 	 * @return See above.
 	 */
 	public boolean canAnnotate();
-	
+
+	/**
+     * Returns <code>true</code> if the permissions of the group allows 
+     * edit <code>false</code> otherwise.
+     *
+     * @return See above.
+     */
+    public boolean canEdit();
+
 	/**
 	 * Returns <code>true</code> if the user currently logged in is the
 	 * owner of the image, <code>false</code> otherwise.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -3222,6 +3222,16 @@ class ImViewerComponent
 	}
 
 	/** 
+     * Implemented as specified by the {@link ImViewer} interface.
+     * @see ImViewer#canEdit()
+     */
+    public boolean canEdit()
+    {
+        if (isUserOwner()) return true;
+        return model.getImage().canEdit();
+    }
+
+	/** 
 	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#isUserOwner()
 	 */


### PR DESCRIPTION
# What this PR does

The user can create a projected image if he/she has the correct permissions
This can only be done if ``canEdit`` is true and not ``canAnnotate``
The problem was reported via QA

# Testing this PR

Test 1 insight only
* log as user-3
* Select the read-annotate group
* Add another user from the group
* Open an image with multiple z
* Click on the projection tab
* Check that the ``Project...`` button is greyed out

Test 2 insight only
* log as user-4
* Select the read-write group
* Add another user from the group
* Open an image with multiple z
* Click on the projection tab
* Check that the ``Project...`` button is not greyed out. Click on the button
* Check that a projected image is created

In both cases, the user should still be able to create a projection preview

# Related reading

see https://trello.com/c/2U0ekjwL/58-save-projected-image-rwra
