### PR TITLE
password script param

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -121,8 +121,9 @@ class ITest(object):
             cls.root.setAgent("OMERO.py.root_test")
             cls.root.createSession("root", rootpass)
             cls.root.getSession().keepAlive(None)
-        except:
-            raise Exception("Could not initiate a root connection")
+        except Exception:
+            cls.log.error("Could not initiate a root connection")
+            raise
 
         cls.group = cls.new_group(perms=cls.DEFAULT_PERMS)
         cls.user = cls.new_user(group=cls.group,

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/include_param.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/include_param.html
@@ -81,7 +81,8 @@
                 {% if i.number %}
                     <input tabIndex="1" type="text" name="{{ i.key }}" class="{{ i.number }}" {% ifnotequal i.default None %} value="{{ i.default }}" {% endifnotequal %} />
                 {% else %}
-                    <input tabIndex="1" type="text" name="{{ i.key }}" {% ifnotequal i.default None %} value="{{ i.default }}" {% endifnotequal %} />
+                    <input tabIndex="1" name="{{ i.key }}" {% ifnotequal i.default None %} value="{{ i.default }}" {% endifnotequal %}
+                        {% ifequal i.name|lower 'password' %} type="password" {% else %} type="text" {% endifequal %} />
                 {% endif %}
             {% endif %}
         {% endif %}

--- a/history.txt
+++ b/history.txt
@@ -12,7 +12,7 @@ This is a bug-fix release.
 
 Improvements include:
 
--  labelled zoom slider bars in the UI to differentiate from horizontal
+-  labeled zoom slider bars in the UI to differentiate from horizontal
    scrollbars and make clear thumbnails can be zoomed (including Plate and
    Well thumbnails)
 -  fixes for installation walkthrough documentation - installation of script
@@ -36,7 +36,7 @@ Improvements include:
    * fixed the CLI metadata tablestest plugin to not use an empty list of
      Columns
 
-This release also upgrades the version of Bio-Formats which OMERO uses to
+This release also upgrades the version of Bio-Formats that OMERO uses to
 5.7.2.
 
 5.4.0 (October 2017)


### PR DESCRIPTION
# What this PR does

If a script ```String``` parameter is named 'password' or 'Password', we use ```type="password"``` in the web script UI to hide input:

See http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2017-December/004093.html

![screen shot 2017-12-11 at 13 09 11](https://user-images.githubusercontent.com/900055/33832780-4951af3c-de75-11e7-8cda-fba55d726308.png)


# Testing this PR

1. Upload a script with String parameter named "Password" or "password".

1. Should see hidden characters in UI.