### PR TITLE
filter_anns_json_by_ns

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -1798,7 +1798,7 @@ def _marshal_exp_obj(experimenter):
 
 def marshal_annotations(conn, project_ids=None, dataset_ids=None,
                         image_ids=None, screen_ids=None, plate_ids=None,
-                        run_ids=None, well_ids=None, ann_type=None,
+                        run_ids=None, well_ids=None, ann_type=None, ns=None,
                         group_id=-1, page=1, limit=settings.PAGE):
 
     annotations = []
@@ -1832,6 +1832,8 @@ def marshal_annotations(conn, project_ids=None, dataset_ids=None,
         where_clause.append('ch.class!=CommentAnnotation')
         where_clause.append("""(ch.ns=null or
             ch.ns!='openmicroscopy.org/omero/insight/rating')""")
+    if ns is not None:
+        where_clause.append('ch.ns=:ns')
 
     dtypes = ["Project", "Dataset", "Image",
               "Screen", "Plate", "PlateAcquisition", "Well"]
@@ -1845,6 +1847,8 @@ def marshal_annotations(conn, project_ids=None, dataset_ids=None,
             continue
         params = init_params(group_id, page, limit)
         params.addIds(ids)
+        if ns is not None:
+            params.add('ns', wrap(ns))
         q = """
             select oal from %sAnnotationLink as oal
             join fetch oal.details.creationEvent

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1163,6 +1163,7 @@ def api_annotations(request, conn=None, **kwargs):
     limit = get_long_or_default(request, 'limit', settings.PAGE)
 
     ann_type = r.get('type', None)
+    ns = r.get('ns', None)
 
     anns, exps = tree.marshal_annotations(conn, project_ids=project_ids,
                                           dataset_ids=dataset_ids,
@@ -1172,6 +1173,7 @@ def api_annotations(request, conn=None, **kwargs):
                                           run_ids=run_ids,
                                           well_ids=well_ids,
                                           ann_type=ann_type,
+                                          ns=ns,
                                           page=page,
                                           limit=limit)
 

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -471,3 +471,28 @@ class TestTreeAnnotations(ITest):
         assert annotations[3] == anns[3]
         assert annotations[4] == anns[4]
         assert experimenters == exps
+
+    def test_filter_by_namespace(self, userA, project_userA, rating_userA,
+                                 comments_userA):
+        """Test filtering of Annotations by Namespace."""
+        conn = get_connection(userA)
+        comment1, comment2 = comments_userA
+        rating = rating_userA
+
+        project = project_userA
+        rating_link = annotate_project(rating, project, userA)
+        annotate_project(comment1, project, userA)
+        annotate_project(comment2, project, userA)
+
+        # Filter by rating namespace should only return a single link
+        rating_ns = omero.constants.metadata.NSINSIGHTRATING
+        marshaled = marshal_annotations(conn=conn,
+                                        project_ids=[project.id.val],
+                                        ns=rating_ns)
+        expected = expected_annotations(userA, [rating_link])
+        assert marshaled[0] == expected[0]
+
+        # Confirm we get all 3 links when we don't filter
+        marshaled = marshal_annotations(conn=conn,
+                                        project_ids=[project.id.val])
+        assert len(marshaled[0]) == 3


### PR DESCRIPTION
# What this PR does

Allows filtering by namespace ```ns``` in webclient/api/annotations
This is needed for Simple FRAP workflow, where we want to load only map annotations with specified namespace into Figure to create labels. See https://github.com/jburel/omero-example-scripts/pull/6

# Testing this PR

1. Add a map annotation to image with a different namespace. E.g. see https://docs.openmicroscopy.org/omero/5.4.0/developers/Python.html but use a different namespace.

2. Using the Image ID, to ```/webclient/api/annotations/?type=map&image=ID``` to see all map annotations.

3. Add ```?ns=your.namespace``` to filter by namespace. Should now only see your map annotation.

4. Test should be passing.