### PR TITLE
Double DEFAULT_TIMEOUT to 6 secs in upgrade_check.py

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/upgrade_check.py
+++ b/components/tools/OmeroPy/src/omero/util/upgrade_check.py
@@ -46,7 +46,7 @@ class UpgradeCheck(object):
     # Default timeout is 3 seconds.
     # * http://docs.python.org/2/library/socket.html#socket.setdefaulttimeout
     #
-    DEFAULT_TIMEOUT = 3.0
+    DEFAULT_TIMEOUT = 6.0
 
     def __init__(self, agent, url="http://upgrade.openmicroscopy.org.uk/",
                  version=omero_version, timeout=DEFAULT_TIMEOUT):


### PR DESCRIPTION
# What this PR does

Attempt to make this test less flaky:
https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/755/testReport/junit/OmeroPy.test.integration.clitest.test_admin/TestAdmin/test_checkupgrade0/
Since this fails with ```ERROR:omero.util.UpgradeCheck:<urlopen error The read operation timed out>```
This PR simply doubles the timeout from 3 to 6 seconds.

# Testing this PR

1. See if the test is less flaky (currently 2 fails in last 30 tests)