### PR TITLE
Fix PlateGrid thumbprefix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1475,11 +1475,19 @@ def plateGrid_json(request, pid, field=0, conn=None, **kwargs):
         field = long(field or 0)
     except ValueError:
         field = 0
+    prefix = kwargs.get('thumbprefix', 'webgateway.views.render_thumbnail')
     thumbsize = getIntOrDefault(request, 'size', None)
     logger.debug(thumbsize)
     server_id = kwargs['server_id']
 
-    plateGrid = PlateGrid(conn, pid, field, kwargs.get('urlprefix', ''))
+    def get_thumb_url(iid):
+        if thumbsize is not None:
+            return reverse(prefix, args=(iid, thumbsize))
+        return reverse(prefix, args=(iid,))
+
+    plateGrid = PlateGrid(conn, pid, field,
+                          kwargs.get('urlprefix', get_thumb_url))
+
     plate = plateGrid.plate
     if plate is None:
         return Http404

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -300,8 +300,7 @@ class TestPlateGrid(object):
                     assert well_metadata['name'] == img.name.val
                     # by default thumbprefix is not set,
                     # thumbnail url is not restored
-                    # this is string, see PlateGrid
-                    assert well_metadata['thumb_url'] == str(img.id.val)
+                    assert well_metadata['thumb_url'] == img.id.val
 
     def test_well_images(self, django_client, plate_wells, conn):
         """

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -298,9 +298,10 @@ class TestPlateGrid(object):
                 if len(well_samples) > field:
                     img = well_samples[field].getImage()
                     assert well_metadata['name'] == img.name.val
-                    # by default thumbprefix is not set,
-                    # thumbnail url is not restored
-                    assert well_metadata['thumb_url'] == img.id.val
+                    # expect default thumbnail (no size specified)
+                    assert well_metadata['thumb_url'] ==\
+                        reverse('webgateway.views.render_thumbnail',
+                                args=[img.id.val])
 
     def test_well_images(self, django_client, plate_wells, conn):
         """


### PR DESCRIPTION
# What this PR does

This returns the default behaviour of thumbnail URLs in PlateGrid JSON to returning ```/webgateway/render_thumbnail/ID/```

# Testing this PR

1. For a given Plate ID, go to ```/webgateway/plate/{ID}/0/```

2. Should see a valid url for each 'thumb_url' E.g
 ``` "thumb_url": "/webgateway/render_thumbnail/66164/", ```

# Related reading

This functionality was removed in 641a696b86b but I don't know why.
Discovered this when looking again at https://github.com/will-moore/omero-parade which uses these urls for Plate thumbnails.