### PR TITLE
have import fail fast if into illegal container

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2005-2018 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -495,6 +495,13 @@ public class ImportLibrary implements IObservable
                 container.getUsedFiles().length));
                 return Collections.emptyList();
             }
+        }
+        final IObject target = container.getTarget();
+        if (target != null && !target.getDetails().getPermissions().canLink()) {
+            /* stop this import before file upload commences */
+            final String message = "Cannot link to target";
+            log.error(message);
+            throw new IllegalArgumentException(message);
         }
         final ImportProcessPrx proc = createImport(container);
         final String[] srcFiles = container.getUsedFiles();

--- a/components/tools/OmeroJava/test/integration/ImporterTest.java
+++ b/components/tools/OmeroJava/test/integration/ImporterTest.java
@@ -1,7 +1,8 @@
 /*
- *   Copyright 2006-2017 University of Dundee. All rights reserved.
+ *   Copyright 2006-2018 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package integration;
 
 import java.io.File;
@@ -1623,4 +1624,22 @@ public class ImporterTest extends AbstractServerTest {
         }
     }
 
+    /**
+     * Test that import into another's container in a read-annotate group fails.
+     * @throws Throwable expecting importFile to throw IllegalArgumentException
+     */
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testImportImageIntoOthersDataset() throws Throwable {
+        /* create test image file */
+        final File testImage = File.createTempFile(ImporterTest.class.getName() + "-image", "." + OME_FORMAT);
+        new XMLWriter().writeFile(testImage, new XMLMockObjects().createImage(), true);
+        testImage.deleteOnExit();
+        /* one user has a dataset in a read-annotate group */
+        newUserAndGroup("rwra--");
+        Dataset dataset = (Dataset) iUpdate.saveAndReturnObject(mmFactory.simpleDataset()).proxy();
+        /* another user in that group attempts to import into that dataset */
+        newUserInGroup();
+        dataset = (Dataset) iQuery.get(Dataset.class.getSimpleName(), dataset.getId().getValue());
+        importFile(testImage, OME_FORMAT, dataset);
+    }
 }


### PR DESCRIPTION
# What this PR does

For when a user tries to import into a container that they do not have permissions for, this PR makes the import failure faster and clearer.

# Testing this PR

Try importing into, say, somebody else's dataset in a read-annotate group and make sure that file upload does not even start.

https://web-proxy.openmicroscopy.org/next-ci/job/OMERO-test-integration/lastCompletedBuild/testngreports/integration/ImporterTest/testImportImageIntoOthersDataset/

# Related reading

https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8054&p=17168#p17168
https://trello.com/c/dFxZnrag/65-failed-import-on-non-user-dataset