### PR TITLE
extend CLI admin email timeout

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1391,7 +1391,7 @@ present, the user will enter a console""")
 
         try:
             cb = client.submit(
-                req, loops=10, ms=500,
+                req, loops=50, ms=500,
                 failonerror=True, failontimeout=True)
         except omero.CmdError, ce:
             err = ce.err

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -22,6 +22,7 @@ import datetime
 import Ice
 
 from glob import glob
+from math import ceil
 from path import path
 
 import omero
@@ -216,6 +217,7 @@ Examples:
         email.add_argument(
             "--inactive", action="store_true",
             help="Do not filter inactive users.")
+        self._add_wait(email)
         self.add_user_and_group_arguments(email,
                                           action="append",
                                           exclusive=False)
@@ -1389,9 +1391,13 @@ present, the user will enter a console""")
             everyone=args.everyone,
             inactive=args.inactive)
 
+        ms = 500
+        wait = args.wait if args.wait > 0 else 25
+        loops = ceil(wait * 1000.0 / ms)
+
         try:
             cb = client.submit(
-                req, loops=50, ms=500,
+                req, loops=loops, ms=ms,
                 failonerror=True, failontimeout=True)
         except omero.CmdError, ce:
             err = ce.err


### PR DESCRIPTION
# What this PR does

Sending e-mail to a user of our demo server takes around 15s. This PR extends the timeout for `bin/omero admin email ...` so as to be more patient with such slow servers.

# Testing this PR

Use the CLI to send e-mail to a demo server user and check that the e-mail is received and `omero::LockTimeout` is not thrown at you. (I am `mtbcarroll` on that server and I am happy to make anyone else an account on it.) Can also try out the `--wait` option.

# Related reading

https://trello.com/c/bSyOy8Bh/34-cli-or-email-plugin-5s-timeout
  