### PR TITLE
fix big plate thumbs

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.plateview.js
@@ -137,12 +137,14 @@ jQuery._WeblitzPlateview = function (container, options) {
     table.addClass('showWellLabel wellSize' + opts.width);
 
     var imgIds = [];
+    var html = "";
+    // Build table html and append below
     for (i=0; i < data.rowlabels.length; i++) {
-      tr = $('<tr></tr>').appendTo(table);
-      tr.append('<th>'+data.rowlabels[i]+'</th>');
+      html += '<tr>';
+      html += '<th>'+data.rowlabels[i]+'</th>';
       for (var j=0; j<data.grid[i].length; j++) {
         if (data.grid[i][j] === null) {
-          tr.append('<td class="placeholder"><img src="' + spacer_gif_src + '" /></td>');
+          html += '<td class="placeholder"><img src="' + spacer_gif_src + '" /></td>';
         } else {
           imgIds.push(data.grid[i][j].id);
           data.grid[i][j]._wellpos = data.rowlabels[i]+data.collabels[j];
@@ -150,28 +152,30 @@ jQuery._WeblitzPlateview = function (container, options) {
           if (opts.useParentPrefix) {
               parentPrefix = thisid+'-';
           }
-          var td = $('<td class="well" id="'+parentPrefix+'well-'+data.grid[i][j].wellId+'">' +
+          html += '<td class="well" id="'+parentPrefix+'well-'+data.grid[i][j].wellId+'">' +
             '<img class="waiting" src="' + spacer_gif_src + '" />' +
             '<div class="wellLabel">' + data.rowlabels[i] + data.collabels[j] + '</div>' +
-            '<img id="'+parentPrefix+'image-'+data.grid[i][j].id+'" class="loading" name="'+(data.rowlabels[i] + data.collabels[j])+'"></td>');
-          $('img', td)
-            .click(tclick(data.grid[i][j]))
-            .load(function() {
-              $(this).removeClass('loading').siblings('.waiting').remove();
-              if (!thumbsLoaded) {
-                // When first thumbnails loads, we get aspect ratio and use that to scale
-                // all images (including unloaded images and placeholder spacers)
-                thumbAspectRatio = $(this).width()/$(this).height();
-                _this.setSpwThumbSize(opts.width);
-              }
-              _this.self.trigger('thumbLoad', [$(this).parent(), $(this)]);
-            })
-            .data('wellpos', data.rowlabels[i] + data.collabels[j]);
-          tr.append(td);
-          _this.self.trigger('thumbNew', [data.grid[i][j], $('img', td)]);
+            '<img id="'+parentPrefix+'image-'+data.grid[i][j].id+'" class="loading" name="'+(data.rowlabels[i] + data.collabels[j])+'"></td>';
         }
       }
+      html += '</tr>';
     }
+    table.append(html);
+
+
+    // Handle loading of images - NB: need to bind to each image since load events don't bubble
+    $("img.loading", table).on("load", function(){
+      $(this).removeClass('loading').siblings('.waiting').remove();
+      if (!thumbsLoaded) {
+        // When first thumbnails loads, we get aspect ratio and use that to scale
+        // all images (including unloaded images and placeholder spacers)
+        thumbAspectRatio = $(this).width()/$(this).height();
+        _this.setSpwThumbSize(opts.width);
+        thumbsLoaded = true;
+      }
+      _this.self.trigger('thumbLoad', [$(this).parent(), $(this)]);
+    });
+
 
     // load thumbnails in a batches
     var load_thumbnails = function(input, batch) {


### PR DESCRIPTION
This fixes slow loading of thumbnails on big plates, caused by slow jQuery building of plate Tables.

This was originally reported as slow thumbnail loading, https://trello.com/c/2fQFE3Lb/33-bug-thumbnail-caching, since the jQuery DOM manipulation happens right before thumbnail loading. Therefore, the responses from  ```webgateway/get_thumbnail/``` are not downloaded while DOM layout is still processing, making it appear that the requests themselves were taking a long time.

This was exacerbated on a plate of 20 columns and 35 rows (700 Wells), since we create a much larger table of 96 columns and 64 rows (6144 Cells)!

Now, instead of appending each ```<td>``` individually, we build the entire table html string before appending to the table in a single call.

# Testing this PR

1. User-3 on web-dev-merge: test loading of thumbnails on Damir's large plate.

2. Need regression testing of related plate-loading functionality: Load plate, click on Wells to load images below, switch Field, zoom plate then load another plate (should load at same sized thumbnails) etc.

Some functionality of the old ```for loop``` code has not been reproduced in the new code since we don't iterate through each thumbnail ```<img>``` as we did before so we don't have each in hand:

1. Triggering of the ```thumLoad``` event for every thumbnail image:
```
_this.self.trigger('thumbLoad', [$(this).parent(), $(this)]);
```
We could likely reproduce this behaviour by an additional ```$("img.loading", table).forEach()``` loop, but I can't see that this is used or tested anywhere so don't know if it's worth preserving?

2. Setting of ```wellpos``` data on each ```<img>```. Can't see that this is used anywhere either:
```
.data('wellpos', data.rowlabels[i] + data.collabels[j]);
```