### PR TITLE
allow SciJava native lib loader loglevel to be configured

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -1,13 +1,9 @@
 /*
- *   $Id$
- *
  *   Copyright 2009-2016 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
 package ome.formats.importer;
-
-import static omero.rtypes.rstring;
 
 import java.awt.Rectangle;
 import java.io.BufferedReader;

--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -348,6 +348,7 @@ public class ImportConfig {
          setLevel("ome.services.blitz", level);
          setLevel("ome.system", level);
          setLevel("loci", level);
+         setLevel("org.scijava.nativelib", level);
      }
 
      private void setLevel(String loggerName, Level level) {


### PR DESCRIPTION
# What this PR does

Applies the CLI `import` subcommand's `--debug` log-level option to SciJava's native library loader.

# Testing this PR

Ensure CI remains green. You may require Linux to verify that the original problem exists:

```
cd components/tools/OmeroPy/
./setup.py test -t test/integration/clitest/test_import.py -k testDebugArgument
```

# Related reading

https://trello-attachments.s3.amazonaws.com/58a61e289c74e2d5e9c79347/58a1b90b00bd4e7a04bf8982/d64bc1e495a4a8d920b1df7f1fab2927/testDebugArgument.text