### PR TITLE
robot test fixes workflows

### DIFF
--- a/components/tests/ui/testcases/web/webadmin_user_settings.txt
+++ b/components/tests/ui/testcases/web/webadmin_user_settings.txt
@@ -64,9 +64,9 @@ Owner Group Edit
     Submit Form                     css=form.settings_form
 
     # Return to edit group, to check permissions were saved and reset
-    Location Should Be          ${WEBADMIN WELCOME URL}myaccount/
-    Click Element               css=#group_settings_tab a
-    Click Element               xpath=//table[@id='dataTable']//a/span[contains(text(), "Edit")]
+    Wait Until Keyword Succeeds     ${TIMEOUT}     ${INTERVAL}  Location Should Be  ${WEBADMIN WELCOME URL}myaccount/
+    Click Element                   css=#group_settings_tab a
+    Click Element                   xpath=//table[@id='dataTable']//a/span[contains(text(), "Edit")]
     Radio Button Should Be Set To   permissions     1
     Select Radio Button             permissions     2
     Submit Form                     css=form.settings_form


### PR DESCRIPTION
# What this PR does

Attempts to fix failure of this robot test:
https://10.0.51.135:32776/job/OMERO-robot/23/robot/Web%20&%20Web/Web_1/Webadmin%20User%20Settings/Owner%20Group%20Edit/
When testing Group Edit manually, "Save" takes some time. Seems robot test is asserting the location change immediately. This PR waits for this to succeed.

NB: The failure of the test at this point on Firefox means that the permissions of the group do not get reset, so the same test Subsequently fails on Chrome because the permissions are wrong:
https://10.0.51.135:32776/job/OMERO-robot/23/robot/Web%20&%20Web/Web/Webadmin%20User%20Settings/Owner%20Group%20Edit/

# Testing this PR

1. Both tests above should be passing.

cc @jburel 