### PR TITLE
remove product.license and product.final.name from config

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -911,11 +911,9 @@ Ice.IPv6=1
 ### END
 
 #############################################
-## appserver product (ear) configuration
+## Server product name for release artifacts
 #############################################
 product.name=OMERO.server
-product.license="GNU GPL, version 2"
-product.final.name=omero.ear
 
 #############################################
 ## Library versions


### PR DESCRIPTION
# What this PR does

Removes a couple of long-unused properties from `etc/omero.properties`.

# Testing this PR

CI should remain green.