### PR TITLE
CLI admin 'session' command

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -2442,6 +2442,14 @@ class UserGroupControl(BaseControl):
                            help="Name of the user(s)%s" % action)
         return group
 
+    def add_single_user_argument(self, parser, action="", required=True):
+        group = parser.add_mutually_exclusive_group(required=required)
+        group.add_argument("--user-id", metavar="user",
+                           help="ID of the user%s" % action)
+        group.add_argument("--user-name", metavar="user",
+                           help="Name of the user%s" % action)
+        return group
+
     def list_users(self, a, args, use_context=False):
         """
         Retrieve users from the arguments defined in
@@ -2500,6 +2508,14 @@ class UserGroupControl(BaseControl):
         group.add_argument(
             "--group-name", metavar="group", nargs="+",
             help="Name of the group(s)%s" % action)
+        return group
+
+    def add_single_group_argument(self, parser, action="", required=True):
+        group = parser.add_mutually_exclusive_group(required=required)
+        group.add_argument("--group-id", metavar="group",
+                           help="ID of the group%s" % action)
+        group.add_argument("--group-name", metavar="group",
+                           help="Name of the group%s" % action)
         return group
 
     def list_groups(self, a, args, use_context=False):
@@ -2582,3 +2598,25 @@ class UserGroupControl(BaseControl):
                     groups.append(gid)
 
         return users, groups
+
+    def get_single_user_group(self, args, iadmin):
+        u = None
+        g = None
+        if args.user_name:
+            uid, u = self.find_user_by_name(
+                iadmin, args.user_name, fatal=False)
+
+        if args.user_id:
+            uid, u = self.find_user_by_id(
+                iadmin, args.user_id, fatal=False)
+
+        if args.group_name:
+            gid, g = self.find_group_by_name(
+                iadmin, args.group_name, fatal=False)
+
+        if args.group_id:
+            for group_id in args.group_id:
+                gid, g = self.find_group_by_id(
+                    iadmin, args.group_id, fatal=False)
+
+        return u, g

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -420,23 +420,6 @@ present, the user will enter a console""")
                 " should  be activated. Common values are: \"debug\", "
                 "\"trace\" ")
 
-        sessionAction = Action("session",
-                               "Create or close user sessions").parser
-        sessionAction.add_login_arguments()
-        group = sessionAction.add_mutually_exclusive_group()
-        group.add_argument(
-            "--open", nargs="?", dest="username",
-            help="Create a session for the given user (username)")
-        group.add_argument(
-            "--close", nargs="?", dest="sessionId",
-            help="Close the session with the given sessionId")
-        sessionAction.add_argument("--groupname", nargs="?",
-                                   help="Optional group name "
-                                        "(default: user's default group)")
-        sessionAction.add_argument("--timeout", nargs="?", default="0",
-                                   help="Optional timeout in seconds "
-                                        "(default: maximum possible)")
-
         # DISABLED = """ see: http://www.zeroc.com/forums/bug-reports/\
         # 4237-sporadic-freeze-errors-concurrent-icegridnode-access.html
         #   restart [filename] [targets]      : Calls stop followed by start \
@@ -1363,37 +1346,6 @@ present, the user will enter a console""")
                 sb = " ".join([str(x) for x in v])
                 self._item("JVM settings", " %s" % (k[0].upper() + k[1:]))
                 self.ctx.out("%s" % sb)
-
-    def session(self, args):
-        client = self.ctx.conn(args)
-
-        if args.username:
-            p = omero.sys.Principal()
-            p.name = args.username
-            if args.groupname:
-                p.group = args.groupname
-            p.eventType = "User"
-            svc = client.sf.getSessionService()
-            sessId = svc.createSessionWithTimeout(p, (int(args.timeout)
-                                                      * 1000))
-            if args.groupname:
-                self.ctx.out("Session created for user %s in group %s" %
-                             (args.username, args.groupname))
-            else:
-                self.ctx.out("Session created for user %s" % args.username)
-            self.ctx.out("Session ID: %s" % sessId.getUuid().val)
-
-        if args.sessionId:
-            svc = client.sf.getSessionService()
-            session = None
-            try:
-                session = svc.getSession(args.sessionId)
-            except Exception:
-                self.ctx.err("No session with the given ID found.")
-
-            if session:
-                svc.closeSession(session)
-                self.ctx.out("Session %s closed." % args.sessionId)
 
     def email(self, args):
         client = self.ctx.conn(args)

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -42,8 +42,9 @@ from omero.rtypes import rlong
 from omero.rtypes import unwrap
 from omero.util import get_user
 from omero.util.sessions import SessionsStore
-from omero.cli import UserGroupControl, CLI
+from omero.cli import UserGroupControl, CLI, admin_only
 from omero_ext.argparse import SUPPRESS
+from omero.model.enums import AdminPrivilegeSudo
 
 HELP = """Control and create user sessions
 
@@ -275,6 +276,7 @@ class SessionsControl(UserGroupControl):
     def help(self, args):
         self.ctx.out(LONGHELP % {"prog": args.prog})
 
+    @admin_only(AdminPrivilegeSudo)
     def open(self, args):
         client = self.ctx.conn(args)
         admin = client.sf.getAdminService()

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -336,6 +336,10 @@ class SessionsControl(UserGroupControl):
         self.ctx.err(msg)
         self.ctx.out(sessId)
 
+        store = self.store(args)
+        host, name, uuid, port = store.get_current()
+        store.add(host, name, sessId, {}, sudo=username)
+
     def close(self, args):
         client = self.ctx.conn(args)
         svc = client.sf.getSessionService()

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -283,6 +283,8 @@ class SessionsControl(UserGroupControl):
         admin = client.sf.getAdminService()
 
         user, group = self.get_single_user_group(args, admin)
+        if not user:
+            self.ctx.die(156, "No user found")
         username = user.omeName.val
         groupname = None
         if group:
@@ -318,7 +320,7 @@ class SessionsControl(UserGroupControl):
             self.ctx.err("No session with the given ID found.")
 
         if session:
-            svc.closeSession(session)
+            client.destroySession(args.sessionId)
             self.ctx.out("Session %s closed." % args.sessionId)
 
     def login(self, args):

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -308,13 +308,6 @@ class SessionsControl(UserGroupControl):
         self.ctx.err(msg)
         self.ctx.out(sessId)
 
-        store = self.store(args)
-        # TODO: this is a race condition in the general design of
-        # SessionStore. Likely on login the file should be read,
-        # and afterwards not accessed.
-        host, sudo_user, uuid, port = store.get_current()
-        store.add(host, username, sessId, {}, sudo=sudo_user)
-
     def close(self, args):
         client = self.ctx.conn(args)
         svc = client.sf.getSessionService()

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -322,14 +322,19 @@ class SessionsControl(UserGroupControl):
             p.group = groupname
         p.eventType = "User"
         svc = client.sf.getSessionService()
-        sessId = svc.createSessionWithTimeout(p, (int(args.timeout)
-                                                  * 1000))
+        sess = svc.createSessionWithTimeout(p, (int(args.timeout)
+                                                * 1000))
+        sessId = sess.getUuid().val
+        tti = sess.getTimeToIdle().val / 1000
+        ttl = sess.getTimeToLive().val / 1000
+
+        msg = "Session created for user %s" % username
         if groupname:
-            self.ctx.out("Session created for user %s in group %s" %
-                         (username, groupname))
-        else:
-            self.ctx.out("Session created for user %s" % username)
-        self.ctx.out("Session ID: %s" % sessId.getUuid().val)
+            msg += " in group %s" % groupname
+        msg += " (timeToIdle: %d sec, timeToLive: %d sec)" % (tti, ttl)
+
+        self.ctx.err(msg)
+        self.ctx.out(sessId)
 
     def close(self, args):
         client = self.ctx.conn(args)

--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -309,8 +309,11 @@ class SessionsControl(UserGroupControl):
         self.ctx.out(sessId)
 
         store = self.store(args)
-        host, name, uuid, port = store.get_current()
-        store.add(host, name, sessId, {}, sudo=username)
+        # TODO: this is a race condition in the general design of
+        # SessionStore. Likely on login the file should be read,
+        # and afterwards not accessed.
+        host, sudo_user, uuid, port = store.get_current()
+        store.add(host, username, sessId, {}, sudo=sudo_user)
 
     def close(self, args):
         client = self.ctx.conn(args)

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -23,6 +23,7 @@ from test.integration.clitest.cli import CLITest
 from omero.cli import NonZeroReturnCode
 from omero.model import Experimenter
 import pytest
+import re
 
 permissions = ["rw----", "rwr---", "rwra--", "rwrw--"]
 
@@ -305,3 +306,22 @@ class TestSessions(CLITest):
         # Attempt who
         self.args = ["sessions", "who"]
         self.cli.invoke(self.args, strict=True)
+
+    # open session
+    # =======================================================================
+    def testOpen(self, capsys):
+        asUser = self.new_user()
+
+        self.set_login_args('root')
+        passwd = self.root.getProperty("omero.rootpass")
+        self.args += ["-w", passwd]
+        self.cli.invoke(self.args, strict=True)
+
+        self.args = ["sessions", "open"]
+        self.args += ["--user-name", asUser.omeName.val]
+        self.cli.invoke(self.args, strict=True)
+        o, e = capsys.readouterr()
+
+        pat = re.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
+                         "[a-f0-9]{4}-[a-f0-9]{12}")
+        assert pat.match(o)

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -317,6 +317,18 @@ class TestSessions(CLITest):
 
     # open session
     # =======================================================================
+
+    @staticmethod
+    def assert_uuid(o):
+        # Check that only a UUID is printed
+        pat = re.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
+                         "[a-f0-9]{4}-[a-f0-9]{12}")
+        m = pat.match(o)
+        if not m:
+            raise Exception("%s is not a UUID" % o)
+        else:
+            return m.group()
+
     def test_open(self, capsys):
 
         as_user = self.new_user()
@@ -333,11 +345,7 @@ class TestSessions(CLITest):
         self.args += ["--user-name", as_user_name]
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
-
-        # Check that only a UUID is printed
-        pat = re.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
-                         "[a-f0-9]{4}-[a-f0-9]{12}")
-        assert pat.match(o)
+        self.assert_uuid(o)
 
         # Check that the UUID is *not* in our store
         self.args = ["sessions", "list"]
@@ -361,11 +369,7 @@ class TestSessions(CLITest):
         self.args += ["--user-id", str(as_user_id)]
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
-
-        # Check that only a UUID is printed
-        pat = re.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
-                         "[a-f0-9]{4}-[a-f0-9]{12}")
-        assert pat.match(o)
+        self.assert_uuid(o)
 
         # Check that the UUID is *not* in our store
         self.args = ["sessions", "list"]
@@ -418,11 +422,7 @@ class TestSessions(CLITest):
         self.args += ["--user-name", as_user_name]
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
-
-        # Check that only a UUID is printed
-        pat = re.compile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
-                         "[a-f0-9]{4}-[a-f0-9]{12}")
-        assert pat.match(o)
+        self.assert_uuid(o)
 
         # Check that the UUID is *not* in our store
         self.args = ["sessions", "list"]
@@ -448,10 +448,7 @@ class TestSessions(CLITest):
         self.args += ["--user-name", as_user_name]
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
-
-        # Retrieve the session ID
-        id = re.findall("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
-                        "[a-f0-9]{4}-[a-f0-9]{12}", o)[0]
+        id = self.assert_uuid(o)
 
         # Close the session
         self.args = ["sessions", "close"]

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -337,14 +337,8 @@ class TestSessions(CLITest):
                          "[a-f0-9]{4}-[a-f0-9]{12}")
         assert pat.match(o)
 
-        # Check that the UUID is in our store
+        # Check that the UUID is *not* in our store
         self.args = ["sessions", "list"]
         self.cli.invoke(self.args, strict=True)
         o2, e2 = capsys.readouterr()
-        assert o.strip() in o2
-
-        # So that trying to login should work without password or key
-        self.set_login_args(asUserName)
-        self.cli.invoke(self.args, strict=True)
-        o3, e3 = capsys.readouterr()
-        assert o.strip() in e3
+        assert o.strip() not in o2

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -328,7 +328,7 @@ class TestSessions(CLITest):
         self.args += ["-w", passwd]
         self.cli.invoke(self.args, strict=True)
 
-        # Open a session for asUser
+        # Open a session for as_user
         self.args = ["sessions", "open"]
         self.args += ["--user-name", as_user_name]
         self.cli.invoke(self.args, strict=True)
@@ -356,7 +356,7 @@ class TestSessions(CLITest):
         self.args += ["-w", passwd]
         self.cli.invoke(self.args, strict=True)
 
-        # Open a session for asUser
+        # Open a session for as_user
         self.args = ["sessions", "open"]
         self.args += ["--user-id", str(as_user_id)]
         self.cli.invoke(self.args, strict=True)
@@ -379,7 +379,7 @@ class TestSessions(CLITest):
         as_user = self.new_user()
         as_user_name = as_user.omeName.val
 
-        # create user with chown privilege
+        # create user with Chown privilege
         exp = self.new_user(privileges=["Chown"])
         host = self.root.getProperty("omero.host")
         port = self.root.getProperty("omero.port")
@@ -404,7 +404,7 @@ class TestSessions(CLITest):
         as_user = self.new_user()
         as_user_name = as_user.omeName.val
 
-        # create user with chown privilege
+        # create user with Sudo privilege
         exp = self.new_user(privileges=["Sudo"])
         host = self.root.getProperty("omero.host")
         port = self.root.getProperty("omero.port")
@@ -443,13 +443,13 @@ class TestSessions(CLITest):
         self.args += ["-w", passwd]
         self.cli.invoke(self.args, strict=True)
 
-        # Open a session for asUser
+        # Open a session for as_user
         self.args = ["sessions", "open"]
         self.args += ["--user-name", as_user_name]
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
 
-        # Check that only a UUID is printed
+        # Retrieve the session ID
         id = re.findall("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-"
                         "[a-f0-9]{4}-[a-f0-9]{12}", o)[0]
 


### PR DESCRIPTION
# What this PR does

Adds a ~~'session'~~ 'open' and 'close' command to the CLI ~~admin~~ session plugin, which enables the creation and removal of user sessions.

See https://trello.com/c/I2eVKJGQ/19-rfe-create-session-for-user-cli

Although I'm not sure if that solves the problem of the 'long running' sessions. According to https://downloads.openmicroscopy.org/omero/5.4.0/api/ome/api/ISession.html#createSessionWithTimeout-ome.system.Principal-long- , if one specifies no timeout value (the plugin will then pass on `0`) the maximum timeToLive will be used. I have no idea what this maximum timeToLive actually is.
 
# Testing this PR

- Use the plugin to create a user session. Check with Insight (copy/paste session ID as username and password), that you can connect to the server. 
- Use the `close` command to close the session again. Verify (e.g. with Insight) that the connection is closed.
- Create another session with a short timeout, e. g. 30s. Check that you can connect using the session ID, wait a bit, check again that you cannot connect with the session id any longer.
- Check `test_sessions.py` integration tests
