### PR TITLE
tables: use omero.repo.wait rather than SECONDS_SLEEP

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -28,7 +28,6 @@ tables = __import__("tables")  # Pytables
 
 VERSION = '2'
 RETRIES = 20
-SECONDS_SLEEP = 5
 
 
 def slen(rv):
@@ -390,11 +389,20 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
                          str(self._storage_factory.__module__),
                          self._storage_factory.__class__.__name__)
 
-        e = None
+        self.repo_cfg = None
+        self.repo_mgr = None
+        self.repo_obj = None
         self.repo_svc = None
+        self.repo_uuid = None
+
         if retries is None:
             retries = RETRIES
 
+        wait = float(self.communicator.getProperties().getPropertyWithDefault(
+            "omero.repo.wait", "1"))
+        per_loop = wait / retries
+
+        e = None
         for x in range(retries):
             try:
                 self._get_dir()
@@ -405,20 +413,13 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
 
             if self.repo_svc:
                 break
+            else:
+                msg = "waiting %ss (%s of %s)" % (per_loop, x+1, retries)
+                self.logger.debug(msg)
+                self.stop_event.wait(per_loop)
 
         if e:
             raise e
-
-    def _do_with_wait(self, method, seconds_sleep=SECONDS_SLEEP):
-        """
-        Run a method in a loop until true, waiting for the configured
-        time during each iteration
-        """
-        wait = int(self.communicator.getProperties().getPropertyWithDefault(
-            "omero.repo.wait", "1"))
-        if not method():
-            self.logger.debug("waiting %s seconds" % seconds_sleep)
-            self.stop_event.wait(seconds_sleep)
 
     def _get_dir(self):
         """
@@ -435,17 +436,8 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
                 ).getConfigService().getConfigValue("omero.data.dir")
 
         self.repo_cfg = path(self.repo_dir) / ".omero" / "repository"
-
-        def _check_repo_cfg():
-            if not self.repo_cfg.exists():
-                self.logger.info("%s doesn't exist" % self.repo_cfg)
-                return False
-            return True
-        self._do_with_wait(_check_repo_cfg)
-
         if not self.repo_cfg.exists():
             msg = "No repository found: %s" % self.repo_cfg
-            self.logger.error(msg)
             raise omero.ResourceError(None, None, msg)
 
     def _get_uuid(self):
@@ -466,13 +458,9 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
         """
 
         uuidfile = self.instance / "repo_uuid"
-
-        def _check_repo_uuid():
-            if not uuidfile.exists():
-                self.logger.info("%s doesn't exist" % uuidfile)
-                return False
-            return True
-        self._do_with_wait(_check_repo_uuid)
+        if not uuidfile.exists():
+            msg = "%s doesn't exist" % uuidfile
+            raise IOError(msg)
 
         # Get and parse the uuid from the RandomAccessFile format from
         # FileMaker

--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -416,8 +416,7 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
         """
         wait = int(self.communicator.getProperties().getPropertyWithDefault(
             "omero.repo.wait", "1"))
-        start = time.time()
-        while not method() and wait < (time.time() - start):
+        if not method():
             self.logger.debug("waiting %s seconds" % seconds_sleep)
             self.stop_event.wait(seconds_sleep)
 

--- a/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
+++ b/components/tools/OmeroPy/test/unit/tablestest/test_servants.py
@@ -24,7 +24,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 # Don't retry since we expect errors
 omero.tables.RETRIES = 1
-omero.tables.SECONDS_SLEEP = 1
 
 
 class communicator_provider(object):


### PR DESCRIPTION
The previous loop checked for the elapsed time
to see whether waiting was necessary. The with-
wait method doesn't have access to the elapsed
time and so should run unconditionally.

# Testing this PR

Testing is difficult since tables initialization needs to fail. *If* it fails, then several seconds should be waited. I tested locally by modifying https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/unit/tablestest/test_servants.py#L27 and causing the method to fail.

# Related reading

See https://github.com/openmicroscopy/openmicroscopy/pull/5593
