### PR TITLE
fetch artifacts from repos over HTTPS, not HTTP (rebased from develop)

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -67,16 +67,16 @@
       <ibiblio name="ome-simple-artifactory"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
-           root="http://artifacts.openmicroscopy.org/artifactory/simple/${simple.repository}/"/>
+           root="https://artifacts.openmicroscopy.org/artifactory/simple/${simple.repository}/"/>
       <ibiblio name="ome-artifactory" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
-          root="http://artifacts.openmicroscopy.org/artifactory/maven/"/>
+          root="https://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
       <ibiblio name="unidata.releases" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
-          root="http://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"/>
+          root="https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/"/>
 
       <ibiblio name="zeroc" cache="maven"
           usepoms="true" useMavenMetadata="true"


### PR DESCRIPTION
# What this PR does

Has Ivy fetch third-party artifacts over HTTPS rather than simple HTTP.

# Testing this PR

OMERO should build fine even *without* a local maven cache already populated.

# Related reading

https://github.com/openmicroscopy/bioformats/pull/2992
--rebased-from #5569
--depends-on #5620