### PR TITLE
Close fileinput

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -560,8 +560,8 @@ Bash examples:
                         line = line.strip()
                         if line and not line.startswith("#"):
                             actions.append(self.parse(state, line=line))
-                except Exception:
-                    self.ctx.die(999, "Cannot read file")
+                except IOError:
+                    self.ctx.die(337, "Cannot read file")
                 finally:
                     if fi is not None:
                         fi.close()

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -553,11 +553,18 @@ Bash examples:
         if not args.command:
             if args.file:
                 path = args.file
-                for line in fileinput.input([path]):
-                    line = line.strip()
-                    if line and not line.startswith("#"):
-                        actions.append(self.parse(state, line=line))
-                fileinput.close()
+                fi = None
+                try:
+                    fi = fileinput.FileInput([path])
+                    for line in fi:
+                        line = line.strip()
+                        if line and not line.startswith("#"):
+                            actions.append(self.parse(state, line=line))
+                except Exception:
+                    self.ctx.die(999, "Cannot read file")
+                finally:
+                    if fi is not None:
+                        fi.close()
             else:
                 self.ctx.die(100, "No command provided")
         else:

--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -557,6 +557,7 @@ Bash examples:
                     line = line.strip()
                     if line and not line.startswith("#"):
                         actions.append(self.parse(state, line=line))
+                fileinput.close()
             else:
                 self.ctx.die(100, "No command provided")
         else:


### PR DESCRIPTION
# What this PR does

Implements @mtbc suggestion to close the `fileinput` in `obj.py` plugin after parsing.

Should fix the failed integration tests: https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/782/testReport/ 

I couldn't replicate the failed integration tests locally, so couldn't check if that really solves the issue. But we'll see tomorrow on CI.

# Testing this PR

Check python integration tests.
