### PR TITLE
5.4.2 version history

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -12,28 +12,28 @@ This is a bug-fix release.
 
 Improvements include:
 
--  made projecting images belonging to another user only possible for users
-   with the required permissions to save the new images
 -  added documentation on a complete workflow for publishing data from
    OMERO.server
 -  added references to the new OMERO pyramid format documentation (within the
    OME Data Model and File Formats documentation)
+-  faster loading of thumbnails for large Plates after a recent regression
+-  made projecting images belonging to another user only possible for users
+   with the required permissions to save the new images
 -  updated SwingX library version used by OMERO.insight to stop insight-ij
    plugin crashing in Fiji
--  faster loading of thumbnails for large Plates
--  trying to import into a container without the necessary permissions now
-   fails before file upload starts and more transparently
 -  CLI updates:
 
-   * ``import --target`` and ``import --debug`` fixes
-   * ``admin mail`` timeout improvements
-   * added ``admin log`` command
+   * ``import --target`` into a container without the necessary permissions now
+     fails before file upload starts and more transparently
+   * ``admin mail`` timeout is now configurable via ``--wait``
+   * added ``admin log`` command for inserting statements to the server log
 
 Sysadmin changes include:
 
 -  added warning about the need to regenerate your NGINX config for every
    upgrade
 -  fixed documentation bug affecting OMERO-version-specific guidance
+-  fixed OMERO.tables startup race condition
 -  server performance improvements
 
 Developer updates include:

--- a/history.txt
+++ b/history.txt
@@ -38,9 +38,9 @@ Sysadmin changes include:
 
 Developer updates include:
 
--  various testing improvements including refactoring and build system changes
-   designed to permit integration tests in downstream projects (see
-   `this PR on GitHub <https://github.com/openmicroscopy/openmicroscopy/pull/5616>`_
+-  various testing improvements including refactoring and build system
+   changes, designed to permit integration tests in downstream projects and
+   testing of external CLI plugins (see `this PR on GitHub <https://github.com/openmicroscopy/openmicroscopy/pull/5616>`_
    for further details)
 -  added methods for updating OMERO.tables
 -  Java Gateway fixes for sessions and rendering

--- a/history.txt
+++ b/history.txt
@@ -18,10 +18,8 @@ Improvements include:
    OMERO.server
 -  added references to the new OMERO pyramid format documentation (within the
    OME Data Model and File Formats documentation)
--  updated swingx library version used by OMERO.insight to stop insight-ij
+-  updated SwingX library version used by OMERO.insight to stop insight-ij
    plugin crashing in Fiji
--  fixed issue with polygon and polyline ROIs created in OMERO.iviewer and 
-   then viewed in Fiji using the insight-ij plugin
 -  faster loading of thumbnails for large Plates
 -  trying to import into a container without the necessary permissions now
    fails before file upload starts and more transparently

--- a/history.txt
+++ b/history.txt
@@ -45,7 +45,7 @@ Developer updates include:
 -  improved 'Editing OMERO.web' documentation
 -  improved Slice documentation for API deprecations
 -  substantial effort to make third-party repositories easily testable;
-   see `omero-test-infra <https://github.com/openmicroscopy/omero-test-infra>`
+   see `omero-test-infra <https://github.com/openmicroscopy/omero-test-infra>_`
    for more information
 
 This release also upgrades the version of Bio-Formats that OMERO uses to

--- a/history.txt
+++ b/history.txt
@@ -33,21 +33,20 @@ Sysadmin changes include:
 -  added warning about the need to regenerate your NGINX config for every
    upgrade
 -  fixed documentation bug affecting OMERO-version-specific guidance
--  fixed OMERO.tables startup race condition
--  server performance improvements
+-  improved OMERO.tables startup stability
+-  server performance improvements and reduction in ERROR logging
 
 Developer updates include:
 
--  various testing improvements including refactoring and build system
-   changes, designed to permit integration tests in downstream projects and
-   testing of external CLI plugins (see `this PR on GitHub <https://github.com/openmicroscopy/openmicroscopy/pull/5616>`_
-   for further details)
+-  extended Python and Java examples to include Map Annotations and histograms
 -  added methods for updating OMERO.tables
 -  Java Gateway fixes for sessions and rendering
--  extended Python and Java examples to include Map Annotations and histograms
+-  fixed retrieval of Plate thumbnail URLs
 -  improved 'Editing OMERO.web' documentation
 -  improved Slice documentation for API deprecations
--  fixed retrieval of Plate thumbnail URLs
+-  substantial effort to make third-party repositories easily testable;
+   see `omero-test-infra <https://github.com/openmicroscopy/omero-test-infra>`
+   for more information
 
 This release also upgrades the version of Bio-Formats that OMERO uses to
 5.7.3.

--- a/history.txt
+++ b/history.txt
@@ -5,6 +5,55 @@
 OMERO version history
 =====================
 
+5.4.2 (January 2018)
+--------------------
+
+This is a bug-fix release.
+
+Improvements include:
+
+-  made projecting images belonging to another user only possible for users
+   with the required permissions to save the new images
+-  added documentation on a complete workflow for publishing data from
+   OMERO.server
+-  added references to the new OMERO pyramid format documentation (within the
+   OME Data Model and File Formats documentation)
+-  updated swingx library version used by OMERO.insight to stop insight-ij
+   plugin crashing in Fiji
+-  fixed issue with polygon and polyline ROIs created in OMERO.iviewer and 
+   then viewed in Fiji using the insight-ij plugin
+-  faster loading of thumbnails for large Plates
+-  trying to import into a container without the necessary permissions now
+   fails before file upload starts and more transparently
+-  CLI updates:
+
+   * ``import --target`` and ``import --debug`` fixes
+   * ``admin mail`` timeout improvements
+   * added ``admin log`` command
+
+Sysadmin changes include:
+
+-  added warning about the need to regenerate your NGINX config for every
+   upgrade
+-  fixed documentation bug affecting OMERO-version-specific guidance
+-  server performance improvements
+
+Developer updates include:
+
+-  various testing improvements including refactoring and build system changes
+   designed to permit integration tests in downstream projects (see
+   `this PR on GitHub <https://github.com/openmicroscopy/openmicroscopy/pull/5616>`_
+   for further details)
+-  added methods for updating OMERO.tables
+-  Java Gateway fixes for sessions and rendering
+-  extended Python and Java examples to include Map Annotations and histograms
+-  improved 'Editing OMERO.web' documentation
+-  improved Slice documentation for API deprecations
+-  fixed retrieval of Plate thumbnail URLs
+
+This release also upgrades the version of Bio-Formats that OMERO uses to
+5.7.3.
+
 5.4.1 (November 2017)
 ---------------------
 

--- a/history.txt
+++ b/history.txt
@@ -19,6 +19,7 @@ Improvements include:
 -  faster loading of thumbnails for large Plates after a recent regression
 -  made projecting images belonging to another user only possible for users
    with the required permissions to save the new images
+-  improved the public user experience for password-less access
 -  updated SwingX library version used by OMERO.insight to stop insight-ij
    plugin crashing in Fiji
 -  CLI updates:
@@ -44,6 +45,8 @@ Developer updates include:
 -  fixed retrieval of Plate thumbnail URLs
 -  improved 'Editing OMERO.web' documentation
 -  improved Slice documentation for API deprecations
+-  added instructions to :doc:`/developers/cli/extensions` on how to
+   create CLI plugins that are ``pip`` installable
 -  substantial effort to make third-party repositories easily testable;
    see `omero-test-infra <https://github.com/openmicroscopy/omero-test-infra>_`
    for more information


### PR DESCRIPTION
# What this PR does

Adds the version history for the 5.4.2 release.

# Testing this PR

Proofread. To check formatting for the docs, you'll need to manually copy the content into the matching docs page and build the sphinx docs.

# Related reading

See https://trello.com/c/ENudeoWD/30-version-history-pr and the 5.4.2 milestones on this repo & OME docs repo

 * [x] public_user
 * [x] developers section
 * [x] admin section
 * [x] scripts
 * [ ] other repos?