### PR TITLE
fix typo in exception message

### DIFF
--- a/components/server/src/ome/services/util/ServiceHandler.java
+++ b/components/server/src/ome/services/util/ServiceHandler.java
@@ -252,7 +252,7 @@ public class ServiceHandler implements MethodInterceptor, ApplicationListener {
                 ValidationException ve = new ValidationException(t.getMessage());
                 ve.setStackTrace(t.getStackTrace());
                 printException(
-                        "HibernateObjectRetrievealFailureException thrown.", t);
+                        "HibernateObjectRetrievalFailureException thrown.", t);
                 return ve;
             }
 


### PR DESCRIPTION
Fix a minor typo in an exception message. I happened to notice it in a community-submitted logfile.