### PR TITLE
processor: pass OMERO_TMPDIR to child processes

### DIFF
--- a/components/tools/OmeroPy/src/omero/processor.py
+++ b/components/tools/OmeroPy/src/omero/processor.py
@@ -146,6 +146,7 @@ class ProcessI(omero.grid.Process, omero.util.SimpleServant):
             "JYTHON_HOME",
             "LD_LIBRARY_PATH",
             "MLABRAW_CMD_STR",
+            "OMERO_TMPDIR",
             "PATH",
             "PYTHONPATH",
         )

--- a/components/tools/OmeroPy/src/omero/processor.py
+++ b/components/tools/OmeroPy/src/omero/processor.py
@@ -146,6 +146,7 @@ class ProcessI(omero.grid.Process, omero.util.SimpleServant):
             "JYTHON_HOME",
             "LD_LIBRARY_PATH",
             "MLABRAW_CMD_STR",
+            "OMERO_TEMPDIR",
             "OMERO_TMPDIR",
             "PATH",
             "PYTHONPATH",


### PR DESCRIPTION
If a sysadmin starts OMERO with the OMERO_TMPDIR environment
variable set, the script subprocesses started by processor.py
should respect the value.

# What this PR does

_Potential_ fix for server crashes on `Batch_Image_Export.py`. Scripts were not being given the `OMERO_TMPDIR` property setting. The value now propagates to the subprocesses.

# Test script

```
import omero.scripts as OS
import omero.util.temp_files as OT
import os

OS.client("debug")
print os.environ.get("OMERO_TMPDIR", None)
print OT.create_path("foo")
```

# Testing this PR

1. Place the test script above under `lib/scripts/omero/debug.py`
2. See that it's loaded properly with `bin/omero script list`
3. Without this PR, set `export OMERO_TMPDIR=/tmp/` and restart your server: `bin/omero admin restart`
4. Launch the script with `bin/omero script launch /omero/debug.py`
5. Restart your server *with* `OMERO_TMPDIR` *and* this PR
6. Re-launch the script as above. 

# Broken output

```
	*** start stdout (id=153)***
	* None
	* /Users/jamoore/omero/tmp/omero_jamoore/61482/fooZMmuvY.tmp
	*
	*** end stdout ***


	*** out parameters ***
	***  done ***
```
# Fixed output

```
Job 153 ready
Waiting....
Callback received: FINISHED

	*** start stdout (id=203)***
	* /tmp
	* /tmp/omero_jamoore/61638/fooegbp4p.tmp
	*
	*** end stdout ***


	*** out parameters ***
	***  done ***
```

# Related reading

* https://trello.com/c/TKwNsevG/37-bug-server-goes-down-after-single-export
