### PR TITLE
disable the chown-all targetusers feature

### DIFF
--- a/components/blitz/resources/omero/cmd/Graphs.ice
+++ b/components/blitz/resources/omero/cmd/Graphs.ice
@@ -177,7 +177,7 @@ module omero {
             long userId;
 
             /**
-             * The users who should have all their data targeted.
+             * The users who should have all their data targeted. <strong>Temporarily disabled.</strong>
              **/
             omero::api::LongList targetUsers;
         };

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -299,7 +299,9 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
             switch (step) {
             case 0:
                 if (CollectionUtils.isNotEmpty(targetUsers)) {
-                    targetAllUsersObjects();
+                    // targetAllUsersObjects();
+                    final Exception e = new IllegalArgumentException("targetUsers is temporarily disabled");
+                    throw helper.cancel(new ERR(), e, "feature-disabled");
                 }
                 return null;
             case 1:

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1296,7 +1296,7 @@ public class LightAdminRolesTest extends RolesTests {
      * @throws Exception unexpected
      * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUserLightAdmin.pptx">graphical explanation</a>
      */
-    @Test(dataProvider = "isPrivileged cases")
+    @Test(dataProvider = "isPrivileged cases", groups = "broken")
     public void testChownAllBelongingToUser(boolean isPrivileged, String groupPermissions) throws Exception {
         /* Chown privilege is sufficient for the workflow.*/
         final boolean chownPassing = isPrivileged;

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -436,7 +436,7 @@ public class PermissionsTest extends AbstractServerTest {
      * @see <a href="https://downloads.openmicroscopy.org/resources/experimental/tests/graph-permissions/0.1/testChownAllBelongingToUser.pptx">graphical explanation</a>
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "chown targetUser test cases")
+    @Test(dataProvider = "chown targetUser test cases", groups = "broken")
     public void testChownAllBelongingToUser(boolean areDataOwnersInOneGroup, boolean isAdmin, boolean isGroupOwner, boolean isRecipientInGroup,
             boolean isExpectSuccessOneTargetUser, boolean isExpectSuccessTwoTargetUsers,
             String groupPermissions) throws Exception {

--- a/components/tools/OmeroPy/src/omero/plugins/chown.py
+++ b/components/tools/OmeroPy/src/omero/plugins/chown.py
@@ -24,7 +24,8 @@ transferred or specify users from whom the ownership of all their data
 will be transferred. These two usage ways can be combined.
 
 The usage with specified users has to be considered as advanced usage
-and might potentially be slow.
+and might potentially be slow.  WARNING: It is also temporarily
+disabled on some OMERO 5.4 servers to protect users from a bug.
 
 This command can only be used by OMERO administrators and group owners.
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -58,6 +58,7 @@ class TestChown(CLITest):
         assert obj.id.val == oid
         assert obj.details.owner.id.val == user.id.val
 
+    @pytest.mark.broken(reason="Chown2.targetUsers disabled")
     def testChownBasicUsageTargetUser(self, simpleHierarchy):
         proj, dset, img = simpleHierarchy
         argument = "Experimenter"


### PR DESCRIPTION
# What this PR does

While https://trello.com/c/DaJKgLoY/40-chown-all-scriptjob-failures remains in play it's easiest to disable the chown-all feature for now. Can probably revert this PR for OMERO 5.4.3, we'll see.

# Testing this PR

Attempt https://docs.openmicroscopy.org/omero/5.4.1/users/cli/chown.html#transferring-all-objects-belonging-to-specified-users and check that you *are* refused. Other kinds of chown should remain available.

# Related reading

https://github.com/openmicroscopy/ome-documentation/pull/1831