### PR TITLE
flaky test_search

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -235,7 +235,7 @@ class TestSearch(ITest):
     def simple_uuid(self):
         uuid = self.uuid()
         uuid = uuid.replace("-", "")
-        uuid = "t" + self.uuid().replace("-", "")[0:8]
+        uuid = "t" + self.uuid().replace("-", "")[0:12]
         return uuid
 
     def testFilename(self):


### PR DESCRIPTION
# What this PR does

Use a 12 character string instead of 8 characters for generating a 'simple' uuid.
Maybe that's enough to fix the occasionally failing [OmeroPy.test.integration.test_search](https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/791/testReport/OmeroPy.test.integration.test_search/TestSearch/testFilename/)
