### PR TITLE
omero.gateway.BlitzGateway.__del__ hangs server (rebased onto metadata53)

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1914,10 +1914,6 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-    def __del__(self):
-        logger.debug("##GARBAGE COLLECTOR KICK IN")
-        self._assert_unregistered()
-
     def _createProxies(self):
         """
         Creates proxies to the server services. Called on connection or


### PR DESCRIPTION

This is the same as gh-5637 but rebased onto metadata53.

----

*Problem*: having any blocking actions in a __del__ method
can lead to hung gunicorn processes in OMERO.web. The addition
of the method was intended to detect dangling services, but
each call left further resources, detectable with `lsof`.

*Short-term fix*: By removing the method, OMERO.web should
no longer need to be periodically restarted.

*Long-term fix*: as a next step, the `_assert_unregistered`
method will need to again be invoked, perhaps by integration
tests, to detect the resources that were being left open.
Eventually, a rewrite of the `login_requred` decorator as
well as the `close` logic of BlitzGateway should be considered
so that resource cleanup can be guaranteed.

# Testing this PR

1. start OMERO.web 5.4.2 with public user (see https://github.com/openmicroscopy/omero-test-infra/pull/6)
2. run a number of calls against the server (e.g. `ab -c 5 -n 1000 http://host/webgateway...`)
3. find the gunicorn processes of OMERO.web (`ps auxw -H | grep gunicorn`)
4. find the number of file descriptors used by those processes (`lsof -p $PID | grep pipe`)
5. *watch it grow!*
6. install this patch and repeat the process


                