### PR TITLE
PyTest: attempt to fix import test

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -132,11 +132,9 @@ class TestImport(CLITest):
     def do_import(self, capfd, strip_logs=True):
         try:
 
-            # Check that there's no previous out/err
+            # Discard previous out/err
             # left over from previous test.
-            o, e = capfd.readouterr()
-            if o or e:
-                raise Exception(o, e)
+            capfd.readouterr()
 
             self.cli.invoke(self.args, strict=True)
             o, e = capfd.readouterr()

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -131,6 +131,13 @@ class TestImport(CLITest):
 
     def do_import(self, capfd, strip_logs=True):
         try:
+
+            # Check that there's no previous out/err
+            # left over from previous test.
+            o, e = capfd.readouterr()
+            if o or e:
+                raise Exception(o, e)
+
             self.cli.invoke(self.args, strict=True)
             o, e = capfd.readouterr()
             if strip_logs:


### PR DESCRIPTION
stderr of:
```
Image:Image:5525
5525
```

is being captured and passed to subsequent methods which fails the
expected regex (`^Image:(?P<id>\d+)$`). A possibility is that the
stdout and stderr are left over from a previous test. If this is
the case, then this commit will throw an exception. Later, we may
decide to just clean the captured streams before relying on them.

See:
 * https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration/911/consoleFull
 * https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/799/testReport/OmeroPy.test.integration.clitest.test_import/TestImport/testMultipleNameModelTargets___False_/
 * https://docs.pytest.org/en/2.9.0/capture.html#accessing-captured-output-from-a-test-function
