### PR TITLE
bioformats: make org in ivy files configurable

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -64,12 +64,12 @@
     <!-- from Java 9 on javax.activation is not included any longer -->
     <dependency org="javax.activation" name="activation" rev="${versions.activation}"/>
     <!-- Bioformats -->
-    <dependency org="ome" name="formats-bsd" rev="${versions.bioformats}">
+    <dependency org="${org.bioformats}" name="formats-bsd" rev="${versions.bioformats}">
         <exclude org="com.jgoodies"/>
         <exclude org="org.slf4j"/>
         <exclude org="xml-apis"/>
     </dependency>
-    <dependency org="ome" name="formats-gpl" rev="${versions.bioformats}">
+    <dependency org="${org.bioformats}" name="formats-gpl" rev="${versions.bioformats}">
         <exclude org="org.slf4j"/>
         <exclude org="commons-logging"/>
     </dependency>

--- a/components/model/ivy.xml
+++ b/components/model/ivy.xml
@@ -18,7 +18,7 @@
     <!-- Internal -->
     <dependency name="dsl" rev="${omero.version}" changing="true" conf="build->build;client->runtime;server->runtime"/>
     <!-- Bio-Formats -->
-    <dependency org="ome" name="formats-bsd" rev="${versions.bioformats}" transitive="true">
+    <dependency org="${org.bioformats}" name="formats-bsd" rev="${versions.bioformats}" transitive="true">
         <exclude org="com.jgoodies"/>
         <exclude org="org.perf4j"/>
         <exclude org="org.slf4j"/>

--- a/components/romio/ivy.xml
+++ b/components/romio/ivy.xml
@@ -17,7 +17,7 @@
   <dependencies defaultconfmapping="build,client,server->default">
     <!-- Internal -->
     <dependency name="common" rev="${omero.version}" changing="true" conf="build->build;server->server;client->client"/>
-    <dependency org="ome" name="formats-gpl" rev="${versions.bioformats}">
+    <dependency org="${org.bioformats}" name="formats-gpl" rev="${versions.bioformats}">
         <exclude org="org.perf4j"/>
         <exclude org="org.slf4j"/>
         <exclude org="commons-logging"/>

--- a/components/tools/OmeroJava/ivy.xml
+++ b/components/tools/OmeroJava/ivy.xml
@@ -32,13 +32,13 @@
     <!-- Internal -->
     <dependency org="omero" name="blitz" rev="${omero.version}" changing="true" conf="build->build"/>
     <!-- Bio-Formats -->
-    <dependency org="ome" name="formats-bsd" rev="${versions.bioformats}" transitive="true">
+    <dependency org="${org.bioformats}" name="formats-bsd" rev="${versions.bioformats}" transitive="true">
         <exclude org="org.perf4j"/>
         <exclude org="org.slf4j"/>
         <exclude org="xml-apis"/>
         <exclude org="xml-apis"/>
     </dependency>
-    <dependency org="ome" name="formats-gpl" rev="${versions.bioformats}" transitive="true">
+    <dependency org="${org.bioformats}" name="formats-gpl" rev="${versions.bioformats}" transitive="true">
         <exclude org="org.slf4j"/>
     </dependency>
   </dependencies>

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -915,10 +915,15 @@ Ice.IPv6=1
 #############################################
 product.name=OMERO.server
 
+
 #############################################
 ## Library versions
 #############################################
+
+org.bioformats=ome
+versions.bioformats=5.7.3
 versions.ome-java=2007-Aug-07-r3052
+
 ##
 versions.JHotDraw=7.0.9
 versions.TableLayout=bin-jdk1.5-2009-08-26
@@ -931,7 +936,6 @@ versions.activation=1.1.1
 versions.axis=1.4
 versions.backport=3.1
 versions.batik=1.8pre-jdk6
-versions.bioformats=5.7.3
 versions.btm=2.1.3
 versions.cglib=2.2
 versions.checkstyle=4.3


### PR DESCRIPTION
In order to support forks of Bio-Formats, not just
the version number but also the organization name
itself needs to be configurable. This was previously
done for the IDR fork of Bio-Formats by hard-coding
`org="idr"`.

see: gh-4927