### PR TITLE
remove omero.logbase from server templates

### DIFF
--- a/etc/templates/grid/osxtemplates.xml
+++ b/etc/templates/grid/osxtemplates.xml
@@ -205,8 +205,6 @@
         <option>-Djava.awt.headless=true</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback.xml</option>
         <option>-Domero.logfile=${OMERO_LOGFILE}</option>
-        <!-- This is a hack, the value needs to come from omero.properties -->
-        <option>-Domero.logbase=/OMERO/ManagedRepository/</option>
         <option>-Domero.name=Blitz-${index}</option>
         <target name="jmx">
             <!-- Be sure to understand the consequences of enabling JMX.

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -205,8 +205,6 @@
         <option>-Djava.awt.headless=true</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback.xml</option>
         <option>-Domero.logfile=${OMERO_LOGFILE}</option>
-        <!-- This is a hack, the value needs to come from omero.properties -->
-        <option>-Domero.logbase=/OMERO/ManagedRepository/</option>
         <option>-Domero.name=Blitz-${index}</option>
         <target name="jmx">
             <!-- Be sure to understand the consequences of enabling JMX.


### PR DESCRIPTION
# What this PR does

Removes `omero.logbase` from `etc/templates/grid/` as it is no longer used by the server.

# Testing this PR

CI should remain green. Server logs should still appear where expected.