### PR TITLE
Tiny bugfix for the admin log command

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1724,7 +1724,6 @@ present, the user will enter a console""")
 
     @admin_only(AdminPrivilegeReadSession)
     def log(self, args):
-        self.check_access()
         client = self.ctx.conn(args)
         req = RawAccessRequest(command='log', path=args.level,
                                repoUuid=args.repo, args=[args.message])


### PR DESCRIPTION
# What this PR does

Tiny PR just to remove the unnecessary `check_access()` call which made the command too restrictive.

# Related reading

https://trello.com/c/GCsVUiNI/36-rfe-make-bin-omero-admin-log-more-permissive
