### PR TITLE
CLImporter: allow forcing encrypted connection

### DIFF
--- a/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
+++ b/components/blitz/src/ome/formats/OMEROMetadataStoreClient.java
@@ -698,10 +698,17 @@ public class OMEROMetadataStoreClient
     {
         secure(server, port);
         serviceFactory = c.joinSession(sessionKey);
-    if (!isSecure)
-    {
-            unsecure();
-    }
+        if (!isSecure)
+        {
+            try
+            {
+                unsecure();
+            } catch (Ice.ConnectionRefusedException cre)
+            {
+                log.warn("Cannot fallback. Using secure connection", cre);
+            }
+        }
+
         initializeServices(true);
     }
 

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -608,6 +608,9 @@ public class CommandLineImporter {
         LongOpt outputFormat =
                 new LongOpt("output", LongOpt.REQUIRED_ARGUMENT, null, 25);
 
+        LongOpt encryptedConnection =
+                new LongOpt("encrypted", LongOpt.REQUIRED_ARGUMENT, null, 26);
+
         // DEPRECATED OPTIONS
         LongOpt minutesWaitDeprecated =
                 new LongOpt("minutes_wait", LongOpt.REQUIRED_ARGUMENT, null, 86);
@@ -645,7 +648,7 @@ public class CommandLineImporter {
                                 closeCompleted, waitCompleted, autoClose,
                                 exclude, target, noStatsInfo,
                                 noUpgradeCheck, qaBaseURL,
-                                outputFormat,
+                                outputFormat, encryptedConnection,
                                 plateName, plateName2,
                                 plateDescription, plateDescription2,
                                 noThumbnailsDeprecated,
@@ -802,6 +805,12 @@ public class CommandLineImporter {
                 String outputArg = g.getOptarg();
                 log.info("Setting output format: {}", outputArg);
                 outputChoice = ImportOutput.valueOf(outputArg);
+                break;
+            }
+            case 26: {
+                String encrytpedArg = g.getOptarg();
+                log.info("Setting encrypted: {}", encrytpedArg);
+                config.encryptedConnection.set(Boolean.valueOf(encrytpedArg));
                 break;
             }
             // ADVANCED END ---------------------------------------------------

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -808,9 +808,9 @@ public class CommandLineImporter {
                 break;
             }
             case 26: {
-                String encrytpedArg = g.getOptarg();
-                log.info("Setting encrypted: {}", encrytpedArg);
-                config.encryptedConnection.set(Boolean.valueOf(encrytpedArg));
+                String encryptedArg = g.getOptarg();
+                log.info("Setting encrypted: {}", encryptedArg);
+                config.encryptedConnection.set(Boolean.valueOf(encryptedArg));
                 break;
             }
             // ADVANCED END ---------------------------------------------------

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -420,6 +420,11 @@ class ImportControl(BaseControl):
             "--output", choices=OUTPUT_CHOICES,
             help="Set an alternative output style",
             metavar="TYPE")
+        add_java_argument(
+            "--encrypted",
+            choices=("true", "false"),
+            help="Whether the import should use SSL or not",
+            metavar="TYPE")
 
         # Arguments previously *following" `--`
         advjava_group = parser.add_argument_group(

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -1175,3 +1175,17 @@ class TestImport(CLITest):
 
         with pytest.raises(NonZeroReturnCode):
             self.do_import(capfd)
+
+    @pytest.mark.parametrize("arg",
+                             ['', '--encrypted=false', '--encrypted=true'])
+    def testEncryption(self, tmpdir, capfd, arg):
+        """Test encryption import"""
+
+        fakefile = tmpdir.join("test.fake")
+        fakefile.write('')
+
+        self.args += [str(fakefile)]
+        self.args += [arg]
+
+        out, err = self.do_import(capfd)
+        assert self.get_object(out, 'Image')


### PR DESCRIPTION
By default, the CLI importer uses the TCP port (unencrypted)
for performance reasons. If no TCP port is available, however,
clients should be able to use the SSL port (encrypted). This
is now possible with the `--encrypted=true` flag.

# Testing this PR

1. Find a host which only has the 4064 port (potentially with prefix) available. (This may be most manageable via ssh port forwarding. `ssh -L 4064:localhost:4064 somelocation`)
2. Attempt to import with `--encrypted=true`: **pass**
3. Attempt to import with no `--encrypted` flag: pass but prints warning below
4. Attempt to import with `--encrypted=false` (the default): pass but prints warning below

```
2018-02-19 10:45:02,981 1947       [      main] INFO       ome.formats.OMEROMetadataStoreClient - Insecure connection requested, falling back
2018-02-19 10:45:03,085 2051       [      main] WARN       ome.formats.OMEROMetadataStoreClient - Cannot fallback. Using secure connection
```