### PR TITLE
Django 1.11

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -19,7 +19,7 @@
 
 """Handles all 'api' urls."""
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from omeroweb.api import views
 from omeroweb.webgateway.views import LoginView
 from . import api_settings
@@ -292,8 +292,7 @@ api_image_rois = url(
 GET ROIs that belong to an Image, using omero-marshal to generate json
 """
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     api_versions,
     api_base,
     api_token,
@@ -327,4 +326,4 @@ urlpatterns = patterns(
     api_plate_screens,
     api_rois,
     api_image_rois,
-)
+]

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -28,13 +28,12 @@ import traceback
 from django.http import Http404, HttpResponse, HttpResponseRedirect, \
     JsonResponse
 from django.http import HttpResponseForbidden, StreamingHttpResponse
+from django.shortcuts import render
 
 from django.conf import settings
 from django.utils.http import urlencode
 from functools import update_wrapper
 from django.core.urlresolvers import reverse, resolve, NoReverseMatch
-from django.template import loader as template_loader
-from django.template import RequestContext
 from django.core.cache import cache
 
 from omeroweb.utils import reverse_with_params
@@ -545,7 +544,5 @@ class render_response(object):
             else:
                 # allow additional processing of context dict
                 ctx.prepare_context(request, context, *args, **kwargs)
-                t = template_loader.get_template(template)
-                c = RequestContext(request, context)
-                return HttpResponse(t.render(c))
+                return render(request, template, context)
         return update_wrapper(wrapper, f)

--- a/components/tools/OmeroWeb/omeroweb/feedback/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/urls.py
@@ -23,16 +23,15 @@
 # Version: 1.0
 #
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from django.views.generic import TemplateView
 
 from omeroweb.feedback import views
 
 # url patterns
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^feedback/', views.send_feedback, name="fsend"),
     url(r'^comment/', views.send_comment, name="csend"),
     url(r'^thanks/', TemplateView.as_view(template_name='thanks.html'),
         name="fthanks"),
-)
+]

--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -34,12 +34,11 @@ import traceback
 import logging
 
 from django.conf import settings
-from django.template import loader as template_loader
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.http import HttpResponseServerError, HttpResponseNotFound
-from django.template import RequestContext
 from django.views.defaults import page_not_found
 from django.core.urlresolvers import reverse
+from django.shortcuts import render
 
 from django.views.debug import get_exception_reporter_filter
 from django.utils.encoding import force_text
@@ -95,9 +94,7 @@ def send_feedback(request):
             return HttpResponseRedirect(reverse("fthanks"))
 
     context = {'form': form, 'error': error}
-    t = template_loader.get_template('500.html')
-    c = RequestContext(request, context)
-    return HttpResponse(t.render(c))
+    return render(request, '500.html', context)
 
 
 def send_comment(request):
@@ -122,9 +119,7 @@ def send_comment(request):
                 return HttpResponseRedirect(reverse("fthanks"))
 
     context = {'form': form, 'error': error}
-    t = template_loader.get_template('comment.html')
-    c = RequestContext(request, context)
-    return HttpResponse(t.render(c))
+    return render(request, 'comment.html', context)
 
 
 ##############################################################################
@@ -175,9 +170,7 @@ def handler500(request):
 
     form = ErrorForm(initial={'error': error500})
     context = {'form': form}
-    t = template_loader.get_template('500.html')
-    c = RequestContext(request, context)
-    return HttpResponseServerError(t.render(c))
+    return render(request, '500.html', context)
 
 
 def handler404(request):
@@ -210,6 +203,4 @@ def handlerInternalError(request, error):
         return HttpResponseNotFound(error)
 
     context = {"error": error}
-    t = template_loader.get_template("error.html")
-    c = RequestContext(request, context)
-    return HttpResponseNotFound(t.render(c))
+    return render(request, "error.html", context)

--- a/components/tools/OmeroWeb/omeroweb/manage.py
+++ b/components/tools/OmeroWeb/omeroweb/manage.py
@@ -28,6 +28,7 @@ import sys
 import logging
 
 from django.core.management import execute_from_command_line
+from django.core.servers.basehttp import WSGIServer
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +47,8 @@ if __name__ == "__main__":
     # Monkeypatch Django development web server to always run in single thread
     # even if --nothreading is not specified on command line
     def force_nothreading(addr, port, wsgi_handler, ipv6=False,
-                          threading=False):
-        django_core_servers_basehttp_run(addr, port, wsgi_handler, ipv6, False)
+                          threading=False, server_cls=WSGIServer):
+        django_core_servers_basehttp_run(addr, port, wsgi_handler, ipv6, False, server_cls)
     import django.core.servers.basehttp
     if django.core.servers.basehttp.run.__module__ != 'settings':
         django_core_servers_basehttp_run = django.core.servers.basehttp.run

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -583,26 +583,26 @@ CUSTOM_SETTINGS_MAPPINGS = {
     # Pipeline is an asset packaging library for Django, providing both CSS
     # and JavaScript concatenation and compression, built-in JavaScript
     # template support, and optional data-URI image and font embedding.
-    "omero.web.pipeline_js_compressor":
-        ["PIPELINE_JS_COMPRESSOR",
-         None,
-         identity,
-         ("Compressor class to be applied to JavaScript files. If empty or "
-          "None, JavaScript files won't be compressed.")],
-    "omero.web.pipeline_css_compressor":
-        ["PIPELINE_CSS_COMPRESSOR",
-         None,
-         identity,
-         ("Compressor class to be applied to CSS files. If empty or None,"
-          " CSS files won't be compressed.")],
-    "omero.web.pipeline_staticfile_storage":
-        ["STATICFILES_STORAGE",
-         "pipeline.storage.PipelineStorage",
-         str,
-         ("The file storage engine to use when collecting static files with"
-          " the collectstatic management command. See `the documentation "
-          "<http://django-pipeline.readthedocs.org/en/latest/storages.html>`_"
-          " for more details.")],
+    # "omero.web.pipeline_js_compressor":
+    #     ["PIPELINE_JS_COMPRESSOR",
+    #      None,
+    #      identity,
+    #      ("Compressor class to be applied to JavaScript files. If empty or "
+    #       "None, JavaScript files won't be compressed.")],
+    # "omero.web.pipeline_css_compressor":
+    #     ["PIPELINE_CSS_COMPRESSOR",
+    #      None,
+    #      identity,
+    #      ("Compressor class to be applied to CSS files. If empty or None,"
+    #       " CSS files won't be compressed.")],
+    # "omero.web.pipeline_staticfile_storage":
+    #     ["STATICFILES_STORAGE",
+    #      "pipeline.storage.PipelineStorage",
+    #      str,
+    #      ("The file storage engine to use when collecting static files with"
+    #       " the collectstatic management command. See `the documentation "
+    #       "<http://django-pipeline.readthedocs.org/en/latest/storages.html>`_"
+    #       " for more details.")],
 
     # Customisation
     "omero.web.login_logo":
@@ -1117,7 +1117,7 @@ INSTALLED_APPS += (
     'omeroweb.webgateway',
     'omeroweb.webredirect',
     'omeroweb.api',
-    'pipeline',
+    # 'pipeline',
 )
 
 logger.debug('INSTALLED_APPS=%s' % [INSTALLED_APPS])

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -1067,6 +1067,9 @@ TEMPLATES = [
                 'omeroweb.custom_context_processor.url_suffix',
                 'omeroweb.custom_context_processor.base_include_template',
             ],
+            'builtins': [
+                'omeroweb.webgateway.templatetags.defaulttags',
+            ],
         },
     },
 ]

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -130,7 +130,7 @@ LOGGING = {
         },
         'null': {
             'level': 'DEBUG',
-            'class': 'django.utils.log.NullHandler',
+            'class': 'logging.StreamHandler',
         },
         'console': {
             'level': 'DEBUG',

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -25,7 +25,7 @@
 
 from django.conf import settings
 from django.apps import AppConfig
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.shortcuts import redirect
 
@@ -46,26 +46,20 @@ def redirect_urlpatterns():
     Helper function to return a URL pattern for index page http://host/.
     """
     if settings.INDEX_TEMPLATE is None:
-        return patterns(
-            '',
-            url(r'^$', never_cache(
-                RedirectView.as_view(url=reverse_lazy('webindex'),
-                                     permanent=True)),
-                name="index")
-            )
+        return [url(r'^$', never_cache(
+                   RedirectView.as_view(url=reverse_lazy('webindex'),
+                                        permanent=True)),
+                   name="index")]
     else:
-        return patterns(
-            '',
-            url(r'^$', never_cache(
+        return [url(r'^$', never_cache(
                 RedirectView.as_view(url=reverse_lazy('webindex_custom'),
                                      permanent=True)),
-                name="index"),
-            )
+                name="index")]
 
 
 # url patterns
 
-urlpatterns = patterns('',)
+urlpatterns = []
 
 for app in settings.ADDITIONAL_APPS:
     if isinstance(app, AppConfig):
@@ -86,28 +80,26 @@ for app in settings.ADDITIONAL_APPS:
         pass
     else:
         regex = '^(?i)%s/' % label
-        urlpatterns += patterns('', (regex, include(urlmodule)),)
+        urlpatterns.append(url(regex, include(urlmodule)))
 
-urlpatterns += patterns(
-    '',
-    (r'^favicon\.ico$',
+urlpatterns.extend([
+    url(r'^favicon\.ico$',
      lambda request: redirect('%swebgateway/img/ome.ico'
                               % settings.STATIC_URL)),
-    (r'^(?i)webgateway/', include('omeroweb.webgateway.urls')),
-    (r'^(?i)webadmin/', include('omeroweb.webadmin.urls')),
-    (r'^(?i)webclient/', include('omeroweb.webclient.urls')),
+    url(r'^(?i)webgateway/', include('omeroweb.webgateway.urls')),
+    url(r'^(?i)webadmin/', include('omeroweb.webadmin.urls')),
+    url(r'^(?i)webclient/', include('omeroweb.webclient.urls')),
 
-    (r'^(?i)url/', include('omeroweb.webredirect.urls')),
-    (r'^(?i)feedback/', include('omeroweb.feedback.urls')),
+    url(r'^(?i)url/', include('omeroweb.webredirect.urls')),
+    url(r'^(?i)feedback/', include('omeroweb.feedback.urls')),
 
-    (r'^(?i)api/', include('omeroweb.api.urls')),
+    url(r'^(?i)api/', include('omeroweb.api.urls')),
 
-    url(r'^index/$', 'omeroweb.webclient.views.custom_index',
-        name="webindex_custom"),
-)
+    url(r'^index/$', custom_index, name="webindex_custom"),
+])
 
-urlpatterns += redirect_urlpatterns()
+urlpatterns.extend(redirect_urlpatterns())
 
 
 if settings.DEBUG:
-    urlpatterns += staticfiles_urlpatterns()
+    urlpatterns.extend(staticfiles_urlpatterns())

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -34,6 +34,8 @@ from django.utils.functional import lazy
 from django.views.generic import RedirectView
 from django.views.decorators.cache import never_cache
 
+from omeroweb.webclient.views import custom_index
+
 # error handler
 handler404 = "omeroweb.feedback.views.handler404"
 handler500 = "omeroweb.feedback.views.handler500"

--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -86,22 +86,22 @@ ROLE_CHOICES = (
 )
 
 
-class RoleRenderer(forms.RadioSelect.renderer):
-    """Allows disabling of 'administrator' Radio button."""
-    def render(self):
-        midList = []
-        for x, wid in enumerate(self):
-            disabled = self.attrs.get('disabled')
-            if ROLE_CHOICES[x][0] == 'administrator':
-                if hasattr(self, 'disable_admin'):
-                    disabled = getattr(self, 'disable_admin')
-            if disabled:
-                wid.attrs['disabled'] = True
-            midList.append(u'<li>%s</li>' % force_unicode(wid))
-        finalList = mark_safe(u'<ul id="id_role">\n%s\n</ul>'
-                              % u'\n'.join([u'<li>%s</li>'
-                                           % w for w in midList]))
-        return finalList
+# class RoleRenderer(forms.RadioSelect.renderer):
+#     """Allows disabling of 'administrator' Radio button."""
+#     def render(self):
+#         midList = []
+#         for x, wid in enumerate(self):
+#             disabled = self.attrs.get('disabled')
+#             if ROLE_CHOICES[x][0] == 'administrator':
+#                 if hasattr(self, 'disable_admin'):
+#                     disabled = getattr(self, 'disable_admin')
+#             if disabled:
+#                 wid.attrs['disabled'] = True
+#             midList.append(u'<li>%s</li>' % force_unicode(wid))
+#         finalList = mark_safe(u'<ul id="id_role">\n%s\n</ul>'
+#                               % u'\n'.join([u'<li>%s</li>'
+#                                            % w for w in midList]))
+#         return finalList
 
 
 class ExperimenterForm(NonASCIIForm):
@@ -146,7 +146,7 @@ class ExperimenterForm(NonASCIIForm):
         # so required=False to avoid validation error.
         self.fields['role'] = forms.ChoiceField(
             choices=ROLE_CHOICES,
-            widget=forms.RadioSelect(renderer=RoleRenderer),
+            widget=forms.RadioSelect(),
             required=False,
             initial='user')
         # If current user is restricted Admin, can't create full Admin

--- a/components/tools/OmeroWeb/omeroweb/webadmin/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/urls.py
@@ -23,14 +23,13 @@
 # Version: 1.0
 #
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 from omeroweb.webadmin import views
 from omeroweb.webclient.views import WebclientLoginView
 
 # url patterns
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^$', views.index, name="waindex"),
     url(r'^login/$', WebclientLoginView.as_view(),
         name="walogin"),
@@ -63,4 +62,4 @@ urlpatterns = patterns(
         views.manage_avatar, name="wamanageavatar"),
     url(r'^myphoto/$', views.myphoto, name="wamyphoto"),
     url(r'^email/$', views.email, name="waemail"),
-)
+]

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -38,12 +38,11 @@ import omeroweb.webclient.views
 from omero_version import build_year
 from omero_version import omero_version
 
-from django.template import loader as template_loader
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, HttpResponseRedirect
-from django.template import RequestContext as Context
+from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
 from django.utils.encoding import smart_str
+from django.shortcuts import render
 
 from forms import ForgottonPasswordForm, ExperimenterForm, GroupForm
 from forms import GroupOwnerForm, MyAccountForm, ChangePassword
@@ -353,10 +352,8 @@ def forgotten_password(request, **kwargs):
 
     context = {'error': error, 'form': form, 'build_year': build_year,
                'omero_version': omero_version}
-    t = template_loader.get_template(template)
-    c = Context(request, context)
-    rsp = t.render(c)
-    return HttpResponse(rsp)
+    return render(request, template, context)
+
 
 
 @login_required()

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -181,7 +181,7 @@
         WEBCLIENT.URLS.api_tags_and_tagged = "{% url 'api_tags_and_tagged' %}";
         WEBCLIENT.URLS.fileset_check = "{% url 'fileset_check' 'delete' %}";
         WEBCLIENT.URLS.deletemany = "{% url 'manage_action_containers' 'deletemany' %}";
-        WEBCLIENT.URLS.copy_image_rdef_json = "{% url 'webgateway.views.copy_image_rdef_json' %}";
+        WEBCLIENT.URLS.copy_image_rdef_json = "{% url 'copy_image_rdef_json' %}";
         WEBCLIENT.URLS.reset_owners_rdef_json = "{% url 'reset_owners_rdef_json' %}";
         WEBCLIENT.URLS.reset_rdef_json = "{% url 'reset_rdef_json' %}";
         // jsTree code in ome.tree.js and center panel code in center_plugin.thumbs.js.html uses initially_select
@@ -209,7 +209,7 @@
         {% endif %}
 
         WEBCLIENT.HAS_RDEF = false;
-        $.getJSON("{% url 'webgateway.views.get_image_rdef_json' %}", function(data){
+        $.getJSON("{% url 'get_image_rdef_json' %}", function(data){
             WEBCLIENT.HAS_RDEF = !!(data && data.rdef);
         });
 
@@ -217,7 +217,7 @@
         // Loaded scripts can call OME.setOpenWithEnabledHandler and/or
         // OME.setOpenWithActionHandler to override default behaviour
         WEBCLIENT.OPEN_WITH = [];
-        $.getJSON("{% url 'webgateway.views.open_with_options' %}", function(data){
+        $.getJSON("{% url 'open_with_options' %}", function(data){
             if (data && data.open_with_options) {
                 WEBCLIENT.OPEN_WITH = data.open_with_options;
                 // Try to load scripts if specified:

--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -24,14 +24,19 @@
 #
 
 from django.conf import settings
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 
 from omeroweb.webclient import views
 from omeroweb.webgateway import views as webgateway
 from omeroweb.webclient.webclient_gateway import defaultThumbnail
+import importlib
 
-urlpatterns = patterns(
-    '',
+module_name, method_name = settings.VIEWER_VIEW.rsplit(".",1)
+viewer_module = importlib.import_module(module_name)
+viewer_view = getattr(viewer_module, method_name)
+
+
+urlpatterns = [
 
     # Home page is the main 'Data' page
     url(r'^$', views.load_template, {'menu': 'userdata'}, name="webindex"),
@@ -154,7 +159,7 @@ urlpatterns = patterns(
         {'download': True},
         name="web_render_image_download"),
     url(r'^(?:(?P<share_id>[0-9]+)/)?img_detail/(?P<iid>[0-9]+)/$',
-        settings.VIEWER_VIEW,
+        viewer_view,
         name="web_image_viewer"),
     url(r'^(?:(?P<share_id>[0-9]+)/)?imgData/(?P<iid>[0-9]+)/$',
         webgateway.imageData_json,
@@ -321,5 +326,4 @@ urlpatterns = patterns(
 
     url(r'^api/shares/$', views.api_share_list, name='api_shares'),
 
-
-)
+]

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -50,12 +50,12 @@ from django.template import loader as template_loader
 from django.http import Http404, HttpResponse, HttpResponseRedirect, \
     JsonResponse
 from django.http import HttpResponseServerError, HttpResponseBadRequest
-from django.template import RequestContext as Context
 from django.utils.http import urlencode
 from django.core.urlresolvers import reverse
 from django.utils.encoding import smart_str
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST
+from django.shortcuts import render
 
 from webclient_utils import _formatReport, _purgeCallback
 from forms import GlobalSearchForm, ContainerForm
@@ -243,17 +243,14 @@ class WebclientLoginView(LoginView):
             'build_year': build_year,
             'error': error,
             'form': form}
-        url = request.GET.get("url")
-        if url is not None and len(url) != 0:
-            context['url'] = urlencode({'url': url})
+        url = request.GET.get("url" ,"")
+        # if url is not None and len(url) != 0:
+        context['url'] = urlencode({'url': url})
 
         if hasattr(settings, 'LOGIN_LOGO'):
             context['LOGIN_LOGO'] = settings.LOGIN_LOGO
 
-        t = template_loader.get_template(self.template)
-        c = Context(request, context)
-        rsp = t.render(c)
-        return HttpResponse(rsp)
+        return render(request, self.template, context)
 
 
 @login_required(ignore_login_fail=True)
@@ -329,10 +326,7 @@ def logout(request, conn=None, **kwargs):
         context = {
             'url': reverse('weblogout'),
             'submit': "Do you want to log out?"}
-        t = template_loader.get_template(
-            'webgateway/base/includes/post_form.html')
-        c = Context(request, context)
-        return HttpResponse(t.render(c))
+        return render(request, 'webgateway/base/includes/post_form.html', context)
 
 
 ###########################################################################

--- a/components/tools/OmeroWeb/omeroweb/webgateway/__init__.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/__init__.py
@@ -20,7 +20,3 @@
 #
 # Author: Aleksandra Tarkowska <A(dot)Tarkowska(at)dundee(dot)ac(dot)uk>, 2012.
 #
-
-from django.template.base import add_to_builtins
-
-add_to_builtins('omeroweb.webgateway.templatetags.defaulttags')

--- a/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/urls.py
@@ -13,15 +13,16 @@
 #
 # Author: Carlos Neves <carlos(at)glencoesoftware.com>
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
+from omeroweb.webgateway import views
 
-webgateway = url(r'^$', 'webgateway.views.index', name="webgateway")
+webgateway = url(r'^$', views.index, name="webgateway")
 """
 Returns a main prefix
 """
 
 annotations = url(r'^annotations/(?P<objtype>[\w.]+)/(?P<objid>\d+)/$',
-                  'webgateway.views.annotations',
+                  views.annotations,
                   name="webgateway_annotations")
 """
 Retrieve annotations for object specified by object type and identifier,
@@ -29,7 +30,7 @@ optionally traversing object model graph.
 """
 
 table_query = url(r'^table/(?P<fileid>\d+)/query/$',
-                  'webgateway.views.table_query',
+                  views.table_query,
                   name="webgateway_table_query")
 """
 Query a table specified by fileid
@@ -37,16 +38,16 @@ Query a table specified by fileid
 
 object_table_query = url(
     r'^table/(?P<objtype>[\w.]+)/(?P<objid>\d+)/query/$',
-    'webgateway.views.object_table_query',
+    views.object_table_query,
     name="webgateway_object_table_query")
 """
 Query bulk annotations table attached to an object specified by
 object type and identifier, optionally traversing object model graph.
 """
 
-render_image = (
+render_image = url(
     r'^render_image/(?P<iid>[0-9]+)/(?:(?P<z>[0-9]+)/)?(?:(?P<t>[0-9]+)/)?$',
-    'webgateway.views.render_image')
+    views.render_image)
 """
 Returns a jpeg of the OMERO image. See L{views.render_image}. Rendering
 settings can be specified in the request parameters. See
@@ -57,9 +58,9 @@ Params in render_image/<iid>/<z>/<t>/ are:
     - t:    T index
 """
 
-render_image_region = (
+render_image_region = url(
     r'^render_image_region/(?P<iid>[0-9]+)/(?P<z>[0-9]+)/(?P<t>[0-9]+)/$',
-    'webgateway.views.render_image_region')
+    views.render_image_region)
 """
 Returns a jpeg of the OMERO image, rendering only a region specified in query
 string as region=x,y,width,height. E.g. region=0,512,256,256 See
@@ -71,9 +72,9 @@ Params in render_image/<iid>/<z>/<t>/ are:
     - t:    T index
 """
 
-render_split_channel = (
+render_split_channel = url(
     r'^render_split_channel/(?P<iid>[0-9]+)/(?P<z>[0-9]+)/(?P<t>[0-9]+)/$',
-    'webgateway.views.render_split_channel')
+    views.render_split_channel)
 """
 Returns a jpeg of OMERO Image with channels split into different panes in a
 grid. See L{views.render_split_channel}.
@@ -84,10 +85,10 @@ Params in render_split_channel/<iid>/<z>/<t> are:
     - t:    T index
 """
 
-render_row_plot = (
+render_row_plot = url(
     r'^render_row_plot/(?P<iid>[0-9]+)/(?P<z>[0-9]+)/(?P<t>[0-9]+)/'
     '(?P<y>[0-9]+)/(?:(?P<w>[0-9]+)/)?$',
-    'webgateway.views.render_row_plot')
+    views.render_row_plot)
 """
 Returns a gif graph of pixel values for a row of an image plane. See
 L{views.render_row_plot}.
@@ -100,10 +101,10 @@ Params in render_row_plot/<iid>/<z>/<t>/<y>/<w> are:
     - w:    Optional line width of plot
 """
 
-render_col_plot = (
+render_col_plot = url(
     r'^render_col_plot/(?P<iid>[0-9]+)/(?P<z>[0-9]+)/(?P<t>[0-9]+)'
     '/(?P<x>[0-9]+)/(?:(?P<w>[0-9]+)/)?$',
-    'webgateway.views.render_col_plot')
+    views.render_col_plot)
 """
 Returns a gif graph of pixel values for a column of an image plane. See
 L{views.render_col_plot}.
@@ -119,7 +120,7 @@ Params in render_col_plot/<iid>/<z>/<t>/<x>/<w> are:
 render_thumbnail = url(
     r'^render_thumbnail/(?P<iid>[0-9]+)'
     '/(?:(?P<w>[0-9]+)/)?(?:(?P<h>[0-9]+)/)?$',
-    'webgateway.views.render_thumbnail')
+    views.render_thumbnail)
 """
 Returns a thumbnail jpeg of the OMERO Image, optionally scaled to max-width
 and max-height.
@@ -131,31 +132,31 @@ Params in render_thumbnail/<iid>/<w>/<h> are:
     - h:    Optional max height
 """
 
-render_roi_thumbnail = (
+render_roi_thumbnail = url(
     r'^render_roi_thumbnail/(?P<roiId>[0-9]+)/?$',
-    'webgateway.views.render_roi_thumbnail')
+    views.render_roi_thumbnail)
 """
 Returns a thumbnail jpeg of the OMERO ROI. See L{views.render_roi_thumbnail}.
 Uses current rendering settings.
 """
 
-render_shape_thumbnail = (
+render_shape_thumbnail = url(
     r'^render_shape_thumbnail/(?P<shapeId>[0-9]+)/?$',
-    'webgateway.views.render_shape_thumbnail')
+    views.render_shape_thumbnail)
 """
 Returns a thumbnail jpeg of the OMERO Shape. See
 L{views.render_shape_thumbnail}. Uses current rendering settings.
 """
 
-render_shape_mask = (r'^render_shape_mask/(?P<shapeId>[0-9]+)/$',
-                     'webgateway.views.render_shape_mask')
+render_shape_mask = url(r'^render_shape_mask/(?P<shapeId>[0-9]+)/$',
+                     views.render_shape_mask)
 """
 Returns a mask for the specified shape
 """
 
-render_birds_eye_view = (
+render_birds_eye_view = url(
     r'^render_birds_eye_view/(?P<iid>[0-9]+)/(?:(?P<size>[0-9]+)/)?$',
-    'webgateway.views.render_birds_eye_view')
+    views.render_birds_eye_view)
 """
 Returns a bird's eye view JPEG of the OMERO Image.
 See L{views.render_birds_eye_view}. Uses current rendering settings.
@@ -165,8 +166,8 @@ Params in render_birds_eye_view/<iid>/ are:
              view.
 """
 
-render_ome_tiff = (r'^render_ome_tiff/(?P<ctx>[^/]+)/(?P<cid>[0-9]+)/$',
-                   'webgateway.views.render_ome_tiff')
+render_ome_tiff = url(r'^render_ome_tiff/(?P<ctx>[^/]+)/(?P<cid>[0-9]+)/$',
+                   views.render_ome_tiff)
 """
 Generates an OME-TIFF of an Image (or zip for multiple OME-TIFFs) and returns
 the file or redirects to a temp file location. See L{views.render_ome_tiff}
@@ -176,9 +177,9 @@ Image.
     - cid:      ID of container.
 """
 
-render_movie = (
+render_movie = url(
     r'^render_movie/(?P<iid>[0-9]+)/(?P<axis>[zt])/(?P<pos>[0-9]+)/$',
-    'webgateway.views.render_movie')
+    views.render_movie)
 """
 Generates a movie file from the image, spanning Z or T frames. See
 L{views.render_movie}
@@ -191,15 +192,15 @@ Params in render_movie/<iid>/<axis>/<pos> are:
 
 # json methods...
 
-listProjects_json = (r'^proj/list/$', 'webgateway.views.listProjects_json')
+listProjects_json = url(r'^proj/list/$', views.listProjects_json)
 """
 json method: returning list of all projects available to current user. See
 L{views.listProjects_json} .
 List of E.g. {"description": "", "id": 651, "name": "spim"}
 """
 
-projectDetail_json = (r'^proj/(?P<pid>[0-9]+)/detail/$',
-                      'webgateway.views.projectDetail_json')
+projectDetail_json = url(r'^proj/(?P<pid>[0-9]+)/detail/$',
+                      views.projectDetail_json)
 """
 json method: returns details of specified Project. See
 L{views.projectDetail_json}. Returns E.g
@@ -208,8 +209,8 @@ L{views.projectDetail_json}. Returns E.g
     - pid:  Project ID
 """
 
-listDatasets_json = (r'^proj/(?P<pid>[0-9]+)/children/$',
-                     'webgateway.views.listDatasets_json')
+listDatasets_json = url(r'^proj/(?P<pid>[0-9]+)/children/$',
+                     views.listDatasets_json)
 """
 json method: returns list of Datasets belonging to specified Project. See
 L{views.listDatasets_json}. Returns E.g
@@ -219,8 +220,8 @@ list of {"child_count": 4, "description": "", "type": "Dataset", "id": 901,
     - pid:  Project ID
 """
 
-datasetDetail_json = (r'^dataset/(?P<did>[0-9]+)/detail/$',
-                      'webgateway.views.datasetDetail_json')
+datasetDetail_json = url(r'^dataset/(?P<did>[0-9]+)/detail/$',
+                      views.datasetDetail_json)
 """
 json method: returns details of specified Dataset. See
 L{views.datasetDetail_json}. Returns E.g
@@ -230,7 +231,7 @@ L{views.datasetDetail_json}. Returns E.g
 """
 
 webgateway_listimages_json = url(
-    r'^dataset/(?P<did>[0-9]+)/children/$', 'webgateway.views.listImages_json',
+    r'^dataset/(?P<did>[0-9]+)/children/$', views.listImages_json,
     name="webgateway_listimages_json")
 """
 json method: returns list of Images belonging to specified Dataset. See
@@ -243,7 +244,7 @@ L{views.listImages_json}. Returns E.g list of
     - request variables:
       - thumbUrlPrefix: view key whose reverse url is to be used as prefix for
                         thumb_url instead of default
-                        webgateway.views.render_thumbnail
+                        views.render_thumbnail
       - tiled: if set with anything other than an empty string will add
                information on whether each image is tiled on this server
 
@@ -251,7 +252,7 @@ L{views.listImages_json}. Returns E.g list of
 
 webgateway_listwellimages_json = url(
     r'^well/(?P<did>[0-9]+)/children/$',
-    'webgateway.views.listWellImages_json',
+    views.listWellImages_json,
     name="webgateway_listwellimages_json")
 """
 json method: returns list of Images belonging to specified Well. See
@@ -265,14 +266,14 @@ L{views.listWellImages_json}. Returns E.g list of
 
 webgateway_plategrid_json = url(
     r'^plate/(?P<pid>[0-9]+)/(?:(?P<field>[0-9]+)/)?$',
-    'webgateway.views.plateGrid_json', name="webgateway_plategrid_json")
+    views.plateGrid_json, name="webgateway_plategrid_json")
 """
 """
 
 
 webgateway_get_thumbnails_json = url(
     r'^get_thumbnails/(?:(?P<w>[0-9]+)/)?$',
-    'webgateway.views.get_thumbnails_json')
+    views.get_thumbnails_json)
 """
 Returns a set of thumbnail base64 encoded of the OMERO Images,
 optionally scaled to max-longest-side.
@@ -282,7 +283,7 @@ Image ids are specified in query string as list, e.g. id=1&id=2.
 webgateway_get_thumbnail_json = url(
     r'^get_thumbnail/(?P<iid>[0-9]+)'
     '/(?:(?P<w>[0-9]+)/)?(?:(?P<h>[0-9]+)/)?$',
-    'webgateway.views.get_thumbnail_json')
+    views.get_thumbnail_json)
 """
 Returns a thumbnail base64 encoded of the OMERO Images,
 optionally scaled to max-width and max-height.
@@ -294,8 +295,8 @@ Params in render_thumbnail/<iid>/<w>/<h> are:
     - h:    Optional max height
 """
 
-imageData_json = (r'^imgData/(?P<iid>[0-9]+)/(?:(?P<key>[^/]+)/)?$',
-                  'webgateway.views.imageData_json')
+imageData_json = url(r'^imgData/(?P<iid>[0-9]+)/(?:(?P<key>[^/]+)/)?$',
+                  views.imageData_json)
 """
 json method: returns details of specified Image. See L{views.imageData_json}.
 Returns E.g
@@ -307,7 +308,7 @@ Returns E.g
 """
 
 wellData_json = url(r'^wellData/(?P<wid>[0-9]+)/$',
-                    'webgateway.views.wellData_json',
+                    views.wellData_json,
                     name='webgateway_wellData_json')
 """
 json method: returns details of specified Well. See L{views.wellData_json}.
@@ -315,7 +316,7 @@ json method: returns details of specified Well. See L{views.wellData_json}.
     - wid:  Well ID
 """
 
-webgateway_search_json = url(r'^search/$', 'webgateway.views.search_json',
+webgateway_search_json = url(r'^search/$', views.search_json,
                              name="webgateway_search_json")
 """
 json method: returns search results. All parameters in request. See
@@ -323,7 +324,7 @@ L{views.search_json}
 """
 
 get_rois_json = url(r'^get_rois_json/(?P<imageId>[0-9]+)/$',
-                    'webgateway.views.get_rois_json',
+                    views.get_rois_json,
                     name='webgateway_get_rois_json')
 """
 gets all the ROIs for an Image as json. Image-ID is request: imageId=123
@@ -333,7 +334,7 @@ gets all the ROIs for an Image as json. Image-ID is request: imageId=123
 
 get_shape_json = url(
     r'^get_shape_json/(?P<roiId>[0-9]+)/(?P<shapeId>[0-9]+)/$',
-    'webgateway.views.get_shape_json', name='webgateway_get_shape_json')
+    views.get_shape_json, name='webgateway_get_shape_json')
 """
 gets a Shape as json. ROI-ID, Shape-ID is request: roiId=123 and shapeId=123
 {'type':'Rectangle', 'theZ':5, 'theT':0, 'x':250, 'y':100, 'width':10,
@@ -342,7 +343,7 @@ gets a Shape as json. ROI-ID, Shape-ID is request: roiId=123 and shapeId=123
 
 histogram_json = url(
     r'^histogram_json/(?P<iid>[0-9]+)/channel/(?P<theC>[0-9]+)/',
-    'webgateway.views.histogram_json',
+    views.histogram_json,
     name="histogram_json")
 """
 Gets a histogram of 256 columns (grey levels) for the chosen
@@ -350,7 +351,7 @@ channel of an image. A single plane is specified by ?theT=1&theZ=2.
 """
 
 full_viewer = url(r'^img_detail/(?P<iid>[0-9]+)/$',
-                  "webgateway.views.full_viewer",
+                  views.full_viewer,
                   name="webgateway_full_viewer")
 """
 Returns html page displaying full image viewer and image details, rendering
@@ -360,8 +361,8 @@ See L{views.full_viewer}.
     - iid:  Image ID.
 """
 
-save_image_rdef_json = (r'^saveImgRDef/(?P<iid>[0-9]+)/$',
-                        'webgateway.views.save_image_rdef_json')
+save_image_rdef_json = url(r'^saveImgRDef/(?P<iid>[0-9]+)/$',
+                        views.save_image_rdef_json)
 """
 Saves rendering definition (from request parameters) on the image. See
 L{views.save_image_rdef_json}.
@@ -371,22 +372,22 @@ Returns 'true' if worked OK.
     - iid:  Image ID.
 """
 
-get_image_rdef_json = (r'^getImgRDef/$',
-                       'webgateway.views.get_image_rdef_json')
+get_image_rdef_json = url(r'^getImgRDef/$', views.get_image_rdef_json,
+                          name="get_image_rdef_json")
 """
 Gets rendering definition from the 'session' if saved.
 Returns json dict of 'c', 'm', 'z', 't'.
 """
 
-listLuts_json = (r'^luts/$', 'webgateway.views.listLuts_json')
+listLuts_json = url(r'^luts/$', views.listLuts_json)
 """
 json method: returning list of all lookup tables available
 for rendering engine.
 E.g. list of {path: "/luts/", size: 800, id: 37, name: "cool.lut"},
 """
 
-list_compatible_imgs_json = (r'^compatImgRDef/(?P<iid>[0-9]+)/$',
-                             'webgateway.views.list_compatible_imgs_json')
+list_compatible_imgs_json = url(r'^compatImgRDef/(?P<iid>[0-9]+)/$',
+                             views.list_compatible_imgs_json)
 """
 json method: returns list of IDs for images that have channels compatible with
 the specified image, such that rendering settings can be copied from the image
@@ -396,14 +397,14 @@ specified image is in.
     - iid:  Image ID.
 """
 
-copy_image_rdef_json = (r'^copyImgRDef/$',
-                        'webgateway.views.copy_image_rdef_json')
+copy_image_rdef_json = url(r'^copyImgRDef/$', views.copy_image_rdef_json,
+                           name="copy_image_rdef_json")
 """
 Copy the rendering settings from one image to a list of images, specified in
 request by 'fromid' and list of 'toids'. See L{views.copy_image_rdef_json}
 """
 
-reset_rdef_json = url(r'^resetRDef/$', 'webgateway.views.reset_rdef_json',
+reset_rdef_json = url(r'^resetRDef/$', views.reset_rdef_json,
                       name="reset_rdef_json")
 """
 Reset the images within specified objects to their rendering settings at
@@ -412,7 +413,7 @@ Objects defined in request by E.g. totype=dataset&toids=1&toids=2
 """
 
 reset_owners_rdef_json = url(r'^applyOwnersRDef/$',
-                             'webgateway.views.reset_rdef_json',
+                             views.reset_rdef_json,
                              {'toOwners': True},
                              name="reset_owners_rdef_json")
 """
@@ -420,7 +421,7 @@ Apply the owner's rendering settings to the specified objects.
 Objects defined in request by E.g. totype=dataset&toids=1&toids=2
 """
 
-webgateway_su = url(r'^su/(?P<user>[^/]+)/$', 'webgateway.views.su',
+webgateway_su = url(r'^su/(?P<user>[^/]+)/$', views.su,
                     name="webgateway_su")
 """
 Admin method to switch to the specified user, identified by username: <user>
@@ -428,10 +429,10 @@ Returns 'true' if switch went OK.
 """
 
 download_as = url(r'^download_as/(?:(?P<iid>[0-9]+)/)?$',
-                  'webgateway.views.download_as', name="download_as")
+                  views.download_as, name="download_as")
 
 archived_files = url(r'^archived_files/download/(?:(?P<iid>[0-9]+)/)?$',
-                     'webgateway.views.archived_files', name="archived_files")
+                     views.archived_files, name="archived_files")
 """
 This url will download the Original Image File(s) archived at import time. If
 it's a single file, this will be downloaded directly. For multiple files, they
@@ -439,7 +440,7 @@ are assembled into a zip file on the fly, and this is downloaded.
 """
 
 original_file_paths = url(r'^original_file_paths/(?P<iid>[0-9]+)/$',
-                          'webgateway.views.original_file_paths',
+                          views.original_file_paths,
                           name="original_file_paths")
 """
 Get a json dict of original file paths.
@@ -447,7 +448,7 @@ Get a json dict of original file paths.
 'client' is a list of paths for original files on the client when imported
 """
 
-open_with_options = url(r'^open_with/$', 'webgateway.views.open_with_options',
+open_with_options = url(r'^open_with/$', views.open_with_options,
                         name='open_with_options')
 """
 This makes the settings.OPEN_WITH configuration available via json
@@ -455,15 +456,14 @@ This makes the settings.OPEN_WITH configuration available via json
 
 
 get_image_rdefs_json = url(r'^get_image_rdefs_json/(?P<img_id>[0-9]+)/$',
-                           'webgateway.views.get_image_rdefs_json',
+                           views.get_image_rdefs_json,
                            name="webgateway_get_image_rdefs_json")
 """
 This url will retrieve all rendering definitions for a given image (id)
 """
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     webgateway,
     render_image,
     render_image_region,
@@ -516,4 +516,4 @@ urlpatterns = patterns(
     table_query,
     object_table_query,
     open_with_options,
-)
+]

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2232,9 +2232,7 @@ def full_viewer(request, iid, conn=None, **kwargs):
 
         template = kwargs.get('template',
                               "webgateway/viewport/omero_image.html")
-        t = template_loader.get_template(template)
-        c = Context(request, d)
-        rsp = t.render(c)
+        return render(request, tempalte, context)
     except omero.SecurityViolation:
         logger.warn("SecurityViolation in Image:%s", iid)
         logger.warn(traceback.format_exc())
@@ -2586,10 +2584,8 @@ def su(request, user, conn=None, **kwargs):
         context = {
             'url': reverse('webgateway_su', args=[user]),
             'submit': "Do you want to su to %s" % user}
-        t = template_loader.get_template(
-            'webgateway/base/includes/post_form.html')
-        c = Context(request, context)
-        return HttpResponse(t.render(c))
+        return render(request, 'webgateway/base/includes/post_form.html',
+                      context)
 
 
 def _annotations(request, objtype, objid, conn=None, **kwargs):

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -22,12 +22,11 @@ import omero.clients
 from django.http import HttpResponse, HttpResponseBadRequest, \
     HttpResponseServerError, JsonResponse
 from django.http import HttpResponseRedirect, HttpResponseNotAllowed, Http404
-from django.template import loader as template_loader
 from django.views.decorators.http import require_POST
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.conf import settings
-from django.template import RequestContext as Context
-from django.core.servers.basehttp import FileWrapper
+from django.shortcuts import render
+from wsgiref.util import FileWrapper
 from omero.rtypes import rlong, unwrap
 from omero.constants.namespaces import NSBULKANNOTATIONS
 from omero.util.ROI_utils import pointsStringToXYlist, xyListToBbox

--- a/components/tools/OmeroWeb/omeroweb/webredirect/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webredirect/urls.py
@@ -23,10 +23,9 @@
 # Version: 1.0
 #
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url
 from omeroweb.webredirect import views
 
-urlpatterns = patterns(
-    'django.views.generic.simple',
+urlpatterns = [
     url(r'^$', views.index, name='webredirect'),
-)
+]

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -5,7 +5,7 @@
 #
 
 zeroc-ice>3.5,<3.7
-Django>=1.8,<1.9
+Django>=1.11,<1.12
 django-pipeline==1.3.20
 gunicorn>=19.3
 


### PR DESCRIPTION
# What this PR does

Updates OMERO.web to use Django 1.11.
https://trello.com/c/qOUsiP0P/43-upgrade-to-django-111

Django 1.8 support ends at start of April 2018 (see https://www.djangoproject.com/download/).

NB: Heads-up. Django 1.11 series ends in 2 years and it's the last to support Python 2.
https://docs.djangoproject.com/en/2.0/releases/1.11/
cc @joshmoore @chris-allan 

# Testing this PR

1. Not ready to be tested yet, but will need a lot!

TODO:
 - I temporarily removed Pipeline and custom forms renderer so we could push a "working" branch. Will now look to get that functionality back.
