### PR TITLE
Bio-Formats: rollback to idr:*:0.4.4

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -25,7 +25,7 @@ import loci.formats.IFormatReader;
 import loci.formats.MissingLibraryException;
 import loci.formats.UnknownFormatException;
 import loci.formats.UnsupportedCompressionException;
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import ome.formats.ImageNameMetadataStore;
 import ome.formats.importer.util.ErrorHandler;
@@ -423,7 +423,7 @@ public class ImportCandidates extends DirectoryWalker
                 reader.close();
                 reader.setMetadataStore(new ImageNameMetadataStore());
                 reader.setMetadataOptions(
-                        new DefaultMetadataOptions(METADATA_LEVEL));
+                        new DynamicMetadataOptions(METADATA_LEVEL));
                 reader.setId(path);
                 format = reader.getFormat();
                 usedFiles = getOrderedFiles();

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import loci.formats.meta.MetadataStore;
 import ome.formats.OMEROMetadataStoreClient;
@@ -169,7 +169,7 @@ public class CommandLineImporter {
             store = config.createStore();
             store.logVersionInfo(config.getIniVersionNumber());
             reader.setMetadataOptions(
-                    new DefaultMetadataOptions(MetadataLevel.ALL));
+                    new DynamicMetadataOptions(MetadataLevel.ALL));
 
             library = new ImportLibrary(store, reader,
                     transfer, exclusions, minutesToWait);

--- a/components/blitz/src/ome/formats/importer/cli/ImportCloser.java
+++ b/components/blitz/src/ome/formats/importer/cli/ImportCloser.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import loci.formats.meta.MetadataStore;
 import ome.formats.OMEROMetadataStoreClient;

--- a/components/blitz/test/ome/formats/utests/MetadataValidatorTest.java
+++ b/components/blitz/test/ome/formats/utests/MetadataValidatorTest.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 import loci.common.DataTools;
 import loci.formats.FormatException;
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import ome.formats.Index;
 import ome.formats.OMEROMetadataStoreClient;
@@ -138,10 +138,10 @@ public class MetadataValidatorTest
                 new BlitzInstanceProvider(minimalStore.getEnumerationProvider()));
         wrapper = new OMEROWrapper(config);
         wrapper.setMetadataOptions(
-                new DefaultMetadataOptions(MetadataLevel.ALL));
+                new DynamicMetadataOptions(MetadataLevel.ALL));
         minimalWrapper = new OMEROWrapper(config);
         minimalWrapper.setMetadataOptions(
-                new DefaultMetadataOptions(MetadataLevel.MINIMUM));
+                new DynamicMetadataOptions(MetadataLevel.MINIMUM));
         wrapper.setMetadataStore(store);
         store.setReader(wrapper.getImageReader());
         minimalStore.setReader(minimalWrapper.getImageReader());

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -921,7 +921,7 @@ product.name=OMERO.server
 #############################################
 
 org.bioformats=idr
-versions.bioformats=0.4.2
+versions.bioformats=0.4.4-SNAPSHOT
 versions.ome-java=2007-Aug-07-r3052
 
 ##

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -921,7 +921,7 @@ product.name=OMERO.server
 #############################################
 
 org.bioformats=idr
-versions.bioformats=0.4.4-SNAPSHOT
+versions.bioformats=0.4.4
 versions.ome-java=2007-Aug-07-r3052
 
 ##

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -920,8 +920,8 @@ product.name=OMERO.server
 ## Library versions
 #############################################
 
-org.bioformats=ome
-versions.bioformats=5.7.3
+org.bioformats=idr
+versions.bioformats=0.4.2
 versions.ome-java=2007-Aug-07-r3052
 
 ##


### PR DESCRIPTION
The simplest path to having a running IDR on OMERO 5.4
is to use the version of Bio-Formats in the current IDR.
Unfortunately, API differences in MetadataOptions require
some hard-coding. This commit may end up being temporary
until we can update the IDR version of Bio-Formats.