### PR TITLE
Insight bug fixes

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -29,11 +29,11 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Map.Entry;
 
 import javax.imageio.ImageIO;
@@ -537,8 +537,9 @@ class OmeroImageServiceImpl
                     .getFacility(BrowseFacility.class).getLookupTables(ctx);
             return OmeroImageServiceImpl.LOOKUP_TABLES;
         } catch (Exception e) {
+            context.getLogger().warn(this, e.getMessage());
         }
-        return null;
+        return Collections.emptyList();
     }
 	
 	/** 
@@ -748,7 +749,9 @@ class OmeroImageServiceImpl
 					exp.getId());
 			proxy = PixelsServicesFactory.resetRenderingControl(context,
 					pixelsID, proxies, def);
-			proxy.setAvailableLookupTables(getLookupTables(ctx));
+			if (proxy != null)
+			    // the RenderingControlProxy can be closed already
+			    proxy.setAvailableLookupTables(getLookupTables(ctx));
 			return proxy;
 		} catch (Exception e) {
 			throw new RenderingServiceException("Cannot restart the " +


### PR DESCRIPTION
# What this PR does

Some bugfixes for Insight.

- If an image has been open for a while ( > 10min) in the image viewer and you try to save modified rendering settings when closing the image viewer an error dialog popped up (but the rendering settings are saved). Reported by @mporter-gre .
- If an image is open in the image viewer and the server is restarted, the rendering engine did not get reloaded, and on every change of the rendering settings (e.g. switch a channel on/off), Insight "thought" it lost connection to the server and tried to reconnect again. This was unfortunately a side effect of #5513 . Reported by @jburel on 5.4.2 release testing ( row 9 https://docs.google.com/spreadsheets/d/1iRCuIDLTA0k7QeZK1xLwSXbYdirUoNIpNXnDLBbdQLE/edit#gid=420881033 ).

I leave this PR open and gradually add some more bugfixes. As Insight is in maintenance mode this will be either critical ones or easy-to-fix ones. 

# Testing this PR

Basically try to replicate the bugs described in above section.


