### PR TITLE
Javagateway bugfixes

### DIFF
--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -1633,11 +1633,20 @@ public class Gateway implements AutoCloseable {
         Connector c = null;
         try {
             ctx.setServerInformation(login.getServer());
-            // client will be cleaned up by connector
-            client client = new client(login.getServer().getHostname(), login
-                    .getServer().getPort());
-            ServiceFactoryPrx prx = client.createSession(login.getUser()
-                    .getUsername(), login.getUser().getPassword());
+
+            client client;
+            ServiceFactoryPrx prx;
+            if (login.getArguments() != null) {
+                List<String> args = login.getArguments();
+                client = new client(
+                        args.toArray(new String[args.size()]));
+                prx = client.createSession();
+            } else {
+                client = new client(login.getServer().getHostname(),
+                        login.getServer().getPort());
+                prx = client.createSession(login.getUser().getUsername(), login
+                        .getUser().getPassword());
+            }
 
             if (ctx.getGroupID() >= 0)
                 prx.setSecurityContext(new ExperimenterGroupI(ctx.getGroupID(),

--- a/components/blitz/src/omero/gateway/rnd/Plane2D.java
+++ b/components/blitz/src/omero/gateway/rnd/Plane2D.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2007 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -112,6 +112,15 @@ public class Plane2D
     }
 
     /**
+     * Returns the pixels values
+     * 
+     * @return See above.
+     */
+    public double[][] getPixelValues() {
+        return copyArray(mappedData);
+    }
+
+    /**
      * Returns the raw data value at the given offset
      *
      * @param offset The offset
@@ -120,5 +129,21 @@ public class Plane2D
     public byte getRawValue(int offset)
     {
         return data.get(offset);
+    }
+    
+    /**
+     * Simply copies a 2-dimensional double array
+     * 
+     * @param src
+     *            The array to copy
+     * @return A copy of the array
+     */
+    private double[][] copyArray(double[][] src) {
+        int length = src.length;
+        double[][] target = new double[length][src[0].length];
+        for (int i = 0; i < length; i++) {
+            System.arraycopy(src[i], 0, target[i], 0, src[i].length);
+        }
+        return target;
     }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -22,13 +22,20 @@ package integration.gateway;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.UUID;
 
 import integration.AbstractServerTest;
 import omero.gateway.Gateway;
 import omero.gateway.JoinSessionCredentials;
 import omero.gateway.LoginCredentials;
+import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSOutOfServiceException;
+import omero.gateway.facility.AdminFacility;
+import omero.gateway.facility.BrowseFacility;
+import omero.gateway.facility.DataManagerFacility;
+import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
+import omero.gateway.model.GroupData;
 import omero.log.SimpleLogger;
 
 import org.testng.Assert;
@@ -176,4 +183,48 @@ public class GatewayUsageTest extends AbstractServerTest
         }
     }
 
+    @Test
+    public void testSwitchGroup() throws DSOutOfServiceException {
+        omero.client client = new omero.client();
+        String[] args = new String[4];
+        args[0] = "--omero.host=" + client.getProperty("omero.host");
+        args[1] = "--omero.port=" + client.getProperty("omero.port");
+        args[2] = "--omero.user=root";
+        args[3] = "--omero.pass=" + client.getProperty("omero.rootpass");
+        LoginCredentials c = new LoginCredentials(args);
+
+        long groupId = -1;
+
+        // Create a new group
+        try (Gateway gw = new Gateway(new SimpleLogger())) {
+            ExperimenterData root = gw.connect(c);
+            SecurityContext rootCtx = new SecurityContext(root.getGroupId());
+            AdminFacility af = gw.getFacility(AdminFacility.class);
+            GroupData g = new GroupData();
+            g.setName(UUID.randomUUID().toString().substring(0, 8));
+            g = af.createGroup(rootCtx, g, root,
+                    GroupData.PERMISSIONS_GROUP_READ);
+            groupId = g.getId();
+        } catch (Exception e1) {
+            Assert.fail("Create group failed.", e1);
+        }
+
+        // do something within the group context
+        try (Gateway gw = new Gateway(new SimpleLogger())) {
+            ExperimenterData root = gw.connect(c);
+
+            // do something with root context...
+            SecurityContext rootCtx = new SecurityContext(root.getGroupId());
+            gw.getFacility(BrowseFacility.class).getDatasets(rootCtx);
+
+            // then switch group
+            SecurityContext groupCtx = new SecurityContext(groupId);
+            DataManagerFacility df = gw.getFacility(DataManagerFacility.class);
+            DatasetData ds = new DatasetData();
+            ds.setName(UUID.randomUUID().toString().substring(0, 8));
+            df.createDataset(groupCtx, ds, null);
+        } catch (Exception e1) {
+            Assert.fail("Create dataset in new group failed.", e1);
+        }
+    }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -205,6 +205,7 @@ public class GatewayUsageTest extends AbstractServerTest
             g = af.createGroup(rootCtx, g, root,
                     GroupData.PERMISSIONS_GROUP_READ);
             groupId = g.getId();
+            Assert.assertTrue(groupId > 0, "Create group failed");
         } catch (Exception e1) {
             Assert.fail("Create group failed.", e1);
         }
@@ -222,7 +223,11 @@ public class GatewayUsageTest extends AbstractServerTest
             DataManagerFacility df = gw.getFacility(DataManagerFacility.class);
             DatasetData ds = new DatasetData();
             ds.setName(UUID.randomUUID().toString().substring(0, 8));
-            df.createDataset(groupCtx, ds, null);
+            ds = df.createDataset(groupCtx, ds, null);
+            Assert.assertTrue(ds.getId() >= 0,
+                    "Dataset in new group was not created");
+            Assert.assertEquals(ds.getGroupId(), groupId,
+                    "Dataset does not belong to new group");
         } catch (Exception e1) {
             Assert.fail("Create dataset in new group failed.", e1);
         }

--- a/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
@@ -174,10 +174,10 @@ public class RawDataFacilityTest extends GatewayTest {
     }
     
     /**
-     * This is basically Byte.toUnsignedInt(byte b) 
-     * in Java >= 8
-     * @param x
-     * @return
+     * This is basically Byte.toUnsignedInt(byte b) in Java >= 8
+     * (TODO: Remove this method when Java 7 support is dropped)
+     * @param x The byte value
+     * @return The byte as unsigned integer value
      */
     private int toUnsignedInt(byte x) {
         return ((int) x) & 0xff;

--- a/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -72,6 +72,26 @@ public class RawDataFacilityTest extends GatewayTest {
             planeData[i] = plane.getRawValue(i);
         
         Assert.assertEquals(planeData, rawData);
+    }
+    
+    @Test
+    public void testGetPixelValues() throws DataSourceException,
+            DSOutOfServiceException, DSAccessException {
+        ImageData img = browseFacility.getImage(rootCtx, imgId);
+        Plane2D plane = rawdataFacility.getPlane(rootCtx,
+                img.getDefaultPixels(), 0, 0, 0);
+        double[][] pixelData = new double[100][100];
+        double[][] expPixelData = new double[100][100];
+        for (int i = 0; i < 10000; i++) {
+            int x = i % 100;
+            int y = i / 100;
+            pixelData[x][y] = plane.getPixelValue(x, y);
+            expPixelData[x][y] = (double) Byte.toUnsignedInt(plane
+                    .getRawValue(y * 100 + x));
+        }
+
+        Assert.assertEquals(pixelData, expPixelData);
+        Assert.assertEquals(plane.getPixelValues(), expPixelData);
     }
     
     @Test

--- a/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
@@ -86,7 +86,7 @@ public class RawDataFacilityTest extends GatewayTest {
             int x = i % 100;
             int y = i / 100;
             pixelData[x][y] = plane.getPixelValue(x, y);
-            expPixelData[x][y] = (double) Byte.toUnsignedInt(plane
+            expPixelData[x][y] = (double) toUnsignedInt(plane
                     .getRawValue(y * 100 + x));
         }
 
@@ -171,5 +171,15 @@ public class RawDataFacilityTest extends GatewayTest {
         }
         store.setPlane(rawData, 0, 0, 0);
         gw.closeService(rootCtx, store);
+    }
+    
+    /**
+     * This is basically Byte.toUnsignedInt(byte b) 
+     * in Java >= 8
+     * @param x
+     * @return
+     */
+    private int toUnsignedInt(byte x) {
+        return ((int) x) & 0xff;
     }
 }


### PR DESCRIPTION
# What this PR does

A bugfix and an RFE for the Java gateway. Would be nice to get it into 5.4.4, if possible?

RFE (first commit): Very simple RFE, but requested a few times: "Why do you have to request each single pixel value from a Plane2D object? I just want the whole thing". The commit simply adds a getter for the pixel values array. /cc @bramalingam 

Bugfix (second commit): When using the `LoginCredentials(String[] args)` constructor it wasn't possible to switch the group (create a connector for a different `SecurityContext`), just noticed that when trying the workflow https://github.com/openmicroscopy/ome-documentation/pull/1844 .



