### PR TITLE
Lucene search

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4420,6 +4420,8 @@ class _BlitzGateway (object):
         :param created:     :class:`omero.rtime` list or tuple (start, stop)
         :param useAcquisitionDate: if True, then use Image.acquisitionDate
                                    rather than import date for queries.
+        :param rawQuery     If True, the text is passed directly to byFullText()
+                            without processing. fields is ignored.
         :return:            List of Object wrappers. E.g. :class:`ImageWrapper`
         """
         if not text:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4410,7 +4410,7 @@ class _BlitzGateway (object):
 
     def searchObjects(self, obj_types, text, created=None, fields=(),
                       batchSize=1000, page=0, searchGroup=None, ownedBy=None,
-                      useAcquisitionDate=False):
+                      useAcquisitionDate=False, rawQuery=True):
         """
         Search objects of type "Project", "Dataset", "Image", "Screen", "Plate"
         Returns a list of results
@@ -4480,10 +4480,14 @@ class _BlitzGateway (object):
             for t in types:
                 def actualSearch():
                     search.onlyType(t().OMERO_CLASS, ctx)
-                    search.byLuceneQueryBuilder(
-                        ",".join(fields),
-                        d_from, d_to, d_type,
-                        text, ctx)
+                    if rawQuery:
+                        # TODO: need to handle dates: d_from, d_to, d_type
+                        search.byFullText(text, ctx)
+                    else:
+                        search.byLuceneQueryBuilder(
+                            ",".join(fields),
+                            d_from, d_to, d_type,
+                            text, ctx)
 
                 timeit(actualSearch)()
                 # get results

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4420,7 +4420,7 @@ class _BlitzGateway (object):
         :param created:     :class:`omero.rtime` list or tuple (start, stop)
         :param useAcquisitionDate: if True, then use Image.acquisitionDate
                                    rather than import date for queries.
-        :param rawQuery     If True, the text is passed directly to byFullText()
+        :param rawQuery     If True, text is passed directly to byFullText()
                             without processing. fields is ignored.
         :return:            List of Object wrappers. E.g. :class:`ImageWrapper`
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4418,10 +4418,11 @@ class _BlitzGateway (object):
         :param obj_types:   E.g. ["Dataset", "Image"]
         :param text:        The text to search for
         :param created:     :class:`omero.rtime` list or tuple (start, stop)
+        :param fields:      Lucene fields e.g. ['name', 'file.contents', 'tag']
         :param useAcquisitionDate: if True, then use Image.acquisitionDate
                                    rather than import date for queries.
         :param rawQuery     If True, text is passed directly to byFullText()
-                            without processing. fields is ignored.
+                            without processing. fields and created are ignored.
         :return:            List of Object wrappers. E.g. :class:`ImageWrapper`
         """
         if not text:
@@ -4483,7 +4484,6 @@ class _BlitzGateway (object):
                 def actualSearch():
                     search.onlyType(t().OMERO_CLASS, ctx)
                     if rawQuery:
-                        # TODO: need to handle dates: d_from, d_to, d_type
                         search.byFullText(text, ctx)
                     else:
                         search.byLuceneQueryBuilder(

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -51,8 +51,9 @@ class BaseSearch(BaseController):
         BaseController.__init__(self, conn)
 
     def search(self, query, onlyTypes, fields, searchGroup, ownedBy,
-               useAcquisitionDate, date=None):
-
+               useAcquisitionDate, date=None, rawQuery=False):
+        # If rawQuery, the raw lucene query is used in search.byFullText()
+        # and fields is ignored.
         # If fields contains 'annotation', we really want to search files too
         # docs.openmicroscopy.org/latest/omero/developers/Modules/Search.html
         fields = set(fields)
@@ -99,7 +100,9 @@ class BaseSearch(BaseController):
                 batchSize=batchSize,
                 searchGroup=searchGroup,
                 ownedBy=ownedBy,
-                useAcquisitionDate=useAcquisitionDate))
+                useAcquisitionDate=useAcquisitionDate,
+                rawQuery=rawQuery),
+                )
             return obj_list
 
         self.containers = {}

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -561,13 +561,13 @@ button::-moz-focus-inner {
 	    }
 	    
 		.standard_form label {
-			width:25%;
+			padding-right: 5px;
 			display:inline-block;
 			color:hsl(210,10%,50%);
 			font-size:1.2em;
 			text-shadow: 0 1px 0 white;
 			vertical-align: top;
-			margin-top: 3px;
+			margin-top: 4px;
 		}
 		
 		.standard_form input, .standard_form select, .standard_form textarea {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -1748,15 +1748,12 @@
 
 .search_panel {
 	position: relative;
-	padding: 0 8px;
-	min-width: 340px;
+	padding: 0;
 }
 
 .search_panel_header {
 	position: relative;
-	width: 100%;
-	height: 33px;
-	padding: 8px 0;
+	padding: 10px 10px 0 10px;
 }
 
 .search_panel_header__text {
@@ -1773,10 +1770,7 @@
 }
 
 .search_panel_header__text--hints {
-	position: absolute;
-	top: 50%;
-	right: 0;
-  	transform: translateY(-50%);
+	float: right;
 }
 
 .search_tips__button {
@@ -1785,6 +1779,36 @@
 
 .search_tips__image {
 	vertical-align: middle;
+}
+
+.search_panel select {
+	max-width: 55%;
+}
+
+#basic_search input.search {
+	width: calc(100% - 65px);
+    float: right;
+}
+
+#basic_search hr {
+	clear: both;
+	margin: 15px 0 10px 0;
+}
+
+#advanced_search input.advanced_search {
+	width: calc(100% - 6px); 	/* padding & border = 6px */
+	margin: 5px 0;
+}
+
+#advanced_search p {
+	margin: 5px 0;
+}
+
+#advanced_search code {
+	background: #fff;
+	margin: 5px 0;
+	padding: 3px;
+	font-size: 110%;
 }
 
 
@@ -1855,9 +1879,8 @@ ul.criteria_right input{
 }
 
 #searching input[type=submit] {
-	float: none;
-	margin-left: 80px;
-	margin-top: 10px;
+	float: right;
+	margin-top: 2px;
 }
     
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -309,8 +309,9 @@
                 </div>
 
                 <div id="advanced_search">
-                    <input type="checkbox" name="advanced" style="visibility: hidden" />
                     <label for="advanced_search">Advanced:</label>
+                    <!-- Checkbox is checked when user switches to Advanced tab -->
+                    <input type="checkbox" name="advanced" style="visibility: hidden" />
                     <input class="advanced_search" name="advanced_search" value="{{ init.query }}" size="35"/>
                     <p>Enter raw search term, for example:</p>
                     <code>name:Control AND tag:"GFP H2B"</code>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -197,7 +197,6 @@
                     return false;
                 });
 
-<<<<<<< HEAD
                 $("#show_annotations").click(function(){
                     $("#search_ann_type").toggleClass("hide");
 
@@ -207,13 +206,14 @@
                     } else {
                         // otherwise, uncheck ALL annotation radio buttons
                         $("#search_ann_type input[type='radio']").prop('checked',false);
-=======
+                    }
+                });
+
                 $("#searching_tabs").tabs({
                     activate: function( event, ui ) {
                         // Checkk hidden checkbox if we're on the 'advanced search' tab
                         // This will be included in search submitted data
                         $('input[name="advanced"]').prop('checked', ui.newPanel.attr('id') === 'advanced_search');
->>>>>>> 86cbbdd34b... UI changes to add an Advanced search tab for Lucene
                     }
                 });
         });

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -211,9 +211,16 @@
 
                 $("#searching_tabs").tabs({
                     activate: function( event, ui ) {
-                        // Checkk hidden checkbox if we're on the 'advanced search' tab
+                        // Check hidden checkbox if we're on the 'advanced search' tab
+                        var advancedSearch = (ui.newPanel.attr('id') === 'advanced_search');
                         // This will be included in search submitted data
-                        $('input[name="advanced"]').prop('checked', ui.newPanel.attr('id') === 'advanced_search');
+                        $('input[name="advanced"]').prop('checked', advancedSearch);
+                        // Date range not supported for search.byFullText()
+                        if (advancedSearch) {
+                            $("#search_dates").hide();
+                        } else {
+                            $("#search_dates").show();
+                        }
                     }
                 });
         });
@@ -304,7 +311,6 @@
                         <li><input type="radio" name="field" value="file">Files</li>
                         <li><input type="radio" name="field" value="tag">Tags</li>
                     </ul>
-                    <hr>
 
                 </div>
 
@@ -389,39 +395,40 @@
 
             <hr>
 
-            <label for="startdateinput">{% trans "Date" %}:</label>
+            <div id="search_dates">
+                <label for="startdateinput">{% trans "Date" %}:</label>
 
-            <select name="useAcquisitionDate" id="useAcquisitionDate">
-                <option value="false" title="Date Imported / Created">Import date</option>
-                <option value="true" title="Date Acquired, for Images only">Acquisition date</option>
-            </select>
+                <select name="useAcquisitionDate" id="useAcquisitionDate">
+                    <option value="false" title="Date Imported / Created">Import date</option>
+                    <option value="true" title="Date Acquired, for Images only">Acquisition date</option>
+                </select>
 
-            <span class="searching_info" data-content="Search by date imported / created or acquired.<br>
-                    Acquisition dates are for Images only.">
-                    <img src="{% static "webgateway/img/help16.png" %}" />
-            </span>
-
-            <br/>
-            <span style="position: relative">
-                <input type="text" id="startdateinput" name="startdateinput" size="12"
-                    value="{{ manager.criteria.period }}" title="Search for data 'From' this date"/>
-                <span class="clearDate">
-                    <img src="{% static "webclient/image/icon_basic_delete.png" %}" />
+                <span class="searching_info" data-content="Search by date imported / created or acquired.<br>
+                        Acquisition dates are for Images only.">
+                        <img src="{% static "webgateway/img/help16.png" %}" />
                 </span>
-            </span>
-            -
-            <span style="position: relative">
-                <input type="text" id="enddateinput" name="enddateinput" value="" size="12"
-                    title="Search for data 'To' this date. Leave blank for 'today'."/>
-                <span class="clearDate">
-                    <img src="{% static "webclient/image/icon_basic_delete.png" %}" />
-                </span>
-            </span>
-            <span id="daterange" data-content="The 'to' date will be today's date if left blank.">
-                    <img src="{% static "webgateway/img/help16.png" %}" />
-            </span>
 
-            <hr>
+                <br/>
+                <span style="position: relative">
+                    <input type="text" id="startdateinput" name="startdateinput" size="12"
+                        value="{{ manager.criteria.period }}" title="Search for data 'From' this date"/>
+                    <span class="clearDate">
+                        <img src="{% static "webclient/image/icon_basic_delete.png" %}" />
+                    </span>
+                </span>
+                -
+                <span style="position: relative">
+                    <input type="text" id="enddateinput" name="enddateinput" value="" size="12"
+                        title="Search for data 'To' this date. Leave blank for 'today'."/>
+                    <span class="clearDate">
+                        <img src="{% static "webclient/image/icon_basic_delete.png" %}" />
+                    </span>
+                </span>
+                <span id="daterange" data-content="The 'to' date will be today's date if left blank.">
+                        <img src="{% static "webgateway/img/help16.png" %}" />
+                </span>
+                <hr>
+            </div>
 
             <input id="search_button" type="submit" value="Search" />
         </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -197,6 +197,7 @@
                     return false;
                 });
 
+<<<<<<< HEAD
                 $("#show_annotations").click(function(){
                     $("#search_ann_type").toggleClass("hide");
 
@@ -206,6 +207,13 @@
                     } else {
                         // otherwise, uncheck ALL annotation radio buttons
                         $("#search_ann_type input[type='radio']").prop('checked',false);
+=======
+                $("#searching_tabs").tabs({
+                    activate: function( event, ui ) {
+                        // Checkk hidden checkbox if we're on the 'advanced search' tab
+                        // This will be included in search submitted data
+                        $('input[name="advanced"]').prop('checked', ui.newPanel.attr('id') === 'advanced_search');
+>>>>>>> 86cbbdd34b... UI changes to add an Advanced search tab for Lucene
                     }
                 });
         });
@@ -226,47 +234,98 @@
 
     <form id="searching_form" class="search_panel standard_form" action="{% url 'load_searching' 'form' %}">
 
-        <div class="search_panel_header">
+        <div id="searching_tabs">
+            <ul id="left_panel_tab_list" class="ui-tabs-nav">
+                <li id="explore_tab" class="ui-state-default">
+                    <a href="#basic_search" class="ui-tabs-anchor" title="Explore">Search</a>
+                </li>
+                <li id="tags_tab" class="ui-state-default">
+                    <a href="#advanced_search" class="ui-tabs-anchor" title="Advanced Search">Advanced</a>
+                </li>
+            </ul>
 
-            <div class="search_panel_header__text" >
 
-                <div class="search_panel_header__text--title">
-                    <!-- h2 style has a bottom margin -->
-                    <h2 style="margin-bottom: 0">{% trans "General Search" %}</h2>
+            <div class="search_panel_header">
+
+                <div id="basic_search">
+                    <div class="search_panel_header__text" >
+
+                        <div class="search_panel_header__text--hints" >
+                            <a id="showSearchHints" class="search_tips__button" href="#">Show search hints</a>
+                            <span class="searching_info" data-content="? Single character wildcard<br>* Multiple character wildcard<br>'AND' Results will contain both terms. E.g: GFP AND H2B">
+                                <img class="search_tips__image" src="{% static "webgateway/img/help16.png" %}"/>
+                            </span>
+                        </div>
+
+                    </div>
+                    <div style="clear: both; height: 10px;"></div>
+                    <!-- Hidden hints box shown when the user clicks to show hints -->
+                    <div id="searchHints" style="display: none">
+                        <ul>
+                            <li> <strong> ? </strong> Single character wildcard</li>
+                            <li> <strong> * </strong> Multiple character wildcard</li>
+                            <li> <strong> AND </strong> Results will contain both terms. E.g: GFP AND H2B</li>
+                        </ul>
+                        <br>
+                        <div>
+                            For more info, see the
+                            <a title="Open link in new Tab" target="new" href="http://help.openmicroscopy.org/search.html">
+                                User Help</a>
+                            pages.
+                        </div>
+                    </div>
+
+
+                    <label for="query">{% trans "Search" %}:</label>
+                    <input class="search" name="query" value="{{ init.query }}" size="35"/>
+                    <hr>
+
+                    <label style="white-space:nowrap;">
+                        Restrict by Field:
+                        <span class="searching_info" data-content="Restrict search to specified fields.<br>If none chosen, we search across all fields">
+                            <img src="{% static "webgateway/img/help16.png" %}" />
+                        </span>
+                    </label>
+
+                    <ul class="criteria">
+                        <li><input type="checkbox" name="field" value="name" />{% trans "Name" %}</li>
+                        <li><input type="checkbox" name="field" value="description" />{% trans "Description" %}</li>
+                        <!-- The Annotations checkbox has no name (not submitted in form). Just shows radio buttons below -->
+                        <li style="white-space:nowrap;">
+                            <input id="show_annotations" type="checkbox" />{% trans "Annotations" %}
+                            <span class="searching_info" data-content="Includes file attachments, tags, comments etc">
+                               <img src="{% static "webgateway/img/help16.png" %}" />
+                            </span>
+                        </li>
+                    </ul>
+
+                    <ul id="search_ann_type" class="criteria criteria_right hide">
+                        <li><input type="radio" name="field" value="annotation">All Annotations</li>
+                        <li><input type="radio" name="field" value="file">Files</li>
+                        <li><input type="radio" name="field" value="tag">Tags</li>
+                    </ul>
+                    <hr>
+
                 </div>
 
-                <div class="search_panel_header__text--hints" >
-                    <a id="showSearchHints" class="search_tips__button" href="#">Show search hints</a>
-                    <span class="searching_info" data-content="? Single character wildcard<br>* Multiple character wildcard<br>'AND' Results will contain both terms. E.g: GFP AND H2B">
-                        <img class="search_tips__image" src="{% static "webgateway/img/help16.png" %}"/>
-                    </span>
+                <div id="advanced_search">
+                    <input type="checkbox" name="advanced" style="visibility: hidden" />
+                    <label for="advanced_search">Advanced:</label>
+                    <input class="advanced_search" name="advanced_search" value="{{ init.query }}" size="35"/>
+                    <p>Enter raw search term, for example:</p>
+                    <code>name:Control AND tag:"GFP H2B"</code>
+                    <p>
+                        See the
+                        <a href="https://docs.openmicroscopy.org/latest/omero/developers/Modules/Search.html">
+                            Search documentation
+                        </a>
+                    </p>
                 </div>
-
             </div>
-
-            <!-- Hidden hints box shown when the user clicks to show hints -->
-            <div id="searchHints" style="display: none">
-                <ul>
-                    <li> <strong> ? </strong> Single character wildcard</li>
-                    <li> <strong> * </strong> Multiple character wildcard</li>
-                    <li> <strong> AND </strong> Results will contain both terms. E.g: GFP AND H2B</li>
-                </ul>
-                <br>
-                <div>
-                    For more info, see the
-                    <a title="Open link in new Tab" target="new" href="http://help.openmicroscopy.org/search.html">
-                        User Help</a>
-                    pages.
-                </div>
-            </div>
-
         </div>
 
         <div style="clear:both"></div>
-
-            <label for="query">{% trans "Search" %}:</label>
-            <input class="search" name="query" value="{{ init.query }}" size="35"/>
-
+        <div style="padding: 0 10px">
             <hr>
 
             <label id="criteria">Search for:</label>
@@ -280,32 +339,6 @@
                 <li><input type="checkbox" name="datatype" value="screens" CHECKED />{% trans "Screens" %}</li>
             </ul>
 
-            <hr>
-
-            <label style="white-space:nowrap;">
-                Restrict by Field:
-                <span class="searching_info" data-content="Restrict search to specified fields.<br>If none chosen, we search across all fields">
-                    <img src="{% static "webgateway/img/help16.png" %}" />
-                </span>
-            </label>
-
-            <ul class="criteria">
-                <li><input type="checkbox" name="field" value="name" />{% trans "Name" %}</li>
-                <li><input type="checkbox" name="field" value="description" />{% trans "Description" %}</li>
-                <!-- The Annotations checkbox has no name (not submitted in form). Just shows radio buttons below -->
-                <li style="white-space:nowrap;">
-                    <input id="show_annotations" type="checkbox" />{% trans "Annotations" %}
-                    <span class="searching_info" data-content="Includes file attachments, tags, comments etc">
-                       <img src="{% static "webgateway/img/help16.png" %}" />
-                    </span>
-                </li>
-            </ul>
-
-            <ul id="search_ann_type" class="criteria criteria_right hide">
-                <li><input type="radio" name="field" value="annotation">All Annotations</li>
-                <li><input type="radio" name="field" value="file">Files</li>
-                <li><input type="radio" name="field" value="tag">Tags</li>
-            </ul>
             <hr>
 
             <label>Scope:</label>
@@ -389,7 +422,8 @@
 
             <hr>
 
-        <input id="search_button" type="submit" value="Search" />
+            <input id="search_button" type="submit" value="Search" />
+        </div>
 
     </form>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1383,6 +1383,10 @@ def load_searching(request, form=None, conn=None, **kwargs):
     r = request.GET
     if form is not None:
         query_search = r.get('query').replace("+", " ")
+        advanced = toBoolean(r.get('advanced'))
+        # If this is an advanced search use 'advanced_search' for query
+        if advanced:
+            query_search = r.get('advanced_search')
         template = "webclient/search/search_details.html"
 
         onlyTypes = r.getlist("datatype")
@@ -1409,7 +1413,7 @@ def load_searching(request, form=None, conn=None, **kwargs):
         # search is carried out and results are stored in
         # manager.containers.images etc.
         manager.search(query_search, onlyTypes, fields, searchGroup, ownedBy,
-                       useAcquisitionDate, date)
+                       useAcquisitionDate, date, rawQuery=advanced)
 
         # if the query is only numbers (separated by commas or spaces)
         # we search for objects by ID


### PR DESCRIPTION
# What this PR does

See https://trello.com/c/ILIGB0vf/117-rfe-search-cross-feature
NB: This isn't currently targeted for OMERO 5.4.4

TODO: Add robot tests

# Testing this PR

1. Search using Advanced tab to input raw lucene queries.
1. Switching between Advanced and regular search by switching tabs (without needing to remove search terms from each input)
1. Other form elements should work as before: Search for Project, Dataset Image etc and filter by Group & Owner.
1. Suggestions to improve the UI? Want to give the user some clue as to what advanced search is and how to use it without having to visit the docs pages. Example query shows:
    - usage of ```AND```
    - Searching by different fields and separation of field:query with colon.
    - Usage of double quotes

![screen shot 2018-02-12 at 15 31 39](https://user-images.githubusercontent.com/900055/36104421-e1e77734-1009-11e8-9693-77b385c7f47d.png)

cc @joshmoore I believe you've been requesting this feature for some time?