### PR TITLE
Handle bot get requests

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -88,7 +88,7 @@ urlpatterns = patterns(
     # load history
     url(r'^load_calendar/(?:(\d{4})/(\d{1,2})/)?$', views.load_calendar,
         name="load_calendar"),
-    url(r'^load_history/(?:(\d{4})/(\d{1,2})/(\d{1,2})/)?$',
+    url(r'^load_history/(\d{4})/(\d{1,2})/(\d{1,2})/$',
         views.load_history, name="load_history"),
 
     # load search

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1396,7 +1396,10 @@ def load_searching(request, form=None, conn=None, **kwargs):
     # form = 'form' if we are searching. Get query from request...
     r = request.GET
     if form is not None:
-        query_search = r.get('query').replace("+", " ")
+        query_search = r.get('query', None)
+        if query_search is None:
+            return HttpResponse("No search '?query' included")
+        query_search = query_search.replace("+", " ")
         template = "webclient/search/search_details.html"
 
         onlyTypes = r.getlist("datatype")

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2563,8 +2563,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
         # Used within the jsTree to add a new Project, Dataset, Tag,
         # Tagset etc under a specified parent OR top-level
         if not request.method == 'POST':
-            return HttpResponseRedirect(reverse("manage_action_containers",
-                                        args=["edit", o_type, o_id]))
+            return JsonResponse({"Error": "Must use POST to create container"})
 
         form = ContainerForm(data=request.POST.copy())
         if form.is_valid():
@@ -2642,7 +2641,7 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
         context = {'manager': manager, 'form': form}
 
     elif action == 'edit':
-        # form for editing an Object. E.g. Project etc. TODO: not used now?
+        # form for editing Shares only
         if o_type == "share" and o_id > 0:
             template = "webclient/public/share_form.html"
             manager.getMembers(o_id)
@@ -2659,12 +2658,6 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
                 initial['expiration'] = \
                     manager.share.getExpireDate().strftime("%Y-%m-%d")
             form = ShareForm(initial=initial)  # 'guests':share.guestsInShare,
-            context = {'manager': manager, 'form': form}
-        elif hasattr(manager, o_type) and o_id > 0:
-            obj = getattr(manager, o_type)
-            template = "webclient/data/container_form.html"
-            form = ContainerForm(
-                initial={'name': obj.name, 'description': obj.description})
             context = {'manager': manager, 'form': form}
     elif action == 'save':
         # Handles submission of the 'edit' form above. TODO: not used now?

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1339,7 +1339,8 @@ def load_chgrp_groups(request, conn=None, **kwargs):
     targetGroupIds = set.intersection(*groupSets)
     # ...but not 'user' group
     userGroupId = conn.getAdminService().getSecurityRoles().userGroupId
-    targetGroupIds.remove(userGroupId)
+    if userGroupId in targetGroupIds:
+        targetGroupIds.remove(userGroupId)
 
     # if all the Objects are in a single group, exclude it from the target
     # groups

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -911,7 +911,8 @@ def api_links(request, conn=None, **kwargs):
     """
     if request.method not in ['POST', 'DELETE']:
         return JsonResponse(
-            {'Error': 'Need to POST or DELETE JSON data to update links'})
+            {'Error': 'Need to POST or DELETE JSON data to update links'},
+            status=405)
     # Handle link creation/deletion
     json_data = json.loads(request.body)
 
@@ -2569,7 +2570,8 @@ def manage_action_containers(request, action, o_type=None, o_id=None,
         # Used within the jsTree to add a new Project, Dataset, Tag,
         # Tagset etc under a specified parent OR top-level
         if not request.method == 'POST':
-            return JsonResponse({"Error": "Must use POST to create container"})
+            return JsonResponse({"Error": "Must use POST to create container"},
+                                status=405)
 
         form = ContainerForm(data=request.POST.copy())
         if form.is_valid():
@@ -4059,7 +4061,8 @@ def chgrp(request, conn=None, **kwargs):
     Adds the callback handle to the request.session['callback']['jobId']
     """
     if not request.method == 'POST':
-        return JsonResponse({'Error': "Need to POST to chgrp"})
+        return JsonResponse({'Error': "Need to POST to chgrp"},
+                            status=405)
     # Get the target group_id
     group_id = getIntOrDefault(request, 'group_id', None)
     if group_id is None:

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -909,6 +909,9 @@ def api_links(request, conn=None, **kwargs):
     We delegate depending on request method to
     create or delete links between objects.
     """
+    if request.method not in ['POST', 'DELETE']:
+        return JsonResponse(
+            {'Error': 'Need to POST or DELETE JSON data to update links'})
     # Handle link creation/deletion
     json_data = json.loads(request.body)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -4055,10 +4055,12 @@ def chgrp(request, conn=None, **kwargs):
     Handles submission of chgrp form: all data in POST.
     Adds the callback handle to the request.session['callback']['jobId']
     """
+    if not request.method == 'POST':
+        return JsonResponse({'Error': "Need to POST to chgrp"})
     # Get the target group_id
     group_id = getIntOrDefault(request, 'group_id', None)
     if group_id is None:
-        raise AttributeError("chgrp: No group_id specified")
+        return JsonResponse({'Error': "chgrp: No group_id specified"})
     group_id = long(group_id)
 
     def getObjectOwnerId(r):


### PR DESCRIPTION
# What this PR does

Handles various GET requests that are not used by webclient but we see errors from bots trying to use these on nightshade.
See https://trello.com/c/FYWseOU8/23-get-webclient-action-addnewcontainer
Now, instead of raising Errors that will be reported we simply return a 'Not supported' response.

# Testing this PR

To test, visit various urls in your browser:

 - /webclient/action/addnewcontainer/
 - /webclient/load_searching/form/
 - /webclient/chgrp/
 - /webclient/load_history/
 - /webclient/api/links/

All should return a suitable message, mostly saying that you need to use ```POST``` instead of ```GET```.