### PR TITLE
filter_search_css_fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -1017,6 +1017,7 @@ button::-moz-focus-inner {
 	/* Filter Search */
 	
     .filtersearch{
+        position: relative;
         margin:4px;
         width:90%;
         height:22px;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -1023,6 +1023,17 @@ button::-moz-focus-inner {
         height:22px;
     }
 
+    .searchresult_filter {
+        position: absolute;
+        top: 1px;
+        left: 5px;
+        width: 180px;
+    }
+
+    .searchresult_filter input {
+    	box-sizing: border-box;
+    	width: 180px;
+    }
   
         .filtersearch input {
             border:solid 1px rgba(0,0,0,.6);

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -401,7 +401,7 @@
 
 	<div id="center_panel_header" >
 		
-		<form class="search filtersearch" id="filtersearch" action="#" style="display:none">
+		<form class="search filtersearch searchresult_filter" id="filtersearch" action="#" style="display:none">
 		    <div>
 		        <label for="id_search">
 		            Filter Results
@@ -412,12 +412,10 @@
 			<span class="loading">
 				<img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
 			</span>
-
-            <ul style="position: relative; left: 180px; width: 300px; top: 7px; font-size:110%">
-                <li id="searchResultCount"></li>
-            </ul>
 		</form>
-		
+		<ul style="position: relative; left: 200px; width: 300px; top: 12px; font-size:110%">
+            <li id="searchResultCount"></li>
+        </ul>
 	</div>
 
 	<div id="content_details" class="center_panel_content"> </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -408,7 +408,6 @@
 		        </label>
 			    <input type="text" id="id_search" size="25" />
 			</div>
-			<input type="submit" value="Go" />
 			<span class="loading">
 				<img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
 			</span>


### PR DESCRIPTION
# What this PR does

Fixes css bug from #5568 which caused the 'Filter Results' placeholder in the Search results page to shift offset.
Bug looks like this:

![screen shot 2018-02-12 at 15 16 29](https://user-images.githubusercontent.com/900055/36103727-12230ed8-1008-11e8-8c54-4e00f25deacd.png)

# Testing this PR

1. Label should be correctly aligned again.


