### PR TITLE
admin fixpyramids

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -931,7 +931,7 @@ present, the user will enter a console""")
         else:
             self.ctx.call(command)
 
-    @admin_only()
+    @admin_only(AdminPrivilegeReadSession)
     @with_config
     def fixpyramids(self, args, config):
         self.check_access()


### PR DESCRIPTION
# What this PR does

Fix bugs found when working on the pyramid fix
Allow users with correct privileges to run command

bug was introduced during the lightadmin work
# Testing this PR

Run as an admin  ``bin/omero admin fixpyramids /OMERO --dry-run``
This should  no longer return an error


 cc @pwalczysko @mtbc 
