### PR TITLE
Provide better error message for the user on version mismatch

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginService.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.login.LoginService
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -216,6 +216,9 @@ public interface LoginService
 	/** Indicates that a failure occurred preventing the client to start.*/
 	public static final int		SYSTEM_FAILURE_INDEX = 105;
 	
+    /** Indicates that the client and server versions are not compatible. */
+    public static final int VERSION_MISMATCH = 106;
+    
     /**
      * Flag to denote the Idle state.
      * While in this state, the Login Service is waiting for a login request.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
@@ -186,7 +186,8 @@ public class LoginServiceImpl
                     if (cause.getCause() instanceof SecurityViolation)
                         failureIndex = ACTIVE_INDEX;
                 }
-                else if (exception.getMessage().contains("is not compatible")) {
+                else if (exception.getMessage() != null
+                        && exception.getMessage().contains("is not compatible")) {
                     failureIndex = VERSION_MISMATCH;
                     failureDetails = exception.getMessage();
                 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.login.LoginServiceImpl
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  * 	This program is free software; you can redistribute it and/or modify
@@ -96,6 +96,9 @@ public class LoginServiceImpl
 
     /** The index set if an error occurred while trying to connect. */
     private int failureIndex;
+    
+    /** The error message */
+    private String failureDetails;
 
     /** Allows to easily access the service's configuration. */
     protected LoginConfig config;
@@ -183,7 +186,12 @@ public class LoginServiceImpl
                     if (cause.getCause() instanceof SecurityViolation)
                         failureIndex = ACTIVE_INDEX;
                 }
-            } else failureIndex = SYSTEM_FAILURE_INDEX;
+                else if (exception.getMessage().contains("is not compatible")) {
+                    failureIndex = VERSION_MISMATCH;
+                    failureDetails = exception.getMessage();
+                }
+            } else
+                failureIndex = SYSTEM_FAILURE_INDEX;
             LogMessage msg = new LogMessage();
             msg.println("Failed to log onto OMERO.");
             msg.println("Reason: "+exception.getMessage());
@@ -306,7 +314,7 @@ public class LoginServiceImpl
             text = "Please check the server address\nor try again later.";
             break;
         case LoginService.CONNECTION_INDEX:
-            text = "Please check the port\nor try again later.";
+            text = "Please check the server address/port\nor try again later.";
             break;
         case LoginService.ACTIVE_INDEX:
             text = "Your user account is no longer active.\nPlease" +
@@ -318,6 +326,25 @@ public class LoginServiceImpl
         case LoginService.SYSTEM_FAILURE_INDEX:
             text = "Error: System Failure.";
             break;
+        case LoginService.VERSION_MISMATCH:
+            String cv = "";
+            try {
+                cv = failureDetails.split("\\s")[2];
+            } catch (Exception e) {
+                // just ignore
+            }
+            String sv = "";
+            try {
+                String[] tmp = failureDetails.split("\\s");
+                sv = tmp[tmp.length - 1];
+                sv = sv.substring(0, sv.lastIndexOf('.'));
+            } catch (Exception e) {
+                // just ignore
+            }
+            text = "OMERO."+getAgent()+" version "+ cv
+                    + " is not compatible with the server version.\n"
+                    + "Please download the latest "+ sv + " OMERO."+ getAgent()+".";
+            break;
         case LoginService.PERMISSION_INDEX:
         default:
             text = "Please check your user name\nand/or password " +
@@ -328,6 +355,23 @@ public class LoginServiceImpl
                 IconManager.getDefaultErrorIcon());
         dialog.pack();  
         UIUtilities.centerAndShow(dialog);
+    }
+
+    /**
+     * Just get the currently used agent name.
+     * 
+     * @return See above
+     */
+    private String getAgent() {
+        int v = (Integer) container.getRegistry().lookup(
+                LookupNames.ENTRY_POINT);
+        if (v == LookupNames.INSIGHT_ENTRY)
+            return "Insight";
+        if (v == LookupNames.IMPORTER_ENTRY)
+            return "Importer";
+        if (v == LookupNames.IMAGE_J)
+            return "ImageJPlugin";
+        return "Client";
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/login/LoginServiceImpl.java
@@ -342,9 +342,9 @@ public class LoginServiceImpl
             } catch (Exception e) {
                 // just ignore
             }
-            text = "OMERO."+getAgent()+" version "+ cv
+            text = getAgent()+" version "+ cv
                     + " is not compatible with the server version.\n"
-                    + "Please download the latest "+ sv + " OMERO."+ getAgent()+".";
+                    + "Please download the latest "+ sv + " "+getAgent()+".";
             break;
         case LoginService.PERMISSION_INDEX:
         default:
@@ -367,11 +367,11 @@ public class LoginServiceImpl
         int v = (Integer) container.getRegistry().lookup(
                 LookupNames.ENTRY_POINT);
         if (v == LookupNames.INSIGHT_ENTRY)
-            return "Insight";
+            return "OMERO.insight";
         if (v == LookupNames.IMPORTER_ENTRY)
-            return "Importer";
+            return "OMERO.importer";
         if (v == LookupNames.IMAGE_J)
-            return "ImageJPlugin";
+            return "OMERO ImageJ plugin";
         return "Client";
     }
 


### PR DESCRIPTION
# What this PR does

With this PR the user gets a better error message, in case he connects with an incompatible client. Before the dialog showed "Check username and password", which is obviously wrong and misleading.

![screen shot 2018-02-14 at 14 57 08](https://user-images.githubusercontent.com/6575139/36211337-df3b034e-1198-11e8-8500-1e9f162ee27b.png)

# Testing this PR

Connect with a incompatible Insight/Importer to a server with a higher or lower version number.

Also check other error conditions (wrong server, port, username/password) and make sure they still show appropriate error messages.

# Related reading

https://trello.com/c/0c3vG5rs/49-insight-failed-login-message

Too late for 5.4.4 @jburel @pwalczysko ?

--

By the way, a very quick and easy method to spin up OMERO.servers with different versions (thanks @sbesson  !): Clone `https://github.com/openmicroscopy/omero-test-infra`, change the `OMERO.version` in `.env`, run `docker-compose up`.