### PR TITLE
full_admin: fix exception on no arguments

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -34,8 +34,6 @@ from omero.cli import NonZeroReturnCode
 from omero.cli import DiagnosticsControl
 from omero.cli import UserGroupControl
 
-from omero.model.enums import AdminPrivilegeReadSession
-
 from omero.plugins.prefs import \
     WriteableConfigControl, with_config
 from omero.install.windows_warning import windows_warning, WINDOWS_WARNING

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -931,7 +931,7 @@ present, the user will enter a console""")
         else:
             self.ctx.call(command)
 
-    @admin_only(AdminPrivilegeReadSession)
+    @admin_only()
     @with_config
     def fixpyramids(self, args, config):
         self.check_access()

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -931,7 +931,7 @@ present, the user will enter a console""")
         else:
             self.ctx.call(command)
 
-    @admin_only()
+    @admin_only(full_admin=True)
     @with_config
     def fixpyramids(self, args, config):
         self.check_access()
@@ -1692,7 +1692,7 @@ present, the user will enter a console""")
                            stdout=sys.stdout, stderr=sys.stderr)
         self.ctx.rv = p.wait()
 
-    @admin_only(AdminPrivilegeReadSession)
+    @admin_only(full_admin=True)
     def cleanse(self, args):
         self.check_access()
         from omero.util.cleanse import cleanse


### PR DESCRIPTION
When no arguments were being passed, an exception was being throw
which trigger an early exit so that even root could not run the
method.

# Testing this PR

1. Without this PR, try `bin/omero admin fixpyramids /OMERO` as root -- **fail**
2. Try `bin/omero admin fixpyramids /OMERO` as root with this PR -- **ok**
3. Try add an admin with all privileges with this PR -- **ok**
4. Try add an admin with even one privilege removed -- **fail**

# Seealso

 * https://github.com/openmicroscopy/openmicroscopy/pull/5657
 * Note: in trying to write tests for this, the fact that this is a local-only plugin reared it's head again. I assume that's why this was not found sooner.