### PR TITLE
Add 5.4.4 version history

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -31,7 +31,7 @@ Sysadmin improvements include:
    Debian 9, Ubuntu 16.04 and CentOS 7
 -  added an admin command and script to allow deletion of corrupted pyramids
    created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
-   then be generated)
+   then be generated - see :doc:`/sysadmins/server-upgrade` for details)
 -  allowed enforcement of a secure connection when importing data
 -  added commands to the CLI sessions plugin to enable the creation and
    removal of user sessions

--- a/history.txt
+++ b/history.txt
@@ -12,7 +12,7 @@ This is a bug-fix release which also introduces some new functionality.
 
 Improvements include:
 
--  images can now be filtered by Tag in the center panel
+-  images can now be filtered by Tag in the center panel of OMERO.web
 -  enabled search by "File" and "Tag" annotations separately, as opposed to
    only being able to search by All annotations
 -  fixed an error when projecting an image with all the channels turned off
@@ -22,7 +22,7 @@ Improvements include:
 Sysadmin improvements include:
 
 -  improved installation documentation for OMERO.web, and OMERO.server on
-   Debian 9 and Centos7
+   Debian 9, Ubuntu 16.04 and Centos7
 -  added an admin command and script to allow deletion of corrupted pyramids
    created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
    then be generated)
@@ -32,6 +32,9 @@ Developer updates include:
 -  improved loading speed of LUT
 -  improved test infrastructure and coverage
 -  allowed filtering by namespace (ns) in webclient, API and annotations
+-  added an example for using "sudo" with the Java gateway to the
+   documentation
+-  documentation is now compatible with Sphinx 1.7
 
 This release does not upgrade the version of Bio-Formats which OMERO uses,
 which remains at 5.7.3.

--- a/history.txt
+++ b/history.txt
@@ -33,7 +33,7 @@ Sysadmin improvements include:
    created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
    then be generated)
 -  allowed enforcement of a secure connection when importing data
--  added commands to the CLI session plugin to enable the creation and
+-  added commands to the CLI sessions plugin to enable the creation and
    removal of user sessions
 
 Developer updates include:

--- a/history.txt
+++ b/history.txt
@@ -17,14 +17,15 @@ Improvements include:
    opposed to only being able to search by All annotations
 -  fixed an error when projecting an image with all the channels turned off
 -  fixed parsing of polygons and polyline ROIs so they can be opened in ImageJ
--  fixed creation of OMERO pyramids for little endian files
+-  fixed creation of OMERO pyramids for little-endian files
 -  improved error message when login fails for OMERO.insight
 -  improved handling of idle connections in OMERO.insight
+-  improved loading speed of LUT
 
 Sysadmin improvements include:
 
 -  improved installation documentation for OMERO.web, and OMERO.server on
-   Debian 9, Ubuntu 16.04 and Centos7
+   Debian 9, Ubuntu 16.04 and CentOS 7
 -  added an admin command and script to allow deletion of corrupted pyramids
    created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
    then be generated)
@@ -32,7 +33,6 @@ Sysadmin improvements include:
 
 Developer updates include:
 
--  improved loading speed of LUT
 -  improved test infrastructure and coverage
 -  allowed filtering by namespace (ns) in webclient, API and annotations
 -  added support for more rendering parameters to the API

--- a/history.txt
+++ b/history.txt
@@ -5,6 +5,37 @@
 OMERO version history
 =====================
 
+5.4.4 (March 2018)
+------------------
+
+This is a bug-fix release which also introduces some new functionality.
+
+Improvements include:
+
+-  images can now be filtered by Tag in the center panel
+-  enabled search by "File" and "Tag" annotations separately, as opposed to
+   only being able to search by All annotations
+-  fixed an error when projecting an image with all the channels turned off
+-  fixed parsing of polygons and polyline ROIs so they can be opened in ImageJ
+-  fixed creation of OMERO pyramids for little endian files
+
+Sysadmin improvements include:
+
+-  improved installation documentation for OMERO.web, and OMERO.server on
+   Debian 9 and Centos7
+-  added an admin command and script to allow deletion of corrupted pyramids
+   created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
+   then be generated)
+
+Developer updates include:
+
+-  improved loading speed of LUT
+-  improved test infrastructure and coverage
+-  allowed filtering by namespace (ns) in webclient, API and annotations
+
+This release does not upgrade the version of Bio-Formats which OMERO uses,
+which remains at 5.7.3.
+
 5.4.3 (January 2018)
 --------------------
 

--- a/history.txt
+++ b/history.txt
@@ -13,11 +13,13 @@ This is a bug-fix release which also introduces some new functionality.
 Improvements include:
 
 -  images can now be filtered by Tag in the center panel of OMERO.web
--  enabled search by "File" and "Tag" annotations separately, as opposed to
-   only being able to search by All annotations
+-  enabled search by "File" and "Tag" annotations separately in OMERO.web, as 
+   opposed to only being able to search by All annotations
 -  fixed an error when projecting an image with all the channels turned off
 -  fixed parsing of polygons and polyline ROIs so they can be opened in ImageJ
 -  fixed creation of OMERO pyramids for little endian files
+-  improved error message when login fails for OMERO.insight
+-  improved handling of idle connections in OMERO.insight
 
 Sysadmin improvements include:
 
@@ -26,14 +28,18 @@ Sysadmin improvements include:
 -  added an admin command and script to allow deletion of corrupted pyramids
    created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
    then be generated)
+-  allowed enforcement of a secure connection when importing data
 
 Developer updates include:
 
 -  improved loading speed of LUT
 -  improved test infrastructure and coverage
 -  allowed filtering by namespace (ns) in webclient, API and annotations
--  added an example for using "sudo" with the Java gateway to the
-   documentation
+-  added support for more rendering parameters to the API
+-  added the option to respect a specific tile size
+-  added a method to load planes using JavaGateway
+-  added an example to the documentation for using "sudo" to create sessions
+   for others with the JavaGateway
 -  documentation is now compatible with Sphinx 1.7
 
 This release does not upgrade the version of Bio-Formats which OMERO uses,

--- a/history.txt
+++ b/history.txt
@@ -15,13 +15,15 @@ Improvements include:
 -  images can now be filtered by Tag in the center panel of OMERO.web
 -  enabled search by "File" and "Tag" annotations separately in OMERO.web, as
    opposed to only being able to search by All annotations
--  fixed the image preview when trying to project an image with all the
-   channels turned off
+-  fixed switching between grid display and thumbnail display in OMERO.web
+-  fixed the image preview and disabled projection in OMERO.insight when
+   trying to project an image with all the channels turned off
 -  fixed parsing of polygons and polyline ROIs so they can be opened in ImageJ
 -  fixed creation of OMERO pyramids for little-endian files
 -  improved error message when login fails for OMERO.insight
 -  improved handling of idle connections in OMERO.insight
 -  improved loading speed of LUT
+-  OMERO.insight and OMERO.importer are now compatible with Java 9
 
 Sysadmin improvements include:
 
@@ -31,6 +33,8 @@ Sysadmin improvements include:
    created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
    then be generated)
 -  allowed enforcement of a secure connection when importing data
+-  added commands to the CLI admin session plugin to enable the creation and
+   removal of user sessions
 
 Developer updates include:
 

--- a/history.txt
+++ b/history.txt
@@ -33,7 +33,7 @@ Sysadmin improvements include:
    created by a bug introduced with OMERO 5.2 (new uncorrupted pyramids can
    then be generated)
 -  allowed enforcement of a secure connection when importing data
--  added commands to the CLI admin session plugin to enable the creation and
+-  added commands to the CLI session plugin to enable the creation and
    removal of user sessions
 
 Developer updates include:

--- a/history.txt
+++ b/history.txt
@@ -10,6 +10,9 @@ OMERO version history
 
 This is a bug-fix release which also introduces some new functionality.
 
+It includes a security fix for :secvuln:`2017-SV6 <>`. **It is highly
+recommended that you upgrade your server**.
+
 Improvements include:
 
 -  images can now be filtered by Tag in the center panel of OMERO.web

--- a/history.txt
+++ b/history.txt
@@ -13,9 +13,10 @@ This is a bug-fix release which also introduces some new functionality.
 Improvements include:
 
 -  images can now be filtered by Tag in the center panel of OMERO.web
--  enabled search by "File" and "Tag" annotations separately in OMERO.web, as 
+-  enabled search by "File" and "Tag" annotations separately in OMERO.web, as
    opposed to only being able to search by All annotations
--  fixed an error when projecting an image with all the channels turned off
+-  fixed the image preview when trying to project an image with all the
+   channels turned off
 -  fixed parsing of polygons and polyline ROIs so they can be opened in ImageJ
 -  fixed creation of OMERO pyramids for little-endian files
 -  improved error message when login fails for OMERO.insight


### PR DESCRIPTION
# What this PR does

Adds the version history for 5.4.4

# Testing this PR

Proofread. To test the rendered content you'll need to manually paste the content into the version history docs page and build it locally - the content will be added to the docs via the autogen build *after* merging.

# Related reading

See https://trello.com/c/0B10cnAO/29-version-history-pr