### PR TITLE
Travis should not use "omero db" positional args

### DIFF
--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -49,7 +49,7 @@ java_test()
 
     # make sure that the current db script has no code-generated
     # foreign key names in it
-    dist/bin/omero db script "" "" ome -f- | grep -LiE "fk[a-z]*[0-9]+[a-z0-9]{5}" && {
+    dist/bin/omero db script --password ome -f- | grep -LiE "fk[a-z]*[0-9]+[a-z0-9]{5}" && {
         echo generated FKs found
         exit 2
     } || {


### PR DESCRIPTION
# What this PR does

Corrects OMERO.cli's `db` subcommand's use of positional arguments which are now deprecated.

# Testing this PR

Travis should be green.

# Related reading

https://github.com/openmicroscopy/openmicroscopy/commit/d818b8a56d3