### PR TITLE
layout button css fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -1019,7 +1019,7 @@ button::-moz-focus-inner {
     .filtersearch{
         position: relative;
         margin:4px;
-        width:90%;
+        width: calc(100% - 100px);
         height:22px;
     }
 


### PR DESCRIPTION
# What this PR does

With the filter search div previously having ```width:90%```, we found that a small browser window would cause it to overlap with the layout buttons, meaning that clicks were ignored.

To test:
 - make your browser window quite small
 - Click layout buttons to switch between list and grid layout.

cc @jburel 