### PR TITLE
Projection

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ProjectionProjectAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/actions/ProjectionProjectAction.java
@@ -63,7 +63,8 @@ public class ProjectionProjectAction
     	if (model.getState() == ImViewer.READY && !model.isBigImage()) {
     		if (model.getSelectedIndex() != ImViewer.PROJECTION_INDEX)
     			setEnabled(false);
-    		else setEnabled(model.canEdit());
+    		else setEnabled(model.canEdit() &&
+    		        model.getActiveChannelsInProjection().size() > 0);
     	} else setEnabled(false);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewer.java
@@ -915,6 +915,13 @@ public interface ImViewer
      */
     public List getActiveChannelsInGrid();
 
+    /**
+     * Returns the list of channels turned on in the <code>ProjectionView</code>.
+     * 
+     * @return See above.
+     */
+    public List getActiveChannelsInProjection();
+
     /** Brings up the preferences widget. */
 	public void showPreferences();
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerComponent.java
@@ -2459,6 +2459,16 @@ class ImViewerComponent
 		return view.getActiveChannelsInGrid();
 	}
 
+    /** 
+     * Implemented as specified by the {@link ImViewer} interface.
+     * @see ImViewer#getActiveChannelsInProjection()
+     */
+    public List getActiveChannelsInProjection()
+    {
+        if (model.getState() == DISCARDED) return null;
+        return view.getActiveChannelsInProjection();
+    }
+    
 	/** 
 	 * Implemented as specified by the {@link ImViewer} interface.
 	 * @see ImViewer#showPreferences()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerUI.java
@@ -1966,7 +1966,17 @@ class ImViewerUI
 	{
 		return controlPane.getActiveChannelsInGrid();
 	}
-	
+
+    /**
+     * Returns the collection of the active channels in the projection view.
+     * 
+     * @return See above.
+     */
+    List getActiveChannelsInProjection()
+    {
+        return controlPane.getActiveChannelsInProjection();
+    }
+
 	/** 
 	 * Adds a new item to the history. 
 	 * 


### PR DESCRIPTION
# What this PR does

Disable the ``Project...`` button when all channels are not active
Noticed by @pwalczysko during the rc review

# Testing this PR

* Open an image with multiple z-section
* Go to the projection tab
* Deselect all active channels
* Check that the ``Project...`` button is disabled
* Select a channel.  Check that the ``Project...`` button is enabled
* Unselect the channel. Save the settings and close the viewer
* Re-open the viewer
* * Go to the projection tab
* Check that the ``Project...`` button is disabled

cc @pwalczysko 
