### PR TITLE
Removing assumed male genders, fixes to spelling

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/rnd/RendererModel.java
@@ -176,7 +176,7 @@ class RendererModel
     /** Map hosting the extra dimension if available.*/
     private Map<Integer, ModuloInfo> modulo;
 
-    /** he alternative rendering settings if any.*/
+    /** The alternative rendering settings if any.*/
     private RndProxyDef def;
 
     /** The data used to create the histogram. */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/LinkNotificationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/LinkNotificationDialog.java
@@ -51,7 +51,7 @@ import omero.gateway.model.ImageData;
 
 
 /**
- * Notifies the user that some images he wants to delete are linked to multiple
+ * Notifies the user that some images they want to delete are linked to multiple
  * DataSets
  * 
  * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/TimeRefObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/TimeRefObject.java
@@ -86,7 +86,7 @@ public class TimeRefObject
 	/**
 	 * Creates a new instance.
 	 * 
-	 * @param userID	he user's id.
+	 * @param userID	The user's id.
 	 * @param index		One of the constants defined by this class. 
 	 */
 	public TimeRefObject(long userID, int index)

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/ui/filechooser/FileChooser.java
@@ -566,7 +566,7 @@ public class FileChooser
      * Adds the passed button to add to the control.
      * 
      * @param button The button to add.
-     * @param location he location of the button.
+     * @param location The location of the button.
      */
     public void addControlButton(JButton button, int location)
     {

--- a/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
+++ b/components/tools/OmeroJava/test/integration/LightAdminRolesTest.java
@@ -1889,7 +1889,7 @@ public class LightAdminRolesTest extends RolesTests {
             String groupPermissions) throws Exception {
         /* isPrivileged translates in this test into ModifyGroupMembership permission, see below.*/
         boolean isExpectSuccessUnsetOwnerOfGroup= isPrivileged;
-        /* Set up the normalUser and make him an Owner by passing "true" in the
+        /* Set up the normalUser and make them an Owner by passing "true" in the
          * newUserAndGroup method argument.*/
         final EventContext normalUser = newUserAndGroup(groupPermissions, true);
         List<String> permissions = new ArrayList<String>();


### PR DESCRIPTION
# What this PR does

Increases inclusivity by removing assumed male genders of users and/or developers.

# Testing this PR
None required, only comments or text output changed. 
