### PR TITLE
Minimal Shape Stats - Masks

### DIFF
--- a/components/blitz/src/omero/model/SmartMaskI.java
+++ b/components/blitz/src/omero/model/SmartMaskI.java
@@ -10,31 +10,39 @@ package omero.model;
 import static omero.rtypes.rdouble;
 
 import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
 import java.util.List;
 import java.util.Random;
 
 public class SmartMaskI extends omero.model.MaskI implements SmartShape {
 
     public void areaPoints(PointCallback cb) {
-        throw new UnsupportedOperationException();
+        Shape s = asAwtShape();
+        if (s == null) {
+            return;
+        }
+        if (transform != null) s = Util.transformAwtShape(s, transform);
+        Rectangle2D r = s.getBounds2D();
+        Util.pointsByBoundingBox(s, r, cb);
     }
-    
+
     public Shape asAwtShape() {
-        throw new UnsupportedOperationException();
+        double[] d = data();
+        if (d == null) {
+            return null;
+        }
+        Rectangle2D.Double rect = new Rectangle2D.Double(d[0], d[1], d[2], d[3]);
+        return rect;
     }
 
     public List<Point> asPoints() {
-        try {
-            double x = getX().getValue();
-            double y = getY().getValue();
-            double w = getWidth().getValue();
-            double h = getHeight().getValue();
-            List<Point> points = Util.points(x, y, w, h);
-            assert Util.checkNonNull(points) : "Null points in " + this;
-            return points;
-        } catch (NullPointerException npe) {
+        double[] d = data();
+        if (d == null) {
             return null;
         }
+        List<Point> points = Util.points(d[0], d[1], d[2], d[3]);
+        assert Util.checkNonNull(points) : "Null points in " + this;
+        return points;
     }
 
     public void randomize(Random random) {
@@ -49,4 +57,15 @@ public class SmartMaskI extends omero.model.MaskI implements SmartShape {
         }
     }
 
+    private double[] data() {
+        try {
+            double x = getX().getValue();
+            double y = getY().getValue();
+            double w = getWidth().getValue();
+            double h = getHeight().getValue();
+            return new double[] { x, y, w, h };
+        } catch (NullPointerException npe) {
+            return null;
+        }
+    }
 }

--- a/components/blitz/src/omero/model/SmartMaskI.java
+++ b/components/blitz/src/omero/model/SmartMaskI.java
@@ -28,7 +28,7 @@ public class SmartMaskI extends omero.model.MaskI implements SmartShape {
 
     public Shape asAwtShape() {
         double[] d = data();
-        if (d == null) {
+        if (d == null || d.length != 4) {
             return null;
         }
         Rectangle2D.Double rect = new Rectangle2D.Double(d[0], d[1], d[2], d[3]);
@@ -37,7 +37,7 @@ public class SmartMaskI extends omero.model.MaskI implements SmartShape {
 
     public List<Point> asPoints() {
         double[] d = data();
-        if (d == null) {
+        if (d == null || d.length != 4) {
             return null;
         }
         List<Point> points = Util.points(d[0], d[1], d[2], d[3]);

--- a/components/tools/OmeroJava/test/integration/RoiServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/RoiServiceTest.java
@@ -39,6 +39,8 @@ import omero.model.IObject;
 import omero.model.Image;
 import omero.model.Line;
 import omero.model.LineI;
+import omero.model.Mask;
+import omero.model.MaskI;
 import omero.model.OriginalFile;
 import omero.model.Plate;
 import omero.model.PlateAnnotationLink;
@@ -465,10 +467,10 @@ public class RoiServiceTest extends AbstractServerTest {
             Assert.assertEquals(shapes.size(), 3);
         }
     }
-    
+
     /**
      * Tests that shape fill and stroke color is stored as RGBA integer.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -506,10 +508,10 @@ public class RoiServiceTest extends AbstractServerTest {
         Assert.assertEquals(shape.getShapeSettings().getStroke(), c);
         Assert.assertEquals(shape.getShapeSettings().getFill(), c);
     }
-    
+
     /**
      * Creates an ROI with 3 rectangluar shapes on the specified plane
-     * 
+     *
      * @param img
      *            The Image the ROI will be linked to
      * @param z
@@ -641,6 +643,17 @@ public class RoiServiceTest extends AbstractServerTest {
         t2.setA12(omero.rtypes.rdouble(0));
         polygon.setTransform(t2);
         roi.addShape(polygon);
+
+        // a mask fully in the FF quandrant
+        final Mask mask = new MaskI();
+        mask.setX(omero.rtypes.rdouble(5));
+        mask.setY(omero.rtypes.rdouble(0));
+        mask.setWidth(omero.rtypes.rdouble(4));
+        mask.setHeight(omero.rtypes.rdouble(4));
+        mask.setTheC(omero.rtypes.rint(0));
+        mask.setTheZ(omero.rtypes.rint(0));
+        mask.setTheT(omero.rtypes.rint(0));
+        roi.addShape(mask);
         roi = (RoiI) iUpdate.saveAndReturnObject(roi);
 
         // add all shape ids to the list to be queried
@@ -689,7 +702,14 @@ public class RoiServiceTest extends AbstractServerTest {
                 new double[] {Byte.MAX_VALUE},
                 new double[] {50*Byte.MAX_VALUE},
                 new double[] {((double) 50*Byte.MAX_VALUE)/100},
-                new double[1])
+                new double[1]),
+            new ShapeStats( // mask in FF
+                    0, new long[] {0}, new long[] {16},
+                    new double[] {Byte.MAX_VALUE},
+                    new double[] {Byte.MAX_VALUE},
+                    new double[] {16*Byte.MAX_VALUE},
+                    new double[] {(double)Byte.MAX_VALUE},
+                    new double[1])
         };
         for (int i=0; i<roi.sizeOfShapes();i++) {
             shapeList.put(


### PR DESCRIPTION
https://github.com/openmicroscopy/openmicroscopy/pull/5465 added functionality to query some intensity stats for shapes.

Masks were forgotten. This PR wants to change that.

TEST: check that the amended integration test is green: https://ci.openmicroscopy.org/view/DEV/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration/RoiServiceTest/