### PR TITLE
Fix searchById thumbnails

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search_details.html
@@ -25,7 +25,10 @@
     <script type="text/javascript">
         $(document).ready(function(){
 
-            var iids = {{ manager.iids|json_dumps|safe }};
+            var iids = [];
+            $(".search_thumb").each(function(){
+                iids.push(this.id);
+            });
             var thumbnailsBatch = {{ thumbnails_batch|default:50|json_dumps|safe }};
 
             OME.load_thumbnails(
@@ -103,7 +106,8 @@
                 <tr id="{{ byId.otype }}-{{ c.id }}" class="{{ c.getPermsCss }}">
                     <td class="image" {% if byId.otype == 'image' %}id="image_icon-{{ c.id }}"{% endif %}>
                         {% if byId.otype == 'image' %}
-                            <img class="search_thumb" id="{{ c.id }}" alt="image" title="{{ c.name }}"/>
+                            <img class="search_thumb" id="{{ c.id }}" alt="image" title="{{ c.name }}"
+                                src="{% static "webgateway/img/spinner.gif" %}" />
                         {% elif byId.otype == 'project' %}
                             <img src="{% static "webgateway/img/folder16.png" %}" alt="{{ byId.otype }}" title="{{ c.name }}"/>
                         {% elif byId.otype == 'dataset' %}
@@ -204,7 +208,8 @@
             {% for c in manager.containers.images %}
                 <tr id="image-{{ c.id }}" class="{{ c.getPermsCss }}">
                     <td class="image" id="image_icon-{{ c.id }}">
-                        <img class="search_thumb" id="{{ c.id }}" alt="image" title="{{ c.name }}"/>
+                        <img class="search_thumb" id="{{ c.id }}" alt="image" title="{{ c.name }}"
+                            src="{% static "webgateway/img/spinner.gif" %}" />
                     </td>
                     <td class="desc"><a>{{ c.name|truncatebefor:"65" }}</a></td>
                     <td class="date">{{ c.getDate|date:"Y-m-d H:i:s" }}</td>


### PR DESCRIPTION
# What this PR does

Fixes https://trello.com/c/tHtsq4DY/4682-missing-searchthumb-omerolifesci-webclient

# Testing this PR

1. Search for specified image by entering Image ID in search field.

1. Check that the image thumbnail is displayed correctly in search results.

1. NB: Other minor fix is that for all images in search results, we show a spinner while waiting for thumbnails to load, instead of 'broken image' placeholder.
