### PR TITLE
Fix CLI list subcommand

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -297,7 +297,8 @@ class PrefsControl(WriteableConfigControl):
             if args.KEY and len(args.KEY) == 1:
                 self.ctx.out(config[k])
             else:
-                if is_password(k) and not args.show_password:
+                if is_password(k) and not getattr(
+                        args, "show_password", False):
                     self.ctx.out("%s=%s" % (k, '*' * 8 if config[k] else ''))
                 else:
                     self.ctx.out("%s=%s" % (k, config[k]))

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -150,12 +150,15 @@ class PrefsControl(WriteableConfigControl):
         get.add_argument(
             "KEY", nargs="*", help="Names of keys in the current profile")
 
-        secrets = get.add_mutually_exclusive_group()
-        secrets.add_argument("--show-password", action="store_true",
-                             help="Show values of sensitive keys (passwords, "
-                                  "tokens, etc.) in the current profile")
-        secrets.add_argument("--hide-password", action="store_false",
-                             dest="show_password", help=SUPPRESS)
+        for x in [get, list]:
+            secrets = x.add_mutually_exclusive_group()
+            secrets.add_argument(
+                "--show-password", action="store_true",
+                help="Show values of sensitive keys (passwords, "
+                "tokens, etc.) in the current profile")
+            secrets.add_argument(
+                "--hide-password", action="store_false",
+                dest="show_password", help=SUPPRESS)
 
         set = parser.add(
             sub, self.set,

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -106,11 +106,7 @@ class TestPrefs(object):
             "omero.Z.mypassword": "",
             "omero.Z.pass": "",
             "omero.Z.password": ""}
-
-        for k, v in config.iteritems():
-            self.cli.invoke(self.args + ["set", k, v], strict=True)
-        self.invoke("get")
-        self.assertStdoutStderr(capsys, out=(
+        output_hidden_password = (
             'omero.X.mypassword=********\n'
             'omero.X.pass=********\n'
             'omero.X.password=********\n'
@@ -120,9 +116,8 @@ class TestPrefs(object):
             'omero.Y.Password=********\n'
             'omero.Z.mypassword=\n'
             'omero.Z.pass=\n'
-            'omero.Z.password='))
-        self.invoke("get --show-password")
-        self.assertStdoutStderr(capsys, out=(
+            'omero.Z.password=')
+        output_with_password = (
             'omero.X.mypassword=long_password\n'
             'omero.X.pass=shortpass\n'
             'omero.X.password=medium_password\n'
@@ -132,19 +127,18 @@ class TestPrefs(object):
             'omero.Y.Password=medium_password\n'
             'omero.Z.mypassword=\n'
             'omero.Z.pass=\n'
-            'omero.Z.password='))
+            'omero.Z.password=')
+
+        for k, v in config.iteritems():
+            self.cli.invoke(self.args + ["set", k, v], strict=True)
+        self.invoke("get")
+        self.assertStdoutStderr(capsys, out=output_hidden_password)
+        self.invoke("get --show-password")
+        self.assertStdoutStderr(capsys, out=output_with_password)
         self.invoke("list")
-        self.assertStdoutStderr(capsys, out=(
-            'omero.X.mypassword=********\n'
-            'omero.X.pass=********\n'
-            'omero.X.password=********\n'
-            'omero.X.regular=value\n'
-            'omero.Y.MyPassword=********\n'
-            'omero.Y.Pass=********\n'
-            'omero.Y.Password=********\n'
-            'omero.Z.mypassword=\n'
-            'omero.Z.pass=\n'
-            'omero.Z.password='))
+        self.assertStdoutStderr(capsys, out=output_hidden_password)
+        self.invoke("list --show-password")
+        self.assertStdoutStderr(capsys, out=output_with_password)
 
     @pytest.mark.parametrize('argument', ['A=B', 'A= B'])
     def testSetFails(self, capsys, argument):

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -133,6 +133,18 @@ class TestPrefs(object):
             'omero.Z.mypassword=\n'
             'omero.Z.pass=\n'
             'omero.Z.password='))
+        self.invoke("list")
+        self.assertStdoutStderr(capsys, out=(
+            'omero.X.mypassword=********\n'
+            'omero.X.pass=********\n'
+            'omero.X.password=********\n'
+            'omero.X.regular=value\n'
+            'omero.Y.MyPassword=********\n'
+            'omero.Y.Pass=********\n'
+            'omero.Y.Password=********\n'
+            'omero.Z.mypassword=\n'
+            'omero.Z.pass=\n'
+            'omero.Z.password='))
 
     @pytest.mark.parametrize('argument', ['A=B', 'A= B'])
     def testSetFails(self, capsys, argument):


### PR DESCRIPTION
## Description

This PR addresses a  bug in the CLI config command reported in http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2018-March/004159.html

## Testing

Without this PR e.g. using OMERO.py 5.4.4, `bin/omero config list` should fail with the exception reported in the email thread.

With the PR included, the command should return the same output as `bin/omero config get`. 

## Changes summary

cf9a1e6 extends the unit test to cover this subcommand (fails without the fix and passes with it).
7ab9620 allows any code to call `PrefsControl.get(args, control)` without requiring the password arguments (hiding password as the default)
233a2db implements the same password options in `bin/omero config list` as for `bin/omero config get`
