### PR TITLE
fix Trac URLs in comments

### DIFF
--- a/components/blitz/src/ome/services/blitz/impl/AbstractCloseableAmdServant.java
+++ b/components/blitz/src/ome/services/blitz/impl/AbstractCloseableAmdServant.java
@@ -75,7 +75,7 @@ public abstract class AbstractCloseableAmdServant extends AbstractAmdServant
      * it is possible to raise the message and have the servant
      * cleaned up.
      * 
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1855">ticket:1855</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1855">ticket:1855</a>
      */
     public final void close_async(AMD_StatefulServiceInterface_close __cb,
             Ice.Current __current) {

--- a/components/blitz/src/ome/services/blitz/util/ApiConsistencyCheck.java
+++ b/components/blitz/src/ome/services/blitz/util/ApiConsistencyCheck.java
@@ -49,7 +49,7 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
  * 
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0-Beta3
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/894">ticket:894</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/894">ticket:894</a>
  */
 public class ApiConsistencyCheck implements BeanPostProcessor {
 

--- a/components/blitz/src/ome/services/blitz/util/RegisterServantMessage.java
+++ b/components/blitz/src/ome/services/blitz/util/RegisterServantMessage.java
@@ -18,7 +18,7 @@ import ome.util.messages.InternalMessage;
  * the creation of another servant from SharedResourcesI.
  *
  * @author Josh Moore, josh at glencoesoftware.com
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/2253">ticket:2253</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/2253">ticket:2253</a>
  */
 public class RegisterServantMessage extends FindServiceFactoryMessage {
 

--- a/components/blitz/src/omero/model/PermissionsI.java
+++ b/components/blitz/src/omero/model/PermissionsI.java
@@ -23,7 +23,7 @@ import Ice.Object;
  * link below), but should not be used by clients.
  *
  * @author Josh Moore, josh at glencoesoftware.com
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/685">ticket:685</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/685">ticket:685</a>
  * @see <a href="http://www.zeroc.com/forums/showthread.php?t=3084">ZeroC Thread
  *      3084</a>
  *

--- a/components/blitz/src/omero/util/TempFileManager.java
+++ b/components/blitz/src/omero/util/TempFileManager.java
@@ -203,7 +203,7 @@ public class TempFileManager {
      * <li>inability to lock</li>
      * </ul>
      *
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1653">ticket:1653</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1653">ticket:1653</a>
      */
     protected File tmpdir() {
 

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -20,7 +20,7 @@
     etc. used within OMERO. These values may be pulled from the environment,
     the Java runtime, your Java preferences, or from configuration files.
 
-    See https://trac.openmicroscopy.org.uk/ome/ticket/800 for more information
+    See https://trac.openmicroscopy.org/ome/ticket/800 for more information
     on how this works.
     </description>
 

--- a/components/common/src/ome/annotations/Hidden.java
+++ b/components/common/src/ome/annotations/Hidden.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  * 
  * @author Josh Moore, josh.moore at gmx.de
  * @since 3.0-M3
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/209">ticket:209</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/209">ticket:209</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)

--- a/components/common/src/ome/api/IAdmin.java
+++ b/components/common/src/ome/api/IAdmin.java
@@ -378,7 +378,7 @@ public interface IAdmin extends ServiceInterface {
      * 
      * @param group  a new {@link ExperimenterGroup} instance. Not null.
      * @return id of the newly created {@link ExperimenterGroup}
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1434">ticket:1434"</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1434">ticket:1434"</a>
      */
     long createGroup(ExperimenterGroup group);
 
@@ -601,8 +601,8 @@ public interface IAdmin extends ServiceInterface {
      *            Possibly null to allow logging in with no password.
      * @throws ome.conditions.SecurityViolation
      *             if the user is not authenticated with a password.
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/911">ticket:911</a>
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/3201">ticket:3201</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/911">ticket:911</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/3201">ticket:3201</a>
      */
     void changePassword(@Hidden
     String newPassword);

--- a/components/common/src/ome/api/RawFileStore.java
+++ b/components/common/src/ome/api/RawFileStore.java
@@ -80,8 +80,8 @@ public interface RawFileStore extends StatefulServiceInterface {
      * If save has not been called, {@link RawFileStore} instances will save the
      * {@link OriginalFile} object associated with it on {@link #close()}.
      *
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1651>1651</a>
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/2161>2161</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1651>1651</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/2161>2161</a>
      */
     public OriginalFile save();
 }

--- a/components/common/src/ome/system/Preference.java
+++ b/components/common/src/ome/system/Preference.java
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
  * 
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.0
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/800">#800</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/800">#800</a>
  */
 public class Preference implements BeanNameAware {
 

--- a/components/common/src/ome/system/PreferenceContext.java
+++ b/components/common/src/ome/system/PreferenceContext.java
@@ -42,7 +42,7 @@ import com.google.common.collect.MapMaker;
  * 
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0-Beta3
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/800">#800</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/800">#800</a>
  */
 public class PreferenceContext extends PropertyPlaceholderConfigurer {
 

--- a/components/model/src/ome/model/internal/Permissions.java
+++ b/components/model/src/ome/model/internal/Permissions.java
@@ -46,7 +46,7 @@ import ome.conditions.ApiUsageException;
  * </p>
  * 
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/180">ticket:180</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/180">ticket:180</a>
  */
 public class Permissions implements Serializable {
 
@@ -676,7 +676,7 @@ public class Permissions implements Serializable {
      * the same bit representation.
      * 
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/291">ticket:291</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/291">ticket:291</a>
      */
     // @Override
     public boolean identical(Permissions p) {
@@ -1006,7 +1006,7 @@ public class Permissions implements Serializable {
      * an immutable {@link Permissions} instance with permissions only for the
      * object owner.. Identical to {@link #USER_PRIVATE}.
      *
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1434">ticket:1434</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1434">ticket:1434</a>
      */
     public final static Permissions PRIVATE = USER_PRIVATE;
 
@@ -1015,8 +1015,8 @@ public class Permissions implements Serializable {
      * members to read other members' data. Identical to
      * {@link #GROUP_READABLE}.
      *
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1434">ticket:1434</a>
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1992">ticket:1992</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1434">ticket:1434</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1992">ticket:1992</a>
      */
     public final static Permissions COLLAB_READONLY = GROUP_READABLE;
 
@@ -1024,8 +1024,8 @@ public class Permissions implements Serializable {
      * an immutable {@link Permissions} instance with read and write permissions
      * for group members. Identical to {@link #GROUP_PRIVATE}.
      *
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1434">ticket:1434</a>
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1992">ticket:1992</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1434">ticket:1434</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1992">ticket:1992</a>
      */
     public final static Permissions COLLAB_READLINK = GROUP_PRIVATE;
 

--- a/components/model/src/ome/util/SqlAction.java
+++ b/components/model/src/ome/util/SqlAction.java
@@ -54,8 +54,8 @@ import com.google.common.collect.Lists;
  *
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.2.1
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/73">#73</a>
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/2684">#2684</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/73">#73</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/2684">#2684</a>
  */
 public interface SqlAction {
 

--- a/components/model/test/ome/model/utests/PermissionsTest.java
+++ b/components/model/test/ome/model/utests/PermissionsTest.java
@@ -183,7 +183,7 @@ public class PermissionsTest {
 
     // ~ Equals && HashCode
     // =========================================================================
-    // see https://trac.openmicroscopy.org.uk/ome/ticket/291
+    // see https://trac.openmicroscopy.org/ome/ticket/291
 
     @Test(groups = "ticket:291")
     public void testEquals() throws Exception {

--- a/components/romio/test/ome/io/nio/utests/PathUtil.java
+++ b/components/romio/test/ome/io/nio/utests/PathUtil.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * Any other attempt to acquire the omero.data.dir directly may cause issues in
  * non-standard environments.
  * 
- * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/800">ticket:800</a>
+ * @see <a href="https://trac.openmicroscopy.org/ome/ticket/800">ticket:800</a>
  */
 class PathUtil {
 

--- a/components/server/src/ome/logic/AdminImpl.java
+++ b/components/server/src/ome/logic/AdminImpl.java
@@ -1072,9 +1072,9 @@ public class AdminImpl extends AbstractLevel2Service implements LocalAdmin,
      *
      * @see IAdmin#changePermissions(IObject, Permissions)
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/293">ticket:293</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/293">ticket:293</a>
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/1434">ticket:1434</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/1434">ticket:1434</a>
      */
     @RolesAllowed("user")
     @Transactional(readOnly = false)

--- a/components/server/src/ome/logic/ConfigImpl.java
+++ b/components/server/src/ome/logic/ConfigImpl.java
@@ -93,7 +93,7 @@ public class ConfigImpl extends AbstractLevel2Service implements LocalConfig {
      * serializable themselves, or be set to null before serialization. Here
      * we've marked the jdbc field as transient out of habit.
      * 
-     * @see https://trac.openmicroscopy.org.uk/ome/ticket/173
+     * @see https://trac.openmicroscopy.org/ome/ticket/173
      */
     private transient SqlAction sql;
 

--- a/components/server/src/ome/security/SecurityFilter.java
+++ b/components/server/src/ome/security/SecurityFilter.java
@@ -22,11 +22,11 @@ import ome.system.EventContext;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 4.4
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/117">ticket117</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/117">ticket117</a>
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/1154">ticket1154</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/1154">ticket1154</a>
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/3529">ticket3529</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/3529">ticket3529</a>
  */
 public interface SecurityFilter {
 

--- a/components/server/src/ome/security/SecuritySystem.java
+++ b/components/server/src/ome/security/SecuritySystem.java
@@ -238,11 +238,11 @@ public interface SecuritySystem {
      * a {@link ExperimenterGroup} value, then throw as well.
      *
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/1434>1434</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/1434>1434</a>
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/1769>1769</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/1769>1769</a>
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/9474>9474</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/9474>9474</a>
      * @param details the details
      * @return if the graph is critical
      */

--- a/components/server/src/ome/security/SystemTypes.java
+++ b/components/server/src/ome/security/SystemTypes.java
@@ -43,7 +43,7 @@ public class SystemTypes {
      * classes which cannot be created by regular users.
      * 
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/156">ticket156</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/156">ticket156</a>
      */
     public boolean isSystemType(Class<?> klass) {
 

--- a/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
+++ b/components/server/src/ome/security/basic/AllGroupsSecurityFilter.java
@@ -48,9 +48,9 @@ import org.springframework.orm.hibernate3.FilterDefinitionFactoryBean;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/117">ticket117</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/117">ticket117</a>
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/1154">ticket1154</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/1154">ticket1154</a>
  */
 public class AllGroupsSecurityFilter extends AbstractSecurityFilter {
 

--- a/components/server/src/ome/security/basic/BasicSecuritySystem.java
+++ b/components/server/src/ome/security/basic/BasicSecuritySystem.java
@@ -203,7 +203,7 @@ public class BasicSecuritySystem implements SecuritySystem,
      * classes which cannot be created by regular users.
      * 
      * @see <a
-     *      href="https://trac.openmicroscopy.org.uk/ome/ticket/156">ticket156</a>
+     *      href="https://trac.openmicroscopy.org/ome/ticket/156">ticket156</a>
      */
     public boolean isSystemType(Class<? extends IObject> klass) {
         return sysTypes.isSystemType(klass);

--- a/components/server/src/ome/security/basic/CurrentDetails.java
+++ b/components/server/src/ome/security/basic/CurrentDetails.java
@@ -426,7 +426,7 @@ public class CurrentDetails implements PrincipalHolder {
      * group as well as the user's umask.
      *
      * @return details for the current security context
-     * @see <a href="https://trac.openmicroscopy.org.uk/trac/omero/ticket:1434">ticket:1434</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1434">ticket:1434</a>
      */
     public Details createDetails() {
         final BasicEventContext c = current();

--- a/components/server/src/ome/security/basic/OmeroInterceptor.java
+++ b/components/server/src/ome/security/basic/OmeroInterceptor.java
@@ -1153,7 +1153,7 @@ public class OmeroInterceptor implements Interceptor {
             }
             // otherwise throw an exception, because as seen in ticket:346,
             // it can lead to confusion otherwise. See:
-            // https://trac.openmicroscopy.org.uk/ome/ticket/346
+            // https://trac.openmicroscopy.org/ome/ticket/346
             else {
 
                 // no one change them.
@@ -1187,7 +1187,7 @@ public class OmeroInterceptor implements Interceptor {
             }
             // otherwise throw an exception, because as seen in ticket:346,
             // it can lead to confusion otherwise. See:
-            // https://trac.openmicroscopy.org.uk/ome/ticket/346
+            // https://trac.openmicroscopy.org/ome/ticket/346
             else {
 
                 // no one change them, but this is less likely intentional

--- a/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
+++ b/components/server/src/ome/security/basic/OneGroupSecurityFilter.java
@@ -37,9 +37,9 @@ import ome.system.Roles;
  * @author Josh Moore, josh at glencoesoftware.com
  * @since 3.0
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/117">ticket117</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/117">ticket117</a>
  * @see <a
- *      href="https://trac.openmicroscopy.org.uk/ome/ticket/1154">ticket1154</a>
+ *      href="https://trac.openmicroscopy.org/ome/ticket/1154">ticket1154</a>
  */
 public class OneGroupSecurityFilter extends AbstractSecurityFilter {
 

--- a/components/server/src/ome/services/delete/DeleteBean.java
+++ b/components/server/src/ome/services/delete/DeleteBean.java
@@ -519,7 +519,7 @@ public class DeleteBean extends AbstractLevel2Service implements IDelete {
 
     /**
      * Uses bulk update
-     * @see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/1654">ticket:1654</a>
+     * @see <a href="https://trac.openmicroscopy.org/ome/ticket/1654">ticket:1654</a>
      */
     private void clearRois(Session session, Image i) {
 

--- a/components/server/src/ome/services/query/PojosGetImagesQueryDefinition.java
+++ b/components/server/src/ome/services/query/PojosGetImagesQueryDefinition.java
@@ -56,7 +56,7 @@ public class PojosGetImagesQueryDefinition extends AbstractClassIdsOptionsQuery 
 	        qb.join("objective.correction", "co", true, true);
         }
         
-        // see https://trac.openmicroscopy.org.uk/ome/ticket/296
+        // see https://trac.openmicroscopy.org/ome/ticket/296
         if (Image.class.isAssignableFrom(klass)) {
             qb.where();
             qb.and("img.id in (:ids)");

--- a/components/server/test/ome/server/itests/ImmutabilityTest.java
+++ b/components/server/test/ome/server/itests/ImmutabilityTest.java
@@ -38,7 +38,7 @@ public class ImmutabilityTest extends AbstractManagedContextTest {
         i.getDetails().setCreationEvent(newEvent);
 
         // This fails because it gets silently copied to our new instance. See:
-        // https://trac.openmicroscopy.org.uk/ome/ticket/346
+        // https://trac.openmicroscopy.org/ome/ticket/346
         // i = iUpdate.saveAndReturnObject(i);
         // assertEquals( i.getDetails().getCreationEvent().getId(),
         // oldEvent.getId());

--- a/components/server/test/ome/server/itests/hibernate/ExtendedMetadataTest.java
+++ b/components/server/test/ome/server/itests/hibernate/ExtendedMetadataTest.java
@@ -113,7 +113,7 @@ public class ExtendedMetadataTest extends AbstractManagedContextTest {
 
     @Test(groups = "ticket:357")
     // quirky because of defaultTag
-    // see https://trac.openmicroscopy.org.uk/ome/ticket/357
+    // see https://trac.openmicroscopy.org/ome/ticket/357
     public void testPixelsLocksImage() throws Exception {
         Pixels p = ObjectFactory.createPixelGraph(null);
         Image i = new Image();
@@ -162,7 +162,7 @@ public class ExtendedMetadataTest extends AbstractManagedContextTest {
 
     @Test(groups = "ticket:357")
     // quirky because of defaultTag
-    // see https://trac.openmicroscopy.org.uk/ome/ticket/357
+    // see https://trac.openmicroscopy.org/ome/ticket/357
     public void testImageCanBeUnlockedFromPixels() throws Exception {
         assertContains(metadata.getLockChecks(Image.class), Pixels.class
                 .getName(), "image");

--- a/components/server/test/ome/server/itests/update/UpdateTest.java
+++ b/components/server/test/ome/server/itests/update/UpdateTest.java
@@ -173,8 +173,8 @@ public class UpdateTest extends AbstractUpdateTest {
 
         // The instances must be unloaded to prevent spurious deletes!
         // Need versions. See:
-        // https://trac.openmicroscopy.org.uk/ome/ticket/118
-        // https://trac.openmicroscopy.org.uk/ome/ticket/346
+        // https://trac.openmicroscopy.org/ome/ticket/118
+        // https://trac.openmicroscopy.org/ome/ticket/346
         e = iUpdate.saveAndReturnObject(e);
         g_1 = iUpdate.saveAndReturnObject(g_1);
         g_2 = iUpdate.saveAndReturnObject(g_2);
@@ -213,8 +213,8 @@ public class UpdateTest extends AbstractUpdateTest {
 
         // The instances must be unloaded to prevent spurious deletes!
         // Need versions. See:
-        // https://trac.openmicroscopy.org.uk/ome/ticket/118
-        // https://trac.openmicroscopy.org.uk/ome/ticket/346
+        // https://trac.openmicroscopy.org/ome/ticket/118
+        // https://trac.openmicroscopy.org/ome/ticket/346
 
         img.setName("j.b." + System.currentTimeMillis());
         img = iUpdate.saveAndReturnObject(img);

--- a/components/tests/ui/library/java/src/org/openmicroscopy/shoola/keywords/JTreeLibrary.java
+++ b/components/tests/ui/library/java/src/org/openmicroscopy/shoola/keywords/JTreeLibrary.java
@@ -352,7 +352,7 @@ public class JTreeLibrary
 
     /**
      * Test if the tree node popup menu item is enabled.
-     * (For motivation, see <a href="https://trac.openmicroscopy.org.uk/ome/ticket/11326">trac #11326</a>.)
+     * (For motivation, see <a href="https://trac.openmicroscopy.org/ome/ticket/11326">trac #11326</a>.)
      * This initial version detects only first-level menu items, not paths to submenus.
      * @param menuItemPath the path of the menu item
      * @param treePath the path to the node whose popup is to be queried

--- a/components/tools/OmeroCpp/test/integration/search.cpp
+++ b/components/tools/OmeroCpp/test/integration/search.cpp
@@ -1874,7 +1874,7 @@ TEST(SearchTest, DISABLED_testCommentAnnotationDoesntTryToLoadUpdateEvent) {
 // =========================================================================
 
 // Test failing due to OMERO server bug
-// https://trac.openmicroscopy.org.uk/ome/ticket/10408
+// https://trac.openmicroscopy.org/ome/ticket/10408
 TEST(SearchTest, DISABLED_testExperimenterDoesntTryToLoadOwner) {
     SearchFixture f;
     SearchPrx search = f.search();
@@ -1884,7 +1884,7 @@ TEST(SearchTest, DISABLED_testExperimenterDoesntTryToLoadOwner) {
 }
 
 // Test failing due to OMERO server bug
-// https://trac.openmicroscopy.org.uk/ome/ticket/10408
+// https://trac.openmicroscopy.org/ome/ticket/10408
 TEST(SearchTest, DISABLED_testLookingForExperimenterWithOwner) {
     SearchFixture f;
     SearchPrx search = f.search();

--- a/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
@@ -114,7 +114,7 @@ public class HierarchyDeleteTest extends AbstractServerTest {
         ds2.linkImage(i1);
         ds2 = (Dataset) iUpdate.saveAndReturnObject(ds2);
 
-        // https://trac.openmicroscopy.org.uk/ome/ticket/3031#comment:7
+        // https://trac.openmicroscopy.org/ome/ticket/3031#comment:7
         // This image is only singly linked and should be removed.
 
         Image i2 = (Image) iUpdate.saveAndReturnObject(mmFactory.createImage());

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -224,7 +224,7 @@ class ConfigXml(object):
         immediately do the upgrade.
         """
         if version == "4.2.0":
-            # https://trac.openmicroscopy.org.uk/ome/ticket/2613
+            # https://trac.openmicroscopy.org/ome/ticket/2613
             # Remove any reference to the ${omero.dollar} workaround
             # then map anything of the form: ${...} to @{...}
             if props:

--- a/components/tools/OmeroPy/src/omero/hdfstorageV1.py
+++ b/components/tools/OmeroPy/src/omero/hdfstorageV1.py
@@ -92,7 +92,7 @@ class HdfList(object):
 
     This also holds a global lock for all HDF5 calls since libhdf5 is usually
     compiled without --enable-threadsafe, see
-    https://trac.openmicroscopy.org.uk/ome/ticket/10464
+    https://trac.openmicroscopy.org/ome/ticket/10464
     """
 
     def __init__(self):
@@ -431,7 +431,7 @@ class HdfStorage(object):
                 # Metadata methods were generally broken for v1 tables so
                 # the introduction of internal metadata attributes is unlikely
                 # to affect anyone.
-                # https://trac.openmicroscopy.org.uk/ome/ticket/12606
+                # https://trac.openmicroscopy.org/ome/ticket/12606
                 msg = 'Tables metadata is only supported for OMERO.tables >= 2'
                 self.logger.error(msg)
                 raise omero.ApiUsageException(None, None, msg)

--- a/components/tools/OmeroPy/src/omero/hdfstorageV2.py
+++ b/components/tools/OmeroPy/src/omero/hdfstorageV2.py
@@ -92,7 +92,7 @@ class HdfList(object):
 
     This also holds a global lock for all HDF5 calls since libhdf5 is usually
     compiled without --enable-threadsafe, see
-    https://trac.openmicroscopy.org.uk/ome/ticket/10464
+    https://trac.openmicroscopy.org/ome/ticket/10464
     """
 
     def __init__(self):
@@ -449,7 +449,7 @@ class HdfStorage(object):
                 # Metadata methods were generally broken for v1 tables so
                 # the introduction of internal metadata attributes is unlikely
                 # to affect anyone.
-                # https://trac.openmicroscopy.org.uk/ome/ticket/12606
+                # https://trac.openmicroscopy.org/ome/ticket/12606
                 msg = 'Tables metadata is only supported for OMERO.tables >= 2'
                 self.logger.error(msg)
                 raise omero.ApiUsageException(None, None, msg)

--- a/components/tools/OmeroPy/src/omero/util/temp_files.py
+++ b/components/tools/OmeroPy/src/omero/util/temp_files.py
@@ -127,7 +127,7 @@ class TempFileManager(object):
          * non-existence
          * inability to lock
 
-        See: https://trac.openmicroscopy.org.uk/ome/ticket/1653
+        See: https://trac.openmicroscopy.org/ome/ticket/1653
         """
         locktest = None
 
@@ -153,7 +153,7 @@ class TempFileManager(object):
         targets.append(path(tempfile.gettempdir()) / "omero" / "tmp")
 
         # Handles existing files named tmp
-        # See https://trac.openmicroscopy.org.uk/ome/ticket/2805
+        # See https://trac.openmicroscopy.org/ome/ticket/2805
         for target in targets:
             if target.exists() and not target.isdir():
                 self.logger.debug("%s exists and is not a directory" % target)

--- a/components/tools/OmeroPy/src/omero_ext/killableprocess.py
+++ b/components/tools/OmeroPy/src/omero_ext/killableprocess.py
@@ -105,7 +105,7 @@ class Popen(subprocess.Popen):
         def _execute_child(self, *args_tuple):
             # The arguments to this internal Python function changed on
             # Windows in 2.7.6
-            # - https://trac.openmicroscopy.org.uk/ome/ticket/12320
+            # - https://trac.openmicroscopy.org/ome/ticket/12320
             # Upstream bug and fix:
             # - https://bugzilla.mozilla.org/show_bug.cgi?id=958609
             # - https://github.com/mozilla/addon-sdk/pull/1379

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -562,7 +562,7 @@ class TestChgrp(ITest):
         D->I
         ChGrp D
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -588,7 +588,7 @@ class TestChgrp(ITest):
         P->D->I
         ChGrp P
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -619,7 +619,7 @@ class TestChgrp(ITest):
         D2->I
         ChGrp D1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -650,7 +650,7 @@ class TestChgrp(ITest):
         D2->I
         ChGrp D1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -686,7 +686,7 @@ class TestChgrp(ITest):
            D2->I
         ChGrp P
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -719,7 +719,7 @@ class TestChgrp(ITest):
            D2->I
         ChGrp P
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -759,7 +759,7 @@ class TestChgrp(ITest):
         P2->D->I
         ChGrp D
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -795,7 +795,7 @@ class TestChgrp(ITest):
         P2->D->I
         ChGrp P1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -828,7 +828,7 @@ class TestChgrp(ITest):
         P2->D->I
         ChGrp P1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -868,7 +868,7 @@ class TestChgrp(ITest):
         P2->D
         ChGrp P1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -897,7 +897,7 @@ class TestChgrp(ITest):
         P2->D
         ChGrp P1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()
@@ -933,7 +933,7 @@ class TestChgrp(ITest):
         P->D2->I
         ChGrp P
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         client, user = self.new_client_and_user(perms=PRIVATE)
         admin = client.sf.getAdminService()

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -578,7 +578,7 @@ class TestDelete(ITest):
         P->D
         Delete P
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         p = self.make_project()
         d = self.make_dataset()
@@ -594,7 +594,7 @@ class TestDelete(ITest):
         P2->D
         Delete P1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         p1 = self.make_project()
         p2 = self.make_project()
@@ -613,7 +613,7 @@ class TestDelete(ITest):
         P2->D
         Delete P1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         p1 = self.make_project()
         p2 = self.make_project()
@@ -636,7 +636,7 @@ class TestDelete(ITest):
         P2->D->I
         Delete P1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         p1 = self.make_project()
         p2 = self.make_project()
@@ -658,7 +658,7 @@ class TestDelete(ITest):
         P2->D->I
         Delete D
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         p1 = self.make_project()
         p2 = self.make_project()
@@ -680,7 +680,7 @@ class TestDelete(ITest):
         D2->I
         Delete D1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
         d1 = self.make_dataset()
         d2 = self.make_dataset()
@@ -699,7 +699,7 @@ class TestDelete(ITest):
         D2->I
         Delete D1
 
-        See https://trac.openmicroscopy.org.uk/ome/ticket/12452
+        See https://trac.openmicroscopy.org/ome/ticket/12452
         """
 
         d1 = self.make_dataset()

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -87,7 +87,7 @@ class TestAdmin(object):
     #
 
     def XtestStartAsync(self):
-        # DISABLED: https://trac.openmicroscopy.org.uk/ome/ticket/10584
+        # DISABLED: https://trac.openmicroscopy.org/ome/ticket/10584
         self.cli.addCall(0)
         self.cli.checksIceVersion()
         self.cli.checksStatus(1)  # I.e. not running

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1231,7 +1231,7 @@ def render_movie(request, iid, axis, pos, conn=None, **kwargs):
                                              img.getSizeT()-1, opts)
         if dext is None and mimetype is None:
             # createMovie is currently only available on 4.1_custom
-            # https://trac.openmicroscopy.org.uk/ome/ticket/3857
+            # https://trac.openmicroscopy.org/ome/ticket/3857
             raise Http404
         if fpath is None:
             movie = open(fn).read()


### PR DESCRIPTION
trac.openmicroscopy.org.uk's SSL certificate is long-expired. This PR does *not* fix all the URLs but it should at least be an improvement.