### PR TITLE
Pyramid thumbnail

### DIFF
--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1101,7 +1101,6 @@ public class ThumbnailBean extends AbstractLevel2Service
      */
     private byte[] retrieveThumbnail(boolean rewriteMetadata)
     {
-        errorIfInvalidState();
         if (inProgress)
         {
             return retrieveThumbnailDirect(

--- a/components/tools/OmeroPy/src/omero/util/cleanse.py
+++ b/components/tools/OmeroPy/src/omero/util/cleanse.py
@@ -38,8 +38,8 @@ import Ice
 from Glacier2 import PermissionDeniedException
 from getopt import getopt, GetoptError
 from omero.cmd import Delete2, DoAll
-from omero.util import get_user
 from omero.sys import ParametersI
+from omero.util import get_user
 from math import ceil
 from stat import ST_SIZE
 


### PR DESCRIPTION
# What this PR does

* Roll back a change in the ThumbnailBean making the caching void
* delete the rendering settings associated to a pyramid. This will allow the thumbnails to be regenerated correctly

# Testing this PR

* Browse a large dataset or a large plate and check the performance e.g. ``InCell``
* Import a fake pyramid ``big&sizeX=4000&sizeY=4000&little=false.fake``
* Browse the dataset containing the imported pyramid. Check that the thumbnail is correctly generated when the pyramid is ready.
* Delete the pyramid: ``omero admin removepyramids --endian=big --imported-after DATE-1day`` where ``DATE=YYYY-MM-DD``
* Browse the dataset containing the imported. Check that the "clock" is displayed. Wait then refresh. The thumbnail should be displayed.
 
# Related reading

https://trello.com/c/7FUOn3U7/13-thumbnails-loading-performance

cc @pwalczysko @chris-allan 