### PR TITLE
Increase OMEROweb log-size to 500MB (rebased onto develop)

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -88,6 +88,8 @@ FULL_REQUEST_LOGFORMAT = (
     ' HTTP %(status_code)d %(request)s')
 
 LOGGING_CLASS = 'omero_ext.cloghandler.ConcurrentRotatingFileHandler'
+LOGSIZE = 500000000
+
 
 LOGGING = {
     'version': 1,
@@ -114,7 +116,7 @@ LOGGING = {
             'class': LOGGING_CLASS,
             'filename': os.path.join(
                 LOGDIR, 'OMEROweb.log').replace('\\', '/'),
-            'maxBytes': 1024*1024*5,  # 5 MB
+            'maxBytes': LOGSIZE,
             'backupCount': 10,
             'formatter': 'standard',
         },
@@ -123,7 +125,7 @@ LOGGING = {
             'class': LOGGING_CLASS,
             'filename': os.path.join(
                 LOGDIR, 'OMEROweb.log').replace('\\', '/'),
-            'maxBytes': 1024*1024*5,  # 5 MB
+            'maxBytes': LOGSIZE,
             'backupCount': 10,
             'filters': ['require_debug_false'],
             'formatter': 'full_request',


### PR DESCRIPTION
This is the same as gh-5386 but rebased onto develop.

----

# What this PR does

OMERO.web logs are currently rotated at 5MB, in contrast to the Java servers such as Blitz which are rotated at 500MB. This PR sets it to 500MB, matching the `LOGSIZE` set for the Python servers https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.0-m2/components/tools/OmeroPy/src/omero/util/__init__.py#L33

# Testing this PR

Install OMERO.web. Interact with the webclient until `OMEROweb.log` is larger than 5MB. Setting `omero.web.debug=true` will help fill the logs up.

This PR is required as OMERO.web generates enough log entries that single 5MB file is rotated away easily in a day on e.g. Dundee's production OMERO.web server.

                