### PR TITLE
Pyramid thumbnail

### DIFF
--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1128,6 +1129,20 @@ public class ThumbnailBean extends AbstractLevel2Service
                 _createThumbnail();
             }
             byte[] thumbnail = ioService.getThumbnail(thumbnailMetadata);
+            //Thumbnails are copied to disk retrieved from disk including
+            //the "clock"
+            //When existing pyramids and thumbnails are deleted from disk
+            //using method like removepyramids, the "clock" will be, the first
+            //time saved to disk, then always as used as the thumbnail since the
+            //current implementation assumes that the image does not already
+            //have some rendering settings.
+            //In the check, the "clock" is deleted from disk after creation.
+            //This means that the clock will have to be created every time until
+            //the correct thumbnail is ready.
+            if (inProgress) {
+                ioService.removeThumbnails(
+                        Arrays.asList(new Long[] { thumbnailMetadata.getId() }));
+            }
             return thumbnail;
         }
         catch (IOException e)

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1129,16 +1129,23 @@ public class ThumbnailBean extends AbstractLevel2Service
                 _createThumbnail();
             }
             byte[] thumbnail = ioService.getThumbnail(thumbnailMetadata);
-            //Thumbnails are copied to disk retrieved from disk including
-            //the "clock"
-            //When existing pyramids and thumbnails are deleted from disk
-            //using method like removepyramids, the "clock" will be, the first
-            //time saved to disk, then always as used as the thumbnail since the
-            //current implementation assumes that the image does not already
-            //have some rendering settings.
-            //In the check, the "clock" is deleted from disk after creation.
-            //This means that the clock will have to be created every time until
-            //the correct thumbnail is ready.
+            //Thumbnails are always saved to disk and then retrieved when the
+            //call stack includes retrieveThumbnail(). This includes the "clock".
+            //inProgress is not set early enough for retrieveThumbnailDirect()
+            //to be called.
+            //
+            //The current implementation assumes that if an image has valid
+            //rendering settings for the current user then it will have a valid
+            //pyramid. When existing pyramids, thumbnail metadata, and cached
+            //thumbnails are deleted from disk using a method like
+            //removepyramids it invalidates this assumption.
+            //The "clock" will first be saved to disk. inProgress will then be
+            //checked and the "clock" deleted from disk after creation.
+            //The "clock" will have to be created, saved to disk, and then
+            //retrieved every time the thumbnail is requested until pyramid
+            //creation completes and the correct thumbnail can be created.
+            //Otherwise the "clock" would stay as the cached thumbnail until
+            //the valid rendering settings for the current user are modified.
             if (inProgress) {
                 ioService.removeThumbnails(
                         Arrays.asList(new Long[] { thumbnailMetadata.getId() }));

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1101,7 +1101,6 @@ public class ThumbnailBean extends AbstractLevel2Service
      */
     private byte[] retrieveThumbnail(boolean rewriteMetadata)
     {
-        errorIfInvalidState();
         if (inProgress)
         {
             return retrieveThumbnailDirect(


### PR DESCRIPTION
# What this PR does

* Roll back a change in the ThumbnailBean making the caching void
* Delete in the thumbnail bean the "clock" thumbnail so that when the pyramid is ready.
The correct thumbnail is displayed. 
* Add integration test checking the pyramid/thumbnail regeneration is correct.

# Testing this PR

* Browse a large dataset or a large plate and check the performance e.g. ``InCell`` or compare browsing of data between merge and latest server
* Import a fake pyramid ``big&sizeX=4000&sizeY=4000&little=false.fake``
* Browse the dataset containing the imported pyramid. Check that the thumbnail is correctly generated when the pyramid is ready.
* Delete the pyramid: ``omero admin removepyramids --endian=big --imported-after DATE-1day`` where ``DATE=YYYY-MM-DD``
* Browse the dataset containing the imported. Check that the "clock" is displayed. Wait then refresh. The thumbnail should be displayed.
* Check that the tests are green
 
# Related reading

https://trello.com/c/7FUOn3U7/13-thumbnails-loading-performance

cc @pwalczysko @chris-allan 