### PR TITLE
public_user_security_violation_fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -30,6 +30,17 @@ from copy import deepcopy
 from omero.gateway import _letterGridLabel
 
 
+def get_group_id(conn, group_id):
+    """Get a valid group ID for use in queries."""
+    if group_id is None:
+        group_id = -1
+    if group_id != -1:
+        # Make sure we don't get security violation.
+        if group_id not in conn.getEventContext().memberOfGroups:
+            group_id = -1
+    return group_id
+
+
 def build_clause(components, name='', join=','):
     ''' Build a string from a list of components.
         This is to simplify building where clauses in particular that
@@ -185,8 +196,7 @@ def marshal_experimenters(conn, group_id=-1, page=1, limit=settings.PAGE):
     params = omero.sys.ParametersI()
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
 
     # This does not actually restrict the results so the restriction to
     # a certain group is done in the query
@@ -306,8 +316,7 @@ def marshal_projects(conn, group_id=-1, experimenter_id=-1,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -397,8 +406,7 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -566,8 +574,7 @@ def marshal_images(conn, dataset_id=None, orphaned=False, share_id=None,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -783,8 +790,7 @@ def marshal_screens(conn, group_id=-1, experimenter_id=-1, page=1,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -878,8 +884,7 @@ def marshal_plates(conn, screen_id=None, orphaned=False, group_id=-1,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -1048,8 +1053,7 @@ def marshal_orphaned(conn, group_id=-1, experimenter_id=-1, page=1,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -1165,8 +1169,7 @@ def marshal_tags(conn, tag_id=None, group_id=-1, experimenter_id=-1, page=1,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -1294,8 +1297,7 @@ def marshal_tagged(conn, tag_id, group_id=-1, experimenter_id=-1, page=1,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     # Paging
@@ -1806,8 +1808,7 @@ def marshal_annotations(conn, project_ids=None, dataset_ids=None,
     service_opts = deepcopy(conn.SERVICE_OPTS)
 
     # Set the desired group context
-    if group_id is None:
-        group_id = -1
+    group_id = get_group_id(conn, group_id)
     service_opts.setOmeroGroup(group_id)
 
     where_clause = ['pa.id in (:ids)']


### PR DESCRIPTION
# What this PR does

Fixes at least one cause of ```SecurityViolation``` reported in https://trello.com/c/sBdAN4L6/1-public-user-workflow-crash

I reproduced the bug by enabling public user and setting timeout to 10 secs
```
$ omero config set omero.sessions.timeout 10000
```
Then logging in as non-public user, wait > 10 secs and refresh tree (or try to expand P/D), as described by @mtbc.
This was because the ```group_id``` is still held in the page ```JavaScript``` and is used to load data in urls with ```?group=2```.
That is fixed with this commit. Instead, you will get no data, or possibly incorrect data returned but no ```SecurityViolation```.

We could check earlier in the request handling that an incorrect group_id is being used and return a 403, causing the webclient to refresh (current not-logged-in behaviour). 

On the trello card @jburel described getting this error with ```Enter http://web-dev-merge.openmicroscopy.org/webclient/``` and I don't see any error in that case. 

# Testing this PR

1. Log in as non-public user, kill session or use short timeout, then refresh tree (see above).
