### PR TITLE
@render_response user_id

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -131,7 +131,7 @@ class render_response(omeroweb.decorators.render_response):
             conn.getEventContext())
         context['ome']['user'] = conn.getUser
         context['ome']['user_id'] = request.session.get('user_id',
-            conn.getUserId())
+                                                        conn.getUserId())
         context['ome']['group_id'] = request.session.get('group_id', None)
         context['ome']['active_group'] = request.session.get(
             'active_group', conn.getEventContext().groupId)

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -130,7 +130,8 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['eventContext'] = eventContextMarshal(
             conn.getEventContext())
         context['ome']['user'] = conn.getUser
-        context['ome']['user_id'] = request.session.get('user_id', None)
+        context['ome']['user_id'] = request.session.get('user_id',
+            conn.getUserId())
         context['ome']['group_id'] = request.session.get('group_id', None)
         context['ome']['active_group'] = request.session.get(
             'active_group', conn.getEventContext().groupId)


### PR DESCRIPTION
Noticed by @mporter-gre while following web templates docs at http://docs.openmicroscopy.org/omero/5.4.4/developers/Web/WritingTemplates.html

When extending base templates that expect ```ome.user_id``` to be in context, this requires users to do 
```request.session['user_id'] = user_id``` in their views.py method (which we do in ```_render_template()```

Otherwise you get a```NoReverseMatch``` error at:
```
WEBCLIENT.URLS.api_experimenter = "
      {% url 'api_experimenter' ome.user_id %}
      ";
```

With this PR, that can be omitted.

# Testing this PR

1. Add a views.py method that uses template ```webclient/base/base_container.html``` or one that extends it.
1. OR, comment out the line ```request.session['user_id'] = user_id``` in webclient/views.py _load_template().
1. Logout, try to go to the page above so that after login you are redirected there.
1. Check you don't get template error.
