### PR TITLE
 resolution level

### DIFF
--- a/components/rendering/src/omeis/providers/re/Renderer.java
+++ b/components/rendering/src/omeis/providers/re/Renderer.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import ome.conditions.ResourceError;
 import ome.io.nio.PixelBuffer;
+import ome.io.nio.RomioPixelBuffer;
 import ome.model.core.Pixels;
 import ome.model.display.ChannelBinding;
 import ome.model.display.QuantumDef;
@@ -956,6 +957,9 @@ public class Renderer {
      **/
     public void setResolutionLevel(int resolutionLevel)
     {
+        if (buffer instanceof RomioPixelBuffer) {
+            return;
+        }
         buffer.setResolutionLevel(resolutionLevel);
     }
 


### PR DESCRIPTION
Do not attempt to set resolution level for romio pixels buffer

# Testing this PR

1. Open a big image and draw a rectangle 3kx3k.
1. Generate an image using the image from ROIs script
1. View the image using ``/webgateway/render_image_region/ImageID/0/0/?tile=0,0,0,512,512``
this should no longer return a 404.

# Related reading

https://trello.com/c/AdRIcaBJ/37-viewing-large-non-tiled-image-fails#comment-5aabb26c699037cedb89c236

cc @will-moore 