### PR TITLE
Project-Dataset bulk annotations

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -937,7 +937,7 @@ class ParsingContext(object):
         image_column = None
         image_name_column = None
         for column in self.columns:
-            columns_by_name[column.name] = column
+            columns_by_name[column.name.lower()] = column
             if column.__class__ is PlateColumn:
                 log.warn("PlateColumn is unimplemented")
             elif column.__class__ is WellColumn:
@@ -964,8 +964,8 @@ class ParsingContext(object):
                 try:
                     well_id = well_column.values[i]
                     plate = None
-                    if "Plate" in columns_by_name:  # FIXME
-                        plate = columns_by_name["Plate"].values[i]
+                    if "plate" in columns_by_name:  # FIXME
+                        plate = columns_by_name["plate"].values[i]
                     v = self.value_resolver.get_well_name(well_id, plate)
                 except KeyError:
                     log.warn(
@@ -986,8 +986,9 @@ class ParsingContext(object):
                     log.debug(image_name_column.values)
                     iid = image_column.values[i]
                     did = self.target_object.id.val
-                    if "Dataset" in columns_by_name:
-                        did = columns_by_name["Dataset"].values[i]
+                    if "dataset" in columns_by_name:
+                        dname = columns_by_name["dataset"].values[i]
+                        did = self.value_resolver.wrapper.datasets_by_name[dname].id.val
                     log.debug("Using Dataset:%d" % did)
                     iname = self.value_resolver.get_image_name_by_id(
                         iid, did)
@@ -1004,8 +1005,8 @@ class ParsingContext(object):
                 iid = image_column.values[i]
                 log.info("Checking image %s", iid)
                 pid = None
-                if 'Plate' in columns_by_name:
-                    pid = columns_by_name['Plate'].values[i]
+                if 'plate' in columns_by_name:
+                    pid = columns_by_name['plate'].values[i]
                 iname = self.value_resolver.get_image_name_by_id(iid, pid)
                 image_name_column.values.append(iname)
                 image_name_column.size = max(
@@ -1015,7 +1016,7 @@ class ParsingContext(object):
                 log.info('Missing image name column, skipping.')
 
             if plate_name_column is not None:
-                plate = columns_by_name['Plate'].values[i]   # FIXME
+                plate = columns_by_name['plate'].values[i]   # FIXME
                 v = self.value_resolver.get_plate_name_by_id(plate)
                 plate_name_column.size = max(plate_name_column.size, len(v))
                 plate_name_column.values.append(v)

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -100,8 +100,8 @@ IMAGE_NAME_COLUMN = 'Image Name'
 
 COLUMN_TYPES = {
     'plate': PlateColumn, 'well': WellColumn, 'image': ImageColumn,
-    'roi': RoiColumn, 'd': DoubleColumn, 'l': LongColumn, 's': StringColumn,
-    'b': BoolColumn
+    'dataset': DatasetColumn, 'roi': RoiColumn,
+    'd': DoubleColumn, 'l': LongColumn, 's': StringColumn, 'b': BoolColumn
 }
 
 REGEX_HEADER_SPECIFIER = r'# header '
@@ -361,6 +361,9 @@ class ValueResolver(object):
             return self.wrapper.resolve_well(column, row, value)
         if PlateColumn is column_class:
             return self.wrapper.resolve_plate(column, row, value)
+        # Prepared to handle DatasetColumn
+        if DatasetColumn is column_class:
+            return self.wrapper.resolve_dataset(column, row, value)
         if column_as_lower in ('row', 'column') \
            and column_class is LongColumn:
             try:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -793,7 +793,7 @@ class ProjectWrapper(PDIWrapper):
                 seen[ikey] = iid
 
             self.images_by_id[did][iid] = image
-            self.images_by_name[dname][iname] = image
+            self.images_by_name[did][iname] = image
             self.datasets_by_id[did] = dataset
             self.datasets_by_name[dname] = dataset
         log.debug('Completed parsing project: %s' % self.target_object.id.val)

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -268,7 +268,7 @@ class HeaderResolver(object):
                               self.DEFAULT_COLUMN_SIZE, list()))
             # Currently hard-coded, but "if image name, then add image id"
             if column.name == IMAGE_NAME_COLUMN:
-                append.append(ImageColumn("image", '', list()))
+                append.append(ImageColumn("Image", '', list()))
         columns.extend(append)
         self.columns_sanity_check(columns)
         return columns

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -87,6 +87,7 @@ Examples:
 Report bugs to ome-devel@lists.openmicroscopy.org.uk""" % (error, cmd, cmd)
     sys.exit(2)
 
+
 # Global thread pool for use by workers
 thread_pool = None
 
@@ -134,7 +135,7 @@ class HeaderResolver(object):
     }
 
     project_keys = {
-        'dataset': StringColumn, # DatasetColumn
+        'dataset': StringColumn,  # DatasetColumn
         'dataset_name': StringColumn,
         'image': ImageColumn,
         'image_name': StringColumn,
@@ -245,7 +246,8 @@ class HeaderResolver(object):
                     log.debug("Adding keys %r" % keys)
                     if keys[header_as_lower] is StringColumn:
                         column = keys[header_as_lower](
-                            name, description, self.DEFAULT_COLUMN_SIZE, list())
+                            name, description,
+                            self.DEFAULT_COLUMN_SIZE, list())
                     else:
                         column = keys[header_as_lower](
                             name, description, list())
@@ -370,11 +372,13 @@ class ValueResolver(object):
                         # DatasetColumn unimplemented at the momnet
                         # We can still access column names though
                         images_by_id = self.wrapper.images_by_id[
-                            self.wrapper.datasets_by_id[int(column_value)].id.val
+                            self.wrapper.datasets_by_id[
+                                int(column_value)].id.val
                         ]
                         log.debug(
                             "Got dataset %i",
-                            self.wrapper.datasets_by_id[int(column_value)].id.val
+                            self.wrapper.datasets_by_id[
+                                int(column_value)].id.val
                         )
                         break
             if images_by_id is None:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -134,7 +134,7 @@ class HeaderResolver(object):
     }
 
     project_keys = {
-        'dataset': DatasetColumn,
+        'dataset': StringColumn,
         'dataset_name': StringColumn,
         'image': ImageColumn,
         'image_name': StringColumn,
@@ -242,11 +242,18 @@ class HeaderResolver(object):
             else:
                 try:
                     keys = getattr(self, "%s_keys" % klass)
-                    column = keys[header_as_lower](
-                        name, description, list())
+                    log.debug("Adding keys %r" % keys)
+                    if keys[header_as_lower] is StringColumn:
+                        column = keys[header_as_lower](
+                            name, description, self.DEFAULT_COLUMN_SIZE, list())
+                    else:
+                        column = keys[header_as_lower](
+                            name, description, list())
                 except KeyError:
+                    log.debug("Adding string column %r" % name)
                     column = StringColumn(
                         name, description, self.DEFAULT_COLUMN_SIZE, list())
+            log.debug("New column %r" % column)
             columns.append(column)
         append = []
         for column in columns:

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -355,7 +355,7 @@ class ValueResolver(object):
                             self.wrapper.plates_by_name[column_value].id.val
                         )
                         break
-                    elif column.name.lower() == "dataset":
+                    elif column.name.lower() == "dataset name":
                         # DatasetColumn unimplemented at the momnet
                         # We can still access column names though
                         images_by_id = self.wrapper.images_by_id[
@@ -364,6 +364,17 @@ class ValueResolver(object):
                         log.debug(
                             "Got dataset %i",
                             self.wrapper.datasets_by_name[column_value].id.val
+                        )
+                        break
+                    elif column.name.lower() == "dataset":
+                        # DatasetColumn unimplemented at the momnet
+                        # We can still access column names though
+                        images_by_id = self.wrapper.images_by_id[
+                            self.wrapper.datasets_by_id[int(column_value)].id.val
+                        ]
+                        log.debug(
+                            "Got dataset %i",
+                            self.wrapper.datasets_by_id[int(column_value)].id.val
                         )
                         break
             if images_by_id is None:
@@ -1002,12 +1013,14 @@ class ParsingContext(object):
                 iname = ""
                 try:
                     log.debug(image_name_column)
-                    log.debug(image_name_column.values)
                     iid = image_column.values[i]
                     did = self.target_object.id.val
-                    if "dataset" in columns_by_name:
-                        dname = columns_by_name["dataset"].values[i]
-                        did = self.value_resolver.wrapper.datasets_by_name[dname].id.val
+                    if "dataset name" in columns_by_name:
+                        dname = columns_by_name["dataset name"].values[i]
+                        did = self.value_resolver.wrapper.datasets_by_name[
+                            dname].id.val
+                    elif "dataset" in columns_by_name:
+                        did = int(columns_by_name["dataset"].values[i])
                     log.debug("Using Dataset:%d" % did)
                     iname = self.value_resolver.get_image_name_by_id(
                         iid, did)
@@ -1025,12 +1038,14 @@ class ParsingContext(object):
                 iid = -1
                 try:
                     log.debug(image_column)
-                    log.debug(image_column.values)
                     iname = image_name_column.values[i]
                     did = self.target_object.id.val
-                    if "dataset" in columns_by_name:
-                        dname = columns_by_name["dataset"].values[i]
-                        did = self.value_resolver.wrapper.datasets_by_name[dname].id.val
+                    if "dataset name" in columns_by_name:
+                        dname = columns_by_name["dataset name"].values[i]
+                        did = self.value_resolver.wrapper.datasets_by_name[
+                            dname].id.val
+                    elif "dataset" in columns_by_name:
+                        did = int(columns_by_name["dataset"].values[i])
                     log.debug("Using Dataset:%d" % did)
                     iid = self.value_resolver.get_image_id_by_name(
                         iname, did)

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -134,7 +134,7 @@ class HeaderResolver(object):
     }
 
     project_keys = {
-        'dataset': StringColumn,
+        'dataset': StringColumn, # DatasetColumn
         'dataset_name': StringColumn,
         'image': ImageColumn,
         'image_name': StringColumn,

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -349,6 +349,8 @@
                     {% elif manager.image %}
                     var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
                     var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
+                    var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child.image' manager.image.id %}";
+                    var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child.image' manager.image.id %}";
                     var query = "Image-{{ manager.image.id }}";
                     {% endif %}
 
@@ -387,6 +389,8 @@
                         if (expanded && $("#bulk_annotations_table").is(":empty")) {
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
                         }
                     });
 
@@ -398,6 +402,8 @@
                         if ($("#bulk_annotations_table").is(":empty")) {
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
                         }
                     }
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -349,8 +349,8 @@
                     {% elif manager.image %}
                     var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
                     var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
-                    var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child.image' manager.image.id %}";
-                    var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child.image' manager.image.id %}";
+                    var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
+                    var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child' manager.image.id %}";
                     var query = "Image-{{ manager.image.id }}";
                     {% endif %}
 


### PR DESCRIPTION
# What this PR does

This PR extends `populate_metadata.py` to work also for Project->Dataset hierarchy. The extension to OMERO.web was also added to display `Tables` in the right hand side panel in the fashion similar to the Screen->Plate.

Screen->Plate workflow is also fixed with this PR.

Since there is no DatasetColumn implementation (just definition) at the moment if Dataset column is needed it should be set to String on import (not to Dataset type). The code was adjusted to resolve the Datasets internally based on their names, the only requirement is to have a column named `Dataset` in the `csv` file.


# Testing this PR

1. Create a csv file with Image column (holding the image IDs) and some other columns with data, doubles or strings.
2. Run populate_metadata.py on the Dataset or Project to which the image ids belong to.
3. Run should complete successfully
4. The project/dataset should have a new file annotation called `bulk_annotation`
5. When image is selected in the OMERO.web the data from the csv file should appear in the `Tables` section in the right hand side panel.


# Related reading
https://github.com/openmicroscopy/openmicroscopy/pull/4455
https://github.com/openmicroscopy/openmicroscopy/pull/5297
https://github.com/openmicroscopy/openmicroscopy/pull/4446
