### PR TITLE
render_image_region

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8982,11 +8982,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 tile_height = round(tile_height / 2.0)
             width = int(tiles_wide * tile_width)
             height = int(tiles_high * tile_height)
-            level = 0
-            if not re.requiresPixelsPyramid():
-                level = None
             jpeg_data = self.renderJpegRegion(
-                z, t, x, y, width, height, level=level)
+                z, t, x, y, width, height, level=0)
             if size is None:
                 return jpeg_data
             # We've been asked to scale the image by its longest side so we'll
@@ -9034,8 +9031,14 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         regionDef.height = int(height)
         self._pd.region = regionDef
         try:
-            if level is not None and self._re.requiresPixelsPyramid():
-                self._re.setResolutionLevel(level)
+            if level is not None:
+                if self._re.requiresPixelsPyramid():
+                    self._re.setResolutionLevel(level)
+                else:
+                    if level != 0:
+                        logger.debug('On renderJpegRegion')
+                        logger.debug('Cannot set resolution %s' % level)
+                        return None
             if compression is not None:
                 try:
                     self._re.setCompressionLevel(float(compression))

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8982,8 +8982,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 tile_height = round(tile_height / 2.0)
             width = int(tiles_wide * tile_width)
             height = int(tiles_high * tile_height)
+            level = 0
+            if not re.requiresPixelsPyramid():
+                level = None
             jpeg_data = self.renderJpegRegion(
-                z, t, x, y, width, height, level=0)
+                z, t, x, y, width, height, level=level)
             if size is None:
                 return jpeg_data
             # We've been asked to scale the image by its longest side so we'll
@@ -9031,7 +9034,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         regionDef.height = int(height)
         self._pd.region = regionDef
         try:
-            if level is not None:
+            if level is not None and self._re.requiresPixelsPyramid():
                 self._re.setResolutionLevel(level)
             if compression is not None:
                 try:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -9032,13 +9032,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         self._pd.region = regionDef
         try:
             if level is not None:
-                if self._re.requiresPixelsPyramid():
-                    self._re.setResolutionLevel(level)
-                else:
-                    if level != 0:
-                        logger.warn('On renderJpegRegion')
-                        logger.warn('Cannot set resolution %s' % level)
-                        return None
+                self._re.setResolutionLevel(level)
             if compression is not None:
                 try:
                     self._re.setCompressionLevel(float(compression))
@@ -9049,6 +9043,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     return self.renderJpeg(z, t, None)
             rv = self._re.renderCompressed(self._pd, self._conn.SERVICE_OPTS)
             return rv
+        except omero.ApiUsageException:
+            logger.debug('On renderJpegRegion')
+            logger.debug('Cannot set resolution %s' % level)
+            logger.debug(traceback.format_exc())
+            return None
         except omero.InternalException:  # pragma: no cover
             logger.debug('On renderJpegRegion')
             logger.debug(traceback.format_exc())

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -9036,8 +9036,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     self._re.setResolutionLevel(level)
                 else:
                     if level != 0:
-                        logger.debug('On renderJpegRegion')
-                        logger.debug('Cannot set resolution %s' % level)
+                        logger.warn('On renderJpegRegion')
+                        logger.warn('Cannot set resolution %s' % level)
                         return None
             if compression is not None:
                 try:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -9043,14 +9043,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     return self.renderJpeg(z, t, None)
             rv = self._re.renderCompressed(self._pd, self._conn.SERVICE_OPTS)
             return rv
-        except omero.ApiUsageException:
-            logger.debug('On renderJpegRegion')
-            logger.debug('Cannot set resolution %s' % level)
-            logger.debug(traceback.format_exc())
-            return None
-        except omero.InternalException:  # pragma: no cover
-            logger.debug('On renderJpegRegion')
-            logger.debug(traceback.format_exc())
+        except (omero.ApiUsageException, omero.InternalException):
+            logger.debug('On renderJpegRegion', exc_info=True)
             return None
         except Ice.MemoryLimitException:  # pragma: no cover
             # Make sure renderCompressed isn't called again on this re,

--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -1146,7 +1146,7 @@ class ITest(object):
         finally:
             store.close()
 
-    def import_pyramid(self, tmpdir, name=None, client=None, skip=None):
+    def import_pyramid(self, tmpdir, name=None, client=None, skip="all"):
         if name is None:
             name = "test&sizeX=4000&sizeY=4000.fake"
         fakefile = tmpdir.join(name)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -389,6 +389,7 @@ class TestImage (object):
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
         assert img_file.size == (width, height)
+        assert self.image._re.getResolutionLevel() == 0
 
     def testRenderJpegRegion_Resolution(self, gatewaywrapper):
         width = 10
@@ -399,6 +400,7 @@ class TestImage (object):
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
         assert img_file.size == (width, height)
+        assert self.image._re.getResolutionLevel() == 0
 
     def testRenderBirdsEyeView(self, gatewaywrapper):
         img = self.image.renderBirdsEyeView(None)
@@ -407,6 +409,7 @@ class TestImage (object):
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
         assert img_file.size == (self.image.getSizeX(), self.image.getSizeY())
+        assert self.image._re.getResolutionLevel() == 0
 
     def testRenderBirdsEyeView_Size(self, gatewaywrapper):
         size = 10
@@ -416,3 +419,4 @@ class TestImage (object):
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
         assert img_file.size == (size, size)
+        assert self.image._re.getResolutionLevel() == 0

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -379,3 +379,40 @@ class TestImage (object):
         finally:
             gatewaywrapper.loginAsAdmin()
             admin = gatewaywrapper.gateway.getAdminService()
+
+    def testRenderJpegRegion(self, gatewaywrapper):
+        width = 10
+        height = 10
+        img = self.image.renderJpegRegion(0, 0, 0, 0, width, height)
+        ifile = StringIO(img)
+        img_file = Image.open(ifile)  # Raises if invalid
+        img_file.verify()  # Raises if invalid
+        assert img_file.format == 'JPEG'
+        assert img_file.size == (width, height)
+
+    def testRenderJpegRegion_Resolution(self, gatewaywrapper):
+        width = 10
+        height = 10
+        img = self.image.renderJpegRegion(0, 0, 0, 0, width, height, level=1)
+        ifile = StringIO(img)
+        img_file = Image.open(ifile)  # Raises if invalid
+        img_file.verify()  # Raises if invalid
+        assert img_file.format == 'JPEG'
+        assert img_file.size == (width, height)
+
+    def testRenderBirdsEyeView(self, gatewaywrapper):
+        img = self.image.renderBirdsEyeView(None)
+        ifile = StringIO(img)
+        img_file = Image.open(ifile)  # Raises if invalid
+        img_file.verify()  # Raises if invalid
+        assert img_file.format == 'JPEG'
+        assert img_file.size == (self.image.getSizeX(), self.image.getSizeY())
+
+    def testRenderBirdsEyeView_Size(self, gatewaywrapper):
+        size = 10
+        img = self.image.renderBirdsEyeView(size)
+        ifile = StringIO(img)
+        img_file = Image.open(ifile)  # Raises if invalid
+        img_file.verify()  # Raises if invalid
+        assert img_file.format == 'JPEG'
+        assert img_file.size == (size, size)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -391,16 +391,22 @@ class TestImage (object):
         assert img_file.size == (width, height)
         assert self.image._re.getResolutionLevel() == 0
 
-    def testRenderJpegRegion_Resolution(self, gatewaywrapper):
+    def testRenderJpegRegion_resolution(self, gatewaywrapper):
         width = 10
         height = 10
-        img = self.image.renderJpegRegion(0, 0, 0, 0, width, height, level=1)
+        img = self.image.renderJpegRegion(0, 0, 0, 0, width, height, level=0)
         ifile = StringIO(img)
         img_file = Image.open(ifile)  # Raises if invalid
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
         assert img_file.size == (width, height)
         assert self.image._re.getResolutionLevel() == 0
+
+    def testRenderJpegRegion_invalid_resolution(self, gatewaywrapper):
+        width = 10
+        height = 10
+        img = self.image.renderJpegRegion(0, 0, 0, 0, width, height, level=1)
+        assert img is None
 
     def testRenderBirdsEyeView(self, gatewaywrapper):
         img = self.image.renderBirdsEyeView(None)

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -946,10 +946,9 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
             x = int(zxyt[1])*w
             y = int(zxyt[2])*h
         except:
-            logger.debug(
-                "render_image_region: tile=%s" % tile, exc_info=True
-            )
-            return HttpResponseBadRequest('malformed tile argument')
+            msg = "malformed tile argument, tile=%s" % tile
+            logger.debug(msg, exc_info=True)
+            return HttpResponseBadRequest(msg)
     elif region:
         try:
             xywh = region.split(",")
@@ -959,10 +958,9 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
             w = int(xywh[2])
             h = int(xywh[3])
         except:
-            logger.debug(
-                "render_image_region: region=%s" % region, exc_info=True
-            )
-            return HttpResponseBadRequest('malformed region argument')
+            msg = "malformed region argument, region=%s" % region
+            logger.debug(msg, exc_info=True)
+            return HttpResponseBadRequest(msg)
     else:
         return HttpResponseBadRequest('tile or region argument required')
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -926,9 +926,6 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
             level = levels-int(zxyt[0])
             x = int(zxyt[1])*w
             y = int(zxyt[2])*h
-            # check if the image requires pyramid
-            if not img._re.requiresPixelsPyramid():
-                level = None
         except:
             logger.debug(
                 "render_image_region: tile=%s" % tile, exc_info=True

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -923,7 +923,14 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
                     if tile_length > max_tile_length:
                         tile_size[i] = max_tile_length
                 w, h = tile_size
-            level = levels-int(zxyt[0])
+            v = int(zxyt[0])
+            if v < 0:
+                logger.debug(
+                    "render_image_region: invalid level %s" % v, exc_info=True
+                )
+                return HttpResponseBadRequest('Invalid resolution')
+
+            level = levels-v
             x = int(zxyt[1])*w
             y = int(zxyt[2])*h
         except:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -925,28 +925,24 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
                 w, h = tile_size
             v = int(zxyt[0])
             if v < 0:
-                logger.debug(
-                    "render_image_region: invalid level %s" % v, exc_info=True
-                )
-                return HttpResponseBadRequest('Invalid resolution')
+                msg = "Invalid resolution level %s < 0" % v
+                logger.debug(msg, exc_info=True)
+                return HttpResponseBadRequest(msg)
 
             if levels == 0:  # non pyramid file
                 if v > 0:
-                    logger.debug(
-                        "render_image_region: invalid level %s" % v,
-                        exc_info=True
-                    )
-                    return HttpResponseBadRequest('Invalid resolution')
+                    msg = "Invalid resolution level %s, non pyramid file" % v
+                    logger.debug(msg, exc_info=True)
+                    return HttpResponseBadRequest(msg)
                 else:
                     level = None
             else:
                 level = levels-v
                 if level < 0:
-                    logger.debug(
-                        "render_image_region: invalid level %s" % v,
-                        exc_info=True
-                    )
-                    return HttpResponseBadRequest('Invalid resolution')
+                    msg = "Invalid resolution level, \
+                    %s > number of available levels %s " % (v, levels)
+                    logger.debug(msg, exc_info=True)
+                    return HttpResponseBadRequest(msg)
             x = int(zxyt[1])*w
             y = int(zxyt[2])*h
         except:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -930,7 +930,7 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
                 )
                 return HttpResponseBadRequest('Invalid resolution')
 
-            if levels == 0: #  non pyramid file
+            if levels == 0:  # non pyramid file
                 if v > 0:
                     logger.debug(
                         "render_image_region: invalid level %s" % v,

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -926,6 +926,9 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
             level = levels-int(zxyt[0])
             x = int(zxyt[1])*w
             y = int(zxyt[2])*h
+            # check if the image requires pyramid
+            if not img._re.requiresPixelsPyramid():
+                level = None
         except:
             logger.debug(
                 "render_image_region: tile=%s" % tile, exc_info=True

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -941,6 +941,12 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
                     level = None
             else:
                 level = levels-v
+                if level < 0:
+                    logger.debug(
+                        "render_image_region: invalid level %s" % v,
+                        exc_info=True
+                    )
+                    return HttpResponseBadRequest('Invalid resolution')
             x = int(zxyt[1])*w
             y = int(zxyt[2])*h
         except:

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -930,7 +930,17 @@ def render_image_region(request, iid, z, t, conn=None, **kwargs):
                 )
                 return HttpResponseBadRequest('Invalid resolution')
 
-            level = levels-v
+            if levels == 0: #  non pyramid file
+                if v > 0:
+                    logger.debug(
+                        "render_image_region: invalid level %s" % v,
+                        exc_info=True
+                    )
+                    return HttpResponseBadRequest('Invalid resolution')
+                else:
+                    level = None
+            else:
+                level = levels-v
             x = int(zxyt[1])*w
             y = int(zxyt[2])*h
         except:

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -387,7 +387,6 @@ class TestRenderImageRegion(IWebTest):
         conn = omero.gateway.BlitzGateway(client_obj=self.client)
         image = conn.getObject("Image", image_id)
         image._prepareRenderingEngine()
-        expTileSize = image._re.getTileSize()
         image._re.close()
 
         request_url = reverse(
@@ -419,7 +418,6 @@ class TestRenderImageRegion(IWebTest):
         conn = omero.gateway.BlitzGateway(client_obj=self.client)
         image = conn.getObject("Image", image_id)
         image._prepareRenderingEngine()
-        expTileSize = image._re.getTileSize()
         image._re.close()
 
         request_url = reverse(

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -375,43 +375,11 @@ class TestRenderImageRegion(IWebTest):
         finally:
             self.assert_no_leaked_rendering_engines()
 
-    def test_render_image_region_tile_params_invalid_resolution(self):
-        """
-        Tests whether the handed in tile parameter is respected
-        by checking the following cases:
-        1. don't hand in tile dimension => use default tile size
-        2. hand in tile dimension => use given tile size
-        3. exceed tile dimension max values => use default tile size
-        """
-        image_id = self.create_test_image(size_c=2, session=self.sf).id.val
-        conn = omero.gateway.BlitzGateway(client_obj=self.client)
-        image = conn.getObject("Image", image_id)
-        image._prepareRenderingEngine()
-        image._re.close()
-
-        request_url = reverse(
-            'webgateway.views.render_image_region',
-            kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
-        )
-        django_client = self.new_django_client_from_session_id(
-            self.client.getSessionId()
-        )
-        data = {}
-        try:
-            data['tile'] = '1,0,0,10,10'
-            response = get(django_client, request_url, data)
-            tile = Image.open(StringIO(response.content))
-            assert tile.size == (10, 10)
-        finally:
-            self.assert_no_leaked_rendering_engines()
-
     def test_render_image_region_tile_params_large_image(self):
         """
-        Tests whether the handed in tile parameter is respected
-        by checking the following cases:
-        1. don't hand in tile dimension => use default tile size
-        2. hand in tile dimension => use given tile size
-        3. exceed tile dimension max values => use default tile size
+        Tests the retrieval of large non pyramid image at different
+        resolution. Resolution changes is not supported in that case.
+        It should default to 0.
         """
         image_id = self.create_test_image(size_x=3000, size_y=3000,
                                           session=self.sf).id.val
@@ -431,7 +399,103 @@ class TestRenderImageRegion(IWebTest):
         try:
             data['tile'] = '0,0,0,512,512'
             response = get(django_client, request_url, data)
-            tile = Image.open(StringIO(response.content))
+            tile_content = response.content
+            tile = Image.open(StringIO(tile_content))
             assert tile.size == (512, 512)
+            digest = self.calculate_sha1(tile_content)
+            # request another resolution. It should default to 0
+            data['tile'] = '1,0,0,512,512'
+            response = get(django_client, request_url, data)
+            tile_res_content = response.content
+            tile = Image.open(StringIO(tile_res_content))
+            assert tile.size == (512, 512)
+            digest_res = self.calculate_sha1(tile_res_content)
+            assert digest == digest_res
+        finally:
+            self.assert_no_leaked_rendering_engines()
+
+    def test_render_image_region_tile_params_big_image(self, tmpdir):
+        """
+        Tests the retrieval of lpyramid image at different
+        resolution. Resolution changes is supported in that case.
+        """
+        image_id = self.import_pyramid(tmpdir, client=self.client)
+
+        request_url = reverse(
+            'webgateway.views.render_image_region',
+            kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
+        )
+        django_client = self.new_django_client_from_session_id(
+            self.client.getSessionId()
+        )
+        data = {}
+        try:
+            data['tile'] = '0,0,0,512,512'
+            response = get(django_client, request_url, data)
+            tile_content = response.content
+            tile = Image.open(StringIO(tile_content))
+            assert tile.size == (512, 512)
+            digest = self.calculate_sha1(tile_content)
+            # request another resolution. It should default to 0
+            data['tile'] = '1,0,0,512,512'
+            response = get(django_client, request_url, data)
+            tile_res_content = response.content
+            tile = Image.open(StringIO(tile_res_content))
+            assert tile.size == (512, 512)
+            digest_res = self.calculate_sha1(tile_res_content)
+            assert digest != digest_res
+        finally:
+            self.assert_no_leaked_rendering_engines()
+
+    def test_render_image_region_region_params(self):
+        """
+        Tests the retrieval of the image using the region parameter
+        """
+        image = self.import_fake_file(name='fake')[0]
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+        image = conn.getObject("Image", image.id.val)
+        image._prepareRenderingEngine()
+        image._re.close()
+
+        request_url = reverse(
+            'webgateway.views.render_image_region',
+            kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
+        )
+        data = {'region': '0,0,10,10'}
+        django_client = self.new_django_client_from_session_id(
+            self.client.getSessionId()
+        )
+
+        try:
+            response = get(django_client, request_url, data)
+            tile = Image.open(StringIO(response.content))
+            assert tile.size == (10, 10)
+        finally:
+            self.assert_no_leaked_rendering_engines()
+
+    def test_render_image_region_region_params_big_image(self, tmpdir):
+        """
+        Tests the retrieval of pyramid image at different
+        resolution. Resolution changes is supported in that case.
+        """
+        image_id = self.import_pyramid(tmpdir, client=self.client)
+
+        request_url = reverse(
+            'webgateway.views.render_image_region',
+            kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
+        )
+        django_client = self.new_django_client_from_session_id(
+            self.client.getSessionId()
+        )
+        data = {}
+        try:
+            data['region'] = '0,0,512,512'
+            response = get(django_client, request_url, data)
+            region = Image.open(StringIO(response.content))
+            assert region.size == (512, 512)
+            data['region'] = '0,0,2000,2000'
+            response = get(django_client, request_url, data)
+            region = Image.open(StringIO(response.content))
+            assert region.size == (2000, 2000)
         finally:
             self.assert_no_leaked_rendering_engines()

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -377,9 +377,7 @@ class TestRenderImageRegion(IWebTest):
 
     def test_render_image_region_tile_params_large_image(self):
         """
-        Tests the retrieval of large non pyramid image at different
-        resolution. Resolution changes is not supported in that case.
-        It should default to 0.
+        Tests the retrieval of large non pyramid image.
         """
         image_id = self.create_test_image(size_x=3000, size_y=3000,
                                           session=self.sf).id.val
@@ -402,15 +400,12 @@ class TestRenderImageRegion(IWebTest):
             tile_content = response.content
             tile = Image.open(StringIO(tile_content))
             assert tile.size == (512, 512)
-            digest = self.calculate_sha1(tile_content)
         finally:
             self.assert_no_leaked_rendering_engines()
 
     def test_render_image_region_tile_params_invalid_resolution(self):
         """
-        Tests the retrieval of large non pyramid image at different
-        resolution. Resolution changes is not supported in that case.
-        It should default to 0.
+        Tests the retrieval of image at an invalid resolution.
         """
         image_id = self.create_test_image(size_x=512, size_y=512,
                                           session=self.sf).id.val
@@ -429,13 +424,13 @@ class TestRenderImageRegion(IWebTest):
         data = {}
         try:
             data['tile'] = '1,0,0,200,200'
-            get(django_client, request_url, data, status_code = 404)
+            get(django_client, request_url, data, status_code=404)
         finally:
             self.assert_no_leaked_rendering_engines()
 
     def test_render_image_region_tile_params_big_image(self, tmpdir):
         """
-        Tests the retrieval of lpyramid image at different
+        Tests the retrieval of pyramid image at different
         resolution. Resolution changes is supported in that case.
         """
         image_id = self.import_pyramid(tmpdir, client=self.client)

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -403,6 +403,31 @@ class TestRenderImageRegion(IWebTest):
         finally:
             self.assert_no_leaked_rendering_engines()
 
+    def test_render_image_region_tile_params_negative_resolution(self):
+        """
+        Tests the retrieval of image at a negative resolution.
+        """
+        image_id = self.create_test_image(size_x=512, size_y=512,
+                                          session=self.sf).id.val
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+        image = conn.getObject("Image", image_id)
+        image._prepareRenderingEngine()
+        image._re.close()
+
+        request_url = reverse(
+            'webgateway.views.render_image_region',
+            kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
+        )
+        django_client = self.new_django_client_from_session_id(
+            self.client.getSessionId()
+        )
+        data = {}
+        try:
+            data['tile'] = '-1,0,0,200,200'
+            get(django_client, request_url, data, status_code=400)
+        finally:
+            self.assert_no_leaked_rendering_engines()
+
     def test_render_image_region_tile_params_invalid_resolution(self):
         """
         Tests the retrieval of image at an invalid resolution.

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -499,3 +499,23 @@ class TestRenderImageRegion(IWebTest):
             assert region.size == (2000, 2000)
         finally:
             self.assert_no_leaked_rendering_engines()
+
+    def test_render_birds_eye_view_big_image(self, tmpdir):
+        """
+        Tests the retrieval of pyramid image at different
+        resolution. Resolution changes is supported in that case.
+        """
+        image_id = self.import_pyramid(tmpdir, client=self.client)
+        request_url = reverse(
+            'webgateway.views.render_birds_eye_view',
+            kwargs={'iid': str(image_id), 'size': '100'}
+        )
+        django_client = self.new_django_client_from_session_id(
+            self.client.getSessionId()
+        )
+        try:
+            response = get(django_client, request_url)
+            region = Image.open(StringIO(response.content))
+            assert region.size == (100, 100)
+        finally:
+            self.assert_no_leaked_rendering_engines()

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -374,3 +374,34 @@ class TestRenderImageRegion(IWebTest):
             assert tile.size == tuple(expTileSize)
         finally:
             self.assert_no_leaked_rendering_engines()
+
+    def test_render_image_region_tile_params_invalid_resolution(self):
+        """
+        Tests whether the handed in tile parameter is respected
+        by checking the following cases:
+        1. don't hand in tile dimension => use default tile size
+        2. hand in tile dimension => use given tile size
+        3. exceed tile dimension max values => use default tile size
+        """
+        image_id = self.create_test_image(size_c=2, session=self.sf).id.val
+        conn = omero.gateway.BlitzGateway(client_obj=self.client)
+        image = conn.getObject("Image", image_id)
+        image._prepareRenderingEngine()
+        expTileSize = image._re.getTileSize()
+        image._re.close()
+
+        request_url = reverse(
+            'webgateway.views.render_image_region',
+            kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
+        )
+        django_client = self.new_django_client_from_session_id(
+            self.client.getSessionId()
+        )
+        data = {}
+        try:
+            data['tile'] = '1,0,0,10,10'
+            response = get(django_client, request_url, data)
+            tile = Image.open(StringIO(response.content))
+            assert tile.size == (10, 10)
+        finally:
+            self.assert_no_leaked_rendering_engines()

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -449,7 +449,7 @@ class TestRenderImageRegion(IWebTest):
         data = {}
         try:
             data['tile'] = '1,0,0,200,200'
-            get(django_client, request_url, data, status_code=404)
+            get(django_client, request_url, data, status_code=400)
         finally:
             self.assert_no_leaked_rendering_engines()
 


### PR DESCRIPTION
# What this PR does

Ignore resolution level for non pyramid file
The problem is also present for small image as soon as the resolution specified was not 0.

# Testing this PR

Test 1:
1. Open a big image and draw a rectangle 3kx3k.
1. Generate an image using the image from ROIs script
1. View the image using ``/webgateway/render_image_region/ImageID/0/0/?tile=0,0,0,512,512``
this should no longer return a 404.

Test 2:
1. Open any small image e.g. dv
1. View the image using ``/webgateway/render_image_region/ImageID/0/0/?tile=1,0,0,512,512``
A 400 will be returned and prevent error like
```
repo/openmicroscopy/dist/lib/python/omero_api_PyramidService_ice.py", line 324, in setResolutionLevel
    return _M_omero.api.PyramidService._op_setResolutionLevel.invoke(self, ((resolutionLevel, ), _ctx))

```

Test 3:
* Open any pyramid
* View the image using ``/webgateway/render_image_region/ImageID/0/0/?tile=0,0,0,512,512``
* View the image using ``/webgateway/render_image_region/ImageID/0/0/?region=0,0,512,512``

Test 4:
Negative resolution
1. Open any small image e.g. dv
1. View the image using ``/webgateway/render_image_region/ImageID/0/0/?tile=-1,0,0,512,512``
A "invalid resolution message" will be returned

Check that the tests are green

cc @will-moore @chris-allan 

problem test 1 reported https://trello.com/c/AdRIcaBJ/37-viewing-large-non-tiled-image-fails
test 2: found while investigating