### PR TITLE
Metadata plugin pixelsize

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -604,20 +604,22 @@ class MetadataControl(BaseControl):
         else:
             raise Exception("Not implemented for type %s" % md.get_type())
 
+        ctx = {'omero.group': '-1'}
+
         params = omero.sys.ParametersI()
         params.addId(md.get_id())
-        pixels = client.getSession().getQueryService()\
+        pixels = client.getSession().getQueryService(ctx)\
                                     .findAllByQuery(q, params)
 
         for pixel in pixels:
             if args.x:
-                pixel.setPhysicalSizeX(omero.model.LengthI(args.x, unit))
+                pixel.setPhysicalSizeX(omero.model.LengthI(args.x, unit), ctx)
             if args.y:
-                pixel.setPhysicalSizeY(omero.model.LengthI(args.y, unit))
+                pixel.setPhysicalSizeY(omero.model.LengthI(args.y, unit), ctx)
             if args.z:
-                pixel.setPhysicalSizeZ(omero.model.LengthI(args.z, unit))
+                pixel.setPhysicalSizeZ(omero.model.LengthI(args.z, unit), ctx)
 
-        client.getSession().getUpdateService().saveCollection(pixels)
+        client.getSession().getUpdateService(ctx).saveCollection(pixels)
 
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -616,34 +616,20 @@ class MetadataControl(BaseControl):
         pixels = client.getSession().getQueryService()\
                                     .findAllByQuery(q, params)
         for pixel in pixels:
-            if args.x:
-                pixSize = pixel.getPhysicalSizeX()
-                if not pixSize:
-                    pixSize = omero.model.LengthI(args.x, units[args.unit])
-                    pixel.setPhysicalSizeX(pixSize)
-                else:
-                    pixSize.setValue(args.x)
-                    pixSize.setUnit(units[args.unit])
+            self._setPixelsize(pixel, args.x, units[args.unit], 'x')
+            self._setPixelsize(pixel, args.y, units[args.unit], 'y')
+            self._setPixelsize(pixel, args.z, units[args.unit], 'z')
 
-            if args.y:
-                pixSize = pixel.getPhysicalSizeY()
-                if not pixSize:
-                    pixSize = omero.model.LengthI(args.y, units[args.unit])
-                    pixel.setPhysicalSizeY(pixSize)
-                else:
-                    pixSize.setValue(args.y)
-                    pixSize.setUnit(units[args.unit])
+        client.getSession().getUpdateService().saveCollection(pixels)
 
-            if args.z:
-                pixSize = pixel.getPhysicalSizeZ()
-                if not pixSize:
-                    pixSize = omero.model.LengthI(args.z, units[args.unit])
-                    pixel.setPhysicalSizeZ(pixSize)
-                else:
-                    pixSize.setValue(args.z)
-                    pixSize.setUnit(units[args.unit])
-
-            client.getSession().getUpdateService().saveAndReturnObject(pixel)
+    def _setPixelsize(self, pixel, size, unit, dim):
+        if size:
+            if dim == 'x':
+                pixel.setPhysicalSizeX(omero.model.LengthI(size, unit))
+            elif dim == 'y':
+                pixel.setPhysicalSizeY(omero.model.LengthI(size, unit))
+            elif dim == 'z':
+                pixel.setPhysicalSizeZ(omero.model.LengthI(size, unit))
 
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -608,8 +608,7 @@ class MetadataControl(BaseControl):
 
         params = omero.sys.ParametersI()
         params.addId(md.get_id())
-        pixels = client.getSession().getQueryService()\
-                                    .findAllByQuery(q, params, ctx)
+        pixels = conn.getQueryService().findAllByQuery(q, params, ctx)
 
         if not pixels:
             self.ctx.die(100, "Failed to get Pixel object(s)")
@@ -622,7 +621,9 @@ class MetadataControl(BaseControl):
             if args.z:
                 pixel.setPhysicalSizeZ(omero.model.LengthI(args.z, unit))
 
-        client.getSession().getUpdateService(ctx).saveCollection(pixels)
+        groupId = pixels[0].getDetails().getGroup().getId().getValue()
+        ctx = {'omero.group': str(groupId)}
+        conn.getUpdateService().saveArray(pixels, ctx)
 
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -608,16 +608,19 @@ class MetadataControl(BaseControl):
 
         params = omero.sys.ParametersI()
         params.addId(md.get_id())
-        pixels = client.getSession().getQueryService(ctx)\
-                                    .findAllByQuery(q, params)
+        pixels = client.getSession().getQueryService()\
+                                    .findAllByQuery(q, params, ctx)
+
+        if not pixels:
+            self.ctx.die(100, "Failed to get Pixel object(s)")
 
         for pixel in pixels:
             if args.x:
-                pixel.setPhysicalSizeX(omero.model.LengthI(args.x, unit), ctx)
+                pixel.setPhysicalSizeX(omero.model.LengthI(args.x, unit))
             if args.y:
-                pixel.setPhysicalSizeY(omero.model.LengthI(args.y, unit), ctx)
+                pixel.setPhysicalSizeY(omero.model.LengthI(args.y, unit))
             if args.z:
-                pixel.setPhysicalSizeZ(omero.model.LengthI(args.z, unit), ctx)
+                pixel.setPhysicalSizeZ(omero.model.LengthI(args.z, unit))
 
         client.getSession().getUpdateService(ctx).saveCollection(pixels)
 


### PR DESCRIPTION
# What this PR does

Adds a `pixelsize` command to the metadata plugin, which allows setting a custom physical pixel size for an Image (or whole Dataset, Project, etc.)

# Testing this PR

Set a custom pixel size:
`./omero metadata pixelsize --x 5 --y 6 --z 7 --unit nanometer Dataset:123 `

Doesn't output anything, so use Insight or Web to check if it was successful.

# Related reading

https://github.com/IDR/idr0042-nirschl-wsideeplearning/issues/1

/cc @sbesson 
