### PR TITLE
Import library python

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/import_library.py
+++ b/components/tools/OmeroPy/src/omero/util/import_library.py
@@ -1,0 +1,124 @@
+
+# From http://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8407
+# Uses code from https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/src/omero/testlib/__init__.py
+
+import omero
+import platform
+import os
+from omero.model import ChecksumAlgorithmI
+# from omero.model import NamedValue
+from omero.model.enums import ChecksumAlgorithmSHA1160
+from omero.rtypes import rstring, rbool
+from omero_version import omero_version
+from omero.callbacks import CmdCallbackI
+from omero.gateway import BlitzGateway
+
+
+def create_fileset(folder_path):
+    fileset = omero.model.FilesetI()
+    # for f in folder.files():
+    for f in os.listdir(folder_path):
+        if f.startswith('.'):
+            continue
+        entry = omero.model.FilesetEntryI()
+        # entry.setClientPath(rstring(str(f.abspath())))
+        entry.setClientPath(rstring(os.path.join(folder_path, f)))
+        fileset.addFilesetEntry(entry)
+
+    # Fill version info
+    system, node, release, version, machine, processor = platform.uname()
+
+    # client_version_info = [
+    #     NamedValue('omero.version', omero_version),
+    #     NamedValue('os.name', system),
+    #     NamedValue('os.version', release),
+    #     NamedValue('os.architecture', machine)
+    # ]
+    # try:
+    #     client_version_info.append(
+    #         NamedValue('locale', locale.getdefaultlocale()[0]))
+    # except:
+    #     pass
+
+    upload = omero.model.UploadJobI()
+    # upload.setVersionInfo(client_version_info)
+    fileset.linkJob(upload)
+    return fileset
+
+
+def create_settings():
+    settings = omero.grid.ImportSettings()
+    settings.doThumbnails = rbool(True)
+    settings.noStatsInfo = rbool(False)
+    settings.userSpecifiedTarget = None
+    settings.userSpecifiedName = None
+    settings.userSpecifiedDescription = None
+    settings.userSpecifiedAnnotationList = None
+    settings.userSpecifiedPixels = None
+    settings.checksumAlgorithm = ChecksumAlgorithmI()
+    s = rstring(ChecksumAlgorithmSHA1160)
+    settings.checksumAlgorithm.value = s
+    return settings
+
+
+def upload_folder(proc, folder_path, client):
+    ret_val = []
+    # for i, fobj in enumerate(folder.files()):  # Assuming same order
+    i = 0
+    for f in os.listdir(folder_path):
+        if f.startswith('.'):
+            continue
+        rfs = proc.getUploader(i)
+        i += 1
+        try:
+            # f = fobj.open()
+            abspath = os.path.join(folder_path, f)
+            f = open(abspath)
+            try:
+                offset = 0
+                block = []
+                rfs.write(block, offset, len(block))  # Touch
+                while True:
+                    block = f.read(1000 * 1000)
+                    if not block:
+                        break
+                    rfs.write(block, offset, len(block))
+                    offset += len(block)
+                ret_val.append(client.sha1(abspath))
+            finally:
+                f.close()
+        finally:
+            rfs.close()
+    return ret_val
+
+
+def assert_passes(cb, loops=10, wait=500):
+    cb.loop(loops, wait)
+    rsp = cb.getResponse()
+    if isinstance(rsp, omero.cmd.ERR):
+        raise Exception(rsp)
+    return rsp
+
+
+def assert_import(client, proc, folder):
+    hashes = upload_folder(proc, folder, client)
+    handle = proc.verifyUpload(hashes)
+    cb = CmdCallbackI(client, handle)
+    rsp = assert_passes(cb)
+    assert len(rsp.pixels) > 0
+    return rsp
+
+
+def full_import(client, folder_path):
+    """
+    Re-usable method for a basic import
+    """
+    mrepo = client.getManagedRepository()
+    fileset = create_fileset(folder_path)
+    settings = create_settings()
+
+    proc = mrepo.importFileset(fileset, settings)
+    try:
+        return assert_import(client, proc, folder_path)
+    finally:
+        proc.close()

--- a/components/tools/OmeroPy/src/omero/util/import_library.py
+++ b/components/tools/OmeroPy/src/omero/util/import_library.py
@@ -1,17 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-# From http://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8407
-# Uses code from https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/src/omero/testlib/__init__.py
+# Copyright (C) 2018 University of Dundee
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+"""Import library."""
 
 import omero
 import platform
-import os
 from omero.model import ChecksumAlgorithmI
 # from omero.model import NamedValue
 from omero.model.enums import ChecksumAlgorithmSHA1160
 from omero.rtypes import rstring, rbool
-from omero_version import omero_version
+# from omero_version import omero_version
 from omero.callbacks import CmdCallbackI
-from omero.gateway import BlitzGateway
 
 try:
     import hashlib
@@ -22,13 +38,15 @@ except:
 
 
 class ImportLibrary(object):
+    """Main Import Class."""
 
     def __init__(self, client):
-
+        """Constructor takes the omero client."""
         self.client = client
         self.mrepo = client.getManagedRepository()
 
     def create_settings(self):
+        """Create omero.grid.ImportSettings."""
         settings = omero.grid.ImportSettings()
         settings.doThumbnails = rbool(True)
         settings.noStatsInfo = rbool(False)
@@ -43,8 +61,8 @@ class ImportLibrary(object):
         return settings
 
     def create_fileset(self, client_path_gen):
+        """Create new Fileset and populates with client paths."""
         fileset = omero.model.FilesetI()
-        # for f in folder.files():
         for abspath in client_path_gen:
             entry = omero.model.FilesetEntryI()
             entry.setClientPath(rstring(abspath))
@@ -71,6 +89,7 @@ class ImportLibrary(object):
         return fileset
 
     def upload_folder(self, proc, folder_gen):
+        """Iterate through folder_gen, uploading files in chunks."""
         ret_val = []
         i = 0
         for chunk_gen in folder_gen:
@@ -91,6 +110,7 @@ class ImportLibrary(object):
         return ret_val
 
     def assert_passes(self, cb, loops=10, wait=500):
+        """Wait on callback and check it completes without error."""
         cb.loop(loops, wait)
         rsp = cb.getResponse()
         if isinstance(rsp, omero.cmd.ERR):
@@ -98,6 +118,7 @@ class ImportLibrary(object):
         return rsp
 
     def createImport(self, client_path_gen):
+        """Create Fileset and import it to managed repository."""
         settings = self.create_settings()
         fileset = self.create_fileset(client_path_gen)
         return self.mrepo.importFileset(fileset, settings)

--- a/components/tools/OmeroPy/src/omero/util/import_library.py
+++ b/components/tools/OmeroPy/src/omero/util/import_library.py
@@ -14,111 +14,110 @@ from omero.callbacks import CmdCallbackI
 from omero.gateway import BlitzGateway
 
 
-def create_fileset(folder_path):
-    fileset = omero.model.FilesetI()
-    # for f in folder.files():
-    for f in os.listdir(folder_path):
-        if f.startswith('.'):
-            continue
-        entry = omero.model.FilesetEntryI()
-        # entry.setClientPath(rstring(str(f.abspath())))
-        entry.setClientPath(rstring(os.path.join(folder_path, f)))
-        fileset.addFilesetEntry(entry)
+class ImportLibrary(object):
 
-    # Fill version info
-    system, node, release, version, machine, processor = platform.uname()
+    def __init__(self, client):
 
-    # client_version_info = [
-    #     NamedValue('omero.version', omero_version),
-    #     NamedValue('os.name', system),
-    #     NamedValue('os.version', release),
-    #     NamedValue('os.architecture', machine)
-    # ]
-    # try:
-    #     client_version_info.append(
-    #         NamedValue('locale', locale.getdefaultlocale()[0]))
-    # except:
-    #     pass
+        self.client = client
+        self.mrepo = client.getManagedRepository()
 
-    upload = omero.model.UploadJobI()
-    # upload.setVersionInfo(client_version_info)
-    fileset.linkJob(upload)
-    return fileset
+    def create_settings(self):
+        settings = omero.grid.ImportSettings()
+        settings.doThumbnails = rbool(True)
+        settings.noStatsInfo = rbool(False)
+        settings.userSpecifiedTarget = None
+        settings.userSpecifiedName = None
+        settings.userSpecifiedDescription = None
+        settings.userSpecifiedAnnotationList = None
+        settings.userSpecifiedPixels = None
+        settings.checksumAlgorithm = ChecksumAlgorithmI()
+        s = rstring(ChecksumAlgorithmSHA1160)
+        settings.checksumAlgorithm.value = s
+        return settings
 
+    def create_fileset(self, folder_path):
+        fileset = omero.model.FilesetI()
+        # for f in folder.files():
+        for f in os.listdir(folder_path):
+            if f.startswith('.'):
+                continue
+            entry = omero.model.FilesetEntryI()
+            # entry.setClientPath(rstring(str(f.abspath())))
+            entry.setClientPath(rstring(os.path.join(folder_path, f)))
+            fileset.addFilesetEntry(entry)
 
-def create_settings():
-    settings = omero.grid.ImportSettings()
-    settings.doThumbnails = rbool(True)
-    settings.noStatsInfo = rbool(False)
-    settings.userSpecifiedTarget = None
-    settings.userSpecifiedName = None
-    settings.userSpecifiedDescription = None
-    settings.userSpecifiedAnnotationList = None
-    settings.userSpecifiedPixels = None
-    settings.checksumAlgorithm = ChecksumAlgorithmI()
-    s = rstring(ChecksumAlgorithmSHA1160)
-    settings.checksumAlgorithm.value = s
-    return settings
+        # Fill version info
+        system, node, release, version, machine, processor = platform.uname()
 
+        # client_version_info = [
+        #     NamedValue('omero.version', omero_version),
+        #     NamedValue('os.name', system),
+        #     NamedValue('os.version', release),
+        #     NamedValue('os.architecture', machine)
+        # ]
+        # try:
+        #     client_version_info.append(
+        #         NamedValue('locale', locale.getdefaultlocale()[0]))
+        # except:
+        #     pass
 
-def upload_folder(proc, folder_path, client):
-    ret_val = []
-    # for i, fobj in enumerate(folder.files()):  # Assuming same order
-    i = 0
-    for f in os.listdir(folder_path):
-        if f.startswith('.'):
-            continue
-        rfs = proc.getUploader(i)
-        i += 1
-        try:
-            # f = fobj.open()
-            abspath = os.path.join(folder_path, f)
-            f = open(abspath)
+        upload = omero.model.UploadJobI()
+        # upload.setVersionInfo(client_version_info)
+        fileset.linkJob(upload)
+        return fileset
+
+    def upload_folder(self, proc, folder_path):
+        ret_val = []
+        # for i, fobj in enumerate(folder.files()):  # Assuming same order
+        i = 0
+        for f in os.listdir(folder_path):
+            if f.startswith('.'):
+                continue
+            rfs = proc.getUploader(i)
+            i += 1
             try:
-                offset = 0
-                block = []
-                rfs.write(block, offset, len(block))  # Touch
-                while True:
-                    block = f.read(1000 * 1000)
-                    if not block:
-                        break
-                    rfs.write(block, offset, len(block))
-                    offset += len(block)
-                ret_val.append(client.sha1(abspath))
+                # f = fobj.open()
+                abspath = os.path.join(folder_path, f)
+                f = open(abspath)
+                try:
+                    offset = 0
+                    block = []
+                    rfs.write(block, offset, len(block))  # Touch
+                    while True:
+                        block = f.read(1000 * 1000)
+                        if not block:
+                            break
+                        rfs.write(block, offset, len(block))
+                        offset += len(block)
+                    ret_val.append(self.client.sha1(abspath))
+                finally:
+                    f.close()
             finally:
-                f.close()
+                rfs.close()
+        return ret_val
+
+    def assert_passes(self, cb, loops=10, wait=500):
+        cb.loop(loops, wait)
+        rsp = cb.getResponse()
+        if isinstance(rsp, omero.cmd.ERR):
+            raise Exception(rsp)
+        return rsp
+
+    def createImport(self, folder_path):
+        settings = self.create_settings()
+        fileset = self.create_fileset(folder_path)
+        return self.mrepo.importFileset(fileset, settings)
+
+    def importImage(self, folder_path):
+
+        proc = self.createImport(folder_path)
+
+        try:
+            hashes = self.upload_folder(proc, folder_path)
+            handle = proc.verifyUpload(hashes)
+            cb = CmdCallbackI(self.client, handle)
+            rsp = self.assert_passes(cb)
+            assert len(rsp.pixels) > 0
+            return rsp
         finally:
-            rfs.close()
-    return ret_val
-
-
-def assert_passes(cb, loops=10, wait=500):
-    cb.loop(loops, wait)
-    rsp = cb.getResponse()
-    if isinstance(rsp, omero.cmd.ERR):
-        raise Exception(rsp)
-    return rsp
-
-
-def assert_import(client, proc, folder):
-    hashes = upload_folder(proc, folder, client)
-    handle = proc.verifyUpload(hashes)
-    cb = CmdCallbackI(client, handle)
-    rsp = assert_passes(cb)
-    assert len(rsp.pixels) > 0
-    return rsp
-
-
-def full_import(client, folder_path):
-    """
-    Re-usable method for a basic import
-    """
-    mrepo = client.getManagedRepository()
-    fileset = create_fileset(folder_path)
-    settings = create_settings()
-
-    proc = mrepo.importFileset(fileset, settings)
-    try:
-        return assert_import(client, proc, folder_path)
-    finally:
-        proc.close()
+            proc.close()


### PR DESCRIPTION
See https://trello.com/c/3zH1PSo7/311-omeropy-importlibrary

# What this PR does

Takes code from https://gist.github.com/will-moore/f5402e451ea471fd05893f8b38a077ce (see discussion at https://www.openmicroscopy.org/community/viewtopic.php?t=8407&p=18839) and attempts to organise it like [ImportLibrary.java](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/blitz/src/ome/formats/importer/ImportLibrary.java) with an ```importImage``` and ```createImport``` methods.

Also removes the directory traversing from the library, instead it takes generators of file chunks and file paths.
This allows the same logic to be used with files uploaded to the web.

Tested locally with this code that creates a fileset from all images in a given folder and imports it.
```
from omero.util.import_library import ImportLibrary

folder_path = "/path/to/images/folder"

def folder_gen(folder_path):
    for f in os.listdir(folder_path):
        if f.startswith('.'):
            continue
        yield os.path.join(folder_path, f)

def chunks_gen(open_file):
    while True:
        block = open_file.read(1000 * 1000)
        if not block:
            break
        yield block

def file_gen(folder_path):
    for abspath in folder_gen(folder_path):
        with open(abspath) as f:
            yield chunks_gen(f)

file_paths = folder_gen(folder_path)
file_chunks = file_gen(folder_path)

import_library = ImportLibrary(client)
rsp = import_library.importImage(file_paths, file_chunks)
for p in rsp.pixels:
    print 'Imported Image ID:', p.image.id.val
```

# Testing this PR

1. TODO: Add tests....

Maybe this code should live somewhere other than ```utils.py```?
(forum discussion was asking how to import using BlitzGateway).