### PR TITLE
Leakage paranoia

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -7749,9 +7749,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
     PARENT_WRAPPER_CLASS = ['DatasetWrapper', 'WellSampleWrapper']
     _thumbInProgress = False
 
-    def __del__(self):
-        self._re and self._re.untaint()
-
     def __loadedHotSwap__(self):
         ctx = self._conn.SERVICE_OPTS.copy()
         ctx.setOmeroGroup(self.getDetails().group.id.val)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1922,6 +1922,7 @@ class _BlitzGateway (object):
                 oldC.__del__()
                 oldC = None
                 self.c = None
+                self._session = None
 
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1903,16 +1903,21 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connecion (uuid=%s)" % str(self._sessionUuid))
 
-    def close(self):  # pragma: no cover
+    def close(self, hard=True):  # pragma: no cover
         """
-        Terminates connection with killSession(). The session is terminated
-        regardless of its connection refcount.
+        Terminates connection with killSession(), where the session is
+        terminated regardless of its connection refcount, or closeSession().
+
+        :param hard: If True, use killSession(), otherwise closeSession()
         """
         self._connected = False
         oldC = self.c
+        for proxy in self._proxies.values():
+            proxy.close()
         if oldC is not None:
             try:
-                self._closeSession()
+                if hard:
+                    self._closeSession()
             finally:
                 oldC.__del__()
                 oldC = None

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4789,13 +4789,14 @@ class ProxyObjectWrapper (object):
         """
 
         self._conn = conn
-        self._sf = conn.c.sf
 
         def cf():
             if self._func_str is None:
-                return self._cast_to(self._sf.getByName(self._service_name))
+                return self._cast_to(
+                    self._conn.c.sf.getByName(self._service_name)
+                )
             else:
-                obj = getattr(self._sf, self._func_str)()
+                obj = getattr(self._conn.c.sf, self._func_str)()
                 if isinstance(obj, omero.api.StatefulServiceInterfacePrx):
                     conn._register_service(str(obj), traceback.extract_stack())
                 return obj
@@ -4839,7 +4840,7 @@ class ProxyObjectWrapper (object):
         """
 
         try:
-            if not self._sf.keepAlive(self._obj):
+            if not self._conn.c.sf.keepAlive(self._obj):
                 logger.debug("... died, recreating ...")
                 self._obj = self._create_func()
         except Ice.ObjectNotExistException:

--- a/components/tools/OmeroWeb/omeroweb/connector.py
+++ b/components/tools/OmeroWeb/omeroweb/connector.py
@@ -165,9 +165,10 @@ class Connector(object):
     def create_connection(self, useragent, username, password,
                           is_public=False, userip=None):
         self.is_public = is_public
+        connection = self.create_gateway(
+            useragent, username, password, userip
+        )
         try:
-            connection = self.create_gateway(
-                useragent, username, password, userip)
             if connection.connect():
                 logger.debug('Successfully created connection for: %s'
                              % username)
@@ -175,6 +176,7 @@ class Connector(object):
                 return connection
         except:
             logger.debug('Cannot create a new connection.', exc_info=True)
+        connection.close()
         return None
 
     def create_guest_connection(self, useragent, is_public=False):

--- a/components/tools/OmeroWeb/omeroweb/connector.py
+++ b/components/tools/OmeroWeb/omeroweb/connector.py
@@ -216,19 +216,22 @@ class Connector(object):
 
     def check_version(self, useragent):
         connection = self.create_guest_connection(useragent)
-        if connection is None:
-            return False
         try:
-            server_version = connection.getServerVersion()
-            server_version = self.SERVER_VERSION_RE.match(server_version)
-            server_version = server_version.group(1).split('.')
+            if connection is None:
+                return False
+            try:
+                server_version = connection.getServerVersion()
+                server_version = self.SERVER_VERSION_RE.match(server_version)
+                server_version = server_version.group(1).split('.')
 
-            client_version = self.SERVER_VERSION_RE.match(omero_version)
-            client_version = client_version.group(1).split('.')
-            logger.info("Client version: '%s'; Server version: '%s'"
-                        % (client_version, server_version))
-            return server_version == client_version
-        except:
-            logger.error('Cannot compare server to client version.',
-                         exc_info=True)
-        return False
+                client_version = self.SERVER_VERSION_RE.match(omero_version)
+                client_version = client_version.group(1).split('.')
+                logger.info("Client version: '%s'; Server version: '%s'"
+                            % (client_version, server_version))
+                return server_version == client_version
+            except:
+                logger.error('Cannot compare server to client version.',
+                             exc_info=True)
+            return False
+        finally:
+            connection.close()

--- a/components/tools/OmeroWeb/omeroweb/connector.py
+++ b/components/tools/OmeroWeb/omeroweb/connector.py
@@ -194,8 +194,8 @@ class Connector(object):
         return None
 
     def join_connection(self, useragent, userip=None):
+        connection = self.create_gateway(useragent, userip=userip)
         try:
-            connection = self.create_gateway(useragent, userip=userip)
             if connection.connect(sUuid=self.omero_session_key):
                 logger.debug('Successfully joined connection: %s'
                              % self.omero_session_key)
@@ -204,6 +204,7 @@ class Connector(object):
                 return connection
         except:
             logger.debug('Cannot create a new connection.', exc_info=True)
+        connection.close()
         return None
 
     def is_server_up(self, useragent):

--- a/components/tools/OmeroWeb/omeroweb/connector.py
+++ b/components/tools/OmeroWeb/omeroweb/connector.py
@@ -205,14 +205,17 @@ class Connector(object):
 
     def is_server_up(self, useragent):
         connection = self.create_guest_connection(useragent)
-        if connection is None:
-            return False
         try:
-            connection.getServerVersion()
-            return True
-        except:
-            logger.error('Cannot request server version.', exc_info=True)
-        return False
+            if connection is None:
+                return False
+            try:
+                connection.getServerVersion()
+                return True
+            except:
+                logger.error('Cannot request server version.', exc_info=True)
+            return False
+        finally:
+            connection.close()
 
     def check_version(self, useragent):
         connection = self.create_guest_connection(useragent)

--- a/components/tools/OmeroWeb/omeroweb/connector.py
+++ b/components/tools/OmeroWeb/omeroweb/connector.py
@@ -180,17 +180,18 @@ class Connector(object):
         return None
 
     def create_guest_connection(self, useragent, is_public=False):
-        connection = None
         guest = 'guest'
+        connection = self.create_gateway(useragent, guest, guest, None)
         try:
-            connection = self.create_gateway(useragent, guest, guest, None)
             if connection.connect():
                 logger.debug('Successfully created a guest connection.')
+                return connection
             else:
                 logger.warn('Cannot create a guest connection.')
         except:
             logger.error('Cannot create a guest connection.', exc_info=True)
-        return connection
+        connection.close()
+        return None
 
     def join_connection(self, useragent, userip=None):
         try:

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -481,9 +481,7 @@ class login_required(object):
                         'Doing connection cleanup? %s' % doConnectionCleanup)
                     if doConnectionCleanup:
                         if conn is not None and conn.c is not None:
-                            for v in conn._proxies.values():
-                                v.close()
-                            conn.c.closeSession()
+                            conn.close(hard=False)
                 except:
                     logger.warn('Failed to clean up connection', exc_info=True)
             return retval

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2896,17 +2896,20 @@ class LoginView(View):
                 conn = connector.create_connection(
                     self.useragent, username, password,
                     userip=get_client_ip(request))
-                if conn is not None:
-                    request.session['connector'] = connector
-                    # UpgradeCheck URL should be loaded from the server or
-                    # loaded omero.web.upgrades.url allows to customize web
-                    # only
-                    try:
-                        upgrades_url = settings.UPGRADES_URL
-                    except:
-                        upgrades_url = conn.getUpgradesUrl()
-                    upgradeCheck(url=upgrades_url)
-                    return self.handle_logged_in(request, conn, connector)
+                try:
+                    if conn is not None:
+                        request.session['connector'] = connector
+                        # UpgradeCheck URL should be loaded from the server or
+                        # loaded omero.web.upgrades.url allows to customize web
+                        # only
+                        try:
+                            upgrades_url = settings.UPGRADES_URL
+                        except:
+                            upgrades_url = conn.getUpgradesUrl()
+                        upgradeCheck(url=upgrades_url)
+                        return self.handle_logged_in(request, conn, connector)
+                finally:
+                    conn.close(hard=False)
             # Once here, we are not logged in...
             # Need correct error message
             if not connector.is_server_up(self.useragent):

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2896,8 +2896,8 @@ class LoginView(View):
                 conn = connector.create_connection(
                     self.useragent, username, password,
                     userip=get_client_ip(request))
-                try:
-                    if conn is not None:
+                if conn is not None:
+                    try:
                         request.session['connector'] = connector
                         # UpgradeCheck URL should be loaded from the server or
                         # loaded omero.web.upgrades.url allows to customize web
@@ -2908,8 +2908,8 @@ class LoginView(View):
                             upgrades_url = conn.getUpgradesUrl()
                         upgradeCheck(url=upgrades_url)
                         return self.handle_logged_in(request, conn, connector)
-                finally:
-                    conn.close(hard=False)
+                    finally:
+                        conn.close(hard=False)
             # Once here, we are not logged in...
             # Need correct error message
             if not connector.is_server_up(self.useragent):


### PR DESCRIPTION
# What this PR does

After feedback regarding OMERO.web resource accumulation over time (openmicroscopy/management_tools#703) superficial research indicated that both `PIPE` and thread accumulation is possible under a variety of conditions. Especially in scenarios where the `Ice.Communicator` is **not** destroyed. This accumulation was reproduced in isolated scenarios of ascending complexity:

 1. Raw `omero.client` usage
 1. `BlitzGateway` usage
 1. OMERO.web usage

**Any** raw `omero.client` usage that does not follow the following pattern has the possibility to leak both pipes and threads; possibly until the process exits:

```
...
client =omero.client(...)
try:
   ...
finally:
   client.closeSession()
...
```

In order for `BlitzGateway` users to be compliant with this, they need to know about `.c` and to call `closeSession()` on it. As OMERO.web is an extensive user of `BlitzGateway` all uses there also need to conform.

This PR ensures that the canonical OMERO.web connection cleanup is available via `BlitzGateway.close()`. Users should now be in a safer scenario as not to unknowingly accumulate leaked resources. If this PR is approved **all** documented examples should be updated to reflect the aforementioned pattern.

This PR also addresses several cases where OMERO.web is not following the pattern and would leak pipes and threads under the following conditions:

 * Whenever a check for server version is made
 * Whenever a check for server up/down status is made
 * On every failed login
 * On every valid login

After some limited fuzzing I'm now of the opinion that **any** thread accumulation is a signal of not following the aforementioned pattern. Without this PR pipes and threads **will** accumulate in OMERO.web workers. `maxrequests` or regular, scheduled worker restarts are **essential** until this PR or a similar implementation is merged.

Finally, during the aforementioned research as to the causes of resource accumulation circular references were identified to be a significant contributor. This PR attempts to reduce the number of those circular references in the `BlitzGateway` implementation and cleans them up as part of `close()`.

# Testing this PR

As this PR makes changes to the fundamentals of `BlitzGateway` connection handling code and how it is interacted with in OMERO.web thorough testing of both valid and invalid user workflows will be required. Furthermore, it is essential that we attempt to monitor thread counts and see if we can find any other cases where valid gateway resource handling is not being performed.

/cc @emilroz, @stick, @kennethgillen 