### PR TITLE
Fix pageCount when childCount % PAGE_COUNT = 0

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -271,7 +271,10 @@ $(document).ready(function() {
 
         var childCount = parentNode.data.obj.childCount;
         if (PAGE_SIZE < childCount) {
-            json.pageCount = parseInt(childCount / PAGE_SIZE, 10) + 1;
+            json.pageCount = parseInt(childCount / PAGE_SIZE, 10);
+            if ((childCount % PAGE_SIZE) > 0) {
+                json.pageCount += 1;
+            }
             json.paging = true;
             json.page = inst.get_page(parentNode);
         }


### PR DESCRIPTION
# What this PR does

Fixes https://trello.com/c/4KHktsx7/15-bug-third-page-of-pagination-empty

# Testing this PR

1. Check that when child-count exactly fits onto a number of pages (e.g. 400 images) that we don't get an extra empty page shown.
1. Check pageCount is correct for other child counts.