### PR TITLE
remove unused configuration property versions.ome-java

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -922,7 +922,6 @@ product.name=OMERO.server
 
 org.bioformats=ome
 versions.bioformats=5.7.3
-versions.ome-java=2007-Aug-07-r3052
 
 ##
 versions.JHotDraw=7.0.9


### PR DESCRIPTION
Removes the `versions.ome-java` config property from `omero.properties`: it is an unused vestige of the ancient past.