### PR TITLE
fix typos in Python documentation string

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -510,8 +510,8 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["PUBLIC_URL_FILTER",
          r'(?#This regular expression matches nothing)a^',
          re.compile,
-         ("Set a regular expression that matches URLs the public user is"
-          "allowed to access. If this is not set, no URLS will be"
+         ("Set a regular expression that matches URLs the public user is "
+          "allowed to access. If this is not set, no URLs will be "
           "publicly available.")],
     "omero.web.public.get_only":
         ["PUBLIC_GET_ONLY",


### PR DESCRIPTION
Fixes the documentation at https://docs.openmicroscopy.org/omero/5.4.5/sysadmins/config.html#std:property-omero.web.public.url_filter.