### PR TITLE
deprecated Repository::pixels(string) as apparently unused

### DIFF
--- a/components/blitz/resources/omero/Repositories.ice
+++ b/components/blitz/resources/omero/Repositories.ice
@@ -113,6 +113,7 @@ module omero {
              **/
             omero::api::RawFileStore* file(string path, string mode) throws ServerError;
 
+            ["deprecate:may be wholly removed in next major version"]
             omero::api::RawPixelsStore*  pixels(string path) throws ServerError;
 
             omero::api::RawFileStore* fileById(long id) throws ServerError;

--- a/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/PublicRepositoryI.java
@@ -360,6 +360,7 @@ public class PublicRepositoryI implements _RepositoryOperations, ApplicationCont
         return checkPath(path, null, __current).mustExist().getMimetype();
     }
 
+    @Deprecated
     public RawPixelsStorePrx pixels(String path, Current __current) throws ServerError {
         final CheckedPath checked = checkPath(path, null, __current);
 


### PR DESCRIPTION
Deprecates https://downloads.openmicroscopy.org/omero/5.4.5/api/slice2html/omero/grid/Repository.html#pixels as it appears to be unused and it represents a small maintenance burden. See https://trello.com/c/q5L39XPZ/5-bioformatscache-is-expecting-read-write#comment-5ab36609b5fc3a034e14bbfd.