### PR TITLE
Allow clearing user passwords from CLI

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/db.py
+++ b/components/tools/OmeroPy/src/omero/plugins/db.py
@@ -74,7 +74,8 @@ class DatabaseControl(BaseControl):
         pw_spec = pw.add_mutually_exclusive_group()
         pw_spec.add_argument("password", nargs="?")
         pw_spec.add_argument("--empty", action="store_true",
-            help="Remove the password, allowing any for login.")
+                             help=("Remove the password, "
+                                   "allowing any for login."))
         pw.add_argument("--user-id",
                         help="User ID to salt into the password. "
                         "Defaults to '0', i.e. 'root'",

--- a/components/tools/OmeroPy/src/omero/plugins/db.py
+++ b/components/tools/OmeroPy/src/omero/plugins/db.py
@@ -263,7 +263,7 @@ BEGIN;
             password_hash = self._get_password_hash(args, root_pass,
                                                     old_prompt)
         self.ctx.out("UPDATE password SET hash = '%s' "
-                     "WHERE experimenter_id  = %s;""" %
+                     "WHERE experimenter_id = %s;""" %
                      (password_hash, user_id))
 
     @windows_warning

--- a/components/tools/OmeroPy/src/omero/plugins/db.py
+++ b/components/tools/OmeroPy/src/omero/plugins/db.py
@@ -73,7 +73,7 @@ class DatabaseControl(BaseControl):
         pw.set_defaults(func=self.password)
         pw_spec = pw.add_mutually_exclusive_group()
         pw_spec.add_argument("password", nargs="?")
-        pw_spec.add_argument("--no-password", action="store_true",
+        pw_spec.add_argument("--empty", action="store_true",
             help="Remove the password, allowing any for login.")
         pw.add_argument("--user-id",
                         help="User ID to salt into the password. "
@@ -257,7 +257,7 @@ BEGIN;
             root_pass = args.password
         except Exception, e:
             self.ctx.dbg("While getting arguments:" + str(e))
-        if args.no_password:
+        if args.empty:
             password_hash = ""
         else:
             password_hash = self._get_password_hash(args, root_pass,

--- a/components/tools/OmeroPy/src/omero/plugins/db.py
+++ b/components/tools/OmeroPy/src/omero/plugins/db.py
@@ -75,7 +75,7 @@ class DatabaseControl(BaseControl):
         pw_spec.add_argument("password", nargs="?")
         pw_spec.add_argument("--empty", action="store_true",
                              help=("Remove the password, "
-                                   "allowing any for login."))
+                                   "allowing any for login when guest."))
         pw.add_argument("--user-id",
                         help="User ID to salt into the password. "
                         "Defaults to '0', i.e. 'root'",

--- a/components/tools/OmeroPy/src/omero/plugins/db.py
+++ b/components/tools/OmeroPy/src/omero/plugins/db.py
@@ -70,8 +70,11 @@ class DatabaseControl(BaseControl):
         pw = sub.add_parser(
             "password",
             help="Prints SQL command for updating your root password")
-        pw.add_argument("password", nargs="?")
         pw.set_defaults(func=self.password)
+        pw_spec = pw.add_mutually_exclusive_group()
+        pw_spec.add_argument("password", nargs="?")
+        pw_spec.add_argument("--no-password", action="store_true",
+            help="Remove the password, allowing any for login.")
         pw.add_argument("--user-id",
                         help="User ID to salt into the password. "
                         "Defaults to '0', i.e. 'root'",
@@ -254,7 +257,11 @@ BEGIN;
             root_pass = args.password
         except Exception, e:
             self.ctx.dbg("While getting arguments:" + str(e))
-        password_hash = self._get_password_hash(args, root_pass, old_prompt)
+        if args.no_password:
+            password_hash = ""
+        else:
+            password_hash = self._get_password_hash(args, root_pass,
+                                                    old_prompt)
         self.ctx.out("UPDATE password SET hash = '%s' "
                      "WHERE experimenter_id  = %s;""" %
                      (password_hash, user_id))

--- a/components/tools/OmeroPy/test/unit/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_db.py
@@ -202,7 +202,7 @@ class TestDatabase(object):
 
     def password_output(self, user_id, no_salt):
         update_msg = "UPDATE password SET hash = \'%s\'" \
-            " WHERE experimenter_id  = %s;"
+            " WHERE experimenter_id = %s;"
         if not user_id:
             user_id = "0"
         return update_msg % (hash_map[(user_id, no_salt)], user_id)


### PR DESCRIPTION
Effects https://trello.com/c/EeM6Ekrp/45-allow-setting-empty-passwords by providing a `bin/omero db password --empty`.