### PR TITLE
for CLI user add, one must specify a group

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -2502,10 +2502,11 @@ class UserGroupControl(BaseControl):
 
         return uid_list, u_list
 
-    def add_group_arguments(self, parser, action=""):
+    def add_group_arguments(self, parser, action="", mandatory=False):
         group = parser.add_argument_group('Group arguments')
+        nargs = "+" if mandatory else "*"
         group.add_argument(
-            "group_id_or_name",  metavar="group", nargs="*",
+            "group_id_or_name",  metavar="group", nargs=nargs,
             help="ID or name of the group(s)%s" % action)
         group.add_argument(
             "--group-id", metavar="group", nargs="+",

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -42,7 +42,7 @@ class UserControl(UserGroupControl):
         add.add_argument("username", help="User's login name")
         add.add_argument("firstname", help="User's given name")
         add.add_argument("lastname", help="User's surname name")
-        self.add_group_arguments(add, " to join")
+        self.add_group_arguments(add, " to join", mandatory=True)
 
         password_group = add.add_mutually_exclusive_group()
         password_group.add_argument(


### PR DESCRIPTION
Make it clear that `bin/omero user add` requires a group: see https://trello.com/c/qNsR2iC7/13-omero-user-add-help-is-misleading.