### PR TITLE
fix thumbnail group checks

### DIFF
--- a/components/server/src/ome/services/PerGroupActor.java
+++ b/components/server/src/ome/services/PerGroupActor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2017-2018 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -78,7 +78,7 @@ abstract class PerGroupActor {
         }
         for (final Map.Entry<Long, Collection<Long>> pixelsOneGroup : pixelsByGroup.asMap().entrySet()) {
             final Long groupId = pixelsOneGroup.getKey();
-            if (groupId == currentGroupId) {
+            if (groupId.equals(currentGroupId)) {
                 actOnOneGroup((Set<Long>) pixelsOneGroup.getValue());
             } else {
                 final Map<String, String> groupContext = new HashMap<>();

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2010-2017 University of Dundee. All rights reserved.
+ *   Copyright 2010-2018 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -251,7 +251,7 @@ public class ThumbnailCtx
         // Now check to see if we're in a state where missing settings requires
         // us to use the owner's settings (we're "graph critical") and load
         // them if possible.
-        new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentEventId()) {
+        new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentGroupId()) {
             @Override
             protected void actOnOneGroup(Set<Long> pixelsIds) {
                 if (isExtendedGraphCritical(pixelsIds)) {
@@ -396,7 +396,7 @@ public class ThumbnailCtx
         if (count > 0) {
             log.info(count + " pixels without settings");
             final List<Long> allImageIds = new ArrayList<>(count);
-            new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentEventId()) {
+            new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentGroupId()) {
                 @Override
                 protected void actOnOneGroup(Set<Long> pixelsIds) {
                     if (isExtendedGraphCritical(pixelsIds)) {
@@ -525,7 +525,7 @@ public class ThumbnailCtx
         private boolean isCritical;
 
         private ExtendedGraphCriticalCheck(long pixelsId) {
-            super(applicationContext, queryService, securitySystem.getEventContext().getCurrentEventId());
+            super(applicationContext, queryService, securitySystem.getEventContext().getCurrentGroupId());
             if (securitySystem.getEventContext().getCurrentShareId() == null) {
                 actOnByGroup(Collections.singleton(pixelsId));
             } else {
@@ -996,7 +996,7 @@ public class ThumbnailCtx
             // Now check to see if we're in a state where missing metadata
             // requires us to use the owner's metadata (we're "graph critical")
             // and load them if possible.
-            new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentEventId()) {
+            new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentGroupId()) {
                 @Override
                 protected void actOnOneGroup(Set<Long> pixelsIds) {
                     if (isExtendedGraphCritical(pixelsIds)) {
@@ -1090,7 +1090,7 @@ public class ThumbnailCtx
                 "omero.createMissingThumbnailMetadata");
         Set<Long> pixelsIdsWithoutMetadata =
             getPixelsIdsWithoutMetadata(pixelsIdPixelsMap.keySet());
-        new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentEventId()) {
+        new PerGroupActor(applicationContext, queryService, securitySystem.getEventContext().getCurrentGroupId()) {
             @Override
             protected void actOnOneGroup(Set<Long> pixelsIds) {
                 final List<Thumbnail> toSave = new ArrayList<Thumbnail>();

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -184,7 +184,7 @@ public class ThumbnailCtx
     }
 
     /**
-     * Bulk loads a set of rendering settings for a  group of pixels sets and
+     * Bulk loads a set of rendering settings for a group of pixels sets and
      * prepares our internal data structures.
      * @param pixelsIds Set of Pixels IDs to prepare rendering settings for.
      */
@@ -194,7 +194,7 @@ public class ThumbnailCtx
     }
 
     /**
-     * Bulk loads a set of rendering settings for a  group of pixels sets and
+     * Bulk loads a set of rendering settings for a group of pixels sets and
      * prepares our internal data structures.
      * @param ids Set of IDs to prepare rendering settings for.
      * @param klass Either <code>Image</code> or <code>Pixels</code> qualifying

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -53,6 +53,8 @@ public class ThumbnailCtx
      */
     public static class NoThumbnail extends Exception {
 
+        private static final long serialVersionUID = 8383673110828921831L;
+
         public NoThumbnail(String message) {
             super(message);
         }


### PR DESCRIPTION
It looks to me as if there are some coding bugs among the group membership checks for delivering thumbnails. This PR fixes those but it is worth then checking thumbnail behavior for any regressions.