### PR TITLE
public login reset group and user

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -324,6 +324,7 @@ class login_required(object):
                 userip=get_client_ip(request))
             request.session['connector'] = connector
             # Clear any previous context so we don't try to access this
+            # NB: we also do this in WebclientLoginView.handle_logged_in()
             if 'active_group' in request.session:
                 del request.session['active_group']
             if 'user_id' in request.session:

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -323,6 +323,10 @@ class login_required(object):
                 self.useragent, username, password, is_public=True,
                 userip=get_client_ip(request))
             request.session['connector'] = connector
+            # Clear any previous context so we don't try to access this
+            del request.session['active_group']
+            del request.session['user_id']
+            request.session.modified = True
             self.set_public_user_connector(connector)
         elif connection is not None:
             is_anonymous = connection.isAnonymous()

--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -324,8 +324,10 @@ class login_required(object):
                 userip=get_client_ip(request))
             request.session['connector'] = connector
             # Clear any previous context so we don't try to access this
-            del request.session['active_group']
-            del request.session['user_id']
+            if 'active_group' in request.session:
+                del request.session['active_group']
+            if 'user_id' in request.session:
+                del request.session['user_id']
             request.session.modified = True
             self.set_public_user_connector(connector)
         elif connection is not None:

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -199,6 +199,7 @@ class WebclientLoginView(LoginView):
         # webclient has various state that needs cleaning up...
         # if 'active_group' remains in session from previous
         # login, check it's valid for this user
+        # NB: we do this for public users in @login_required.get_connection()
         if request.session.get('active_group'):
             if (request.session.get('active_group') not in
                     conn.getEventContext().memberOfGroups):


### PR DESCRIPTION
# What this PR does

Another potential fix for SecurityVioloation seen in https://trello.com/c/sBdAN4L6/375-public-user-workflow-crash.

To test:
 - Need to have public user enabled.
 - Login as non-public user and switch group context in web UI (this sets 'active_group' in session).
 - Allow session to timeout or kill it. E.g. if computer sleeps so that webclient doesn't ping server. Or can simply restart OMERO, or set very short session timeout (options described in trello card)
 - Now visit /webclient/, logged in as public user. Should see no error and be displayed data in public group.
