### PR TITLE
have CLI try using previous port for session

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -950,7 +950,7 @@ class SessionsControl(UserGroupControl):
     def _get_server(self, store, name, port):
         defserver = store.last_host()
         if not port:
-            port = str(omero.constants.GLACIER2PORT)
+            port = store.last_port()
         self._require_tty("cannot request server")
         rv = self.ctx.input("Server: [%s:%s]" % (defserver, port))
         if not rv:


### PR DESCRIPTION
Fixes https://trello.com/c/9dejKUh6/61-previous-port-apparently-ignored:

1. `bin/omero login` to some server on non-4064 port, see https://docs.openmicroscopy.org/contributing/ci-omero.html#deployment-servers-and-web
1. `bin/omero logout`
1. `bin/omero login` with no options
1. See that it prompts you with the same port as your last login.