### PR TITLE
Bump to Bio-Formats 5.8.2 (rc1)

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -921,8 +921,7 @@ product.name=OMERO.server
 #############################################
 
 org.bioformats=ome
-versions.bioformats=5.8.2-SNAPSHOT
-versions.ome-java=2007-Aug-07-r3052
+versions.bioformats=5.8.2-rc1
 
 ##
 versions.JHotDraw=7.0.9

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -921,7 +921,7 @@ product.name=OMERO.server
 #############################################
 
 org.bioformats=ome
-versions.bioformats=5.7.3
+versions.bioformats=5.8.2-SNAPSHOT
 versions.ome-java=2007-Aug-07-r3052
 
 ##


### PR DESCRIPTION
Upgrades the version of Bio-Formats in use by OMERO.

Primarily for the new Memoizer method added in
https://github.com/openmicroscopy/bioformats/pull/3115