### PR TITLE
Restore history

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/urls.py
@@ -88,7 +88,7 @@ urlpatterns = patterns(
     # load history
     url(r'^load_calendar/(?:(\d{4})/(\d{1,2})/)?$', views.load_calendar,
         name="load_calendar"),
-    url(r'^load_history/(\d{4})/(\d{1,2})/(\d{1,2})/$',
+    url(r'^load_history/(?:(\d{4})/(\d{1,2})/(\d{1,2})/)?$',
         views.load_history, name="load_history"),
 
     # load search

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -3056,6 +3056,9 @@ def load_calendar(request, year=None, month=None, conn=None, **kwargs):
 def load_history(request, year, month, day, conn=None, **kwargs):
     """ The data for a particular date that is loaded into the center panel """
 
+    if year is None or month is None or day is None:
+        raise Http404('Year, month, and day are required')
+
     template = "webclient/history/history_details.html"
 
     # get page


### PR DESCRIPTION
# What this PR does

Restore the functionality of the "History" tab in OMERO.web which was broken by openmicroscopy/openmicroscopy#5654. This PR was released as part of 5.4.4.

# Testing this PR

1. Navigate to the "History" tab in OMERO.web

2. Page should load normally, calendar should display in the left-hand panel. If the response of the XHR to `/webclient/load_calendar/` is inspected `'/webclient/load_history'` should be present correctly in the JavaScript that the template renders.

3. Visiting `/webclient/load_history/` in your web browser without the required trailing part of the URL should result in a 404.


# Related reading

Link to cards, tickets, other PRs:

1. openmicroscopy/openmicroscopy#5654

2. https://trello.com/c/HOUhWHaQ/382-bug-get-loadcalendar
