### PR TITLE
Use supplied client for wait_for_pyramid()

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -1127,8 +1127,10 @@ class ITest(object):
 
         self.do_submit(command, client)
 
-    def wait_for_pyramid(self, id):
-        store = self.client.sf.createRawPixelsStore()
+    def wait_for_pyramid(self, id, client=None):
+        if client is None:
+            client = self.client
+        store = client.sf.createRawPixelsStore()
         not_ready = True
         count = 0
         elapse_time = 1  # time in seconds
@@ -1139,8 +1141,9 @@ class ITest(object):
                     store.setPixelsId(id, True)
                     # No exception. The pyramid is now ready
                     not_ready = False
-                except Exception:
+                except Exception, ex:
                     # try again in elapse_time
+                    print count, "Pyramid not ready:", ex.message
                     time.sleep(elapse_time)
                     count = count + elapse_time
         finally:
@@ -1158,7 +1161,7 @@ class ITest(object):
         id = long(float(pixels))
         assert id >= 0
         # wait for the pyramid to be generated
-        self.wait_for_pyramid(id)
+        self.wait_for_pyramid(id, client)
         query_service = client.sf.getQueryService()
         pix = query_service.findByQuery(
             "select p from Pixels p where p.id = :id",


### PR DESCRIPTION
# What this PR does

Adds ```client``` parameter to the ```testlib. wait_for_pyramid()```.

Previously, without this, when used with the default ```self.client``` the ```store.setPixelsId()``` failed once with ```Cannot read pixels``` exception but then the loop didn't repeat, leading to subsequent ```MissingPyramidException```s in the test when trying to render the pyramid. 

# Testing this PR

1. Required for figure tests to pass in https://github.com/ome/omero-figure/pull/243