### PR TITLE
OmeroReader: use RawPixelsStore.getTile to retrieve tiles

### DIFF
--- a/components/blitz/src/loci/ome/io/OmeroReader.java
+++ b/components/blitz/src/loci/ome/io/OmeroReader.java
@@ -185,7 +185,7 @@ public class OmeroReader extends FormatReader {
         try {
             store = serviceFactory.createRawPixelsStore();
             store.setPixelsId(pix.getId().getValue(), false);
-            plane = store.getPlane(zct[0], zct[1], zct[2]);
+            plane = store.getTile(zct[0], zct[1], zct[2], x, y, w, h);
         }
         catch (ServerError e) {
             throw new FormatException(e);
@@ -201,10 +201,7 @@ public class OmeroReader extends FormatReader {
             }
         }
 
-        try (RandomAccessInputStream s = new RandomAccessInputStream(plane)) {
-            readPlane(s, x, y, w, h, buf);
-        }
-
+        System.arraycopy(plane, 0, buf, 0, plane.length);
         return buf;
     }
 


### PR DESCRIPTION
# What this PR does

Instead of calling ```getPlane``` on ```RawPixelsStore``` and then cropping, this
updates the reader to pass the tile parameters in ```openBytes``` through to
```RawPixelsStore.getTile(...)```.  This allows ```OmeroReader``` (and thus OMERO.insight-ij) to support big images.

# Testing this PR

First import a big image with more than 2GB of pixels per plane into an OMERO server without this PR.  I was using ```data_repo/curated/svs/public/77917.svs``` and a local server built from current develop (https://github.com/openmicroscopy/openmicroscopy/commit/0f0bf5c99543ff2bd5e29427ccbec4f89387f1ea).  If using a big image that requires pyramid generation, wait for the pyramid generation to complete.

To observe the original problem:

1. Install Bio-Formats 5.8.2-SNAPSHOT and OMERO.insight-ij built without this PR into ImageJ.
2. Start ImageJ and select ```OMERO > Connect to OMERO```.
3. Log in to the server used for import and navigate to the imported big image (```77917.svs [Series 1]``` if using the noted test file).
4. Double-click on the image; the ```Bio-Formats Import Options``` window should appear.
5. Check the ```Autoscale``` and ```Crop on import``` options, leaving all others unchecked, and click ```OK```.
6. In the crop options window, enter parameters for a small tile (e.g. ```0```, ```0```, ```512```, and ```512```) and click ```OK```.
7. An error message should be shown, with an ```ApiUsageException``` in the ImageJ log window.  The stack trace should be consistent with attempting to read more than 2GB of data into a single byte array.

To verify the fix:

1. Install OMERO.insight-ij built with this PR into ImageJ (overwriting the previous installation).
2. Repeat steps 2-6 above
3. An image with the specified tile dimensions should appear with no error message or logged exception.
4. Check that the image is correct by opening the file from disk using ```Plugins > Bio-Formats > Bio-Formats Importer``` and the same options described in steps 5-6 above.

I would not expect the server itself to need rebuilding, redeploying or restarting with this PR included.  Only the OMERO.insight-ij client needs to be rebuilt and reinstalled to test.

# Related reading

See https://trello.com/c/2GKksxIS/59-omero-imagej-plugin-cannot-open-big-images

This isn't urgent from my perspective, so feel free to defer until a later release as needed.