### PR TITLE
deprecate server's TinyImportFixture

### DIFF
--- a/components/server/src/ome/formats/importer/util/TinyImportFixture.java
+++ b/components/server/src/ome/formats/importer/util/TinyImportFixture.java
@@ -26,6 +26,7 @@ import org.springframework.util.ResourceUtils;
  * @see ome.formats.OMEROMetadataStore
  * @since 3.0-M3
  */
+@Deprecated
 public class TinyImportFixture
 {
 


### PR DESCRIPTION
`TinyImportFixture` appears to be an unused server class.