### PR TITLE
in Python parse strings in creating wrapped Boolean values

### DIFF
--- a/components/tools/OmeroPy/src/omero/rtypes.py
+++ b/components/tools/OmeroPy/src/omero/rtypes.py
@@ -3,8 +3,6 @@
 """
 ::
     /*
-     *   $Id$
-     *
      *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
      *   Use is subject to license terms supplied in LICENSE.txt
      *
@@ -171,6 +169,8 @@ def rbool(val):
     """
     if val is None or isinstance(val, omero.RBool):
         return val
+    elif isinstance(val, basestring):
+        return rbool(val.lower() == 'true')
     elif val:
         return rtrue
     else:

--- a/components/tools/OmeroPy/test/unit/test_rtypes.py
+++ b/components/tools/OmeroPy/test/unit/test_rtypes.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """
 /*
- *   $Id$
- *
  *   Copyright 2008-2014 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -51,10 +49,14 @@ class TestModel(object):
         # RBool
         true1 = rbool(True)
         true2 = rbool(True)
+        true3 = rbool('True')
         false1 = rbool(False)
         false2 = rbool(False)
+        false3 = rbool('False')
         assert true1 == true2
+        assert true1 == true3
         assert false1 == false2
+        assert false1 == false3
         assert true1.getValue()
         assert not false1.getValue()
         assert true1 == true2


### PR DESCRIPTION
@manics noticed that,
```
bin/omero obj new BooleanAnnotation boolValue=false
```
creates annotations whose Boolean value is set to "true".

This PR adjusts the Python RTypes handling to provide more intuitive handling of Boolean string values.