### PR TITLE
adjust copyright on OMERO.importer launch script

### DIFF
--- a/components/insight/launch/OMEROimporter_unix.sh
+++ b/components/insight/launch/OMEROimporter_unix.sh
@@ -2,7 +2,7 @@
 
 # OMERO.importer startup script for Unix
 # ------------------------------------------------------------------------------
-#  Copyright (C) 2006-2001 University of Dundee & Open Microscopy Environment.
+#  Copyright (C) 2006-2013 University of Dundee & Open Microscopy Environment.
 #  All rights reserved.
 #
 #


### PR DESCRIPTION
The copyright year range on the OMERO.importer launch script looks obviously wrong. This PR adjusts it to correspond to https://github.com/openmicroscopy/openmicroscopy/commit/2fc5db07.