### PR TITLE
fix copyright year range typo on C++ unit tests

### DIFF
--- a/components/blitz/test/ome/services/blitz/test/mock/MockDeclarer.java
+++ b/components/blitz/test/ome/services/blitz/test/mock/MockDeclarer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2008-2011. Glencoe Software, Inc. All rights reserved.
+ *   Copyright (C) 2008-2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 package ome.services.blitz.test.mock;

--- a/components/tools/OmeroCpp/src/omero/ObjectFactory.h
+++ b/components/tools/OmeroCpp/src/omero/ObjectFactory.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2014 Unversity of Dundee. All rights reserved.
+ *   Copyright 2014 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
  */

--- a/components/tools/OmeroCpp/src/omero/model/ObjectFactory.h
+++ b/components/tools/OmeroCpp/src/omero/model/ObjectFactory.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2014 Unversity of Dundee. All rights reserved.
+ *   Copyright 2014 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
  */

--- a/components/tools/OmeroCpp/test/unit/rtypes.cpp
+++ b/components/tools/OmeroCpp/test/unit/rtypes.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *   Copyright 20013 Glencoe Software, Inc. All rights reserved.
+ *   Copyright 2013 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
  */


### PR DESCRIPTION
Judging by https://github.com/openmicroscopy/openmicroscopy/commit/ec139b42 this PR fixes an obvious copyright year typo for the C++ unit tests. However, this is a *Glencoe* copyright so @chris-allan should summarily veto/close if this typo should instead be handled in-house.