### PR TITLE
Bump omero-marshal to 0.5.3

### DIFF
--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -9,4 +9,4 @@ Django>=1.8,<1.9
 django-pipeline==1.3.20
 gunicorn>=19.3
 
-omero-marshal==0.5.1
+omero-marshal==0.5.3


### PR DESCRIPTION
See https://github.com/openmicroscopy/omero-marshal/pull/50 for more context

Bumping `omero-marshal` on `metadata53` to fix the Travis build on the master branch of https://github.com/IDR/deployment