### PR TITLE
Bump omero-marshal to 0.5.3 (rebased onto metadata54)

### DIFF
--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -9,5 +9,5 @@ Django>=1.8,<1.9
 django-pipeline==1.3.20
 gunicorn>=19.3
 
-omero-marshal==0.5.2
+omero-marshal==0.5.3
 django-redis>=4.4,<4.9


### PR DESCRIPTION

This is the same as gh-5730 but rebased onto metadata54.

----

See https://github.com/openmicroscopy/omero-marshal/blob/v0.5.3/CHANGELOG.md for the rationale

This PR is required to fix the deployment of OMERO.py/OMERO.web on [CentOS 7](http://docs.openmicroscopy.org/omero/5.4.5/sysadmins/unix/install-web/walkthrough/omeroweb-install-centos7-ice3.6.html) following the PyPI TLS v1.0/1.1 deprecation.

                