### PR TITLE
metadata54: remove all scripts

### DIFF
--- a/components/tools/OmeroPy/test/unit/scriptstest/test_parse.py
+++ b/components/tools/OmeroPy/test/unit/scriptstest/test_parse.py
@@ -188,6 +188,9 @@ if True:
             except Exception, e:
                 assert False, "%s\n%s" % (script, e)
 
+    @pytest.mark.broken(
+        reason=('Scripts are disabled on the metadata branch: '
+                'https://github.com/ome/scripts/pull/129'))
     def testValidateRoiMovieCall(self):
         script = SCRIPTS / "figure_scripts" / "Movie_ROI_Figure.py"
         params = parse_file(str(script))


### PR DESCRIPTION
The prod50 UI should show nothing when clicking on the scripts button. This will need building and releasing as 0.5.0-rc3 via the Trigger-IDR on east-ci.