### PR TITLE
current sessions request should ignore unloaded sessions

### DIFF
--- a/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
@@ -143,7 +143,9 @@ public class CurrentSessionsRequestI extends CurrentSessionsRequest
         Map<String, Session> objects = new HashMap<String, Session>();
         IceMapper mapper = new IceMapper();
         for (ome.model.meta.Session obj : rv) {
-            objects.put(obj.getUuid(), (Session) mapper.map(obj));
+            if (obj.isLoaded()) {
+                objects.put(obj.getUuid(), (Session) mapper.map(obj));
+            }
         }
 
         if (helper.isLast(step)) {


### PR DESCRIPTION
In read-only mode some in-memory sessions reach the proxy cleanup filter and `buildResponse` is thus handed some unloaded sessions. This PR should not prevent sessions from being returned that would have ordinarily been from a read-write server. See https://ci.openmicroscopy.org/job/OMERO-DEV-latest-docs/ws/src/omero/_build/html/developers/Server/Clustering.html#read-only for configuration and use `bin/omero sessions who` to test.