### PR TITLE
ignore unloaded sessions from in-memory session provider

### DIFF
--- a/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
+++ b/components/blitz/src/omero/cmd/admin/CurrentSessionsRequestI.java
@@ -143,7 +143,9 @@ public class CurrentSessionsRequestI extends CurrentSessionsRequest
         Map<String, Session> objects = new HashMap<String, Session>();
         IceMapper mapper = new IceMapper();
         for (ome.model.meta.Session obj : rv) {
-            objects.put(obj.getUuid(), (Session) mapper.map(obj));
+            if (obj.isLoaded()) {
+                objects.put(obj.getUuid(), (Session) mapper.map(obj));
+            }
         }
 
         if (helper.isLast(step)) {


### PR DESCRIPTION
> The proxy cleanup filter unloads those that the Hibernate-based security
would have filtered out anyway. The provider returns loaded sessions but
some are cleaned up before the response can be built.

*Duplicate* PR of gh-5733 against metadata54.