### PR TITLE
testlib script check file_name

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/script.py
+++ b/components/tools/OmeroPy/src/omero/testlib/script.py
@@ -103,15 +103,18 @@ def check_file_annotation(client, file_annotation,
     assert id > 0
 
     conn = BlitzGateway(client_obj=client)
-
     wrapper = conn.getObject("FileAnnotation", id)
+    name = None
+    if file_name is not None:
+        name = wrapper.getFile().getName()
+
     links = sum(1 for i in wrapper.getParentLinks(parent_type))
+    conn.close()
+
     if is_linked:
         assert links == 1
     else:
         assert links == 0
 
     if file_name is not None:
-        name = wrapper.getFile().getName()
         assert name == file_name
-    conn.close()

--- a/components/tools/OmeroPy/src/omero/testlib/script.py
+++ b/components/tools/OmeroPy/src/omero/testlib/script.py
@@ -89,7 +89,8 @@ def points_to_string(points):
 
 
 def check_file_annotation(client, file_annotation,
-                          parent_type="Image", is_linked=True):
+                          parent_type="Image", is_linked=True,
+                          file_name=None):
     """
     Check validity of file annotation. If hasFileAnnotation, check the size,
     name and number of objects linked to the original file.
@@ -105,8 +106,12 @@ def check_file_annotation(client, file_annotation,
 
     wrapper = conn.getObject("FileAnnotation", id)
     links = sum(1 for i in wrapper.getParentLinks(parent_type))
-    conn.close()
     if is_linked:
         assert links == 1
     else:
         assert links == 0
+
+    if file_name is not None:
+        name = wrapper.getFile().getName()
+        assert name == file_name
+    conn.close()


### PR DESCRIPTION
See https://github.com/ome/scripts/pull/139#discussion-diff-182703948R110

This ports changes to the ```def check_file_annotation()``` from the PR above.

No testing needed (not used currently) but check code has been accurately ported.