### PR TITLE
add to Python Gateway methods to check for read-only server

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2715,8 +2715,8 @@ class _BlitzGateway (object):
         key_prefix = 'omero.cluster.read_only.runtime.'
         key_regex = '^' + key_prefix.replace('.', '\.')
         properties = self.getConfigService().getConfigValues(key_regex)
-        return {key[len(key_prefix):]: value.lower() == 'true'
-                for key, value in properties.items()}
+        return dict((key[len(key_prefix):], value.lower() == 'true')
+                    for key, value in properties.items())
 
     def isAnyReadOnly(self, *subsystems):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2702,6 +2702,35 @@ class _BlitzGateway (object):
         """
         return ProxyObjectWrapper(self, 'createExporter')
 
+    ####################
+    # Read-only status #
+
+    def getReadOnlyStatus(self):
+        """
+        Get the read-only status of the server.
+
+        :return:  a map of server subsystems each of whose value indicates if
+                  it is read-only
+        """
+        key_prefix = 'omero.cluster.read_only.runtime.'
+        key_regex = '^' + key_prefix.replace('.', '\.')
+        properties = self.getConfigService().getConfigValues(key_regex)
+        return {key[len(key_prefix):]: value.lower() == 'true'
+                for key, value in properties.items()}
+
+    def isAnyReadOnly(self, *subsystems):
+        """
+        Check specific aspects of the read-only status of the server.
+
+        :param subsystems:  the server subsystems whose status is to be checked
+        :return:            if any of the given subsystems are read-only
+        """
+        subsystems = set(subsystems)
+        for key, value in self.getReadOnlyStatus().items():
+            if value and key in subsystems:
+                return True
+        return False
+
     #############################
     # Top level object fetchers #
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2723,7 +2723,7 @@ class _BlitzGateway (object):
         Check specific aspects of the read-only status of the server.
 
         :param subsystems:  the server subsystems whose status is to be checked
-        :return:            if any of the given subsystems are read-only
+        :return:            True if any of the given subsystems are read-only
         """
         subsystems = set(subsystems)
         for key, value in self.getReadOnlyStatus().items():

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_config_service.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 """
-   Copyright (C) 2016 University of Dundee & Open Microscopy Environment.
+   Copyright (C) 2016-2018 University of Dundee & Open Microscopy Environment.
                       All Rights Reserved.
    Copyright 2013 Glencoe Software, Inc. All rights reserved.
    Use is subject to license terms supplied in LICENSE.txt
@@ -40,3 +40,39 @@ def testInterpolateSetting(gatewaywrapper, interpolate):
             .getConfigDefaults()['omero.client.viewer.interpolate_pixels']
         gatewaywrapper.gateway.getConfigService().setConfigValue(
             "omero.client.viewer.interpolate_pixels", d)
+
+
+def testReadOnlyConsistentResults(gatewaywrapper):
+    """
+    Test that 'db' and 'repo' compose the queryable subsystems among the
+    omero.cluster.read_only.runtime.* properties from getReadOnlyStatus and
+    that isAnyReadOnly returns results consistent with their property
+    values.
+    """
+    gatewaywrapper.loginAsAuthor()
+    gateway = gatewaywrapper.gateway
+
+    read_only_status = gateway.getReadOnlyStatus()
+    assert set(read_only_status.keys()) == set(['db', 'repo'])
+
+    is_read_only_db = read_only_status['db']
+    is_read_only_repo = read_only_status['repo']
+    assert gateway.isAnyReadOnly() is False
+    assert gateway.isAnyReadOnly('db') == is_read_only_db
+    assert gateway.isAnyReadOnly('repo') == is_read_only_repo
+    assert gateway.isAnyReadOnly('db', 'repo') == \
+        is_read_only_db or is_read_only_repo
+
+
+def testReadOnlyBackwardCompatibility(gatewaywrapper):
+    """
+    Test that in the absence of corresponding
+    omero.cluster.read_only.runtime.* properties as from a pre-5.4.6 server
+    the queryable subsystems are reported as being read-write.
+    """
+    gatewaywrapper.loginAsAuthor()
+    gateway = gatewaywrapper.gateway
+
+    absent_subsystem = 'absent subsystem'
+    assert absent_subsystem not in gateway.getReadOnlyStatus()
+    assert gateway.isAnyReadOnly(absent_subsystem) is False


### PR DESCRIPTION
# What this PR does

Adds Python Gateway methods `getReadOnlyStatus` and `isAnyReadOnly` for testing the server's read-only status easily.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.gatewaytest/test_config_service/ because it is via the configuration service that the server reports its read-only status.

Could perhaps also try those methods against `test50-omero{readonly,readwrite}` from `idr-experimental.openmicroscopy.org` or against a local server.

# Related reading

https://docs.openmicroscopy.org/omero/5.4.6-rc2/developers/Server/Clustering.html#read-only
https://trello.com/c/1deeKI1D/50-gateway-methods-to-test-read-only