### PR TITLE
Linear quantization coefficient

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8848,29 +8848,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param family:          The family (string)
         :param coefficient:     The coefficient (float)
         """
-        if channelIndex < 0 or channelIndex >= self.getSizeC():
-            return
-
-        families = self.getFamilies()
-        f = families.get("linear")
-        try:
-            f = families.get(family.lower(), f)
-        except:
-            pass
-
-        c = 1.0
-        try:
-            c = float(coefficient)
-            if c < 0:
-                c = 0
-        except:
-            pass
-
-        # Rendering engine should probably handle this...
-        if family and family.lower() == "linear":
-            c = 1.0
-
-        self._re.setQuantizationMap(channelIndex, f._obj, c, False)
+        f = omero.model.FamilyI()
+        f.value = rstring(family)
+        self._re.setQuantizationMap(channelIndex, f, coefficient, False)
 
     @assert_re()
     def setQuantizationMaps(self, maps):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8867,7 +8867,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
             pass
 
         # Rendering engine should probably handle this...
-        if family.lower() == "linear":
+        if family and family.lower() == "linear":
             c = 1.0
 
         self._re.setQuantizationMap(channelIndex, f._obj, c, False)

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8772,6 +8772,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         return BlitzObjectWrapper(self._conn, self._re.getModel())
 
+    @assert_re()
     def setGreyscaleRenderingModel(self):
         """
         Sets the Greyscale rendering model on this image's current renderer
@@ -8780,6 +8781,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         rm = self.getRenderingModels()
         self._re.setModel(self._rm.get('greyscale', rm[0])._obj)
 
+    @assert_re()
     def setColorRenderingModel(self):
         """
         Sets the HSB rendering model on this image's current renderer

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8759,8 +8759,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if not len(self._rm):
             query_service = self._conn.getQueryService()
             for m in self._conn.getEnumerationEntries('RenderingModel'):
-                mod = query_service.get('RenderingModel', m.id)
-                self._rm[m.value] = BlitzObjectWrapper(self._conn, mod)
+                self._rm[m.value] = m
         return self._rm.values()
 
     @assert_re()
@@ -8834,8 +8833,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if not len(self._qf):
             query_service = self._conn.getQueryService()
             for f in self._conn.getEnumerationEntries('Family'):
-                family = query_service.get('Family', f.id)
-                self._qf[f.value] = BlitzObjectWrapper(self._conn, family)
+                self._qf[f.value] = f
         return self._qf
 
     @assert_re()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8758,9 +8758,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         if not len(self._rm):
-            for m in [BlitzObjectWrapper(self._conn, m)
-                      for m in self._re.getAvailableModels()]:
-                self._rm[m.value.lower()] = m
+            for m in self._conn.getEnumerationEntries('RenderingModel'):
+                mod = omero.model.RenderingModelI()
+                mod.value = rstring(m.value)
+                self._rm[m.value] = BlitzObjectWrapper(self._conn, mod)
         return self._rm.values()
 
     @assert_re()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8866,6 +8866,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         except:
             pass
 
+        # Rendering engine should probably handle this...
+        if family.lower() == "linear":
+            c = 1.0
+
         self._re.setQuantizationMap(channelIndex, f._obj, c, False)
 
     @assert_re()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8748,7 +8748,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         return self.getPixelLine(z, t, x, 'v', channels, range)
 
-    @assert_re()
     def getRenderingModels(self):
         """
         Gets a list of available rendering models.
@@ -8758,9 +8757,9 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         if not len(self._rm):
+            query_service = self._conn.getQueryService()
             for m in self._conn.getEnumerationEntries('RenderingModel'):
-                mod = omero.model.RenderingModelI()
-                mod.value = rstring(m.value)
+                mod = query_service.get('RenderingModel', m.id)
                 self._rm[m.value] = BlitzObjectWrapper(self._conn, mod)
         return self._rm.values()
 
@@ -8825,7 +8824,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         if inverted:
             self._re.addCodomainMapToChannel(r, channelIndex)
 
-    @assert_re()
     def getFamilies(self):
         """
         Gets a dict of available families.
@@ -8834,10 +8832,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     Dict
         """
         if not len(self._qf):
+            query_service = self._conn.getQueryService()
             for f in self._conn.getEnumerationEntries('Family'):
-                family = omero.model.FamilyI()
-                family.value = rstring(f.value)
-                self._qf[f] = BlitzObjectWrapper(self._conn, family)
+                family = query_service.get('Family', f.id)
+                self._qf[f.value] = BlitzObjectWrapper(self._conn, family)
         return self._qf
 
     @assert_re()
@@ -8850,9 +8848,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :param family:          The family (string)
         :param coefficient:     The coefficient (float)
         """
-        f = omero.model.FamilyI()
-        f.value = rstring(family)
-        self._re.setQuantizationMap(channelIndex, f, coefficient, False)
+        f = self.getFamilies().get(family)
+        self._re.setQuantizationMap(channelIndex, f._obj, coefficient, False)
 
     @assert_re()
     def setQuantizationMaps(self, maps):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8861,8 +8861,8 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         c = 1.0
         try:
             c = float(coefficient)
-            if c < 0 or c > 1.0:
-                c = 1.0
+            if c < 0:
+                c = 0
         except:
             pass
 

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8833,9 +8833,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     Dict
         """
         if not len(self._qf):
-            for f in [BlitzObjectWrapper(self._conn, f)
-                      for f in self._re.getAvailableFamilies()]:
-                self._qf[f.value.lower()] = f
+            for f in self._conn.getEnumerationEntries('Family'):
+                family = omero.model.FamilyI()
+                family.value = rstring(f.value)
+                self._qf[f] = BlitzObjectWrapper(self._conn, family)
         return self._qf
 
     @assert_re()

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8757,7 +8757,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         if not len(self._rm):
-            query_service = self._conn.getQueryService()
             for m in self._conn.getEnumerationEntries('RenderingModel'):
                 self._rm[m.value] = m
         return self._rm.values()
@@ -8831,7 +8830,6 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         :rtype:     Dict
         """
         if not len(self._qf):
-            query_service = self._conn.getQueryService()
             for f in self._conn.getEnumerationEntries('Family'):
                 self._qf[f.value] = f
         return self._qf

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -434,9 +434,12 @@ class TestRDefs (object):
             i = 0
             # change and assert for new value per channel
             for c in channels:
-                self.image.setQuantizationMap(i, fam.getValue(), 0.5)
+                coef = 0.5
+                self.image.setQuantizationMap(i, fam.getValue(), coef)
                 assert c.getFamily().getValue() == fam.getValue()
-                assert c.getCoefficient() == 0.5
+                if fam.getValue() == "linear":
+                    coef = 1
+                assert c.getCoefficient() == coef
                 i += 1
         self.image._closeRE()
         g = gatewaywrapper.gateway
@@ -484,10 +487,9 @@ class TestRDefs (object):
         }
         test_cases = [error_case, correct_case, correct_case]
         self.image.setQuantizationMaps(test_cases)
-        assert settings[0] == {
-            "family": channels[0].getFamily().getValue(),
-            "coefficient": channels[0].getCoefficient()
-        }
+        assert channels[0].getFamily().getValue() == settings[0]["family"]
+        assert channels[0].getCoefficient() == 10000
+
         assert correct_case == {
             "family": channels[1].getFamily().getValue(),
             "coefficient": channels[1].getCoefficient()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -416,16 +416,17 @@ class TestRDefs (object):
         g = gatewaywrapper.gateway
         assert not g._assert_unregistered("testQuantizationSettings")
 
-    @pytest.mark.parametrize("settings", ([None, 1],
-                                          ["no_good_family", 1],
-                                          ["polynomial", -0.5]))
-    def testQuantizationSettingsInvalid(self, gatewaywrapper, settings):
+    def testQuantizationSettingsInvalid(self, gatewaywrapper):
         """
         Tests that invalid quantization values throw ApiUsageException
         """
         self.image = gatewaywrapper.getTestImage()
+        with pytest.raises(AttributeError):
+            self.image.setQuantizationMap(0, None, 1)
+        with pytest.raises(AttributeError):
+            self.image.setQuantizationMap(0, "no_good_family", 1)
         with pytest.raises(omero.ApiUsageException):
-            self.image.setQuantizationMap(0, settings[0], settings[1])
+            self.image.setQuantizationMap(0, "polynomial", -0.5)
         self.image._closeRE()
         g = gatewaywrapper.gateway
         assert not g._assert_unregistered("testQuantizationSettings")

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -441,7 +441,7 @@ class TestRDefs (object):
         test_cases = [{"family": "exponential",
                        "coefficient": 0.3},
                       {"family": "polynomial",
-                       "coefficient": 0.1},]
+                       "coefficient": 0.1}]
         self.image.setQuantizationMaps(test_cases)
         channels = self.image.getChannels()
         for t, ch in enumerate(test_cases):


### PR DESCRIPTION
# What this PR does

See https://trello.com/c/CaURcuor/60-bugs-resetquantizationmap

It seems that the rendering engine, Blitz Gateway and iviewer allow rendering with a coefficient different from ```1.0``` with the ```linear``` family, which seems wrong. We don't show the coefficient slider in iviewer when "linear" is selected, but a previously chosen coefficient is still used. This means that switching from linear to polynomial has no effect to the rendered image.
That is now fixed in this PR.

Also, the coefficient was restricted to being less than 1.0 in the Blitz Gateway, even though the coefficient slider in iviewer has a range of 0 - 4. This PR removes the maximum limit.

# Testing this PR

1. In iviewer, choose Advanced settings in the channel colour-picker, then choose Polynomial map. Rendering will be unchanged with Gamma at 1.0.
2. Choose a higher Gamma, should see that the image is rendered differently.
3. Revert to "linear" map. Should see that you revert to the linear rendered image.

cc @pwalczysko @jburel 
