### PR TITLE
with read-only server do not attempt to modify file table

### DIFF
--- a/components/server/src/ome/services/scripts/ScriptRepoHelper.java
+++ b/components/server/src/ome/services/scripts/ScriptRepoHelper.java
@@ -526,7 +526,11 @@ public class ScriptRepoHelper extends OnContextRefreshedEventListener {
                 String hash = null;
                 OriginalFile ofile = null;
                 if (id == null) {
-                    ofile = addOrReplace(session, sqlAction, sf, file, null);
+                    if (readOnly.isReadOnlyDb()) {
+                        log.info("read-only database so ignoring addition of script {}", file.fullname());
+                    } else {
+                        ofile = addOrReplace(session, sqlAction, sf, file, null);
+                    }
                 } else {
                     ofile = load(id, session, sqlAction, true); // checks for type & repo
                     if (ofile == null) {


### PR DESCRIPTION
Prevents read-only servers from attempting modifications to the script repository: see https://trello.com/c/ryGZ2boi/51-getscripts-fails-with-nextval.