### PR TITLE
Linear map

### DIFF
--- a/components/rendering/src/omeis/providers/re/Renderer.java
+++ b/components/rendering/src/omeis/providers/re/Renderer.java
@@ -817,7 +817,7 @@ public class Renderer {
         qs.setQuantizationMap(family, coefficient, noiseReduction);
         ChannelBinding[] cb = getChannelBindings();
         cb[w].setFamily(family);
-        cb[w].setCoefficient(coefficient);
+        cb[w].setCoefficient(qs.getCurveCoefficient());
         cb[w].setNoiseReduction(noiseReduction);
     }
 

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -312,7 +312,7 @@ public abstract class QuantumStrategy {
         this.family = family;
         String value = family.getValue();
         if (value.equals(Family.VALUE_LINEAR)) {
-            //Make sure that linear is always set to one
+            //Make sure that for linear the coefficient is always set to 1
             k = 1.0;
         }
         curveCoefficient = k;

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -308,6 +308,10 @@ public abstract class QuantumStrategy {
      *            The noise reduction flag.
      */
     public void setMapping(Family family, double k, boolean noiseReduction) {
+        if (k <= 0) {
+            throw new IllegalArgumentException("Unsupported curve coefficient: '"
+                    + k + "'");
+        }
         defineMapper(family);
         this.family = family;
         String value = family.getValue();

--- a/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
+++ b/components/rendering/src/omeis/providers/re/quantum/QuantumStrategy.java
@@ -310,6 +310,11 @@ public abstract class QuantumStrategy {
     public void setMapping(Family family, double k, boolean noiseReduction) {
         defineMapper(family);
         this.family = family;
+        String value = family.getValue();
+        if (value.equals(Family.VALUE_LINEAR)) {
+            //Make sure that linear is always set to one
+            k = 1.0;
+        }
         curveCoefficient = k;
         this.noiseReduction = noiseReduction;
     }

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import javax.imageio.ImageIO;
 
+import ome.conditions.ApiUsageException;
 import ome.specification.XMLMockObjects;
 import ome.specification.XMLWriter;
 import omero.api.IRenderingSettingsPrx;
@@ -41,6 +42,7 @@ import omero.model.ChannelBindingI;
 import omero.model.CodomainMapContext;
 import omero.model.ExperimenterGroup;
 import omero.model.Family;
+import omero.model.FamilyI;
 import omero.model.IObject;
 import omero.model.Image;
 import omero.model.OriginalFile;
@@ -4362,6 +4364,109 @@ public class RenderingEngineTest extends AbstractServerTest {
         re.close();
     }
 
+    /**
+     * Tests negative coefficient for quantization
+     * @throws Exception
+     */
+    @Test(expectedExceptions = omero.ApiUsageException.class)
+    public void testQuantizationMapNegativeCoefficient() throws Exception {
+        //First import an image
+        Image image = createBinaryImage(1, 1, 1, 1, 1);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        PlaneDef pDef = new PlaneDef();
+        pDef.t = re.getDefaultT();
+        pDef.z = re.getDefaultZ();
+        pDef.slice = omero.romio.XY.value;
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        for (int k = 0; k < channels.size(); k++) {
+            Assert.assertEquals(1.0, re.getChannelCurveCoefficient(k));
+            double coefficient = -1.0;
+            re.setQuantizationMap(k, re.getChannelFamily(k), coefficient,
+                    re.getChannelNoiseReduction(k));
+        }
+        re.close();
+    }
+
+    /**
+     * Tests negative coefficient for quantization
+     * @throws Exception
+     */
+    @Test(expectedExceptions = omero.ApiUsageException.class)
+    public void testQuantizationMapNullCoefficient() throws Exception {
+        //First import an image
+        Image image = createBinaryImage(1, 1, 1, 1, 1);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        PlaneDef pDef = new PlaneDef();
+        pDef.t = re.getDefaultT();
+        pDef.z = re.getDefaultZ();
+        pDef.slice = omero.romio.XY.value;
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        for (int k = 0; k < channels.size(); k++) {
+            Assert.assertEquals(1.0, re.getChannelCurveCoefficient(k));
+            double coefficient = 0.0;
+            re.setQuantizationMap(k, re.getChannelFamily(k), coefficient,
+                    re.getChannelNoiseReduction(k));
+        }
+        re.close();
+    }
+
+    /**
+     * Tests negative coefficient for quantization
+     * @throws Exception
+     */
+    @Test(expectedExceptions = omero.ApiUsageException.class)
+    public void testQuantizationMapInvalidMap() throws Exception {
+        //First import an image
+        Image image = createBinaryImage(1, 1, 1, 1, 1);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        PlaneDef pDef = new PlaneDef();
+        pDef.t = re.getDefaultT();
+        pDef.z = re.getDefaultZ();
+        pDef.slice = omero.romio.XY.value;
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        for (int k = 0; k < channels.size(); k++) {
+            Assert.assertEquals(1.0, re.getChannelCurveCoefficient(k));
+            Family f = new FamilyI();
+            f.setValue(omero.rtypes.rstring("foo"));
+            re.setQuantizationMap(k, f, re.getChannelCurveCoefficient(k),
+                    re.getChannelNoiseReduction(k));
+        }
+        re.close();
+    }
+    
     //Inner class used to store rnd settings for channels
     class ChannelBindingPrx {
         Family family;

--- a/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
+++ b/components/tools/OmeroJava/test/integration/RenderingEngineTest.java
@@ -4253,6 +4253,115 @@ public class RenderingEngineTest extends AbstractServerTest {
         re.close();
     }
 
+    /**
+     * Tests the linear map: linear + k=1 and linear + k != 1 should generate
+     * the same image
+     * @throws Exception
+     */
+    @Test
+    public void testQuantizationMapLinear() throws Exception {
+        //First import an image
+        Image image = createBinaryImage(1, 1, 1, 1, 1);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        PlaneDef pDef = new PlaneDef();
+        pDef.t = re.getDefaultT();
+        pDef.z = re.getDefaultZ();
+        pDef.slice = omero.romio.XY.value;
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        RenderingModel model = re.getModel();
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class
+                .getName());
+        Iterator<IObject> j = models.iterator();
+        RenderingModel m;
+        // Change the color model so it is not grey scale.
+        while (j.hasNext()) {
+            m = (RenderingModel) j.next();
+            if (m.getId().getValue() != model.getId().getValue())
+                re.setModel(m);
+        }
+
+        for (int k = 0; k < channels.size(); k++) {
+            Family f = re.getChannelFamily(k);
+            Assert.assertEquals("linear", f.getValue().getValue());
+            Assert.assertEquals(re.getChannelCurveCoefficient(k), 1.0);
+            re.setQuantizationMap(k, f, 1.5, re.getChannelNoiseReduction(k));
+            Assert.assertEquals(re.getChannelCurveCoefficient(k), 1.0);
+        }
+        re.close();
+    }
+
+    /**
+     * Tests the polynomial map
+     * @throws Exception
+     */
+    @Test
+    public void testQuantizationMapPolynomial() throws Exception {
+        //First import an image
+        Image image = createBinaryImage(1, 1, 1, 1, 1);
+        Pixels p = image.getPrimaryPixels();
+        long id = p.getId().getValue();
+        factory.getRenderingSettingsService().setOriginalSettingsInSet(
+                Pixels.class.getName(), Arrays.asList(id));
+        RenderingEnginePrx re = factory.createRenderingEngine();
+        re.lookupPixels(id);
+        if (!(re.lookupRenderingDef(id))) {
+            re.resetDefaultSettings(true);
+            re.lookupRenderingDef(id);
+        }
+        re.load();
+        PlaneDef pDef = new PlaneDef();
+        pDef.t = re.getDefaultT();
+        pDef.z = re.getDefaultZ();
+        pDef.slice = omero.romio.XY.value;
+        RenderingDef def = factory.getPixelsService().retrieveRndSettings(id);
+        List<ChannelBinding> channels = def.copyWaveRendering();
+        RenderingModel model = re.getModel();
+        List<IObject> models = factory.getTypesService().allEnumerations(
+                RenderingModel.class
+                .getName());
+        Iterator<IObject> j = models.iterator();
+        RenderingModel m;
+        // Change the color model so it is not grey scale.
+        while (j.hasNext()) {
+            m = (RenderingModel) j.next();
+            if (m.getId().getValue() != model.getId().getValue())
+                re.setModel(m);
+        }
+        ITypesPrx svc = factory.getTypesService();
+        List<IObject> families = svc.allEnumerations(Family.class.getName());
+        Family family = null;
+        String name = "polynomial";
+        for (int i = 0; i < families.size(); i++) {
+            family = ((Family) families.get(i));
+            if (family.getValue().getValue().equals(name)) {
+                break;
+            }
+        }
+        for (int k = 0; k < channels.size(); k++) {
+            Family f = re.getChannelFamily(k);
+            Assert.assertNotEquals(f.getValue().getClass(), family.getValue().getValue());
+            Assert.assertEquals(f.getValue().getValue(), "linear");
+            Assert.assertEquals(1.0, re.getChannelCurveCoefficient(k));
+            double coefficient = 0.3;
+            re.setQuantizationMap(k, family, coefficient, re.getChannelNoiseReduction(k));
+            Assert.assertEquals(re.getChannelCurveCoefficient(k), coefficient);
+            Assert.assertEquals(re.getChannelFamily(k).getValue().getValue(), name);
+        }
+        re.close();
+    }
+
     //Inner class used to store rnd settings for channels
     class ChannelBindingPrx {
         Family family;


### PR DESCRIPTION
# What this PR does

This PR sets the coefficient to 1 for linear mapping
Currently if the family is linear and the coefficient is not 1, the map will be polynomial

Another option could be to throw an exception if an incompatible value is specified.
This problem has been around since the beginning

# Testing this PR
Make sure the tests are green
# Related reading

See https://github.com/openmicroscopy/openmicroscopy/pull/5740
https://trello.com/c/CaURcuor/60-bugs-resetquantizationmap

cc @will-moore @chris-allan @joshmoore 