### PR TITLE
Add startswith polyfill for IE

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/js/ome.popup.js
@@ -181,6 +181,14 @@ String.prototype.capitalize = function() {
     return this.charAt(0).toUpperCase() + this.slice(1);
 };
 
+// IE polyfill from
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(search, pos) {
+        return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
+    };
+}
+
 jQuery.fn.alternateRowColors = function() {
     var $rows = $(this).children().children('tr');
     $rows.not('.hidden').filter(':odd').removeClass('even').addClass('odd');


### PR DESCRIPTION
# What this PR does

Fixes https://trello.com/c/RUkmA4ZP/13-ie-browse-button-problem in IE.

# Testing this PR

1. work on Windows7, IE11
1. login as user-1
1. search for vsi
1. in the search results, click on Browse next to the first result
1. the browser navigates to the main webclient and should show the image