### PR TITLE
clarify the action of fs sets --check in help text

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -280,7 +280,7 @@ class FsControl(CmdControl):
             help="list sets by their in-place import method")
         sets.add_argument(
             "--check", action="store_true",
-            help="checks each fileset for validity (admins only)")
+            help="verify the file checksums for each fileset (admins only)")
 
         ls = parser.add(sub, self.ls)
         ls.add_argument(


### PR DESCRIPTION
Makes the help text for `bin/omero fs sets --check` more specific. See discussion on [[trello] fs sets timeout](https://trello.com/c/cuwJ9NNz/53-fs-sets-timeout).