### PR TITLE
OMERO.web centre panel cleanup

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -89,10 +89,6 @@ OME.handle_tree_selection = function(data, event) {
     // and update_thumbnails_panel, just run them instead
 
     // Check the functions exist, they might not if the central panel has not been loaded
-    if (typeof(syncThumbSelection) === "function") {
-        // safe to use the function
-        syncThumbSelection(data, event);
-    }
     if (typeof(update_thumbnails_panel) === "function") {
         // safe to use the function
         update_thumbnails_panel(event, data);

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/center_plugin.thumbs.js.html
@@ -150,7 +150,7 @@ $(document).ready(function() {
         // Get the current selection
         var selected = inst.get_selected(true);
 
-        if (selected.length === 0) {
+        if (!$("#content_details").is(":visible") || selected.length === 0) {
             $("#content_details").html("");
             parentId = undefined;
             clearThumbnailsPanel();


### PR DESCRIPTION
# What this PR does

The current "Thumbnails" centre panel plugin assumes that it is always active. This PR attempts to minimise background event, and data loading churn when another plugin is active.

# Testing this PR

1. Conditions where there is, and is not, an additional active centre panel plugin should be available

2. All actions where `update_thumbnails_panel()` is called should be tested:
    * Tree cut/copy and paste
    * Tree node move; Image into another Dataset for instance
    * Tree node selection
    * Tree refresh
    * Change group
    * Delete

3. No change in behaviour should be observed

# Notes

`update_thumbnails_panel()` is a window wide function. As such it has effectively become part of the public API of OMERO.web and is deeply coupled to the "Thumbnails" plugin. Many thumbnail refresh and update actions call this function explicitly as outlined in the testing criteria above.

If a third-party centre panel plugin wishes to react to any of these conditions it must find a way to intercept or mimic the behaviour of this function. It also must ensure that anything that it does to facilitate this does not completely break when switching between plugins. The purpose of this PR is definitely not to refactor all `update_thumbnails_panel()` use to an event based model but it is quite sorely needed.

/cc @emilroz, @jburel, @joshmoore 