### PR TITLE
for read-only add canCreate to gateways

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2702,6 +2702,28 @@ class _BlitzGateway (object):
         """
         return ProxyObjectWrapper(self, 'createExporter')
 
+    ####################
+    # Read-only status #
+
+    def canCreate(self):
+        """
+        Get the read-only status of the server.
+        Warning: This is EXPERIMENTAL API that is subject to change.
+
+        :return:  True if the server is wholly in read-write mode,
+                  False if the server is wholly in read-only mode,
+                  otherwise None
+        """
+        key_regex = '^omero\.cluster\.read_only\.runtime\.'
+        properties = self.getConfigService().getConfigValues(key_regex)
+        values = frozenset(properties.values())
+        if not values:
+            return True
+        elif len(values) == 1:
+            return 'false' in values
+        else:
+            return None
+
     #############################
     # Top level object fetchers #
 


### PR DESCRIPTION
Adds ternary `canCreate` to gateways for easy checking of the server's read-only status. Supersedes #5738 and #5739. See https://docs.openmicroscopy.org/omero/5.4.6-rc2/developers/Server/Clustering.html#read-only and https://trello.com/c/1deeKI1D/50-gateway-methods-to-test-read-only.