### PR TITLE
have read-only server's RawFileBean.close() be read-only

### DIFF
--- a/components/server/resources/ome/services/service-ome.api.RawFileStore.xml
+++ b/components/server/resources/ome/services/service-ome.api.RawFileStore.xml
@@ -3,9 +3,7 @@
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # 
-# $Id$
-# 
-# Copyright 2006 University of Dundee. All rights reserved.
+# Copyright 2006-2018 University of Dundee. All rights reserved.
 # Use is subject to license terms supplied in LICENSE.txt
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -33,5 +31,13 @@
     <property name="proxyInterfaces" value="ome.api.RawFileStore"/>
     <property name="target" ref="internal-ome.api.RawFileStore"/>
   </bean>
-  
+
+  <bean id="internal-ome.api.RawFileStoreSubstituter" class="ome.services.util.BeanInstantiationSubstituter">
+    <constructor-arg ref="readOnlyStatus"/>
+    <constructor-arg value="internal-ome.api.RawFileStore"/>
+    <constructor-arg value="ome.services.RawFileBeanReadOnly"/>
+    <property name="isWriteDb" value="true"/>
+    <property name="isWriteRepo" value="true"/>
+  </bean>
+
 </beans>

--- a/components/server/src/ome/services/RawFileBeanReadOnly.java
+++ b/components/server/src/ome/services/RawFileBeanReadOnly.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2006-2018 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package ome.services;
+
+import ome.annotations.RolesAllowed;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Raw file gateway which provides access to the OMERO file repository.
+ *
+ * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:callan@blackcat.ca">callan@blackcat.ca</a>
+ * @since OMERO3.0
+ * @see RawFileBean
+ */
+@Transactional(readOnly = true)
+public class RawFileBeanReadOnly extends RawFileBean {
+
+    /** The logger for this particular class */
+    private static Logger log = LoggerFactory.getLogger(RawFileBean.class);
+
+    private static final long serialVersionUID = 3885987391741946793L;
+
+    /**
+     * default constructor
+     */
+    public RawFileBeanReadOnly() {}
+
+    /**
+     * overridden to allow Spring to set boolean
+     * @param checking
+     */
+    public RawFileBeanReadOnly(boolean checking) {
+        super(checking);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see ome.api.StatefulServiceInterface#close()
+     */
+    @RolesAllowed("user")
+    public synchronized void close() {
+        /* omits save() */
+        clean();
+    }
+}

--- a/components/server/src/ome/services/RawFileBeanReadOnly.java
+++ b/components/server/src/ome/services/RawFileBeanReadOnly.java
@@ -60,6 +60,7 @@ public class RawFileBeanReadOnly extends RawFileBean {
      * @see ome.api.StatefulServiceInterface#close()
      */
     @RolesAllowed("user")
+    @Override
     public synchronized void close() {
         /* omits save() */
         clean();


### PR DESCRIPTION
Allow raw file stores to be closed on a read-only server. See https://trello.com/c/wlML9Pdg/14-need-rawfilebeanreadonly.