### PR TITLE
Read only can create web

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -247,7 +247,12 @@ class login_required(object):
         return False
 
     def load_server_settings(self, conn, request):
-        """Loads Client preferences from the server."""
+        """Loads Client preferences and Read-Only status from the server."""
+        try:
+            request.session['can_create']
+        except KeyError:
+            request.session.modified = True
+            request.session['can_create'] = conn.canCreate()
         try:
             request.session['server_settings']
         except:

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenter_form.html
@@ -310,7 +310,8 @@
         {% else %}
 
         <label>Password</label>
-            <a class="btn btn_text silver" id="change_password" {% if not can_modify_user %} style="pointer-events: none" {% endif %}>
+            <a class="btn btn_text silver" id="change_password"
+                {% if not can_modify_user or not ome.can_create %} style="pointer-events: none" {% endif %}>
                 <span {% if not can_modify_user %} style="color:Gray" {% endif %}>Change User's Password</span>
             </a>
         <span id="password_change_message"></span>
@@ -351,7 +352,7 @@
         <br />
         
         <input type="submit" 
-            {% if not can_modify_user %}
+            {% if not can_modify_user or not ome.can_create %}
                 disabled title="You don't have permissions to edit Users"
             {% endif %}
             value="{% trans 'Save' %}" />

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenters.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenters.html
@@ -71,7 +71,7 @@
         </span>
     </form>
 
-    {% if can_modify_user %}
+    {% if can_modify_user and ome.can_create %}
     <div class="btn blue">
         <a href="{% url 'wamanageexperimenterid' "new" %}">
             <span>{% trans "Add new User" %}</span>

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/group_form.html
@@ -136,9 +136,9 @@
             
             
             <input type="submit" 
-                {% if not can_modify_group%}{% if not can_add_member %}
+                {% if not can_modify_group and not can_add_member or not ome.can_create %}
                     disabled title="You don't have permissions to edit Groups"
-                {% endif %}{% endif %}
+                {% endif %}
                 value="{% trans 'Save' %}" />
             <div style="clear: both"></div>
         </div>

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/groups.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/groups.html
@@ -69,7 +69,7 @@
         </span>
     </form>
 
-    {% if can_modify_group %}
+    {% if can_modify_group and ome.can_create %}
         <div class="btn blue">
             <a href="{% url 'wamanagegroupid' "new" %}">
                 <span>{% trans "Add new Group" %}</span>

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -135,6 +135,7 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['active_group'] = request.session.get(
             'active_group', conn.getEventContext().groupId)
         context['global_search_form'] = GlobalSearchForm()
+        context['ome']['can_create'] = request.session.get('can_create', True)
         # UI server preferences
         if request.session.get('server_settings'):
             context['ome']['email'] = request.session.get(

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -1108,6 +1108,7 @@ $(function() {
                     canLink = OME.nodeHasPermission(node, 'canLink'),
                     parentAllowsCreate = (node.type === "orphaned" || node.type === "experimenter");
 
+                canCreate = canCreate && WEBCLIENT.CAN_CREATE;  // global state for read-only server
                 if(canCreate) {
                     // Enable tag or P/D/I submenus created above
                     config["create"]["_disabled"] = false;

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -964,6 +964,7 @@ OME.formatScriptName = function(name) {
 OME.showScriptList = function(event) {
     // We're almost always going to be triggered from an anchor
     event.preventDefault();
+    if (!WEBCLIENT.CAN_CREATE) return;
 
     // show menu - load if empty
     // $('#scriptList').css('visibility', 'visible');

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/annotations_share.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/annotations_share.html
@@ -235,6 +235,7 @@
             
             <table>
                 <!-- SHARE COMMENT -->
+                {% if ome.can_create %}
                 <tr>
                     <th colspan="3"> 
                         {% trans "Comment:" %}
@@ -255,6 +256,7 @@
                         {% endif %}
                     </th>
                 </tr>
+                {% endif %}
                 <tr>
                     <td colspan="3">
                         <div id="share_comments_container" class="lncomments">

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -207,7 +207,7 @@
         {% endif %}
 
         {% if not share %}
-            {% if image and not image.requiresPixelsPyramid %}
+            {% if image and not image.requiresPixelsPyramid and ome.can_create %}
             <li>
                 <a id="create-ometiff" href="{% url 'ome_tiff_script' image.id %}" 
                 title="Create OME-TIFF File for Download">Export as OME-TIFF...</a>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/toolbar.html
@@ -333,7 +333,7 @@
 
     <!-- Publishing Options (Figure Scripts) -->
     {% if not share %}
-    {% if not differentGroups %}
+    {% if not differentGroups and ome.can_create %}
     {% include "webclient/annotations/includes/figure_scripts_menu.html" %}
     {% endif %}
     {% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -405,7 +405,7 @@
             Save
         </button>
 
-        <button id="rdef-save-all" class="button{%if share and not share.share.isOwned %} button-disabled{% endif %}"
+        <button id="rdef-save-all" class="button{%if share and not share.share.isOwned or not ome.can_create%} button-disabled{% endif %}"
             title="Cannot apply settings to other images">
           <img src="{% static 'webclient/image/icon_save.png' %}" style="position:relative; top:2px" /><br>
             Save to All

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -167,6 +167,7 @@
         WEBCLIENT.USER = {'id': {{ ome.user.id }}, 'fullName': "{{ ome.user.getFullName }}"};
         WEBCLIENT.active_user = {'id': {{ ome.user_id }}, 'fullName': "{{ active_user.getFullName }}"};
         WEBCLIENT.eventContext = {{ ome.eventContext|json_dumps|safe }};
+        WEBCLIENT.CAN_CREATE = {{ ome.can_create|json_dumps|safe }};
 
         WEBCLIENT.URLS = {};
         WEBCLIENT.URLS.webindex = "{% url 'webindex' %}";

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
@@ -24,7 +24,11 @@
             <span>{{ ome.user.getFullName }}</span>
         </div>
         <ul class="dropdown">
-            <li id="user_settings"><a href="{% url 'wamyaccount' 'edit' %}" title="User settings"> User settings</a></li>
+            {% if ome.can_create %}
+              <li id="user_settings"><a href="{% url 'wamyaccount' 'edit' %}" title="User settings">
+                User settings
+              </a></li>
+            {% endif %}
 			<!-- Help -->
             <li id="send"><a href="#" onclick="return OME.openPopup('{% url 'csend' %}')">Send Feedback</a></li>
 			<li id="logout">{% include "webclient/base/includes/logout.html" %}</li>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -295,6 +295,7 @@
                 canCreate = (userId === WEBCLIENT.USER.id || (allMembers && memberOfGroup) ||
                     (!allMembers && writeOwned));
 
+            canCreate = canCreate && WEBCLIENT.CAN_CREATE;  // global state for read-only server
             // These nodes can be Orphans, so creation is not selection-specific
             if (canCreate) {
                 toolbar_config["addproject"] = true;


### PR DESCRIPTION
# What this PR does

NB: This is on top of https://github.com/openmicroscopy/openmicroscopy/pull/5749 since it uses ```conn.canCreate()``` added there.

This uses ```conn.canCreate()``` to populate the ```request.session``` on login, so it doesn't have to be called repeatedly.
Then we pass this into the rendering context and use it to set a global JavaScript variable ```WEBCLIENT.CAN_CREATE``` which is used to disable creating in jsTree and opening of scripts menu.

We also disable OME-TIFF export.

# Testing this PR

1. All create controls should be disabled in jsTree
1. Script menu won't launch
1. OME-TIFF export option is disabled.

cc @mtbc 