### PR TITLE
do not set chgrp, chown permissions if read-only database

### DIFF
--- a/components/server/src/ome/security/basic/BasicACLVoter.java
+++ b/components/server/src/ome/security/basic/BasicACLVoter.java
@@ -645,6 +645,9 @@ public class BasicACLVoter implements ACLVoter {
      * @return the permissions integer, possibly adjusted
      */
     private int addChgrpChownRestrictionBits(Class<? extends IObject> objectClass, Details details, int allow) {
+        if (isReadOnlyDb) {
+            return allow;
+        }
         final EventContext ec = currentUser.getCurrentEventContext();
         final Set<AdminPrivilege> privileges = ec.getCurrentAdminPrivileges();
         final boolean isChgrpPrivilege = privileges.contains(adminPrivileges.getPrivilege(AdminPrivilege.VALUE_CHGRP));


### PR DESCRIPTION
# What this PR does

Prevents `canChgrp`, `canChown` from being viewed as `true` from clients if `omero.cluster.read_only.db=true`.

# Related reading

#5753