### PR TITLE
group user search css fix

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenters.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/experimenters.html
@@ -63,13 +63,6 @@
 {% if experimenterList %}
 
 <div class="one_column_header">
-    <form class="search filtersearch" id="filtersearch" action="#">
-        <input type="text" id="id_search">
-        <input type="submit" value="Go" />
-        <span class="loading">
-            <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
-        </span>
-    </form>
 
     {% if can_modify_user %}
     <div class="btn blue">
@@ -78,6 +71,14 @@
         </a>
     </div>
     {% endif %}
+
+    <form class="search filtersearch" id="filtersearch" action="#" style="width: 160px">
+        <input type="text" id="id_search">
+        <input type="submit" value="Go" />
+        <span class="loading">
+            <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
+        </span>
+    </form>
 
 </div>
 

--- a/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/groups.html
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/templates/webadmin/groups.html
@@ -61,13 +61,6 @@
 {% if groups %}
 
 <div class="one_column_header">
-    <form class="search filtersearch" id="filtersearch" action="#">
-        <input type="text" id="id_search">
-        <input type="submit" value="Go" />
-        <span class="loading">
-            <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
-        </span>
-    </form>
 
     {% if can_modify_group %}
         <div class="btn blue">
@@ -77,6 +70,13 @@
         </div>
     {% endif %}
 
+    <form class="search filtersearch" id="filtersearch" action="#" style="width:160px">
+        <input type="text" id="id_search">
+        <input type="submit" value="Go" />
+        <span class="loading">
+            <img class="loader" alt="Loading" src="{% static "webgateway/img/spinner.gif" %}">
+        </span>
+    </form>
 </div>
 
 <table id="groupTable" class="tablesorter tablesorter_basic">

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -976,6 +976,7 @@ button::-moz-focus-inner {
 		-webkit-box-shadow: 0 1px 0 rgba(255,255,255,.2), inset 0 1px 1px rgba(0,0,0,.2);
 		-moz-box-shadow: 0 1px 0 rgba(255,255,255,.2), inset 0 1px 1px rgba(0,0,0,.2);
 		box-shadow: 0 1px 0 rgba(255,255,255,.15), inset 0 1px 2px rgba(0,0,0,.3);
+		right: 0;
 	}
 
 	#search input[type=submit], .filtersearch input[type=submit]{
@@ -994,10 +995,6 @@ button::-moz-focus-inner {
 		   -moz-transition:   opacity .2s linear;
 		     -o-transition:   opacity .2s linear;
 		        transition:   opacity .2s linear; 
-	}
-	
-	.filtersearch input[type=submit] {
-		right:22px;
 	}
 	
 	#search input[type=submit]:hover, .filtersearch input[type=submit]:hover {
@@ -1059,8 +1056,8 @@ button::-moz-focus-inner {
 		
 		.filtersearch .loading {
 			position:absolute;
-			right:-4px;
-			top:2px;
+			left: 110%;
+			top: 6px;
 		}
 	
 	/* same as .filtersearch label for top search field */

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -1556,6 +1556,7 @@
 				border:solid 1px rgba(0,0,0,.3);
 				border-top:solid 1px rgba(0,0,0,.4);
 				color:#333;
+				box-sizing: border-box;
 			}
 	
 


### PR DESCRIPTION
# What this PR does

CSS fix to filter search element on Groups and Users webadmin pages, created partially by #5669 and others.

<img width="822" alt="screen shot 2018-05-06 at 23 22 20" src="https://user-images.githubusercontent.com/900055/39678501-f8f59920-5185-11e8-9173-01a54f920993.png">

# Testing this PR

1. Layout of Groups and Users table header should appear on a single row, with magnifying glass within the search field and spinner showing beside during filtering.

<img width="827" alt="screen shot 2018-05-06 at 23 34 55" src="https://user-images.githubusercontent.com/900055/39678507-21507714-5186-11e8-9466-068f833aad2c.png">
