### PR TITLE
RepositoryInfo::getFreeSpaceInKilobytes adjustments

### DIFF
--- a/components/server/src/ome/logic/RepositoryInfoImpl.java
+++ b/components/server/src/ome/logic/RepositoryInfoImpl.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -144,6 +142,7 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
      * @see ome.api.IRepositoryInfo#getFreeSpaceInKilobytes()
      */
     @RolesAllowed("user")
+    @Transactional(readOnly = true)
     public long getFreeSpaceInKilobytes() {
         long result = 0L;
 

--- a/components/server/src/ome/logic/RepositoryInfoImpl.java
+++ b/components/server/src/ome/logic/RepositoryInfoImpl.java
@@ -144,18 +144,15 @@ public class RepositoryInfoImpl extends AbstractLevel2Service implements
     @RolesAllowed("user")
     @Transactional(readOnly = true)
     public long getFreeSpaceInKilobytes() {
-        long result = 0L;
+        final long result;
 
         try {
             result = FileSystemUtils.freeSpaceKb(datadir);
-            if (log.isInfoEnabled()) {
-                log.info("Total kilobytes free: " + result);
-            }
         } catch (Throwable t) {
             log.error("Error retrieving usage in KB.", t);
             throw new ResourceError(t.getMessage());
         }
-
+        log.info("Total kilobytes free: {}", result);
         return result;
     }
 


### PR DESCRIPTION
# What this PR does

For http://downloads.openmicroscopy.org/latest/omero5.4/api/slice2html/omero/api/IRepositoryInfo.html#getFreeSpaceInKilobytes implementation,

* run in read-only transaction
* adjust logging code (log output should be unchanged).

cc: @jburel, @will-moore

# Testing this PR

https://github.com/openmicroscopy/openmicroscopy/pull/5753#issuecomment-386834083