### PR TITLE
Exit standalone importer when connected to read-only server

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -636,6 +636,13 @@ public class DataServicesFactory
         long gid = exp.getDefaultGroup().getId();
         SecurityContext ctx = new SecurityContext(gid);
         boolean canCreate = omeroGateway.canCreate(ctx);
+
+        if (!canCreate && LookupNames.MASTER_IMPORTER.equals(name)) {
+            registry.getUserNotifier().notifyError("Read-only server",
+                    "Cannot import on a read-only server!");
+            exitApplication(true, true);
+        }
+
         try {
             GroupData defaultGroup = null;
         	registry.bind(LookupNames.CAN_CREATE, canCreate);


### PR DESCRIPTION
# What this PR does

Popup an error message and exit standalone importer when connected to a read-only server.

# Testing this PR

- Connect to read-only server, check that the error message pops up and the application exits.
- Connect to a non read-only server, check that the importer starts up as usual.

/cc @jburel 

