### PR TITLE
Check PUBLIC_ENABLED before redirect

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -381,7 +381,8 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     # If we failed to find 'show'...
     if request.GET.get('show', None) is not None and first_sel is None:
         # and we're logged in as PUBLIC user...
-        if settings.PUBLIC_USER == conn.getUser().getOmeName():
+        if (settings.PUBLIC_ENABLED and
+            settings.PUBLIC_USER == conn.getUser().getOmeName()):
             # this is likely a regular user who needs to log in as themselves.
             # Login then redirect to current url
             return HttpResponseRedirect(

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -382,7 +382,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     if request.GET.get('show', None) is not None and first_sel is None:
         # and we're logged in as PUBLIC user...
         if (settings.PUBLIC_ENABLED and
-            settings.PUBLIC_USER == conn.getUser().getOmeName()):
+                settings.PUBLIC_USER == conn.getUser().getOmeName()):
             # this is likely a regular user who needs to log in as themselves.
             # Login then redirect to current url
             return HttpResponseRedirect(


### PR DESCRIPTION
# What this PR does

Fix error from https://www.openmicroscopy.org/qa2/qa/feedback/21070/
```
File "/opt/omero/OMERO.server-5.4.3-ice36-b77/lib/python/omeroweb/webclient/views.py", line 383, in _load_template
if settings.PUBLIC_USER == conn.getUser().getOmeName():
File "/usr/lib/python2.7/site-packages/django/conf/__init__.py", line 49, in __getattr__
return getattr(self._wrapped, name)
AttributeError: 'Settings' object has no attribute 'PUBLIC_USER'
```

# Testing this PR

1. Test on a server where PUBLIC_USER is not set
2. Login to webclient
3. Go to /webclient/?show=dataset-ID where ID doesn't exist (enter a random number)
4. Should simply go to webclient page without error.
