### PR TITLE
Shapedata bugfix

### DIFF
--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -760,7 +760,7 @@ public class ROIFacility extends Facility {
                         if (shape != null) {
                             if (!serverCoordMap.containsKey(coord))
                                 serverRoi.addShape(sh);
-                            else if (shape.isDirty()) {  // !!!!
+                            else if (shape.isDirty()) {
                                 shapeIndex = -1;
                                 if (deleted.contains(shape.getId())) {
                                     serverRoi.addShape(sh);

--- a/components/blitz/src/omero/gateway/facility/ROIFacility.java
+++ b/components/blitz/src/omero/gateway/facility/ROIFacility.java
@@ -702,8 +702,8 @@ public class ROIFacility extends Facility {
                         for (int i = 0 ; i < serverRoi.sizeOfShapes(); i++) {
                             s = serverRoi.getShape(i);
                             if (s != null) {
-                                z = 0;
-                                t = 0;
+                                z = -1;
+                                t = -1;
                                 if (s.getTheZ() != null) z = s.getTheZ().getValue();
                                 if (s.getTheT() != null) t = s.getTheT().getValue();
                                 serverCoordMap.put(new ROICoordinate(z, t), s);
@@ -760,7 +760,7 @@ public class ROIFacility extends Facility {
                         if (shape != null) {
                             if (!serverCoordMap.containsKey(coord))
                                 serverRoi.addShape(sh);
-                            else if (shape.isDirty()) {
+                            else if (shape.isDirty()) {  // !!!!
                                 shapeIndex = -1;
                                 if (deleted.contains(shape.getId())) {
                                     serverRoi.addShape(sh);

--- a/components/blitz/src/omero/gateway/model/LineData.java
+++ b/components/blitz/src/omero/gateway/model/LineData.java
@@ -100,6 +100,7 @@ public class LineData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setTextValue(rtypes.rstring(text));
+        setDirty(true);
     }
 
     /**
@@ -128,6 +129,7 @@ public class LineData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setX1(rtypes.rdouble(x1));
+        setDirty(true);
     }
 
     /**
@@ -156,6 +158,7 @@ public class LineData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setX2(rtypes.rdouble(x2));
+        setDirty(true);
     }
 
     /**
@@ -184,6 +187,7 @@ public class LineData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setY1(rtypes.rdouble(y1));
+        setDirty(true);
     }
 
     /**
@@ -212,6 +216,7 @@ public class LineData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setY2(rtypes.rdouble(y2));
+        setDirty(true);
     }
 
 }

--- a/components/blitz/src/omero/gateway/model/MaskData.java
+++ b/components/blitz/src/omero/gateway/model/MaskData.java
@@ -107,6 +107,7 @@ public class MaskData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setTextValue(rtypes.rstring(text));
+        setDirty(true);
     }
 
     /**
@@ -135,6 +136,7 @@ public class MaskData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setX(rtypes.rdouble(x));
+        setDirty(true);
     }
 
     /**
@@ -163,6 +165,7 @@ public class MaskData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setY(rtypes.rdouble(y));
+        setDirty(true);
     }
 
     /**
@@ -191,6 +194,7 @@ public class MaskData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setWidth(rtypes.rdouble(width));
+        setDirty(true);
     }
 
     /**
@@ -219,6 +223,7 @@ public class MaskData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setHeight(rtypes.rdouble(height));
+        setDirty(true);
     }
 
     /**
@@ -230,6 +235,7 @@ public class MaskData
     {
         Mask shape = (Mask) asIObject();
         shape.setBytes(mask);	
+        setDirty(true);
     }
 
     /**
@@ -255,6 +261,7 @@ public class MaskData
                     }
                     setBit(data, (int)(y*getWidth()+x), 1);
                 }
+        setDirty(true);
     }
 
     /**
@@ -343,6 +350,7 @@ public class MaskData
         data[bytePosition] = (byte) ((byte)(data[bytePosition]&
                 (~(byte)(0x1<<bitPosition)))|
                 (byte)(val<<bitPosition));
+        setDirty(true);
     }
 
     /** 

--- a/components/blitz/src/omero/gateway/model/PointData.java
+++ b/components/blitz/src/omero/gateway/model/PointData.java
@@ -100,6 +100,7 @@ extends ShapeData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setTextValue(rtypes.rstring(text));
+        setDirty(true);
     }
 
 
@@ -130,6 +131,7 @@ extends ShapeData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setX(rtypes.rdouble(x));
+        setDirty(true);
     }
 
     /**
@@ -159,6 +161,7 @@ extends ShapeData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setY(rtypes.rdouble(y));
+        setDirty(true);
     }
 
 }

--- a/components/blitz/src/omero/gateway/model/PolygonData.java
+++ b/components/blitz/src/omero/gateway/model/PolygonData.java
@@ -97,6 +97,7 @@ public class PolygonData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setTextValue(rtypes.rstring(text));
+        setDirty(true);
     }
 
     /**
@@ -138,6 +139,7 @@ public class PolygonData
         String pointsValues =
                 toPoints(points.toArray(new Point2D.Double[points.size()]));
         shape.setPoints(rtypes.rstring(pointsValues));
+        setDirty(true);
     }
 
 }

--- a/components/blitz/src/omero/gateway/model/PolylineData.java
+++ b/components/blitz/src/omero/gateway/model/PolylineData.java
@@ -100,6 +100,7 @@ public class PolylineData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setTextValue(rtypes.rstring(text));
+        setDirty(true);
     }
 
     /**
@@ -129,5 +130,6 @@ public class PolylineData
         String pointsValues =
                 toPoints(points.toArray(new Point2D.Double[points.size()]));
         shape.setPoints(rtypes.rstring(pointsValues));
+        setDirty(true);
     }
 }

--- a/components/blitz/src/omero/gateway/model/ROICoordinate.java
+++ b/components/blitz/src/omero/gateway/model/ROICoordinate.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- * Copyright (C) 2006-2009 University of Dundee. All rights reserved.
+ * Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -58,8 +58,8 @@ public class ROICoordinate
     /**
      * Creates a new instance.
      *
-     * @param z The z-section.
-     * @param t The timepoint.
+     * @param z The z-section. (-1 == all z-sections)
+     * @param t The timepoint. (-1 == all timepoints)
      */
     public ROICoordinate(int z, int t)
     {
@@ -69,14 +69,14 @@ public class ROICoordinate
 
     /**
      * Returns the timepoint.
-     *
+     * (-1 == all timepoints)
      * @return See above.
      */
     public int getTimePoint() { return t; }
 
     /**
      * Returns the z-section.
-     *
+     * (-1 == all z-sections)
      * @return See above.
      */
     public int getZSection() { return z; }
@@ -84,7 +84,6 @@ public class ROICoordinate
     /**
      * Implemented as specified by the {@link Comparator} I/F.
      * @see Comparator#compare(Object, Object)
-     * If any attribute == -1 it is not included in comparison.
      */
     public int compare(Object o1, Object o2)
     {
@@ -101,7 +100,6 @@ public class ROICoordinate
 
     /**
      * Overridden to control if the passed object equals the current one.
-     * If any attribute == -1 it is not included in comparison.
      * @see java.lang.Object#equals(Object)
      */
     public boolean equals(Object obj)

--- a/components/blitz/src/omero/gateway/model/ROIData.java
+++ b/components/blitz/src/omero/gateway/model/ROIData.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- * Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ * Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -247,7 +247,9 @@ public class ROIData
      */
     public List<ShapeData> getShapes(int z, int t)
     {
-        return roiShapes.get(new ROICoordinate(z, t));
+        List<ShapeData> res = roiShapes.get(new ROICoordinate(z, t));
+        res.addAll(roiShapes.get(new ROICoordinate(-1, -1)));
+        return res;
     }
 
     /**
@@ -259,39 +261,6 @@ public class ROIData
     {
         return roiShapes.values().iterator();
     }
-
-    /** 
-     * Return the first plane that the ROI starts on.
-     *
-     * @return See above.
-     */
-    public ROICoordinate firstPlane()
-    {
-        return roiShapes.firstKey();
-    }
-
-    /** 
-     * Returns the last plane that the ROI ends on.
-     *
-     * @return See above.
-     */
-    public ROICoordinate lastPlane()
-    {
-        return roiShapes.lastKey();
-    }
-
-    /**
-     * Returns an iterator of the Shapes in the ROI in the range [start, end].
-     *
-     * @param start The starting plane where the Shapes should reside.
-     * @param end The final plane where the Shapes should reside.
-     * @return See above.
-     */
-    public Iterator<List<ShapeData>> getShapesInRange(ROICoordinate start,
-            ROICoordinate end)
-            {
-        return roiShapes.subMap(start, end).values().iterator();
-            }
 
     /**
      * Returns <code>true</code> if the object a client-side object,

--- a/components/blitz/src/omero/gateway/model/ROIData.java
+++ b/components/blitz/src/omero/gateway/model/ROIData.java
@@ -209,9 +209,11 @@ public class ROIData
         ROICoordinate coord = shape.getROICoordinate();
         List<ShapeData> shapeList;
         shapeList = roiShapes.get(coord);
-        shapeList.remove(shape);
-        roi.removeShape((Shape) shape.asIObject());
-        setDirty(true);
+        if (shapeList != null) {
+            shapeList.remove(shape);
+            roi.removeShape((Shape) shape.asIObject());
+            setDirty(true);
+        }
     }
 
     /**
@@ -251,7 +253,11 @@ public class ROIData
     public List<ShapeData> getShapes(int z, int t)
     {
         List<ShapeData> res = roiShapes.get(new ROICoordinate(z, t));
-        res.addAll(roiShapes.get(new ROICoordinate(-1, -1)));
+        if (res == null)
+            res = new ArrayList<ShapeData>();
+        List<ShapeData> allZT = roiShapes.get(new ROICoordinate(-1, -1));
+        if (allZT != null)
+            res.addAll(allZT);
         return res;
     }
 

--- a/components/blitz/src/omero/gateway/model/ROIData.java
+++ b/components/blitz/src/omero/gateway/model/ROIData.java
@@ -218,6 +218,9 @@ public class ROIData
      * Returns the number of planes occupied by the ROI.
      *
      * @return See above.
+     * @deprecated Will be removed in future. Does not work as 
+     * expected if the ROI contains shapes which are associated 
+     * with all planes (Z, C, T == -1)
      */
     public int getPlaneCount() { return roiShapes.size(); }
 
@@ -260,6 +263,47 @@ public class ROIData
     public Iterator<List<ShapeData>> getIterator()
     {
         return roiShapes.values().iterator();
+    }
+
+    /**
+     * Return the first plane that the ROI starts on.
+     *
+     * @return See above.
+     * @deprecated Will be removed in future. Does not work as 
+     * expected if the ROI contains shapes which are associated 
+     * with all planes (Z, C, T == -1)
+     */
+    public ROICoordinate firstPlane() {
+        return roiShapes.firstKey();
+    }
+
+    /**
+     * Returns the last plane that the ROI ends on.
+     *
+     * @return See above.
+     * @deprecated Will be removed in future. Does not work as 
+     * expected if the ROI contains shapes which are associated 
+     * with all planes (Z, C, T == -1)
+     */
+    public ROICoordinate lastPlane() {
+        return roiShapes.lastKey();
+    }
+
+    /**
+     * Returns an iterator of the Shapes in the ROI in the range [start, end].
+     *
+     * @param start
+     *            The starting plane where the Shapes should reside.
+     * @param end
+     *            The final plane where the Shapes should reside.
+     * @return See above.
+     */
+    public Iterator<List<ShapeData>> getShapesInRange(ROICoordinate start,
+            ROICoordinate end) {
+        List<List<ShapeData>> res = new ArrayList<List<ShapeData>>();
+        res.addAll(roiShapes.subMap(start, end).values());
+        res.add(roiShapes.get(new ROICoordinate(-1, -1)));
+        return res.iterator();
     }
 
     /**

--- a/components/blitz/src/omero/gateway/model/ROIData.java
+++ b/components/blitz/src/omero/gateway/model/ROIData.java
@@ -258,6 +258,12 @@ public class ROIData
         List<ShapeData> allZT = roiShapes.get(new ROICoordinate(-1, -1));
         if (allZT != null)
             res.addAll(allZT);
+        List<ShapeData> allZ = roiShapes.get(new ROICoordinate(-1, t));
+        if (allZ != null)
+            res.addAll(allZ);
+        List<ShapeData> allT = roiShapes.get(new ROICoordinate(z, -1));
+        if (allT != null)
+            res.addAll(allT);
         return res;
     }
 
@@ -303,6 +309,9 @@ public class ROIData
      * @param end
      *            The final plane where the Shapes should reside.
      * @return See above.
+     * @deprecated Will be removed in future. Does not work as
+     * expected if the ROI contains shapes which are associated
+     * with all planes (Z, C, T == -1)
      */
     public Iterator<List<ShapeData>> getShapesInRange(ROICoordinate start,
             ROICoordinate end) {

--- a/components/blitz/src/omero/gateway/model/ROIData.java
+++ b/components/blitz/src/omero/gateway/model/ROIData.java
@@ -307,8 +307,12 @@ public class ROIData
     public Iterator<List<ShapeData>> getShapesInRange(ROICoordinate start,
             ROICoordinate end) {
         List<List<ShapeData>> res = new ArrayList<List<ShapeData>>();
-        res.addAll(roiShapes.subMap(start, end).values());
-        res.add(roiShapes.get(new ROICoordinate(-1, -1)));
+        Collection<List<ShapeData>> inRange = roiShapes.subMap(start, end).values();
+        if (inRange != null)
+            res.addAll(inRange);
+        List<ShapeData> allRanges = roiShapes.get(new ROICoordinate(-1, -1));
+        if (allRanges != null)
+            res.add(allRanges);
         return res.iterator();
     }
 

--- a/components/blitz/src/omero/gateway/model/ROIData.java
+++ b/components/blitz/src/omero/gateway/model/ROIData.java
@@ -207,8 +207,7 @@ public class ROIData
         if (roi == null) 
             throw new IllegalArgumentException("No Roi specified.");
         ROICoordinate coord = shape.getROICoordinate();
-        List<ShapeData> shapeList;
-        shapeList = roiShapes.get(coord);
+        List<ShapeData> shapeList = roiShapes.get(coord);
         if (shapeList != null) {
             shapeList.remove(shape);
             roi.removeShape((Shape) shape.asIObject());

--- a/components/blitz/src/omero/gateway/model/RectangleData.java
+++ b/components/blitz/src/omero/gateway/model/RectangleData.java
@@ -100,6 +100,7 @@ public class RectangleData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setTextValue(rtypes.rstring(text));
+        setDirty(true);
     }
 
     /**
@@ -130,6 +131,7 @@ public class RectangleData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setX(rtypes.rdouble(x));
+        setDirty(true);
     }
 
     /**
@@ -160,6 +162,7 @@ public class RectangleData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setY(rtypes.rdouble(y));
+        setDirty(true);
     }
 
     /**
@@ -188,6 +191,7 @@ public class RectangleData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setWidth(rtypes.rdouble(width));
+        setDirty(true);
     }
 
     /**
@@ -216,6 +220,7 @@ public class RectangleData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setHeight(rtypes.rdouble(height));
+        setDirty(true);
     }
 
 }

--- a/components/blitz/src/omero/gateway/model/ShapeData.java
+++ b/components/blitz/src/omero/gateway/model/ShapeData.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- * Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ * Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/components/blitz/src/omero/gateway/model/ShapeData.java
+++ b/components/blitz/src/omero/gateway/model/ShapeData.java
@@ -267,7 +267,8 @@ public abstract class ShapeData
     }
 
     /**
-     * Returns the z-section.
+     * Returns the z-section. -1 if the shape applies to all z-sections of
+     * the image.
      *
      * @return See above.
      */
@@ -284,20 +285,25 @@ public abstract class ShapeData
     /**
      * Sets the z-section.
      *
-     * @param z The value to set.
+     * @param z
+     *            The value to set. Pass -1 to remove z value, i. e. shape
+     *            applies to all z-sections of the image.
      */
     public void setZ(int z)
     {
         Shape shape = (Shape) asIObject();
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
-        if (z < 0) z = 0;
-        shape.setTheZ(rtypes.rint(z));
+        if (z < 0)
+            shape.setTheZ(null);
+        else
+            shape.setTheZ(rtypes.rint(z));
         setDirty(true);
     }
 
     /**
-     * Returns the channel.
+     * Returns the channel. -1 if the shape applies to all channels of
+     * the image.
      *
      * @return See above.
      */
@@ -314,21 +320,26 @@ public abstract class ShapeData
     /**
      * Sets the channel.
      *
-     * @param c The value to set.
+     * @param c 
+     *            The value to set. Pass -1 to remove c value, i. e. shape
+     *            applies to all channels of the image.
      */
     public void setC(int c)
     {
         Shape shape = (Shape) asIObject();
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
-        if (c < 0) c = 0;
-        shape.setTheC(rtypes.rint(c));
+        if (c < 0)
+            shape.setTheC(null);
+        else
+            shape.setTheC(rtypes.rint(c));
         setDirty(true);
     }
 
 
     /**
-     * Returns the time-point.
+     * Returns the time-point. -1 if the shape applies to all time-points of
+     * the image.
      *
      * @return See above.
      */
@@ -345,15 +356,19 @@ public abstract class ShapeData
     /**
      * Sets the time-point.
      *
-     * @param t The value to set.
+     * @param t
+     *            The value to set. Pass -1 to remove t value, i. e. shape
+     *            applies to all time-points of the image.
      */
     public void setT(int t)
     {
         Shape shape = (Shape) asIObject();
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
-        if (t < 0) t = 0;
-        shape.setTheT(rtypes.rint(t));
+        if (t < 0)
+            shape.setTheT(null);
+        else
+            shape.setTheT(rtypes.rint(t));
         setDirty(true);
     }
 
@@ -386,7 +401,6 @@ public abstract class ShapeData
             throw new IllegalArgumentException("No shape specified.");
         int z = getZ();
         int t = getT();
-        if (z < 0 || t < 0) return null;
         return new ROICoordinate(z, t);
     }
 

--- a/components/blitz/src/omero/gateway/model/TextData.java
+++ b/components/blitz/src/omero/gateway/model/TextData.java
@@ -99,6 +99,7 @@ public class TextData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setTextValue(rtypes.rstring(text));
+        setDirty(true);
     }
 
     /**
@@ -127,6 +128,7 @@ public class TextData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setX(rtypes.rdouble(x));
+        setDirty(true);
     }
 
     /**
@@ -155,6 +157,7 @@ public class TextData
         if (shape == null) 
             throw new IllegalArgumentException("No shape specified.");
         shape.setY(rtypes.rdouble(y));
+        setDirty(true);
     }
 
 }

--- a/components/blitz/test/omero/gateway/model/ShapeTest.java
+++ b/components/blitz/test/omero/gateway/model/ShapeTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2017 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2017-2018 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *
@@ -23,11 +23,11 @@ package omero.gateway.model;
 
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
 
 
 /**
@@ -88,4 +88,194 @@ public class ShapeTest {
         Assert.assertEquals(p.y, 4.0);
     }
 
+    private void testAndResetDirty(ShapeData s) {
+        Assert.assertTrue(s.isDirty());
+        s.setDirty(false);
+    }
+
+    @Test
+    public void testDirty() {
+        EllipseData s = new EllipseData(10, 10, 5, 5);
+        s.setDirty(false);
+        s.setX(1);
+        testAndResetDirty(s);
+        s.setY(1);
+        testAndResetDirty(s);
+        s.setRadiusX(1);
+        testAndResetDirty(s);
+        s.setRadiusY(1);
+        testAndResetDirty(s);
+        s.setText("bla");
+        testAndResetDirty(s);
+        s.setC(2);
+        testAndResetDirty(s);
+        s.setT(2);
+        testAndResetDirty(s);
+        s.setT(2);
+        testAndResetDirty(s);
+        s.setC(-1);
+        testAndResetDirty(s);
+        s.setT(-1);
+        testAndResetDirty(s);
+        s.setT(-1);
+        testAndResetDirty(s);
+        
+        LineData l = new LineData(10, 10, 10, 10);
+        l.setDirty(false);
+        l.setX1(1);
+        testAndResetDirty(l);
+        l.setY1(1);
+        testAndResetDirty(l);
+        l.setX2(1);
+        testAndResetDirty(l);
+        l.setY2(1);
+        testAndResetDirty(l);
+        l.setText("bla");
+        testAndResetDirty(l);
+        l.setC(2);
+        testAndResetDirty(l);
+        l.setT(2);
+        testAndResetDirty(l);
+        l.setT(2);
+        testAndResetDirty(l);
+        l.setC(-1);
+        testAndResetDirty(l);
+        l.setT(-1);
+        testAndResetDirty(l);
+        l.setT(-1);
+        testAndResetDirty(l);
+        
+        MaskData m = new MaskData(10, 10, 10, 10, new byte[10]);
+        m.setDirty(false);
+        m.setX(1);
+        testAndResetDirty(m);
+        m.setY(1);
+        testAndResetDirty(m);
+        m.setWidth(1);
+        testAndResetDirty(m);
+        m.setHeight(1);
+        testAndResetDirty(m);
+        m.setMask(new byte[10]);
+        testAndResetDirty(m);
+        m.setText("bla");
+        testAndResetDirty(m);
+        m.setC(2);
+        testAndResetDirty(m);
+        m.setT(2);
+        testAndResetDirty(m);
+        m.setT(2);
+        testAndResetDirty(m);
+        m.setC(-1);
+        testAndResetDirty(m);
+        m.setT(-1);
+        testAndResetDirty(m);
+        m.setT(-1);
+        testAndResetDirty(m);
+        
+        PointData p = new PointData(10, 10);
+        p.setDirty(false);
+        p.setX(1);
+        testAndResetDirty(p);
+        p.setY(1);
+        testAndResetDirty(p);
+        p.setText("bla");
+        testAndResetDirty(p);
+        p.setC(2);
+        testAndResetDirty(p);
+        p.setT(2);
+        testAndResetDirty(p);
+        p.setT(2);
+        testAndResetDirty(p);
+        p.setC(-1);
+        testAndResetDirty(p);
+        p.setT(-1);
+        testAndResetDirty(p);
+        p.setT(-1);
+        testAndResetDirty(p);
+        
+        List<Point2D.Double> points = Arrays.asList(new Point2D.Double[]{new Point2D.Double(1,2), new Point2D.Double(2,3), new Point2D.Double(3,4), new Point2D.Double(4,5)});
+        PolygonData pg = new PolygonData(points);
+        pg.setDirty(false);
+        pg.setPoints(points);
+        testAndResetDirty(pg);
+        pg.setText("bla");
+        testAndResetDirty(pg);
+        pg.setC(2);
+        testAndResetDirty(pg);
+        pg.setT(2);
+        testAndResetDirty(pg);
+        pg.setT(2);
+        testAndResetDirty(pg);
+        pg.setC(-1);
+        testAndResetDirty(pg);
+        pg.setT(-1);
+        testAndResetDirty(pg);
+        pg.setT(-1);
+        testAndResetDirty(pg);
+        
+        PolylineData pl = new PolylineData(points);
+        pl.setDirty(false);
+        pl.setPoints(points);
+        testAndResetDirty(pl);
+        pl.setText("bla");
+        testAndResetDirty(pl);
+        pl.setC(2);
+        testAndResetDirty(pl);
+        pl.setT(2);
+        testAndResetDirty(pl);
+        pl.setT(2);
+        testAndResetDirty(pl);
+        pl.setC(-1);
+        testAndResetDirty(pl);
+        pl.setT(-1);
+        testAndResetDirty(pl);
+        pl.setT(-1);
+        testAndResetDirty(pl);
+        
+        RectangleData r = new RectangleData(10, 10, 10, 10);
+        r.setDirty(false);
+        r.setX(1);
+        testAndResetDirty(r);
+        r.setY(1);
+        testAndResetDirty(r);
+        r.setWidth(1);
+        testAndResetDirty(r);
+        r.setHeight(1);
+        testAndResetDirty(r);
+        r.setText("bla");
+        testAndResetDirty(r);
+        r.setC(2);
+        testAndResetDirty(r);
+        r.setT(2);
+        testAndResetDirty(r);
+        r.setT(2);
+        testAndResetDirty(r);
+        r.setC(-1);
+        testAndResetDirty(r);
+        r.setT(-1);
+        testAndResetDirty(r);
+        r.setT(-1);
+        testAndResetDirty(r);
+        
+        TextData t = new TextData("blup", 10, 10);
+        t.setDirty(false);
+        t.setX(1);
+        testAndResetDirty(t);
+        t.setY(1);
+        testAndResetDirty(t);
+        t.setText("bla");
+        testAndResetDirty(t);
+        t.setC(2);
+        testAndResetDirty(t);
+        t.setT(2);
+        testAndResetDirty(t);
+        t.setT(2);
+        testAndResetDirty(t);
+        t.setC(-1);
+        testAndResetDirty(t);
+        t.setT(-1);
+        testAndResetDirty(t);
+        t.setT(-1);
+        testAndResetDirty(t);
+    }
 }

--- a/components/blitz/test/omero/model/ROICoordinateTest.java
+++ b/components/blitz/test/omero/model/ROICoordinateTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2018 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package omero.model;
+
+import org.junit.Test;
+import org.testng.Assert;
+
+import omero.gateway.model.ROICoordinate;
+
+public class ROICoordinateTest {
+
+    public ROICoordinateTest() {
+    }
+
+    @Test
+    public void testComparison() {
+        ROICoordinate c1 = new ROICoordinate(2, 10);
+        ROICoordinate c2 = new ROICoordinate(1, 11);
+        ROICoordinate c3 = new ROICoordinate(2, 11);
+        ROICoordinate c4 = new ROICoordinate(2, 11);
+        
+        Assert.assertTrue(c1.compare(c1, c2) == -1);
+        Assert.assertTrue(c1.compare(c2, c1) == 1);
+        
+        Assert.assertTrue(c1.compare(c2, c3) == -1);
+        Assert.assertTrue(c1.compare(c3, c2) == 1);
+        
+        Assert.assertTrue(c1.compare(c3, c4) == 0);
+        Assert.assertTrue(c1.compare(c4, c3) == 0);
+        
+        
+        ROICoordinate c5 = new ROICoordinate(-1, -1);
+        ROICoordinate c6 = new ROICoordinate(-1, -1);
+        
+        Assert.assertTrue(c1.compare(c5, c6) == 0);
+        Assert.assertTrue(c1.compare(c6, c5) == 0);
+        
+        Assert.assertTrue(c1.compare(c5, c1) == -1);
+        Assert.assertTrue(c1.compare(c1, c5) == 1);
+    }
+    
+    @Test
+    public void testHashEquals() {
+        ROICoordinate c1 = new ROICoordinate(4, 5);
+        ROICoordinate c2 = new ROICoordinate(4, 6);
+        ROICoordinate c3 = new ROICoordinate(3, 5);
+        ROICoordinate c4 = new ROICoordinate(3, 5);
+        
+        Assert.assertFalse(c1.equals(c2));
+        Assert.assertFalse(c2.equals(c1));
+        Assert.assertFalse(c1.hashCode() == c2.hashCode());
+        
+        Assert.assertFalse(c1.equals(c3));
+        Assert.assertFalse(c3.equals(c1));
+        Assert.assertFalse(c3.hashCode() == c1.hashCode());
+        
+        Assert.assertTrue(c3.equals(c4));
+        Assert.assertTrue(c4.equals(c3));
+        Assert.assertTrue(c3.hashCode() == c4.hashCode());
+        
+        ROICoordinate c5 = new ROICoordinate(-1, -1);
+        ROICoordinate c6 = new ROICoordinate(-1, -1);
+        
+        Assert.assertTrue(c5.equals(c6));
+        Assert.assertTrue(c6.equals(c5));
+        Assert.assertTrue(c5.hashCode() == c6.hashCode());
+        
+        Assert.assertFalse(c5.equals(c4));
+        Assert.assertFalse(c4.equals(c5));
+        Assert.assertFalse(c5.hashCode() == c4.hashCode());
+    }
+    
+    
+}

--- a/components/blitz/test/omero/model/ROIDataTest.java
+++ b/components/blitz/test/omero/model/ROIDataTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2018 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package omero.model;
+
+import omero.gateway.model.ROIData;
+import omero.gateway.model.RectangleData;
+
+import org.junit.Test;
+import org.testng.Assert;
+
+public class ROIDataTest {
+
+    public ROIDataTest() {
+    }
+
+    @Test
+    public void testGetShapes() {
+        ROIData roi = new ROIData();
+
+        RectangleData allZT = new RectangleData(1, 5, 10, 10);
+        allZT.setT(-1);
+        allZT.setZ(-1);
+        roi.addShapeData(allZT);
+        System.out.println("allZT: " + allZT);
+
+        RectangleData allZ = new RectangleData(2, 5, 10, 10);
+        allZ.setT(2);
+        allZ.setZ(-1);
+        roi.addShapeData(allZ);
+        System.out.println("allZT: " + allZT);
+
+        RectangleData allT = new RectangleData(3, 5, 10, 10);
+        allT.setT(-1);
+        allT.setZ(2);
+        roi.addShapeData(allT);
+        System.out.println("allZT: " + allZT);
+
+        RectangleData r = new RectangleData(4, 5, 10, 10);
+        r.setT(3);
+        r.setZ(3);
+        roi.addShapeData(r);
+
+        // all shapes
+        Assert.assertEquals(roi.getShapeCount(), 4);
+
+        // just allZT
+        Assert.assertEquals(roi.getShapes(1, 1).size(), 1);
+        Assert.assertEquals(roi.getShapes(1, 1).iterator().next(), allZT);
+
+        // allZT and allZ at t=2
+        Assert.assertEquals(roi.getShapes(1, 2).size(), 2);
+        Assert.assertTrue(roi.getShapes(1, 2).contains(allZT));
+        Assert.assertTrue(roi.getShapes(1, 2).contains(allZ));
+
+        // allZT and allT at z=2
+        Assert.assertEquals(roi.getShapes(2, 1).size(), 2);
+        Assert.assertTrue(roi.getShapes(2, 1).contains(allZT));
+        Assert.assertTrue(roi.getShapes(2, 1).contains(allT));
+
+        // r and allZT
+        Assert.assertEquals(roi.getShapes(3, 3).size(), 2);
+        Assert.assertTrue(roi.getShapes(3, 3).contains(r));
+        Assert.assertTrue(roi.getShapes(3, 3).contains(allZT));
+    }
+
+}

--- a/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -40,6 +40,7 @@ import omero.model.Folder;
 import omero.model.IObject;
 import omero.model.PixelsType;
 import omero.model.Roi;
+import omero.model.Shape;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -49,6 +50,7 @@ import omero.gateway.model.FolderData;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.ROIData;
 import omero.gateway.model.RectangleData;
+import omero.gateway.model.ShapeData;
 
 /**
  *
@@ -83,13 +85,32 @@ public class ROIFacilityTest extends GatewayTest {
         rois = new ArrayList<ROIData>();
         rois.add(createRectangleROI(0, 0, 10, 10));
         rois.add(createRectangleROI(11, 11, 10, 10));
-        rois = roifac.saveROIs(rootCtx, img.getId(), rois);
+        rois.add(createRectangleROI(12, 12, 10, 10, false));
+        rois.add(createRectangleROI(13, 13, 10, 10, true));
+        
+        Collection<ROIData> saved = roifac.saveROIs(rootCtx, img.getId(), rois);
 
-        Assert.assertEquals(rois.size(), 2);
-        for (ROIData roi : rois) {
+        Assert.assertEquals(saved.size(), rois.size());
+        Assert.assertEquals(getShapes(saved).size(), getShapes(rois).size());
+        for (ROIData roi : saved) {
             Assert.assertTrue(roi.getId() >= 0);
         }
-    }
+        
+        // check that ZCT correctly saved:
+        List<ShapeData> shapes = getShapes(saved);
+        for (ShapeData shape : shapes) {
+            if (shape.getROICoordinate().getTimePoint() == -1)
+                Assert.assertNull(((Shape) shape.asIObject()).getTheT());
+            else
+                Assert.assertNotNull(((Shape) shape.asIObject()).getTheT());
+            if (shape.getROICoordinate().getZSection() == -1)
+                Assert.assertNull(((Shape) shape.asIObject()).getTheZ());
+            else
+                Assert.assertNotNull(((Shape) shape.asIObject()).getTheZ());
+        }
+        
+        rois = saved;
+    } 
 
     @Test
     public void testSaveImagelessROIs() throws DSOutOfServiceException,
@@ -102,19 +123,12 @@ public class ROIFacilityTest extends GatewayTest {
         Assert.assertTrue(r.getId() >= 0);
         Assert.assertNull(r.getImage() );
     }
-    
-    private ROIData createRectangleROI(int x, int y, int w, int h) {
-        ROIData roiData = new ROIData();
-        RectangleData rectangle = new RectangleData(x, y, w, h);
-        roiData.addShapeData(rectangle);
-        return roiData;
-    }
 
     @Test(dependsOnMethods = { "testSaveROIs" })
     public void testGetROICount() throws DSOutOfServiceException,
             DSAccessException {
         int n = roifac.getROICount(rootCtx, img.getId());
-        Assert.assertEquals(2, n);
+        Assert.assertEquals(rois.size(), n);
     }
     
     @Test(dependsOnMethods = { "testSaveROIs" })
@@ -128,18 +142,9 @@ public class ROIFacilityTest extends GatewayTest {
 
         Assert.assertEquals(myRois.size(), rois.size());
 
-        Iterator<ROIData> it = myRois.iterator();
-        while (it.hasNext()) {
-            ROIData r = it.next();
-            for (ROIData r2 : rois) {
-                if (r2.getId() == r.getId())
-                    it.remove();
-            }
-        }
-
-        Assert.assertTrue(myRois.isEmpty());
+        compare(myRois, rois);
     }
-
+    
     @Test
     public void testGetROIFolders() throws DSOutOfServiceException,
             DSAccessException {
@@ -252,6 +257,29 @@ public class ROIFacilityTest extends GatewayTest {
         folder = createRoiFolder(rootCtx, folderRois);
     }
     
+    private ROIData createRectangleROI(int x, int y, int w, int h) {
+        return createRectangleROI(x, y, w, h, null);
+    }
+
+    private ROIData createRectangleROI(int x, int y, int w, int h, Boolean plane) {
+        ROIData roiData = new ROIData();
+        RectangleData rectangle = new RectangleData(x, y, w, h);
+        if (plane != null) {
+            if (plane) {
+                rectangle.setC(1);
+                rectangle.setZ(1);
+                rectangle.setT(1);
+            }
+            else {
+                rectangle.setC(-1);
+                rectangle.setZ(-1);
+                rectangle.setT(-1);
+            }
+        }
+        roiData.addShapeData(rectangle);
+        return roiData;
+    }
+    
     private FolderData createRoiFolder(SecurityContext ctx,
             Collection<ROIData> rois) throws DSOutOfServiceException,
             DSAccessException {
@@ -262,5 +290,39 @@ public class ROIFacilityTest extends GatewayTest {
             f.linkRoi((Roi) roi.asIObject());
         return (FolderData) datamanagerFacility
                 .saveAndReturnObject(ctx, folder);
+    }
+    
+    private void compare(Collection<ROIData> list1, Collection<ROIData> list2) {
+        List<ShapeData> shapes1 = getShapes(list1);
+        List<ShapeData> shapes2 = getShapes(list2);
+        
+        Assert.assertEquals(shapes1.size(), shapes2.size());
+        
+        Iterator<ShapeData> it1 = shapes1.iterator();
+        while(it1.hasNext()) {
+            ShapeData s1 = it1.next();
+            
+            Iterator<ShapeData> it2 = shapes2.iterator();
+            while(it2.hasNext()) {
+                ShapeData s2 = it2.next();
+                if(s1.getId() == s2.getId()) {
+                    Assert.assertEquals(s1.getROICoordinate(), s2.getROICoordinate());
+                    it2.remove();
+                    break;
+                }
+            }
+        }
+        
+        Assert.assertTrue(shapes2.isEmpty());
+    }
+    
+    private List<ShapeData> getShapes(Collection<ROIData> rois) {
+        List<ShapeData> res = new ArrayList<ShapeData>();
+        for(ROIData r : rois) {
+            Iterator<List<ShapeData>> sit = r.getIterator();
+            while(sit.hasNext()) 
+                res.addAll(sit.next());
+        }
+        return res;
     }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/ROIFacilityTest.java
@@ -144,7 +144,7 @@ public class ROIFacilityTest extends GatewayTest {
 
         compare(myRois, rois);
     }
-    
+
     @Test
     public void testGetROIFolders() throws DSOutOfServiceException,
             DSAccessException {


### PR DESCRIPTION
# What this PR does

Allows to remove the C, Z and T of a Shape. Previously when a negative value was passed to `ShapeData.setC()` (etc.) the value was set to `0`.  With this PR passing a negative value will set the underlying Ice Shape object's C, Z, T to `null`.  And for the other way round, if the Shape object's C, Z, T is `null`, `ShapeData.getC()` (etc.) will return `-1`, indicating that the value has not been set, so that getters and setters now also behave in a consistent way.

Had to modify the `ROIData` pojo, too, e.g. remove methods like `firstPlane()` (which isn't used anywhere), because these wouldn't work properly with `null` CZT ROIs (which are supposed to be present on all planes).

Also updated the integration test accordingly.

Another bug was noticed: The various setters (`setX()`, `setY()`, etc.) on the ShapeData subclasses (`RectangleData`, etc.) didn't set the `dirty` flag, that's why the ROIFacility didn't save them back to the server when `saveROIs` was called. Fixed the setters and added an unit test for all setters of all ShapeData classes.

# Testing this PR

- Check ROIFacility integration test.
- Check ShapeData unit test.
- Check that ROI tool in Insight still works as before.

# Related reading

http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2018-May/004199.html

/cc @awalter17
