### PR TITLE
address all-groups-context issue for gateway queries

### DIFF
--- a/components/blitz/src/omero/gateway/Gateway.java
+++ b/components/blitz/src/omero/gateway/Gateway.java
@@ -1649,11 +1649,11 @@ public class Gateway implements AutoCloseable {
                 prx = client.createSession(login.getUser().getUsername(), login
                         .getUser().getPassword());
             }
-
-            if (ctx.getGroupID() >= 0)
-                prx.setSecurityContext(new ExperimenterGroupI(ctx.getGroupID(),
-                        false));
-            
+            if (ctx.getGroupID() >= 0) {
+                prx.setSecurityContext(new ExperimenterGroupI(ctx.getGroupID(), false));
+            } else {
+                throw new IllegalArgumentException("must set security context with a valid group ID");
+            }
             c = new Connector(ctx, client, prx, login.isEncryption(), log);
             for (PropertyChangeListener l : this.pcs
                     .getPropertyChangeListeners())

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -25,6 +25,7 @@ import java.beans.PropertyChangeListener;
 import java.util.UUID;
 
 import integration.AbstractServerTest;
+import omero.SecurityViolation;
 import omero.gateway.Gateway;
 import omero.gateway.JoinSessionCredentials;
 import omero.gateway.LoginCredentials;
@@ -37,10 +38,13 @@ import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.GroupData;
 import omero.log.SimpleLogger;
+import omero.model.LongAnnotation;
+import omero.model.LongAnnotationI;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Tests the login options supported by gateway
@@ -230,6 +234,59 @@ public class GatewayUsageTest extends AbstractServerTest
                     "Dataset does not belong to new group");
         } catch (Exception e1) {
             Assert.fail("Create dataset in new group failed.", e1);
+        }
+    }
+
+    /**
+     * Test that queries respond as expected to group context.
+     * @throws Exception unexpected
+     */
+    @Test(groups = "broken")
+    public void testGroupContextForService() throws Exception {
+        /* as a normal user create an annotation */
+        LongAnnotation annotation = new LongAnnotationI();
+        annotation.setLongValue(omero.rtypes.rlong(1));
+        annotation.setNs(omero.rtypes.rstring("test/" + getClass().getSimpleName() + "/" + UUID.randomUUID()));
+        final long annotationId = iUpdate.saveAndReturnObject(annotation).getId().getValue();
+        final long annotationGroupId = iAdmin.getEventContext().groupId;
+
+        /* now do the rest of the test as the root user via the gateway */
+        final LoginCredentials credentials = new LoginCredentials(
+                roles.rootName, client.getProperty("omero.rootpass"), 
+                client.getProperty("omero.host"), Integer.valueOf(client.getProperty("omero.port")));
+        try (final Gateway gateway = new Gateway(new SimpleLogger())) {
+            gateway.connect(credentials);
+
+            /* set query service to system group's context */
+            iQuery = gateway.getQueryService(new SecurityContext(roles.systemGroupId));
+            try {
+                annotation = (LongAnnotation) iQuery.find(LongAnnotation.class.getSimpleName(), annotationId);
+                Assert.fail("should not see annotation from wrong group");
+            } catch (SecurityViolation sv) {
+                /* expected */
+            }
+
+            /* do query in annotation group's context */
+            iQuery = gateway.getQueryService(new SecurityContext(roles.systemGroupId));
+            annotation = (LongAnnotation) iQuery.find(LongAnnotation.class.getSimpleName(), annotationId,
+                    ImmutableMap.of("omero.group", Long.toString(annotationGroupId)));
+            Assert.assertNotNull(annotation, "should see annotation from query in its group");
+
+            /* set query service to annotation group's context */
+            iQuery = gateway.getQueryService(new SecurityContext(annotationGroupId));
+            annotation = (LongAnnotation) iQuery.find(LongAnnotation.class.getSimpleName(), annotationId);
+            Assert.assertNotNull(annotation, "should see annotation from query service in its group");
+
+            /* do query in all-groups context */
+            iQuery = gateway.getQueryService(new SecurityContext(roles.systemGroupId));
+            annotation = (LongAnnotation) iQuery.find(LongAnnotation.class.getSimpleName(), annotationId,
+                    ALL_GROUPS_CONTEXT);
+            Assert.assertNotNull(annotation, "should see annotation from query in all-groups context");
+
+            /* set query service to all-groups context */
+            iQuery = gateway.getQueryService(new SecurityContext(-1));
+            annotation = (LongAnnotation) iQuery.find(LongAnnotation.class.getSimpleName(), annotationId);  // TODO: fails!
+            Assert.assertNotNull(annotation, "should see annotation from query service in all-groups context");
         }
     }
 }

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -241,7 +241,7 @@ public class GatewayUsageTest extends AbstractServerTest
      * Test that queries respond as expected to group context.
      * @throws Exception unexpected
      */
-    @Test(groups = "broken")
+    @Test
     public void testGroupContextForService() throws Exception {
         /* as a normal user create an annotation */
         LongAnnotation annotation = new LongAnnotationI();
@@ -283,10 +283,13 @@ public class GatewayUsageTest extends AbstractServerTest
                     ALL_GROUPS_CONTEXT);
             Assert.assertNotNull(annotation, "should see annotation from query in all-groups context");
 
-            /* set query service to all-groups context */
-            iQuery = gateway.getQueryService(new SecurityContext(-1));
-            annotation = (LongAnnotation) iQuery.find(LongAnnotation.class.getSimpleName(), annotationId);  // TODO: fails!
-            Assert.assertNotNull(annotation, "should see annotation from query service in all-groups context");
+            try {
+                /* set query service to all-groups context */
+                iQuery = gateway.getQueryService(new SecurityContext(-1));
+                Assert.fail("should not be possible without an equivalent of SERVICE_OPTS");
+            } catch (DSOutOfServiceException dsoose) {
+                Assert.assertEquals(dsoose.getCause().getClass(), IllegalArgumentException.class);
+            }
         }
     }
 }


### PR DESCRIPTION
Sets the Java Gateway to object when `SecurityContext(-1)` is attempted when it is useless, so as to make people fix clients accordingly. The test captures some possible usage patterns surrounding `SecurityContext(-1)`: see the discussion on this PR and at https://trello.com/c/9W8F4Kmq/412-clarify-behavior-of-all-groups-context. It should be passing at https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration.gateway/GatewayUsageTest/testGroupContextForService/.