### PR TITLE
processor: Display error messages for MATLAB scripts

### DIFF
--- a/components/tools/OmeroPy/src/omero/processor.py
+++ b/components/tools/OmeroPy/src/omero/processor.py
@@ -700,7 +700,7 @@ class MATLABProcessI(ProcessI):
         """
         matlab_cmd = [
             self.interpreter, "-nosplash", "-nodisplay", "-nodesktop",
-            "-r", "try, cd('%s'); script; catch, exit(1); end, exit(0)"
+            "-r", "try, cd('%s'); script; catch e, disp(e.identifier); disp(e.message); exit(1); end, exit(0)"
             % self.dir
         ]
         return matlab_cmd

--- a/components/tools/OmeroPy/src/omero/processor.py
+++ b/components/tools/OmeroPy/src/omero/processor.py
@@ -698,10 +698,11 @@ class MATLABProcessI(ProcessI):
         """
         Overrides ProcessI to call MATLAB idiosyncratically.
         """
+        r = "try, cd('%s'); script; " % self.dir
+        r += "catch e, disp(e.identifier); disp(e.message); exit(1); "
+        r += "end, exit(0)"
         matlab_cmd = [
-            self.interpreter, "-nosplash", "-nodisplay", "-nodesktop",
-            "-r", "try, cd('%s'); script; catch e, disp(e.identifier); disp(e.message); exit(1); end, exit(0)"
-            % self.dir
+            self.interpreter, "-nosplash", "-nodisplay", "-nodesktop", "-r", r,
         ]
         return matlab_cmd
 


### PR DESCRIPTION
The catch clause hides all exceptions leading to no feedback
when there are parse issues with the script itself.

# Testing this PR

1. create a simple matlab script:
```
function script(void)
    disp("loading omero"); % should use single quotes
end
```

2. see that the file is listed with `bin/omero script list`
3. try to list the parameters with `bin/omero script param /foo.m`
4. note that the output shows no error
5. with this PR, try the same and note output similar to:
```
MATLAB:m_unexpected_sep
Error: File: /repositories/tmp/omero_hudson/29607/processBru6bf.dir/script.m Line: 6 Column: 26
Expression or statement is incomplete or incorrect.
```
# Related reading

1. https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8495
