### PR TITLE
correct "metadata" spelling

### DIFF
--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -906,7 +906,7 @@ public class ThumbnailCtx
 
     /**
      * Bulk loads thumbnail metadata.
-     * @param dimensions X-Y dimensions to bulk load metdata for.
+     * @param dimensions X-Y dimensions to bulk load metadata for.
      * @param pixelsIds Pixels IDs to bulk load metadata for.
      * @return List of thumbnail objects with <code>thumbnail.pixels</code> and
      * <code>thumbnail.details.updateEvent</code> loaded.

--- a/components/tools/OmeroPy/src/omero/scripts.py
+++ b/components/tools/OmeroPy/src/omero/scripts.py
@@ -327,7 +327,7 @@ def client(*args, **kwargs):
 
     where the returned client is created via the empty constructor to
     omero.client using only --Ice.Config or ICE_CONFIG, and the function
-    arguments are taken as metdata about the current script. With this
+    arguments are taken as metadata about the current script. With this
     information, all script consumers should be able to determine the required
     types for execution.
 

--- a/components/tools/OmeroPy/test/integration/test_metadatastore.py
+++ b/components/tools/OmeroPy/test/integration/test_metadatastore.py
@@ -12,7 +12,7 @@ from omero.testlib import ITest
 import omero
 
 
-class TestMetdataStore(ITest):
+class TestMetadataStore(ITest):
 
     def testBasicUsage(self):
 


### PR DESCRIPTION
The diff speaks for itself.