### PR TITLE
Do not encapsulate null connection behavior in try/finally block

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/connector.py
+++ b/components/tools/OmeroWeb/omeroweb/connector.py
@@ -209,9 +209,9 @@ class Connector(object):
 
     def is_server_up(self, useragent):
         connection = self.create_guest_connection(useragent)
+        if connection is None:
+            return False
         try:
-            if connection is None:
-                return False
             try:
                 connection.getServerVersion()
                 return True
@@ -223,9 +223,9 @@ class Connector(object):
 
     def check_version(self, useragent):
         connection = self.create_guest_connection(useragent)
+        if connection is None:
+            return False
         try:
-            if connection is None:
-                return False
             try:
                 server_version = connection.getServerVersion()
                 server_version = self.SERVER_VERSION_RE.match(server_version)


### PR DESCRIPTION
See https://github.com/openmicroscopy/openmicroscopy/pull/5699 for the set of previous changes to this API

If `connector.create_gateway` fails to create a connection, the current contract is to return None. In the current implementation, this will cause the final `connection.close()` statement to fail.
Moving the nullity tests out of the try/finally block should restore the previous behavior e.g. when performing a failing version check while preserving the termination of connections when such a connection exist.

To test this PR, try to point a Web deployment to a server with a mismatching version (without overriding the version_check property). Without this PR e.g. OMERO.web 5.4.6, the connection should fail with a stack trace. With this PR, it should be handled more gracefully
