### PR TITLE
wholly avoid trying to list mismatching scripts in read-only

### DIFF
--- a/components/server/src/ome/services/scripts/ScriptRepoHelper.java
+++ b/components/server/src/ome/services/scripts/ScriptRepoHelper.java
@@ -528,6 +528,7 @@ public class ScriptRepoHelper extends OnContextRefreshedEventListener {
                 if (id == null) {
                     if (readOnly.isReadOnlyDb()) {
                         log.info("read-only database so ignoring addition of script {}", file.fullname());
+                        continue;
                     } else {
                         ofile = addOrReplace(session, sqlAction, sf, file, null);
                     }
@@ -542,6 +543,7 @@ public class ScriptRepoHelper extends OnContextRefreshedEventListener {
                         if (!hash.equals(ofile.getHash())) {
                             if (readOnly.isReadOnlyDb()) {
                                 log.info("read-only database so ignoring modification of script ID {}", id);
+                                continue;
                             } else {
                                 ofile = addOrReplace(session, sqlAction, sf, file, id);
                             }


### PR DESCRIPTION
Extends robustness of read-only servers of scripts in database not matching scripts in repository: pretends mismatching scripts do not exist.