### PR TITLE
adjust user plugin to first / last name terms

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -40,8 +40,8 @@ class UserControl(UserGroupControl):
             "-a", "--admin", action="store_true",
             help="Whether the user should be an admin")
         add.add_argument("username", help="User's login name")
-        add.add_argument("firstname", help="User's given name")
-        add.add_argument("lastname", help="User's surname name")
+        add.add_argument("firstname", help="User's first name")
+        add.add_argument("lastname", help="User's last name")
         self.add_group_arguments(add, " to join")
 
         password_group = add.add_mutually_exclusive_group()


### PR DESCRIPTION
# What this PR does

Fixes CLI omero user help to be consistent about first / last name terms.

# Testing this PR

`bin/omero user add -h` and compare with this PR's code diff.

# Related reading

https://trello.com/c/g9wMfh5U/67-rfe-surname-name-and-lastname