### PR TITLE
Disable fileannotation delete

### DIFF
--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -260,6 +260,11 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
+    <bean class="ome.system.Preference" id="omero.client.delete_disabled.namespaces">
+       <property name="db" value="false"/>
+       <property name="mutable" value="false"/>
+       <property name="visibility" value="all"/>
+    </bean>
     <!-- End preference list -->
             </list>
         </property>

--- a/components/common/resources/ome/config.xml
+++ b/components/common/resources/ome/config.xml
@@ -260,7 +260,7 @@
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>
     </bean>
-    <bean class="ome.system.Preference" id="omero.client.delete_disabled.namespaces">
+    <bean class="ome.system.Preference" id="omero.client.disable_delete_for_namespaces">
        <property name="db" value="false"/>
        <property name="mutable" value="false"/>
        <property name="visibility" value="all"/>

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -138,20 +138,20 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['can_create'] = request.session.get('can_create', True)
         # UI server preferences
         if request.session.get('server_settings'):
-            s_settings = request.session.get('server_settings')
-            context['ome']['email'] = server_settings.get('email', False)
-            if s_settings.get('ui'):
+            context['ome']['email'] = request.session.get(
+                'server_settings').get('email', False)
+            if request.session.get('server_settings').get('ui'):
                 # don't overwrite existing ui
                 context.setdefault('ui', {'tree': {}})
                 context['ui']['orphans'] = \
-                    s_settings.get('ui', {}).get('tree', {}).get('orphans')
+                    request.session.get('server_settings').get('ui', {}) \
+                    .get('tree', {}).get('orphans')
                 context['ui']['dropdown_menu'] = \
-                    s_settings.get('ui', {}).get('menu', {}).get('dropdown')
+                    request.session.get('server_settings').get('ui', {}) \
+                    .get('menu', {}).get('dropdown')
                 context['ui']['tree']['type_order'] = \
-                    s_settings.get('ui', {}).get('tree', {}).get('type_order')
-            if s_settings.get('disable_delete_for_namespaces'):
-                context['ome']['disable_delete_for_namespaces'] = \
-                    s_settings.get('disable_delete_for_namespaces')
+                    request.session.get('server_settings').get('ui', {}) \
+                    .get('tree', {}).get('type_order')
 
         self.load_settings(request, context, conn)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -138,20 +138,20 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['can_create'] = request.session.get('can_create', True)
         # UI server preferences
         if request.session.get('server_settings'):
-            context['ome']['email'] = request.session.get(
-                'server_settings').get('email', False)
-            if request.session.get('server_settings').get('ui'):
+            s_settings = request.session.get('server_settings')
+            context['ome']['email'] = server_settings.get('email', False)
+            if s_settings.get('ui'):
                 # don't overwrite existing ui
                 context.setdefault('ui', {'tree': {}})
                 context['ui']['orphans'] = \
-                    request.session.get('server_settings').get('ui', {}) \
-                    .get('tree', {}).get('orphans')
+                    s_settings.get('ui', {}).get('tree', {}).get('orphans')
                 context['ui']['dropdown_menu'] = \
-                    request.session.get('server_settings').get('ui', {}) \
-                    .get('menu', {}).get('dropdown')
+                    s_settings.get('ui', {}).get('menu', {}).get('dropdown')
                 context['ui']['tree']['type_order'] = \
-                    request.session.get('server_settings').get('ui', {}) \
-                    .get('tree', {}).get('type_order')
+                    s_settings.get('ui', {}).get('tree', {}).get('type_order')
+            if s_settings.get('disable_delete_for_namespaces'):
+                context['ome']['disable_delete_for_namespaces'] = \
+                    s_settings.get('disable_delete_for_namespaces')
 
         self.load_settings(request, context, conn)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_fileanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_fileanns_pane.js
@@ -156,6 +156,8 @@ var FileAnnsPane = function FileAnnsPane($element, opts) {
                     return prev;
                 }, {});
 
+                disable_delete_ns = data.disable_delete_for_namespaces || [];
+
                 // Populate experimenters within anns
                 var anns = data.annotations.map(function(ann){
                     ann.owner = experimenters[ann.owner.id];
@@ -166,6 +168,7 @@ var FileAnnsPane = function FileAnnsPane($element, opts) {
                     ann.addedBy = [ann.link.owner.id];
                     ann.description = _.escape(ann.description);
                     ann.file.size = ann.file.size !== null ? ann.file.size.filesizeformat() : "";
+                    ann.permissions.canDelete = ann.permissions.canDelete && disable_delete_ns.indexOf(ann.ns) < 0;
                     return ann;
                 });
                 // Don't show companion files

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1198,7 +1198,17 @@ def api_annotations(request, conn=None, **kwargs):
                                           page=page,
                                           limit=limit)
 
-    return JsonResponse({'annotations': anns, 'experimenters': exps})
+    namespaces = None
+    if request.session.get('server_settings'):
+        namespaces = request.session.get('server_settings') \
+            .get('disable_delete_for_namespaces', None)
+
+    rsp_json = {'annotations': anns,
+                'experimenters': exps}
+    if namespaces is not None:
+        rsp_json['disable_delete_for_namespaces'] = namespaces.split(',')
+
+    return JsonResponse(rsp_json)
 
 
 @login_required()

--- a/components/tools/OmeroWeb/test/integration/test_annotate.py
+++ b/components/tools/OmeroWeb/test/integration/test_annotate.py
@@ -29,6 +29,7 @@ from omeroweb.testlib import IWebTest
 from omeroweb.testlib import post, get_json
 
 from django.core.urlresolvers import reverse
+import pytest
 
 
 class TestTagging(IWebTest):
@@ -102,3 +103,34 @@ class TestTagging(IWebTest):
         tagIds = [t['id'] for t in rsp['annotations']]
         assert tag.id.val not in tagIds
         assert tag2.id.val in tagIds
+
+
+class TestConfig(IWebTest):
+
+    @pytest.mark.parametrize("namespaces",
+                             ["omero.web.f.json",
+                              "omero.web.f.json,omero.web.f.tiff",
+                              ""])
+    def testDisableDeleteNamespace(self, namespaces):
+        """
+        Test that api_annotation JSON includes
+        disable_delete_for_namespaces config values
+        """
+        try:
+            self.root.sf.getConfigService().setConfigValue(
+                "omero.client.disable_delete_for_namespaces", namespaces)
+
+            # login each time, since config is cached for each session
+            client, user1 = self.new_client_and_user(perms='rwrw--')
+            omeName = client.sf.getAdminService().getEventContext().userName
+            django_client = self.new_django_client(omeName, omeName)
+            request_url = reverse('api_annotations')
+            rsp = get_json(django_client, request_url, {"image": 1})
+
+            assert rsp['disable_delete_for_namespaces'] == namespaces.split(',')
+
+        finally:
+            d = self.root.sf.getConfigService() \
+                .getConfigDefaults()['omero.client.disable_delete_for_namespaces']
+            self.root.sf.getConfigService().setConfigValue(
+                "omero.client.disable_delete_for_namespaces", d)

--- a/components/tools/OmeroWeb/test/integration/test_annotate.py
+++ b/components/tools/OmeroWeb/test/integration/test_annotate.py
@@ -127,10 +127,12 @@ class TestConfig(IWebTest):
             request_url = reverse('api_annotations')
             rsp = get_json(django_client, request_url, {"image": 1})
 
-            assert rsp['disable_delete_for_namespaces'] == namespaces.split(',')
+            ns_list = namespaces.split(',')
+            assert rsp['disable_delete_for_namespaces'] == ns_list
 
         finally:
             d = self.root.sf.getConfigService() \
-                .getConfigDefaults()['omero.client.disable_delete_for_namespaces']
+                .getConfigDefaults()[
+                    'omero.client.disable_delete_for_namespaces']
             self.root.sf.getConfigService().setConfigValue(
                 "omero.client.disable_delete_for_namespaces", d)

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -905,6 +905,10 @@ omero.client.ui.tree.type_order=tagset,tag,project,dataset,screen,plate,acquisit
 # The default thumbnail size
 omero.client.browser.thumb_default_size=96
 
+# Blacklist of annotation namespaces which the clients will be
+# disabled from deleting. Comma-separated list.
+omero.client.delete_disabled.namespaces=omero.web.figure.json
+
 #############################################
 ## Ice overrides
 ##

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -7,6 +7,9 @@
 ## This properties file is compiled into blitz.jar and serves as a default
 ## for all server-side values (client configuration happens differently).
 ##
+## The properties themselves are defined in
+## components/common/resources/ome/config.xml
+##
 ## Any of these properties can be altered by using bin/omero config. MODIFYING
 ## THIS FILE DOES NOT ALTER SERVER BEHAVIOR. It solely defines the defaults
 ## at compile time!

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -910,7 +910,7 @@ omero.client.browser.thumb_default_size=96
 
 # Blacklist of annotation namespaces which the clients will be
 # disabled from deleting. Comma-separated list.
-omero.client.delete_disabled.namespaces=omero.web.figure.json
+omero.client.disable_delete_for_namespaces=omero.web.figure.json
 
 #############################################
 ## Ice overrides


### PR DESCRIPTION
# What this PR does

In order to allow linking of OMERO.figure FileAnnotations to Images (https://trello.com/c/3dlIno4Q/6-link-json-figure-files-to-images-dataset), we need to disable the Delete button so that users can't accidentally delete figure files.
We do this by specifying a configurable list of namespaces. Linked annotations with these namespaces will not be deletable in the webclient.

# Testing this PR

1. Create a figure file (save a figure)
2. Link this to an Image by Annotation - click [+] and find the figure file name to link to Image.
3. The Figure (with namespace ```omero.web.figure.json```) will not show a Delete X button.
4. The ```"disable_delete_for_namespaces"``` list is added to JSON from e.g. webclient/api/annotations/?type=file&image=9551 - Check URL in browser (image ID is not important)
5. Check that new test for this is passing.

 TODO:
 - Add Robot tests