### PR TITLE
Check settings.PUBLIC_ENABLED before settings.PUBLIC_USER in views.py

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -381,7 +381,8 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     # If we failed to find 'show'...
     if request.GET.get('show', None) is not None and first_sel is None:
         # and we're logged in as PUBLIC user...
-        if settings.PUBLIC_USER == conn.getUser().getOmeName():
+        if settings.PUBLIC_ENABLED and \
+            settings.PUBLIC_USER == conn.getUser().getOmeName():
             # this is likely a regular user who needs to log in as themselves.
             # Login then redirect to current url
             return HttpResponseRedirect(


### PR DESCRIPTION
Fixes bug where you go to an image that doesn't exist when you don't have PUBLIC USER configured.

To test:
 - Without ```PUBLIC_USER``` configured, pick an Image ID that doesn't exist and go to ```/webclient/?show=image-ID```
 - Should show webclient without error.