### PR TITLE
Log locale on server startup

### DIFF
--- a/components/server/src/ome/services/util/JvmSettingsCheck.java
+++ b/components/server/src/ome/services/util/JvmSettingsCheck.java
@@ -19,6 +19,7 @@
 
 package ome.services.util;
 
+import java.util.Locale;
 import java.lang.management.ManagementFactory;
 
 import javax.management.MBeanServer;
@@ -69,6 +70,8 @@ public class JvmSettingsCheck {
             version.append(System.getProperty(key));
         }
 
+        Locale locale = Locale.getDefault();
+        log.info("Language/Country: " + locale.getLanguage() + "/" + locale.getCountry());
         log.info("Java version: " + version);
         log.info(String.format(fmt, "Max Memory (MB):  ", (rt.maxMemory() / mb)));
         log.info(String.format(fmt, "OS Memory (MB):   ", (getPhysicalMemory() / mb)));

--- a/components/server/src/ome/services/util/JvmSettingsCheck.java
+++ b/components/server/src/ome/services/util/JvmSettingsCheck.java
@@ -20,6 +20,7 @@
 package ome.services.util;
 
 import java.util.Locale;
+import java.nio.charset.Charset;
 import java.lang.management.ManagementFactory;
 
 import javax.management.MBeanServer;
@@ -71,7 +72,10 @@ public class JvmSettingsCheck {
         }
 
         Locale locale = Locale.getDefault();
-        log.info("Language/Country: " + locale.getLanguage() + "/" + locale.getCountry());
+        log.info("Language/Country/Charset: " +
+                locale.getLanguage() + "/" + locale.getCountry() + "/" +
+                Charset.defaultCharset());
+
         log.info("Java version: " + version);
         log.info(String.format(fmt, "Max Memory (MB):  ", (rt.maxMemory() / mb)));
         log.info(String.format(fmt, "OS Memory (MB):   ", (getPhysicalMemory() / mb)));


### PR DESCRIPTION
Suggested by @mtbc

# What this PR does

Adds info on the language & country to the server log.


# Testing this PR

e.g.:

```
$ grep Jvm /opt/ome1/dist/var/log/Blitz-0.log
2018-06-08 16:38:59,739 INFO  [      ome.services.util.JvmSettingsCheck] (      main) Language/Country/Charset: en/US/UTF-8
2018-06-08 16:38:59,740 INFO  [      ome.services.util.JvmSettingsCheck] (      main) Java version: 1.8.0_25; Mac OS X; x86_64; 10.12.6
2018-06-08 16:38:59,740 INFO  [      ome.services.util.JvmSettingsCheck] (      main) Max Memory (MB):   =   2290
2018-06-08 16:38:59,741 INFO  [      ome.services.util.JvmSettingsCheck] (      main) OS Memory (MB):    =  16384
2018-06-08 16:38:59,741 INFO  [      ome.services.util.JvmSettingsCheck] (      main) Processors:        =      4
```