### PR TITLE
cli: handle unknown user for 'user password'

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -183,7 +183,13 @@ class UserControl(UserGroupControl):
             self.ctx.dbg(traceback.format_exc(sv))
 
         if args.username:
-            self.ctx.out("Changing password for %s" % args.username)
+            try:
+                e = admin.lookupExperimenter(args.username)
+            except omero.ApiUsageException:
+                self.ctx.die(457, "Unknown user: %s" % args.username)
+                return  # Never reached
+            self.ctx.out("Changing password for %s (id:%s)" % (
+                args.username, e.id.val))
         else:
             self.ctx.out("Changing password for %s" % own_name)
 


### PR DESCRIPTION
# What this PR does

Hides an exception when attempting to change the password of an unknown user


# Testing this PR

```
$ bin/omero user password foo
Please enter password for your user (root):
Verified password.

Unknown user: foo

$ bin/omero group add foo
Added group foo (id=53) with permissions rw----

$ bin/omero user add foo foo foo foo
Please enter password for your new user (foo):
Please re-enter password for your new user (foo):
Added user foo (id=52) with password

$ bin/omero user password foo
Please enter password for your user (root):
Verified password.

Changing password for foo (id:52)
Please enter password to be set:
Please re-enter password to be set:
Password changed
```

# Related reading

Link to cards, tickets, other PRs:

1. https://trello.com/c/qBsJHEy6/68-bug-stacktrace-when-user-doesnt-exist-on-password-reset
