### PR TITLE
Fix loss of privileges when Full Admin edits themselves

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -590,6 +590,7 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
                 privileges = conn.get_privileges_from_form(form)
                 to_add = []
                 to_remove = []
+                # privileges may be None if disabled in form
                 if privileges is not None:
                     # Only update privileges that we have permission to set
                     # (prevents privilege escalation)

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -588,16 +588,18 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
 
                 # Update 'AdminPrivilege' config roles for user
                 privileges = conn.get_privileges_from_form(form)
-                # Only process privileges that we have permission to set
                 to_add = []
                 to_remove = []
                 if privileges is not None:
+                    # Only update privileges that we have permission to set
+                    # (prevents privilege escalation)
                     for p in conn.getCurrentAdminPrivileges():
                         if p in privileges:
                             to_add.append(p)
                         else:
                             to_remove.append(p)
-                conn.updateAdminPrivileges(experimenter.id, to_add, to_remove)
+                    conn.updateAdminPrivileges(experimenter.id,
+                                               to_add, to_remove)
 
                 conn.updateExperimenter(
                     experimenter, omename, firstName, lastName, email, admin,

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -588,17 +588,15 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
 
                 # Update 'AdminPrivilege' config roles for user
                 privileges = conn.get_privileges_from_form(form)
-                if privileges is None:
-                    privileges = []
                 # Only process privileges that we have permission to set
                 to_add = []
                 to_remove = []
-                for p in conn.getCurrentAdminPrivileges():
-                    if p in privileges:
-                        to_add.append(p)
-                    else:
-                        to_remove.append(p)
-
+                if privileges is not None:
+                    for p in conn.getCurrentAdminPrivileges():
+                        if p in privileges:
+                            to_add.append(p)
+                        else:
+                            to_remove.append(p)
                 conn.updateAdminPrivileges(experimenter.id, to_add, to_remove)
 
                 conn.updateExperimenter(

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1143,7 +1143,10 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
         defaultGroup = ExperimenterGroupI(defaultGroupId, False)
 
-        if privileges is not None:
+        if isAdmin:
+            if privileges is None:
+                privileges = []
+
             if defaultGroupId not in otherGroupIds:
                 listOfGroups.append(ExperimenterGroupI(defaultGroupId, False))
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1277,13 +1277,14 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         """
         privileges = []
         role = experimenter_form.cleaned_data['role']
-        if role not in ('restricted_administrator', 'administrator'):
+        # If Role element is disabled, we don't update privileges
+        if role == '':
             return None
         # If user is Admin, we give them ALL privileges!
         if role == 'administrator':
             for p in self.getEnumerationEntries('AdminPrivilege'):
                 privileges.append(p.getValue())
-        else:
+        elif role == 'restricted_administrator':
             # Otherwise, restrict to 'checked' privileges on form
             form_privileges = ['Chgrp',
                                'Chown',

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -1097,7 +1097,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         @type lastName String
         @param email A new email.
         @type email String
-        @param isAdmin An Admin permission.
+        @param isAdmin If True, new user is an Admin or Restricted Admin.
         @type isAdmin Boolean
         @param isActive Active user (user can log in).
         @type isActive Boolean
@@ -1107,6 +1107,8 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         @type otherGroupIds L{ExperimenterGroupI}
         @param password Must pass validation in the security sub-system.
         @type password String
+        @param privileges   List of Admin Privileges. Ignored if isAdmin False.
+        @type privileges    List of Strings
         @param middleName A middle name.
         @type middleName String
         @param institution An institution.
@@ -1276,7 +1278,11 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         """
         Get 'AdminPrivilege' roles from Experimenter Form
 
-        Returns None if Role is User
+        Returns None if Role section of form is disabled.
+        Returns empty list if role is regular 'user', not admin.
+        If role is 'administrator' returns ALL privileges.
+
+        @param experimenter_form    Submitted instance of ExperimenterForm
         """
         privileges = []
         role = experimenter_form.cleaned_data['role']


### PR DESCRIPTION
# What this PR does

Fixes loss of privileges when Admin edits themselves: https://trello.com/c/oJPTE5vq/358-bug-edit-root-user

# Testing this PR

- Create a spare admin account for testing!
- Log in as Admin, and edit yourself (The Role controls will be disabled as before)
- Check that Save doesn't cause you to lose privileges (should still be full Admin after update.

I haven't had a chance to check this fix against ALL possible scenarios with various privileges, editing yourself or other users of various roles. Need a list of all testing scenarios to check.

cc @pwalczysko @mtbc 