### PR TITLE
Close communicator after a failed session creation

### DIFF
--- a/components/tools/OmeroPy/src/omero/util/sessions.py
+++ b/components/tools/OmeroPy/src/omero/util/sessions.py
@@ -342,24 +342,28 @@ class SessionsStore(object):
         client = omero.client(props)
         client.setAgent("OMERO.sessions")
 
-        if sudo is not None:
-            sf = client.createSession(sudo, pasw)
-            principal = omero.sys.Principal()
-            principal.name = name
-            principal.group = props.get("omero.group", None)
-            principal.eventType = "User"
+        try:
+            if sudo is not None:
+                sf = client.createSession(sudo, pasw)
+                principal = omero.sys.Principal()
+                principal.name = name
+                principal.group = props.get("omero.group", None)
+                principal.eventType = "User"
 
-            # Retrieve the default time to idle value
-            uuid = sf.ice_getIdentity().name
-            sess = sf.getSessionService().getSession(uuid)
-            timeToIdle = sess.getTimeToIdle().getValue()
+                # Retrieve the default time to idle value
+                uuid = sf.ice_getIdentity().name
+                sess = sf.getSessionService().getSession(uuid)
+                timeToIdle = sess.getTimeToIdle().getValue()
 
-            sess = sf.getSessionService().createSessionWithTimeouts(
-                principal, 0, timeToIdle)
-            client.closeSession()
-            sf = client.joinSession(sess.getUuid().getValue())
-        else:
-            sf = client.createSession(name, pasw)
+                sess = sf.getSessionService().createSessionWithTimeouts(
+                    principal, 0, timeToIdle)
+                client.closeSession()
+                sf = client.joinSession(sess.getUuid().getValue())
+            else:
+                sf = client.createSession(name, pasw)
+        except:
+            client.__del__()
+            raise
 
         ec = sf.getAdminService().getEventContext()
         uuid = sf.ice_getIdentity().name


### PR DESCRIPTION
If an incorrect password or a bad session is entered, then the client object
was not being cleaned up. Previously, the finalizer was taking care of this,
but changes in newer Ice versions prevented that from happening. Rather than
relying on the Ice behavior, we can (try to) track down all of the unclosed
omero.client objects and close them.

# Testing this PR

1. bin/omero logout
2. bin/omero login (with the wrong password)
3. see if the communicator warning disappears

# Related reading

 * https://trello.com/c/DPv5q2Ec/421-command-line-intermittent-error
