### PR TITLE
Log time zone on server startup

### DIFF
--- a/components/server/src/ome/services/util/JvmSettingsCheck.java
+++ b/components/server/src/ome/services/util/JvmSettingsCheck.java
@@ -19,7 +19,9 @@
 
 package ome.services.util;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.TimeZone;
 import java.nio.charset.Charset;
 import java.lang.management.ManagementFactory;
 
@@ -28,6 +30,8 @@ import javax.management.ObjectName;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import com.google.common.base.Joiner;
 
 /**
  * Hook run by the context which prints out JVM-related
@@ -72,9 +76,8 @@ public class JvmSettingsCheck {
         }
 
         Locale locale = Locale.getDefault();
-        log.info("Language/Country/Charset: " +
-                locale.getLanguage() + "/" + locale.getCountry() + "/" +
-                Charset.defaultCharset());
+        log.info("Language,Country,Charset,Timezone: " + Joiner.on(',').join(Arrays.asList(
+                locale.getLanguage(), locale.getCountry(), Charset.defaultCharset(), TimeZone.getDefault().getID())));
 
         log.info("Java version: " + version);
         log.info(String.format(fmt, "Max Memory (MB):  ", (rt.maxMemory() / mb)));


### PR DESCRIPTION
# What this PR does

Adds note of default time zone to OMERO.server's log.

Switches separator from "/" to "," as many timezone IDs contain "/".

# Testing this PR

Start server then,
 `grep JvmSettingsCheck.*, Blitz-0.log`

# Related reading

#5777