### PR TITLE
Lightweight importer

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ROISaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ROISaver.java
@@ -24,9 +24,11 @@ package org.openmicroscopy.shoola.agents.fsimporter;
 
 import java.util.List;
 
-import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
 import omero.gateway.model.ROIData;
@@ -66,7 +68,7 @@ public class ROISaver
     private List<ROIData> rois;
 
     /** The component to use to notify of saving progress.*/
-    private FileImportComponent c;
+    private FileImportComponentI c;
 
     /**
      * Creates a new instance.
@@ -81,7 +83,7 @@ public class ROISaver
      */
     public ROISaver(Importer viewer, SecurityContext ctx,
             List<ROIData> rois, long imageID, long userID,
-            FileImportComponent c)
+            FileImportComponentI c)
     {
         super(viewer, ctx);
         if (imageID < 0) 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ROISaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ROISaver.java
@@ -26,11 +26,9 @@ import java.util.List;
 
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
-
-import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.views.CallHandle;
 
+import omero.gateway.SecurityContext;
 import omero.gateway.model.ROIData;
 
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ROISaver.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ROISaver.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/actions/CancelAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/actions/CancelAction.java
@@ -25,9 +25,12 @@ package org.openmicroscopy.shoola.agents.fsimporter.actions;
 
 //Java imports
 import java.awt.event.ActionEvent;
+
 import javax.swing.Action;
 
 //Third-party libraries
+
+import javax.swing.SwingUtilities;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.fsimporter.view.Importer;
@@ -89,6 +92,16 @@ public class CancelAction
      * Cancels the on-going import.
      * @see java.awt.event.ActionListener#actionPerformed(ActionEvent)
      */
-    public void actionPerformed(ActionEvent e) { model.cancelAllImports(); }
+    public void actionPerformed(ActionEvent e) { 
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                // This might cause the UI to freeze for a while if there
+                // are thousands of imports to cancel, hence wrapped into 
+                // SwingUtilities.invokeLater
+                model.cancelAllImports(); 
+            }
+        });
+    }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/actions/CancelAction.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/actions/CancelAction.java
@@ -25,7 +25,6 @@ package org.openmicroscopy.shoola.agents.fsimporter.actions;
 
 //Java imports
 import java.awt.event.ActionEvent;
-
 import javax.swing.Action;
 
 //Third-party libraries

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -388,40 +388,10 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/** Displays the location of the import.*/
 	private void showLocationDialog()
 	{
-		if (checkFileCount() && 
-		        locationDialog.centerLocation() == LocationDialog.CMD_ADD) {
+		if (locationDialog.centerLocation() == LocationDialog.CMD_ADD) {
 			addFiles(locationDialog.getImportSettings());
 		}
 	}
-	
-        /**
-         * Check if the user wants to import more files than the current limit
-         * 
-         * @return <code>true</code> if the file limit is exceeded,
-         *         <code>false</code> otherwise
-         */
-        private boolean checkFileCount() {
-            int maxFiles = (Integer) ImporterAgent.getRegistry().lookup(
-                    "/options/ImportFileLimit");
-    
-            File[] files = chooser.getSelectedFiles();
-            int nFiles = 0;
-            for (File file : files) {
-                nFiles += countFiles(file);
-            }
-    
-            nFiles += table.getFilesToImport().size();
-    
-            if (nFiles > maxFiles) {
-                String msg = TEXT_FILE_LIMIT_EXCEEDED.replaceAll(
-                        FILE_LIMIT_WILDCARD, "" + maxFiles);
-                ImporterAgent.getRegistry().getUserNotifier()
-                        .notifyError(TITLE_FILE_LIMIT_EXCEEDED, msg);
-                return false;
-            }
-    
-            return true;
-        }
 	
         /**
          * Counts the files within the given directory (and sub directories)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -11,7 +11,7 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -26,12 +26,7 @@ import ij.ImagePlus;
 import ij.WindowManager;
 import info.clearthought.layout.TableLayout;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.FlowLayout;
-import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
@@ -50,28 +45,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.Icon;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JRootPane;
-import javax.swing.JSeparator;
-import javax.swing.JSplitPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JTable;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
 
 import loci.formats.gui.ComboFileFilter;
@@ -106,7 +80,7 @@ import omero.gateway.model.TagAnnotationData;
 
 /**
  * Dialog used to select the files to import.
- * 
+ *
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
@@ -124,7 +98,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	// public constants
 	/** Bound property indicating to change the import group. */
 	public static final String PROPERTY_GROUP_CHANGED = "groupChanged";
-	
+
 	/** Bound property indicating to create the object. */
 	public static final String CREATE_OBJECT_PROPERTY = "createObject";
 
@@ -177,7 +151,13 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/** Tooltip text for the Import button */
 	private static final String TOOLTIP_IMPORT =
 			"Import the selected files or directories";
-	
+
+	/** Text for metadata pane */
+	private static final String TEXT_FILE_NAMING = "File Naming";
+
+	/** Text for metadata pane */
+	private static final String TEXT_SKIP_COMPUTE = "Skip Compute";
+
 	/** Text for metadata pane */
 	private static final String TEXT_METADATA_DEFAULTS = "Metadata Defaults";
 
@@ -222,26 +202,26 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/** String used to retrieve if the value of the load thumbnail flag. */
 	private static final String LOAD_THUMBNAIL = "/options/LoadThumbnail";
 
-	/** Tooltip for refresh files button */	
+	/** Tooltip for refresh files button */
 	private static final String TOOLTIP_REFRESH_FILES =
 			"Refresh the file chooser list.";
-	
-	/** Text for refresh files button */	
+
+	/** Text for refresh files button */
 	private static final String TEXT_REFRESH_FILES =
 			"Refresh";
-	
+
 	/** Title for the warning dialog if the file limit is exceeded */
 	private static final String TITLE_FILE_LIMIT_EXCEEDED = "File limit exceeded";
-	
+
 	/** Wildcard for the file limit used in the warning message */
 	private static final String FILE_LIMIT_WILDCARD = "@@FILE_LIMIT@@";
-	
+
 	/** Warning if the file limit is exceeded */
 	private static final String TEXT_FILE_LIMIT_EXCEEDED = "The import is limited to "+FILE_LIMIT_WILDCARD+" files at once.\n\nFor importing a large number of files you may\nconsider using the command line tools.";
-	
+
 	/** Warning when de-selecting the name overriding option. */
 	private static final List<String> WARNING;
-	
+
 	static {
 		WARNING = new ArrayList<String>();
 		WARNING.add("NOTE: Some file formats do not include the file name " +
@@ -256,7 +236,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/** The length of a column. */
 	private static final int COLUMN_WIDTH = 200;
-	
+
 	/** The approval option the user chose. */
 	private int option;
 
@@ -322,7 +302,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/** Indicates to show thumbnails in import tab. */
 	private JCheckBox showThumbnails;
-	
+
 	/** The collection of general filters. */
 	private List<FileFilter> bioFormatsFileFilters;
 
@@ -346,7 +326,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/** Indicates to reload the hierarchies when the import is completed. */
 	private boolean reload;
-	
+
 	/**
 	 * The dialog to allow for the user to select the import location.
 	 */
@@ -363,24 +343,24 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Adds the files to the selection.
-	 * 
+	 *
 	 * @param importSettings The import settings.
 	 */
 	private void addFiles(ImportLocationSettings importSettings)
 	{
 		File[] files = chooser.getSelectedFiles();
-		
+
 		if (files == null || files.length == 0)
 			return;
-		
+
 		List<FileObject> fileList = new ArrayList<FileObject>();
-		
+
 		for (int i = 0; i < files.length; i++) {
 			checkFile(files[i], fileList);
 		}
-		
+
 		chooser.setSelectedFile(new File("."));
-		
+
 		table.addFiles(fileList, importSettings);
 		importButton.setEnabled(table.hasFilesToImport());
 	}
@@ -392,10 +372,10 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			addFiles(locationDialog.getImportSettings());
 		}
 	}
-	
+
         /**
          * Counts the files within the given directory (and sub directories)
-         * 
+         *
          * @param file
          *            The directory or file
          * @return The number of files within the directory (and sub directories) or
@@ -403,7 +383,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
          *         directory
          */
         private int countFiles(File file) {
-    
+
             if (file.isDirectory()) {
                 int count = 0;
                 for (File child : file.listFiles()) {
@@ -411,13 +391,13 @@ public class ImportDialog extends ClosableTabbedPaneComponent
                 }
                 return count;
             }
-            
+
             return 1;
         }
 
 	/**
 	 * Handles <code>Enter</code> key pressed.
-	 * 
+	 *
 	 * @param source
 	 *            The source of the mouse pressed.
 	 */
@@ -431,7 +411,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Handles the selection of tags.
-	 * 
+	 *
 	 * @param tags
 	 *            The selected tags.
 	 */
@@ -489,7 +469,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Creates a row.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private JPanel initRow() {
@@ -500,7 +480,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Builds and lays out a tag.
-	 * 
+	 *
 	 * @param tag
 	 *            The tag to display.
 	 * @param icon
@@ -522,7 +502,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Shows the selection wizard.
-	 * 
+	 *
 	 * @param type
 	 *            The type of objects to handle.
 	 * @param available
@@ -557,7 +537,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Initializes the components composing the display.
-	 * 
+	 *
 	 * @param filters The filters to handle.
 	 * @param importerAction The cancel-all-imports action.
 	 */
@@ -572,11 +552,11 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 		showThumbnails = new JCheckBox(TEXT_SHOW_THUMBNAILS);
 		showThumbnails.setVisible(false);
-		
+
 		Registry registry = ImporterAgent.getRegistry();
-		
+
 		Boolean loadThumbnails = (Boolean) registry.lookup(LOAD_THUMBNAIL);
-		
+
 		if (loadThumbnails != null) {
 			if (loadThumbnails.booleanValue()) {
 				showThumbnails.setVisible(true);
@@ -590,14 +570,14 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		if (model.getSelectedGroup() != null)
 		    groupId = model.getSelectedGroup().getGroupId();
 		if (groupId < 0) groupId = ImporterAgent.getUserDetails().getGroupId();
-		
+
 		locationDialog = new LocationDialog(owner, selectedContainer, type,
 				objects, model, groupId, true);
 		locationDialog.addPropertyChangeListener(this);
 		addPropertyChangeListener(locationDialog);
-		
+
 		int plugin = ImporterAgent.runAsPlugin();
-        
+
         if (plugin == LookupNames.IMAGE_J_IMPORT ||
                 plugin == LookupNames.IMAGE_J) {
             detachedDialog = new LocationDialog(owner, selectedContainer, type,
@@ -627,13 +607,13 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		tagsMap = new LinkedHashMap<JButton, TagAnnotationData>();
 
 		IconManager icons = IconManager.getInstance();
-		
-		refreshFilesButton = new JButton(TEXT_REFRESH_FILES);		  	
+
+		refreshFilesButton = new JButton(TEXT_REFRESH_FILES);
 	    refreshFilesButton.setBackground(UIUtilities.BACKGROUND);
 	    refreshFilesButton.setToolTipText(TOOLTIP_REFRESH_FILES);
 	    refreshFilesButton.setActionCommand("" + CMD_REFRESH_FILES);
 	    refreshFilesButton.addActionListener(this);
-				
+
 		tagButton = new JButton(icons.getIcon(IconManager.PLUS_12));
 		UIUtilities.unifiedButtonLookAndFeel(tagButton);
 		tagButton.addActionListener(this);
@@ -661,7 +641,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 			/**
 			 * Adds the files to the import queue.
-			 * 
+			 *
 			 * @see KeyListener#keyPressed(KeyEvent)
 			 */
 			public void keyPressed(KeyEvent e) {
@@ -693,37 +673,37 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		chooser.setControlButtonsAreShown(false);
 		chooser.setApproveButtonText(TEXT_IMPORT);
 		chooser.setApproveButtonToolTipText(TOOLTIP_IMPORT);
-		
+
 		bioFormatsFileFilters = new ArrayList<FileFilter>();
-		
+
 		if (filters != null) {
 			chooser.setAcceptAllFileFilterUsed(false);
-			
+
 			for (FileFilter fileFilter : filters) {
 				if (fileFilter instanceof ComboFileFilter) {
 					bioFormatsFileFiltersCombined = fileFilter;
-					
+
 					ComboFileFilter comboFilter = (ComboFileFilter) fileFilter;
 					FileFilter[] extensionFilters = comboFilter.getFilters();
-					
+
 					for (FileFilter combinedFilter : extensionFilters) {
 						bioFormatsFileFilters.add(combinedFilter);
 					}
 					break;
 				}
 			}
-			
+
 			chooser.addChoosableFileFilter(bioFormatsFileFiltersCombined);
-			
+
 			for (FileFilter fileFilter : bioFormatsFileFilters) {
 				chooser.addChoosableFileFilter(fileFilter);
 			}
-				
+
 			chooser.setFileFilter(bioFormatsFileFiltersCombined);
 		} else {
 			chooser.setAcceptAllFileFilterUsed(true);
 		}
-		
+
 
 		closeButton = new JButton(TEXT_CLOSE);
 		closeButton.setToolTipText(TOOLTIP_CLOSE);
@@ -804,7 +784,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Builds and lays out the tool bar.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private JPanel buildToolBarLeft() {
@@ -822,39 +802,41 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Builds and lays out the components.
-	 * 
+	 *
 	 * @return See above
 	 */
 	private JPanel buildPathComponent() {
 		JLabel directoriesLabel = new JLabel(TEXT_DIRECTORIES_BEFORE_FILE);
-		
+
 		JPanel pathPanel = new JPanel();
 		pathPanel.setLayout(new FlowLayout(FlowLayout.LEFT));
 		pathPanel.add(numberOfFolders);
 		pathPanel.add(directoriesLabel);
-		
+
 		return pathPanel;
 	}
 
 	/**
 	 * Builds and lays out the component displaying the options for the
 	 * metadata.
-	 * 
+	 *
 	 * @return See above.
 	 */
-	private JXTaskPane buildMetadataComponent() {
-		JXTaskPane pane = new JXTaskPane();
-		Font font = pane.getFont();
-		pane.setFont(font.deriveFont(font.getStyle(), font.getSize() - 2));
-		pane.setCollapsed(true);
-		pane.setTitle(TEXT_METADATA_DEFAULTS);
-		pane.add(buildPixelSizeComponent());
-		return pane;
-	}
+
+
+	private JXTaskPane buildPane(String title, JComponent view) {
+        JXTaskPane pane = new JXTaskPane();
+        Font font = pane.getFont();
+        pane.setFont(font.deriveFont(font.getStyle(), font.getSize() - 2));
+        pane.setCollapsed(true);
+        pane.setTitle(title);
+        pane.add(view);
+        return pane;
+    }
 
 	/**
 	 * Builds and lays out the pixels size options.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private JPanel buildPixelSizeComponent() {
@@ -884,7 +866,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Builds and lays out the components displaying the naming options.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private JComponent buildNamingComponent() {
@@ -920,9 +902,17 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		return UIUtilities.buildComponentPanel(p);
 	}
 
+	private JComponent buildSkipFlagsComponent() {
+		JPanel content = new JPanel();
+		content.setBorder(BorderFactory.createTitledBorder("Skip Compute"));
+		content.add(new SkipComputePanel());
+
+		return UIUtilities.buildComponentPanel(content);
+	}
+
 	/**
 	 * Builds the component hosting the controls to add annotations.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private JPanel buildAnnotationComponent() {
@@ -944,27 +934,50 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Builds and lays out the import options available.
-	 * 
-	 * @param container
-	 *            Container where to import the image.
-	 * @return See above.
+	 *
+	 * @return JScrollPane with a JPanel as its Viewport
 	 */
-	private JPanel buildOptionsPane() {
-		// Lays out the options
-		JPanel options = new JPanel();
-		double[][] size = {
-				{ TableLayout.FILL },
-				{ TableLayout.PREFERRED, TableLayout.PREFERRED,
-						TableLayout.PREFERRED } };
-		options.setLayout(new TableLayout(size));
-		options.add(buildNamingComponent(), "0, 1");
-		options.add(buildMetadataComponent(), "0, 2");
-		return options;
-	}
+	private JComponent buildOptionsPane() {
+        // Lays out the options
+        JPanel options = new JPanel();
+        options.setLayout(new GridBagLayout());
+
+        // Set constraints for all child views
+        GridBagConstraints c = new GridBagConstraints();
+        c.weightx = 1;
+        c.fill = GridBagConstraints.HORIZONTAL;
+
+        // Constraints for naming component
+        c.gridx = 0;
+        c.gridy = 0;
+        options.add(buildPane(TEXT_FILE_NAMING, buildNamingComponent()), c);
+
+        // Constraints for flags component
+        c.gridx = 0;
+        c.gridy = 1;
+        options.add(buildPane(TEXT_SKIP_COMPUTE, buildSkipFlagsComponent()), c);
+
+        // Constraints for meta data component
+        c.gridx = 0;
+        c.gridy = 2;
+        options.add(buildPane(TEXT_METADATA_DEFAULTS, buildPixelSizeComponent()), c);
+
+        // Fills in bottom space of GridBagLayout
+        c.gridx = 0;
+        c.gridy = 3;
+        c.weighty = 1;
+        options.add(new JLabel(" "), c);
+
+        // Scroll view to hold the options panel should the import dialog
+        // shrink in size or further options are added
+        JScrollPane scrollPane = new JScrollPane();
+        scrollPane.setViewportView(options);
+        return scrollPane;
+    }
 
 	/**
 	 * Lays out the quota.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private JPanel buildQuotaPane() {
@@ -1011,16 +1024,16 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		    pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
 	                chooser, tablePanel);
 		}
-		
+
 		JPanel mainPanel = new JPanel();
 		double[][] mainPanelDesign = { { TableLayout.FILL },
 				{ TableLayout.PREFERRED, TableLayout.FILL } };
 		mainPanel.setLayout(new TableLayout(mainPanelDesign));
 		mainPanel.setBackground(UIUtilities.BACKGROUND);
 		mainPanel.add(pane, "0, 1");
-		
+
 		this.add(mainPanel, BorderLayout.CENTER);
-		
+
 		JPanel controls = new JPanel();
 		controls.setLayout(new BoxLayout(controls, BoxLayout.Y_AXIS));
 
@@ -1031,7 +1044,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		bar.add(buildToolBarRight());
 		controls.add(new JSeparator());
 		controls.add(bar);
-		
+
 		add(controls, BorderLayout.SOUTH);
 		if (JDialog.isDefaultLookAndFeelDecorated()) {
 			boolean supportsWindowDecorations = UIManager.getLookAndFeel()
@@ -1045,7 +1058,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/**
 	 * Helper method returning <code>true</code> if the connection is fast,
 	 * <code>false</code> otherwise.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private boolean isFastConnection() {
@@ -1056,7 +1069,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Handles the selection of files. Returns the files that can be imported.
-	 * 
+	 *
 	 * @param The selected files.
 	 * @return See above.
 	 */
@@ -1065,7 +1078,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	}
 
 	/** Imports the selected files. */
-	public void importFiles() {
+	public void  importFiles() {
 		option = CMD_IMPORT;
 		importButton.setEnabled(false);
 		// Set the current directory as the defaults
@@ -1098,7 +1111,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 				.lookup(LOAD_THUMBNAIL);
 		if (loadThumbnails != null)
 			object.setLoadThumbnail(loadThumbnails.booleanValue());
-		
+
 		// if slow connection
 		if (!isFastConnection())
 			object.setLoadThumbnail(false);
@@ -1114,7 +1127,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			}
 			object.setTags(l);
 		}
-			
+
 		if (partialName.isSelected()) {
 			Integer number = (Integer) numberOfFolders.getValueAsNumber();
 			if (number != null && number >= 0)
@@ -1138,7 +1151,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		}
 		if (count > 0)
 			object.setPixelsSize(size);
-		
+
 		firePropertyChange(IMPORT_PROPERTY, null, object);
 		table.removeAllFiles();
 		tagsMap.clear();
@@ -1150,7 +1163,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	 * Checks if the file can be added to the passed list. Returns the
 	 * <code>true</code> if the file is a directory, <code>false</code>
 	 * otherwise.
-	 * 
+	 *
 	 * @param f
 	 *            The file to handle.
 	 */
@@ -1174,7 +1187,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/**
 	 * Returns <code>true</code> if the file can be imported, <code>false</code>
 	 * otherwise.
-	 * 
+	 *
 	 * @param f
 	 *            The file to check.
 	 * @return See above.
@@ -1185,7 +1198,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Checks if the passed container is hosting the desired object.
-	 * 
+	 *
 	 * @param container
 	 *            The container to handle.
 	 * @return See above.
@@ -1202,7 +1215,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Creates a new instance.
-	 * 
+	 *
 	 * @param owner
 	 *            The owner of the dialog.
 	 * @param filters
@@ -1235,7 +1248,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Returns the type of the import.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	public int getType() { return type; }
@@ -1243,7 +1256,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/**
 	 * Returns <code>true</code> if only one group for the user,
 	 * <code>false</code> otherwise.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	boolean isSingleGroup()
@@ -1254,11 +1267,11 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/**
 	 * Returns <code>true</code> if the user can import the data for other
 	 * users, <code>false</code> otherwise.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	boolean canImportAs() { return model.canImportAs(); }
-	
+
 	/** Display the size of files to add. */
 	void onSelectionChanged() {
 		if (canvas == null) return;
@@ -1272,7 +1285,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
     /**
 	 * Returns the name to display for a file.
-	 * 
+	 *
 	 * @param fullPath
 	 *            The file's absolute path.
 	 * @return See above.
@@ -1287,7 +1300,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/**
 	 * Returns <code>true</code> if the folder can be used as a container,
 	 * <code>false</code> otherwise.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	boolean useFolderAsContainer() {
@@ -1297,7 +1310,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/**
 	 * Returns <code>true</code> to indicate that the refresh containers view
 	 * needs to be refreshed.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	public boolean isRefreshLocation() {
@@ -1306,7 +1319,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Resets the text and remove all the files to import.
-	 * 
+	 *
 	 * @param objects The possible objects.
 	 * @param type One of the constants used to identify the type of import.
 	 * @param currentGroupId The id of the group.
@@ -1357,7 +1370,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Resets the text and remove all the files to import.
-	 * 
+	 *
 	 * @param selectedContainer The container where to import the files.
 	 * @param objects The possible objects.
 	 * @param type One of the constants used to identify the type of import.
@@ -1372,19 +1385,19 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		this.selectedContainer = checkContainer(selectedContainer);
 		this.objects = objects;
 		this.type = type;
-		
+
 		File[] files = chooser.getSelectedFiles();
 		table.allowAddition(files != null && files.length > 0);
 		handleTagsSelection(new ArrayList<TagAnnotationData>());
 		tabbedPane.setSelectedIndex(0);
-		
+
 		FileFilter[] filters = chooser.getChoosableFileFilters();
-		
+
 		if (filters != null && filters.length > 0)
 		{
 			if(currentFilter == null)
 				currentFilter = filters[0];
-			
+
 			chooser.setFileFilter(currentFilter);
 		}
 
@@ -1400,7 +1413,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Shows the chooser dialog.
-	 * 
+	 *
 	 * @return The option selected.
 	 */
 	public int showDialog() {
@@ -1410,7 +1423,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Shows the chooser dialog.
-	 * 
+	 *
 	 * @return The option selected.
 	 */
 	public int centerDialog() {
@@ -1420,7 +1433,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Sets the collection of existing tags.
-	 * 
+	 *
 	 * @param tags
 	 *            The collection of existing tags.
 	 */
@@ -1448,13 +1461,13 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			else
 				available.add(tag);
 		}
-		
+
 		showSelectionWizard(TagAnnotationData.class, available, selected, true);
 	}
 
 	/**
 	 * Displays the used and available disk space.
-	 * 
+	 *
 	 * @param quota
 	 *            The value to set.
 	 */
@@ -1471,7 +1484,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Notifies that the new object has been created.
-	 * 
+	 *
 	 * @param d The newly created object.
 	 * @param parent The parent of the object.
 	 */
@@ -1497,7 +1510,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/**
 	 * Returns <code>true</code> if need to reload the hierarchies,
 	 * <code>false</code> otherwise.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	public boolean reloadHierarchies() {
@@ -1506,7 +1519,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Sets the selected group.
-	 * 
+	 *
 	 * @param group
 	 *            The group to set.
 	 */
@@ -1609,12 +1622,12 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Reacts to property fired by the table.
-	 * 
+	 *
 	 * @see PropertyChangeListener#propertyChange(PropertyChangeEvent)
 	 */
 	public void propertyChange(PropertyChangeEvent evt) {
 		String name = evt.getPropertyName();
-		
+
 		if (FileSelectionTable.ADD_PROPERTY.equals(name)) {
 			showLocationDialog();
 		} else if (FileSelectionTable.REMOVE_PROPERTY.equals(name)) {
@@ -1659,7 +1672,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	/**
 	 * Cancels or imports the files.
-	 * 
+	 *
 	 * @see ActionListener#actionPerformed(ActionEvent)
 	 */
 	public void actionPerformed(ActionEvent evt) {
@@ -1696,3 +1709,4 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	}
 
 }
+

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -321,6 +321,9 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/** The owner related to the component. */
 	private JFrame owner;
 
+	/** Panel inside options tab */
+	private SkipComputePanel skipComputePanel;
+
 	/** Flag indicating that the containers view needs to be refreshed. */
 	private boolean refreshLocation;
 
@@ -903,10 +906,10 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	}
 
 	private JComponent buildSkipFlagsComponent() {
+		skipComputePanel = new SkipComputePanel();
 		JPanel content = new JPanel();
 		content.setBorder(BorderFactory.createTitledBorder("Skip Compute"));
-		content.add(new SkipComputePanel());
-
+		content.add(skipComputePanel);
 		return UIUtilities.buildComponentPanel(content);
 	}
 
@@ -1151,6 +1154,9 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 		}
 		if (count > 0)
 			object.setPixelsSize(size);
+
+		// Add any options for set for skipping server side compute here!
+		object.setSkipChioces(skipComputePanel.getChoices());
 
 		firePropertyChange(IMPORT_PROPERTY, null, object);
 		table.removeAllFiles();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1108,7 +1108,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	}
 
 	/** Imports the selected files. */
-	public void  importFiles() {
+	public void importFiles() {
 		option = CMD_IMPORT;
 		importButton.setEnabled(false);
 		// Set the current directory as the defaults

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -183,7 +183,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	private static final String TEXT_FILE_NAMING = "File Naming";
 
 	/** Text for metadata pane */
-	private static final String TEXT_SKIP_COMPUTE = "Skip Compute";
+	private static final String TEXT_SKIP_COMPUTE = "Skip Processing";
 
 	/** Text for metadata pane */
 	private static final String TEXT_METADATA_DEFAULTS = "Metadata Defaults";

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -935,7 +935,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	private JComponent buildSkipFlagsComponent() {
 		skipComputePanel = new SkipComputePanel();
 		JPanel content = new JPanel();
-		content.setBorder(BorderFactory.createTitledBorder("Skip Compute"));
+		content.setBorder(BorderFactory.createTitledBorder(TEXT_SKIP_COMPUTE));
 		content.add(skipComputePanel);
 		return UIUtilities.buildComponentPanel(content);
 	}
@@ -1742,4 +1742,3 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	}
 
 }
-

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -26,7 +26,12 @@ import ij.ImagePlus;
 import ij.WindowManager;
 import info.clearthought.layout.TableLayout;
 
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
@@ -45,7 +50,29 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JRootPane;
+import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
+import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTable;
+import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 
 import loci.formats.gui.ComboFileFilter;
@@ -1156,7 +1183,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			object.setPixelsSize(size);
 
 		// Add any options for set for skipping server side compute here!
-		object.setSkipChioces(skipComputePanel.getChoices());
+		object.setSkipChoices(skipComputePanel.getChoices());
 
 		firePropertyChange(IMPORT_PROPERTY, null, object);
 		table.removeAllFiles();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -182,8 +182,11 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	/** Text for metadata pane */
 	private static final String TEXT_FILE_NAMING = "File Naming";
 
+	/** Text for metadata pane title */
+	private static final String TEXT_SKIP_COMPUTE_TITLE = "Import speed-up";
+	
 	/** Text for metadata pane */
-	private static final String TEXT_SKIP_COMPUTE = "Skip Processing";
+    private static final String TEXT_SKIP_COMPUTE = "Shorten the import by skipping...";
 
 	/** Text for metadata pane */
 	private static final String TEXT_METADATA_DEFAULTS = "Metadata Defaults";
@@ -934,9 +937,9 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 
 	private JComponent buildSkipFlagsComponent() {
 		skipComputePanel = new SkipComputePanel();
-		JPanel content = new JPanel();
-		content.setBorder(BorderFactory.createTitledBorder(TEXT_SKIP_COMPUTE));
-		content.add(skipComputePanel);
+		JPanel content = new JPanel(new BorderLayout());
+		content.add(new JLabel(TEXT_SKIP_COMPUTE), BorderLayout.NORTH);
+		content.add(skipComputePanel, BorderLayout.CENTER);
 		return UIUtilities.buildComponentPanel(content);
 	}
 
@@ -985,7 +988,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
         // Constraints for flags component
         c.gridx = 0;
         c.gridy = 1;
-        options.add(buildPane(TEXT_SKIP_COMPUTE, buildSkipFlagsComponent()), c);
+        options.add(buildPane(TEXT_SKIP_COMPUTE_TITLE, buildSkipFlagsComponent()), c);
 
         // Constraints for meta data component
         c.gridx = 0;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -12,7 +12,7 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -43,23 +43,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.Icon;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JTabbedPane;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import javafx.scene.layout.VBox;
 import org.apache.commons.collections.CollectionUtils;
 import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
@@ -93,7 +81,7 @@ import omero.gateway.model.ScreenData;
 
 /**
  * Provides the user with the options to select the location to import data.
- * 
+ *
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
  *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
@@ -114,22 +102,22 @@ class LocationDialog extends JDialog implements ActionListener,
 	/** Default GAP value for UI components */
 	private static final int UI_GAP = 5;
 
-	// other constants	
+	// other constants
 	/** Minimum width of the dialog in pixels */
 	private static final int MIN_WIDTH = 640;
 
 	/** The preferred size of the selection box.*/
 	private static final Dimension SELECTION_BOX_SIZE = new Dimension(200, 130);
-	
+
 	// String constants
-	
+
 	/** The title of the dialog. */
 	private static String TEXT_TITLE =
 			"Import Location - Select where to import your data.";
 
 	/** Text for import as a user */
 	private static final String TEXT_IMPORT_AS = "Import For";
-	
+
 	/** Text for projects */
 	private static final String TEXT_PROJECTS = "Projects";
 
@@ -143,7 +131,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	/** Text for Projects tab */
 	private static final String TOOLTIP_PROJECTS_TAB =
 			"Import settings for Projects";
-	
+
 	/** Text for a project. */
 	private static final String TEXT_PROJECT = "Project";
 
@@ -158,37 +146,43 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/** Tooltip text for New Screen button */
 	private static final String TOOLTIP_NEW_SCREEN = "Create a new Screen.";
-	
+
 	/** Tooltip text for New Dataset button */
 	private static final String TOOLTIP_NEW_DATASET = "Create a new Dataset.";
-	
+
 	/** Tooltip text for New Project button */
 	private static final String TOOLTIP_NEW_PROJECT = "Create a new Project.";
 
 	/** Tooltip for Reload button */
 	private static final String TEXT_REFRESH = "Refresh";
 
+	/** Tooltip for show basic button */
+	private static final String TEXT_BASIC = "Basic";
+
+	/** Tooltip for show basic button */
+	private static final String TEXT_ADVANCED = "Advanced";
+
 	/** Tooltip for Reload button */
 	private static final String TOOLTIP_REFRESH =
 			"Reload the Groups, Projects, Datasets and/or Screens.";
-	
+
 	/** Text for New buttons */
 	private static final String TEXT_NEW = "New...";
 
 	/** Text for Close button */
 	private static final String TEXT_CLOSE = "Close";
-	
+
 	/** Tooltip text for Close button */
-	private static final String TOOLTIP_CLOSE_DIALOGUE = 
+	private static final String TOOLTIP_CLOSE_DIALOGUE =
 			"Close the dialog and do not add the files to the queue.";
 
 	/** Text for Add button */
 	private static final String TEXT_QUEUE_ITEMS = "Add to the Queue";
-	
+
 	/** Tooltip text for Add button */
 	private static final String TOOLTIP_QUEUE_ITEMS =
 			"Add the files to the queue.";
-	
+
 	// Icon constants
 	/** Reference to the <code>Group Private</code> icon. */
 	private static final Icon GROUP_PRIVATE_ICON;
@@ -231,6 +225,12 @@ class LocationDialog extends JDialog implements ActionListener,
 	/** User has chosen to force a refresh of the containers */
 	private static final int CMD_REFRESH_DISPLAY = 4;
 
+	/** Action id to show advanced import options panel */
+	private static final int CMD_SHOW_ADVANCED_PANEL = 7;
+
+	/** Action id to show basic (hide advanced) import panel options panel */
+	private static final int CMD_HIDE_ADVANCED_PANEL = 8;
+
 	/** User has selected to add the files. */
 	final static int CMD_ADD = 5;
 
@@ -246,7 +246,7 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/** The Screen panel tab. */
 	private JPanel screenPanel;
-	
+
 	/** Component indicating to add to the queue. */
 	private JButton addButton;
 
@@ -258,7 +258,7 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/** Component used to select the import user. */
 	private JComboBox usersBox;
-	
+
 	/** Component used to select the default project. */
 	private JComboBox projectsBox;
 
@@ -267,6 +267,9 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/** Component used to select the default screen. */
 	private JComboBox screensBox;
+
+	/** Component used to select advanced import options */
+	private JComboBox advancedBox;
 
 	/** Button to create a new project. */
 	private JButton newProjectButton;
@@ -280,13 +283,22 @@ class LocationDialog extends JDialog implements ActionListener,
 	/** Button used to refresh the groups/projects/datasets & screens */
 	private JButton refreshButton;
 
+	/** Button used to show or hide advanced options for importing images */
+	private JButton basicAdvButton;
+
 	/** Tab pane used to hose the Project/Screen selection UI component. */
 	private JTabbedPane tabbedPane;
-	
+
+	private JPanel advOptsPanel;
+
+	private JCheckBox thumbGenCheckbox;
+	private JCheckBox minMaxCheckBox;
+	private JCheckBox checksumCheckBox;
+
 	// Operational variables & constants
 	/** Constant value for no data type */
 	private static final int NO_DATA_TYPE = -1;
-	
+
 	/** Sorts the objects from the display. */
 	private ViewerSorter sorter;
 
@@ -301,7 +313,7 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/** The current possible import location nodes. */
 	private Collection<TreeImageDisplay> objects;
-	
+
 	/** The list of currently available Projects */
 	private List<DataNode> projects = new ArrayList<DataNode>();
 
@@ -309,7 +321,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	private List<DataNode> screens = new ArrayList<DataNode>();
 
 	/** The projects -> dataset map of currently available Datasets */
-	private Map<DataNode, List<DataNode>> datasets = 
+	private Map<DataNode, List<DataNode>> datasets =
 			new Hashtable<DataNode, List<DataNode>>();
 
 	/** The currently selected Project */
@@ -334,10 +346,10 @@ class LocationDialog extends JDialog implements ActionListener,
 
     /** Indicates the loading progress. */
     private JXBusyLabel     busyLabel;
-    
+
 	/**
 	 * Creates a new instance.
-	 * 
+	 *
 	 * @param parent The parent of the dialog.
 	 * @param selectedContainer The container selected by the user.
 	 * @param objects The screens / projects to be shown.
@@ -359,20 +371,20 @@ class LocationDialog extends JDialog implements ActionListener,
 		this.model = model;
 		setModal(true);
 		setTitle(TEXT_TITLE);
-		
+
 		initUIComponents();
 		layoutUI(ijoption);
 		populateUIWithDisplayData(findWithId(groups, currentGroupId),
 		        model.getImportFor());
-		
+
 		addPropertyChangeListener(this);
-		
+
 		addButton.setEnabled(true);
 	}
 
-	/** 
+	/**
 	 * Populates the various components.
-	 * 
+	 *
 	 * @param selectedGroup The selected group.
 	 * @param userID The id of the selected user.
 	 */
@@ -383,12 +395,12 @@ class LocationDialog extends JDialog implements ActionListener,
 		populateLocationComboBoxes();
 		displayViewFor(dataType);
 	}
-	
+
 	/**
 	 * Returns the loaded experimenter corresponding to the specified user.
-	 * if the user is not loaded. Returns <code>null</code> if no user 
+	 * if the user is not loaded. Returns <code>null</code> if no user
 	 * can be found.
-	 * 
+	 *
 	 * @param owner The experimenter to handle.
 	 * @return see above.
 	 */
@@ -434,14 +446,14 @@ class LocationDialog extends JDialog implements ActionListener,
 	 */
 	private <T extends DataObject> T findWithId(Collection<T> dataObjects,
 			long id) {
-		
+
 		for (T dataObject : dataObjects) {
 			if (dataObject.getId() == id)
 				return dataObject;
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Scans the DataNodes provided and returns the Object with matching id.
 	 * <null> if not found
@@ -453,14 +465,14 @@ class LocationDialog extends JDialog implements ActionListener,
 	{
 		if (CollectionUtils.isEmpty(nodes))
 			return null;
-		
+
 		for (DataNode node : nodes) {
 			if (getIdOf(node) == id)
 				return node;
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Initializes the UI components of the dialog.
 	 */
@@ -470,25 +482,44 @@ class LocationDialog extends JDialog implements ActionListener,
 
 		// main components
 		groupsBox = new JComboBox();
-		
+
 		usersBox = new JComboBox();
 		usersBox.setVisible(model.canImportAs());
-		
+
 		refreshButton = new JButton(TEXT_REFRESH);
 		refreshButton.setBackground(UIUtilities.BACKGROUND);
 		refreshButton.setToolTipText(TOOLTIP_REFRESH);
 		refreshButton.setActionCommand("" + CMD_REFRESH_DISPLAY);
 		refreshButton.addActionListener(this);
-		
+
+		basicAdvButton = new JButton(TEXT_BASIC);
+		basicAdvButton.setBackground(UIUtilities.BACKGROUND);
+		basicAdvButton.setActionCommand("" + CMD_SHOW_ADVANCED_PANEL);
+        basicAdvButton.addActionListener(this);
+
 		projectsBox = new JComboBox();
 		projectsBox.addItemListener(this);
-		
+
 		datasetsBox = new JComboBox();
 		datasetsBox.addItemListener(this);
-		
+
 		screensBox = new JComboBox();
 		screensBox.addItemListener(this);
-		
+
+		// Check box options for advanced panel
+		thumbGenCheckbox = new JCheckBox("Skip thumbnail generation");
+		thumbGenCheckbox.addItemListener(e -> {
+
+		});
+		minMaxCheckBox = new JCheckBox("Skip min/max compute");
+		minMaxCheckBox.addItemListener(e ->  {
+
+		});
+		checksumCheckBox = new JCheckBox("Skip checksum checking");
+		checksumCheckBox.addItemListener(e -> {
+
+		});
+
 		// main location panel buttons
 		newProjectButton = new JButton(TEXT_NEW);
 		newProjectButton.setToolTipText(TOOLTIP_NEW_PROJECT);
@@ -504,26 +535,29 @@ class LocationDialog extends JDialog implements ActionListener,
 		newScreenButton.setToolTipText(TOOLTIP_NEW_SCREEN);
 		newScreenButton.setActionCommand("" + CMD_CREATE_SCREEN);
 		newScreenButton.addActionListener(this);
-		
+
 		// main action buttons
 		addButton = new JButton(TEXT_QUEUE_ITEMS);
 		addButton.setToolTipText(TOOLTIP_QUEUE_ITEMS);
 		addButton.addActionListener(this);
 		addButton.setActionCommand("" + CMD_ADD);
 		addButton.setEnabled(false);
-		
+
 		closeButton = new JButton(TEXT_CLOSE);
 		closeButton.setToolTipText(TOOLTIP_CLOSE_DIALOGUE);
 		closeButton.addActionListener(this);
 		closeButton.setActionCommand("" + CMD_CLOSE);
-		
+
         Dimension d = new Dimension(UIUtilities.DEFAULT_ICON_WIDTH,
                 UIUtilities.DEFAULT_ICON_HEIGHT);
         busyLabel = new JXBusyLabel(d);
         busyLabel.setVisible(true);
         busyLabel.setBusy(true);
-        
+
 		getRootPane().setDefaultButton(addButton);
+
+		// Advanced panel sits under tabbed panel
+		advOptsPanel = buildAdvancedOptionsPanel();
 	}
 
 	/**
@@ -542,22 +576,23 @@ class LocationDialog extends JDialog implements ActionListener,
 		        plugin != LookupNames.IMAGE_J) {
 		    buttonPanel.add(closeButton);
 	        buttonPanel.add(refreshButton);
+            buttonPanel.add(basicAdvButton);
 		} else {
 		    if (!ijoption) {
 		        buttonPanel.add(closeButton);
             }
 		    buttonPanel.add(refreshButton);
 		}
-		
+
 		buttonPanel.add(Box.createHorizontalGlue());
 		buttonPanel.add(addButton);
-		
+
 		buttonPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP, 0, UI_GAP));
-		
+
 		JPanel buttonWrapper = new JPanel(new BorderLayout());
 		buttonWrapper.add(buttonPanel, BorderLayout.CENTER);
 		buttonWrapper.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.BLACK));
-		
+
 		return buttonWrapper;
 	}
 
@@ -568,7 +603,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	private JTabbedPane buildDataTypeTabbedPane()
 	{
 		IconManager icons = IconManager.getInstance();
-		
+
 		Icon projectIcon = icons.getIcon(IconManager.PROJECT);
 		projectPanel = buildProjectSelectionPanel();
 
@@ -581,14 +616,14 @@ class LocationDialog extends JDialog implements ActionListener,
 
 		tabbedPane.addTab(TEXT_SCREENS, screenIcon, screenPanel,
 				TOOLTIP_SCREENS_TAB);
-		
+
 		tabbedPane.addChangeListener(this);
-		
+
 		tabbedPane.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP, UI_GAP, UI_GAP));
-		
+
 		return tabbedPane;
 	}
-	
+
 	/**
 	 * Builds a JPanel holding the group selection section.
 	 * @return JPanel holding the group selection UI elements
@@ -604,7 +639,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		c.weightx = 0;
 		c.weighty = 0;
 		c.anchor = GridBagConstraints.WEST;
-		
+
 		if (groups.size() > 1) {
 	        groupPanel.add(UIUtilities.setTextFont(TEXT_GROUP), c);
 	        c.gridx++;
@@ -618,24 +653,24 @@ class LocationDialog extends JDialog implements ActionListener,
 			groupPanel.add(usersBox, c);
 			c.gridy++;
 		}
-		
+
 		c.gridy = 0;
 		c.gridx = 2;
 		c.weightx = 1;
 		c.fill = GridBagConstraints.NONE;
 		c.anchor = GridBagConstraints.EAST;
-		
-		groupPanel.add(busyLabel, c); 
-		
+
+		groupPanel.add(busyLabel, c);
+
 		c.gridy++;
 		groupPanel.add(new JPanel(), c);
-		
+
 		return groupPanel;
 	}
-	
+
     /**
      * Builds a JPanel holding the project selection section.
-     * 
+     *
      * @return JPanel holding the project selection UI elements
      */
     private JPanel buildProjectSelectionPanel() {
@@ -680,7 +715,7 @@ class LocationDialog extends JDialog implements ActionListener,
 
     /**
      * Builds a JPanel holding the screen selection section.
-     * 
+     *
      * @return JPanel holding the screen selection UI elements
      */
     private JPanel buildScreenSelectionPanel() {
@@ -711,9 +746,40 @@ class LocationDialog extends JDialog implements ActionListener,
         return screenPanel;
     }
 
+    private JPanel buildAdvancedOptionsPanel() {
+    	// Create checkboxes
+		JPanel advPanel = new JPanel(new GridBagLayout());
+		// advPanel.setVisible(false);
+
+		GridBagConstraints c = new GridBagConstraints();
+		c.insets = new Insets(1, 1, 1, 1);
+		c.fill = GridBagConstraints.NONE;
+		c.anchor = GridBagConstraints.WEST;
+
+		c.gridy = 0;
+		c.fill = GridBagConstraints.HORIZONTAL;
+		c.weightx = 1;
+		advPanel.add(thumbGenCheckbox, c);
+
+		c.gridy = 1;
+		c.fill = GridBagConstraints.HORIZONTAL;
+		c.weightx = 1;
+		advPanel.add(minMaxCheckBox, c);
+
+		c.gridy = 2;
+		c.fill = GridBagConstraints.HORIZONTAL;
+		c.weightx = 1;
+		advPanel.add(checksumCheckBox, c);
+
+		advPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
+				UI_GAP, UI_GAP));
+
+		return advPanel;
+	}
+
 	/**
 	 * Builds the toolbar when the importer is the entry point.
-	 * 
+	 *
 	 * @param availableGroups The available group.
 	 * @param selectedGroup The selected group.
 	 * @param userID The selected user.
@@ -736,7 +802,7 @@ class LocationDialog extends JDialog implements ActionListener,
 			if (selectedGroup != null && selectedGroup.getId() == group.getId())
 				selectedGroupItem = item;
 		}
-		
+
 		if (selectedGroupItem != null)
 		{
 			groupsBox.setSelectedItem(selectedGroupItem);
@@ -746,7 +812,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		renderer.setTooltips(tooltips);
 		renderer.setPreferredSize(SELECTION_BOX_SIZE);
 		groupsBox.setRenderer(renderer);
-		
+
 		groupsBox.addItemListener(this);
 	}
 
@@ -754,7 +820,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * Determines if the logged in user is allowed to import data for the user
 	 * in to the selected group. Returns true if the logged in user is the user,
 	 * is a system administrator or is an owner of the group.
-	 * 
+	 *
 	 * @param user The user to import data for.
 	 * @param selectedGroup The group to import data in to.
 	 * @return See above.
@@ -817,7 +883,6 @@ class LocationDialog extends JDialog implements ActionListener,
             buttons.add(b);
             group.add(b);
             b.addItemListener(new ItemListener() {
-
                 @Override
                 public void itemStateChanged(ItemEvent e) {
                     activeWindow = (e.getStateChange() == ItemEvent.SELECTED);
@@ -835,39 +900,48 @@ class LocationDialog extends JDialog implements ActionListener,
         } else {
             pane = buildDataTypeTabbedPane();
         }
-	    
+
 		BorderLayout layout = new BorderLayout();
 		layout.setHgap(UI_GAP);
 		layout.setVgap(UI_GAP);
-		
+
 		JPanel content = new JPanel();
 		content.setLayout(new BorderLayout());
 		content.add(buildGroupSelectionPanel(),BorderLayout.NORTH);
-		content.add(pane, BorderLayout.CENTER);
+
+		JPanel centerPanel = new JPanel();
+		centerPanel.setLayout(new BoxLayout(centerPanel, BoxLayout.Y_AXIS));
+		centerPanel.add(pane);
+
+		advOptsPanel = buildAdvancedOptionsPanel();
+		centerPanel.add(advOptsPanel);
+
+		content.add(centerPanel, BorderLayout.CENTER);
+
 		content.add(buildLowerButtonPanel(ijoption), BorderLayout.SOUTH);
 		content.setBorder(BorderFactory.createEmptyBorder(UI_GAP,UI_GAP,UI_GAP,UI_GAP));
 		this.getContentPane().setLayout(new BorderLayout());
 		this.getContentPane().add(content, BorderLayout.CENTER);
-		
+
 		// resize the window to minimum size
 		setMinimumSize();
 	}
 
 	/**
-	 * Resizes the window and sets the minimum size to the 
+	 * Resizes the window and sets the minimum size to the
 	 * size required by all components.
 	 */
 	private void setMinimumSize()
 	{
 		this.pack();
 		int minHeight = this.getHeight();
-		
+
 		Dimension minSize = new Dimension(MIN_WIDTH, minHeight);
 		this.setMinimumSize(minSize);
 		this.setPreferredSize(minSize);
 		this.setSize(minSize);
 	}
-	
+
 	/**
 	 * Wraps the container in a JPanel with an empty border
 	 * with the border width specified
@@ -931,12 +1005,12 @@ class LocationDialog extends JDialog implements ActionListener,
 	public void actionPerformed(ActionEvent ae)
 	{
 		String actionCommand = ae.getActionCommand();
-		
+
 		try {
 			int commandId = Integer.parseInt(actionCommand);
-			
+
 			DataObject newDataObject = null;
-			
+
 			switch (commandId) {
 				case CMD_CREATE_PROJECT:
 					newDataObject = new ProjectData();
@@ -957,10 +1031,23 @@ class LocationDialog extends JDialog implements ActionListener,
 					storeCurrentSelections();
 					firePropertyChange(ImportDialog.REFRESH_LOCATION_PROPERTY,
 							null, new ImportLocationDetails(dataType));
+					break;
+				case CMD_SHOW_ADVANCED_PANEL:
+					basicAdvButton.setText(TEXT_BASIC);
+                    basicAdvButton.setActionCommand("" + CMD_HIDE_ADVANCED_PANEL);
+					advOptsPanel.setVisible(true);
+					pack();
+					break;
+                case CMD_HIDE_ADVANCED_PANEL:
+                    basicAdvButton.setText(TEXT_ADVANCED);
+                    basicAdvButton.setActionCommand("" + CMD_SHOW_ADVANCED_PANEL);
+					advOptsPanel.setVisible(false);
+					pack();
+                    break;
 			}
 
 			if (newDataObject != null) {
-				
+
 				EditorDialog editor = new EditorDialog((JFrame) getOwner(),
 						newDataObject, false);
 				editor.addPropertyChangeListener(this);
@@ -969,6 +1056,14 @@ class LocationDialog extends JDialog implements ActionListener,
 			}
 		} catch (NumberFormatException nfe) {
 		}
+	}
+
+	private void showAdvancedPanel() {
+
+	}
+
+	private void hideAdvancedPanel() {
+
 	}
 
 	/**
@@ -995,7 +1090,7 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/**
 	 * Returns the import settings chosen but the user.
-	 * 
+	 *
 	 * @return The import settings selected by the user.
 	 */
 	protected ImportLocationSettings getImportSettings()
@@ -1013,7 +1108,7 @@ class LocationDialog extends JDialog implements ActionListener,
 				DataNode screen = getSelectedItem(screensBox);
 				return new ScreenImportLocationSettings(group, user, screen);
 		}
-		
+
 		return new NullImportSettings(group, user);
 	}
 
@@ -1028,7 +1123,7 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/**
 	 * Returns the user corresponding to the specified index.
-	 * 
+	 *
 	 * @param index The index of the user.
 	 * @return see above.
 	 */
@@ -1040,7 +1135,7 @@ class LocationDialog extends JDialog implements ActionListener,
 			return selectedItem.getObject().getData();
 		return null;
 	}
-	
+
 	/**
 	 * Populates the JComboBox with the items provided adding hover tooltips.
 	 * @param comboBox The JComboBox to populate
@@ -1051,11 +1146,11 @@ class LocationDialog extends JDialog implements ActionListener,
 	{
 		displayItems(comboBox, listItems, null, null);
 	}
-	
+
 	/**
 	 * Populates the JComboBox with the items provided adding hover tooltips
 	 * and selecting the specified item.
-	 * 
+	 *
 	 * @param comboBox The JComboBox to populate
 	 * @param listItems The items to populate the box with
 	 * @param selected The item to select in the JComboBox
@@ -1065,11 +1160,11 @@ class LocationDialog extends JDialog implements ActionListener,
 	{
 	    displayItems(comboBox, listItems, selected, null);
 	}
-	
+
 	/**
 	 * Returns <code>true</code> if the specified user is an administrator,
 	 * <code>false</code> otherwise.
-	 * 
+	 *
 	 * @param userID The identifier of the user.
 	 * @return See above.
 	 */
@@ -1091,11 +1186,11 @@ class LocationDialog extends JDialog implements ActionListener,
         }
 	    return false;
 	}
-	
+
 	/**
 	 * Populates the JComboBox with the items provided adding hover tooltips,
 	 * selecting the specified item and attaching the listener.
-	 * 
+	 *
 	 * @param comboBox The JComboBox to populate
 	 * @param listItems The items to populate the box with
 	 * @param select The item to select in the JComboBox
@@ -1117,7 +1212,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		ExperimenterData exp;
 		SelectableComboBoxModel model = new SelectableComboBoxModel();
 		Selectable<DataNode> selected = null;
-		
+
 		GroupData group = getSelectedGroup();
 		ExperimenterData user = getSelectedUser();
 		long userID = -1;
@@ -1135,17 +1230,17 @@ class LocationDialog extends JDialog implements ActionListener,
 			}
 			lines.addAll(UIUtilities.wrapStyleWord(node.getFullName()));
 			tooltips.add(UIUtilities.formatToolTipText(lines));
-			
+
 			boolean selectable = true;
 			if (!node.isDefaultNode()) {
 				selectable = canLink(node.getDataObject(), userID, group,
 						loggedInID, isAdmin, userIsAdmin);
 			}
-			
+
 			Selectable<DataNode> comboBoxItem =
 					new Selectable<DataNode>(node, selectable);
 			if (select != null) {
-			    if (node.getDataObject().getId() < 0 
+			    if (node.getDataObject().getId() < 0
 			            && select.getDataObject().getId() < 0) {
 			        if (node.toString().trim().equals(select.toString().trim()))
 			            selected = comboBoxItem;
@@ -1163,7 +1258,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		renderer.setTooltips(tooltips);
 		comboBox.setModel(model);
 		comboBox.setRenderer(renderer);
-		
+
 		if (selected != null)
 			comboBox.setSelectedItem(selected);
 
@@ -1174,7 +1269,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	/**
 	 * Returns <code>true</code> if the user currently selected
 	 * can link data to the selected object, <code>false</code> otherwise.
-	 * 
+	 *
 	 * @param node The node to handle.
 	 * @param userID The id of the selected user.
 	 * @param group The selected group.
@@ -1210,10 +1305,10 @@ class LocationDialog extends JDialog implements ActionListener,
             return false;
         return isAdmin;
 	}
-	
+
 	/**
 	 * Creates the renderer depending on the selected user.
-	 * 
+	 *
 	 * @return See above.
 	 */
 	private ComboBoxToolTipRenderer createComboboxRenderer()
@@ -1225,9 +1320,9 @@ class LocationDialog extends JDialog implements ActionListener,
 	}
 
 	/**
-	 * Populates the JComboBox with the user details provided, 
+	 * Populates the JComboBox with the user details provided,
 	 * selecting the logged in user and attaching the item listener.
-	 * 
+	 *
 	 * @param comboBox The JComboBox to populate
 	 * @param group The group being displayed
 	 * @param itemListener An item listener to add for the JComboBox
@@ -1284,22 +1379,22 @@ class LocationDialog extends JDialog implements ActionListener,
 			return;
 
 		DataNode newProjectNode = new DataNode(newProject);
-		DataNode newDefaultDatasetNode = new 
+		DataNode newDefaultDatasetNode = new
 				DataNode(DataNode.createDefaultDataset(), newProjectNode);
 		newProjectNode.addNode(newDefaultDatasetNode);
-		
+
 		List<DataNode> newDatasets = new ArrayList<DataNode>();
 		newDatasets.add(newDefaultDatasetNode);
-		
+
 		projects.add(newProjectNode);
-		projects = sortByUser(projects); 
+		projects = sortByUser(projects);
 		datasets.put(newProjectNode, newDatasets);
-		
+
 		currentProject = newProjectNode;
-		
+
 		displayItems(projectsBox, projects, newProjectNode, this);
 		displayItemsWithTooltips(datasetsBox, newDatasets);
-		
+
 		repaint();
 	}
 
@@ -1316,26 +1411,26 @@ class LocationDialog extends JDialog implements ActionListener,
 		DataNode newDatasetNode = new DataNode(dataset, selectedProject);
 
 		List<DataNode> projectDatasets = datasets.get(selectedProject);
-		
+
 		if(projectDatasets == null)
 		{
 			projectDatasets = new ArrayList<DataNode>();
-			DataNode newDefaultDatasetNode = new 
+			DataNode newDefaultDatasetNode = new
 					DataNode(DataNode.createDefaultDataset(), selectedProject);
 			selectedProject.addNode(newDefaultDatasetNode);
-			
+
 			projectDatasets.add(newDefaultDatasetNode);
 		}
-		
+
 		projectDatasets.add(newDatasetNode);
 		projectDatasets = sortByUser(projectDatasets);
-		
+
 		datasets.put(selectedProject, projectDatasets);
 
 		currentDataset = newDatasetNode;
-		
+
 		displayItemsWithTooltips(datasetsBox, projectDatasets, newDatasetNode);
-		
+
 		repaint();
 	}
 
@@ -1349,14 +1444,14 @@ class LocationDialog extends JDialog implements ActionListener,
 			return;
 
 		DataNode newScreenNode = new DataNode(newScreenObject);
-		
+
 		screens.add(newScreenNode);
 		screens = sortByUser(screens);
-		
+
 		currentScreen = newScreenNode;
-		
+
 		displayItemsWithTooltips(screensBox, screens, newScreenNode);
-		
+
 		repaint();
 	}
 
@@ -1390,7 +1485,7 @@ class LocationDialog extends JDialog implements ActionListener,
 					parent = n.getDataObject();
 				}
 			}
-			
+
 			GroupData selectedGroup = getSelectedGroup();
 
 			if (child != null) {
@@ -1399,7 +1494,7 @@ class LocationDialog extends JDialog implements ActionListener,
 						getSelectedUser()));
 			}
 		}
-		
+
         if (ImportDialog.REFRESH_LOCATION_PROPERTY.equals(name)
                 || ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
             busyLabel.setBusy(true);
@@ -1437,17 +1532,17 @@ class LocationDialog extends JDialog implements ActionListener,
 		projects.clear();
 		datasets.clear();
 		screens.clear();
-	
+
 		DataNode defaultProject = new DataNode(DataNode.createDefaultProject());
 		List<DataNode> orphanDatasets = new ArrayList<DataNode>();
-		
+
 		List<DataNode> lp = new ArrayList<DataNode>();
 		List<DataNode> ls = new ArrayList<DataNode>();
 		if (treeNodes != null)
 		{
 			for (TreeImageDisplay treeNode : treeNodes) {
 				Object userObject = treeNode.getUserObject();
-				
+
 				if (userObject instanceof ProjectData)
 				{
 					DataNode project = new DataNode((ProjectData) userObject);
@@ -1474,7 +1569,7 @@ class LocationDialog extends JDialog implements ActionListener,
 				{
 					DataNode dataset = new DataNode((DatasetData) userObject);
 					orphanDatasets.add(dataset);
-				}	
+				}
 			}
 		}
 		List<DataNode> l = new ArrayList<DataNode>();
@@ -1482,14 +1577,14 @@ class LocationDialog extends JDialog implements ActionListener,
 		l.add(new DataNode(DataNode.createNoDataset()));
 		l.addAll(sort(orphanDatasets));
 		datasets.put(defaultProject, l);
-		
+
 		projects.add(defaultProject);
 		projects.addAll(sort(lp));
-		
+
 		screens.add(new DataNode(DataNode.createDefaultScreen()));
 		screens.addAll(sort(ls));
 	}
-	
+
 	/**
 	 * Helper method to sort objects and casts as a List<T>.
 	 * @param list The list to sort
@@ -1499,7 +1594,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	{
 		return (List<T>) sorter.sort(list);
 	}
-	
+
 	/**
 	 * Populates the selection boxes with the currently selected data.
 	 */
@@ -1508,9 +1603,9 @@ class LocationDialog extends JDialog implements ActionListener,
 		DataNode selectedProject = null;
 		DataNode selectedDataset = null;
 		DataNode selectedScreen = null;
-		
-		/* work out what to select, 
-		 * NOTE: this defaults back to the selected container 
+
+		/* work out what to select,
+		 * NOTE: this defaults back to the selected container
 		 * on tab switch / refresh
 		 */
 		if (container != null)
@@ -1523,10 +1618,10 @@ class LocationDialog extends JDialog implements ActionListener,
 			} else if (hostObject instanceof DatasetData)
 			{
 				Object parentNode = getParentUserObject(container);
-				
+
 				selectedProject = findDataNode(projects,
 						parentNode, ProjectData.class);
-				
+
 				DatasetData datasetData = (DatasetData) hostObject;
 				long datasetId = datasetData.getId();
 				selectedDataset = findDataNodeById(
@@ -1562,7 +1657,7 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/**
 	 * Sorts the nodes.
-	 * 
+	 *
 	 * @param nodes The nodes to sort.
 	 * @return See above.
 	 */
@@ -1609,8 +1704,8 @@ class LocationDialog extends JDialog implements ActionListener,
 	}
 
 	/**
-     * Searches the list of nodes returning the entry with the same Id as 
-     * the find parameter, returns <null> if the list is empty, or the first 
+     * Searches the list of nodes returning the entry with the same Id as
+     * the find parameter, returns <null> if the list is empty, or the first
      * item in the list if the find parameter is not found or is null.
      * @param nodes The list of nodes to scan.
      * @param find The node to match Id against.
@@ -1620,12 +1715,12 @@ class LocationDialog extends JDialog implements ActionListener,
     private DataNode findDataNode(List<DataNode> nodes, DataNode find, int index)
     {
         if (CollectionUtils.isEmpty(nodes)) return null;
-        
+
         if (find == null) {
             if (index >= nodes.size()) return nodes.get(0);
             return nodes.get(index);
         }
-        
+
         for (DataNode node : nodes) {
             if (getIdOf(node) == getIdOf(find))
                 return node;
@@ -1633,10 +1728,10 @@ class LocationDialog extends JDialog implements ActionListener,
         if (index >= nodes.size()) return nodes.get(0);
         return nodes.get(index);
     }
-    
+
 	/**
-	 * Searches the list of nodes returning the entry with the same Id as 
-	 * the find parameter, returns <null> if the list is empty, or the first 
+	 * Searches the list of nodes returning the entry with the same Id as
+	 * the find parameter, returns <null> if the list is empty, or the first
 	 * item in the list if the find parameter is not found or is null.
 	 * @param nodes The list of nodes to scan.
 	 * @param find The node to match Id against.
@@ -1656,12 +1751,12 @@ class LocationDialog extends JDialog implements ActionListener,
 		if (node.getParentDisplay() == null) return null;
 		return node.getParentDisplay().getUserObject();
 	}
-	
+
 	/**
-	 * Searches a list of DataNodes for an entry with a matching Id and type to 
+	 * Searches a list of DataNodes for an entry with a matching Id and type to
 	 * that of the DataObject provided
 	 * @param list The list of DataNodes to search through.
-	 * @param find The object to 
+	 * @param find The object to
 	 * @param klass The Class<T> description of the type to match against.
 	 * @return
 	 */
@@ -1677,13 +1772,13 @@ class LocationDialog extends JDialog implements ActionListener,
 		}
 		if(selectedItem == null)
 			selectedItem = list.get(0);
-		
+
 		return selectedItem;
 	}
-	
+
 	/**
 	 * Resets the display to the selection and group specified.
-	 * 
+	 *
 	 * @param container The container that is selected
 	 * @param type The data type identifier (Project / SCreen)
 	 * @param objects The objects to use.
@@ -1713,14 +1808,14 @@ class LocationDialog extends JDialog implements ActionListener,
 		Object source = evt.getSource();
 		if (source == tabbedPane) {
 			JTabbedPane tabbedPane = (JTabbedPane) evt.getSource();
-			
+
 			JPanel activePanel = (JPanel) tabbedPane.getSelectedComponent();
 			// default to projects
 			int newDataType = Importer.PROJECT_TYPE;
-			
+
 			if (activePanel == screenPanel)
 				newDataType = Importer.SCREEN_TYPE;
-			
+
 			storeCurrentSelections();
 			firePropertyChange(ImportDialog.REFRESH_LOCATION_PROPERTY,
 					null, new ImportLocationDetails(newDataType,
@@ -1756,7 +1851,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		}
 		return null;
 	}
-	
+
 	/**
 	 * Returns the Id of the DataNode.
 	 * @param node The node to use.
@@ -1800,7 +1895,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	{
 		groupsBox.setSelectedItem(group);
 	}
-	
+
 	/**
 	 * Enables or disables the user input controls
 	 * @param isEnabled Whether to enable or disable the controls

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -43,11 +43,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JTabbedPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import javafx.scene.layout.VBox;
 import org.apache.commons.collections.CollectionUtils;
 import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
@@ -96,8 +108,8 @@ import omero.gateway.model.ScreenData;
 class LocationDialog extends JDialog implements ActionListener,
 		PropertyChangeListener, ChangeListener, ItemListener {
 
-    /**Bound property indicating to add the files to the queue.*/
-    static final String ADD_TO_QUEUE_PROPERTY = "addToQueue";
+	/**Bound property indicating to add the files to the queue.*/
+	static final String ADD_TO_QUEUE_PROPERTY = "addToQueue";
 
 	/** Default GAP value for UI components */
 	private static final int UI_GAP = 5;
@@ -155,12 +167,6 @@ class LocationDialog extends JDialog implements ActionListener,
 
 	/** Tooltip for Reload button */
 	private static final String TEXT_REFRESH = "Refresh";
-
-	/** Tooltip for show basic button */
-	private static final String TEXT_BASIC = "Basic";
-
-	/** Tooltip for show basic button */
-	private static final String TEXT_ADVANCED = "Advanced";
 
 	/** Tooltip for Reload button */
 	private static final String TOOLTIP_REFRESH =
@@ -225,12 +231,6 @@ class LocationDialog extends JDialog implements ActionListener,
 	/** User has chosen to force a refresh of the containers */
 	private static final int CMD_REFRESH_DISPLAY = 4;
 
-	/** Action id to show advanced import options panel */
-	private static final int CMD_SHOW_ADVANCED_PANEL = 7;
-
-	/** Action id to show basic (hide advanced) import panel options panel */
-	private static final int CMD_HIDE_ADVANCED_PANEL = 8;
-
 	/** User has selected to add the files. */
 	final static int CMD_ADD = 5;
 
@@ -268,9 +268,6 @@ class LocationDialog extends JDialog implements ActionListener,
 	/** Component used to select the default screen. */
 	private JComboBox screensBox;
 
-	/** Component used to select advanced import options */
-	private JComboBox advancedBox;
-
 	/** Button to create a new project. */
 	private JButton newProjectButton;
 
@@ -283,17 +280,8 @@ class LocationDialog extends JDialog implements ActionListener,
 	/** Button used to refresh the groups/projects/datasets & screens */
 	private JButton refreshButton;
 
-	/** Button used to show or hide advanced options for importing images */
-	private JButton basicAdvButton;
-
 	/** Tab pane used to hose the Project/Screen selection UI component. */
 	private JTabbedPane tabbedPane;
-
-	private JPanel advOptsPanel;
-
-	private JCheckBox thumbGenCheckbox;
-	private JCheckBox minMaxCheckBox;
-	private JCheckBox checksumCheckBox;
 
 	// Operational variables & constants
 	/** Constant value for no data type */
@@ -337,15 +325,15 @@ class LocationDialog extends JDialog implements ActionListener,
 	private Importer model;
 
 
-    /**
-     * Flag indicating to import the image from the current window if
-     * <code>true</code>, <code>false</code> to import the images from
-     * all windows.
-     */
-    private boolean activeWindow;
+	/**
+	 * Flag indicating to import the image from the current window if
+	 * <code>true</code>, <code>false</code> to import the images from
+	 * all windows.
+	 */
+	private boolean activeWindow;
 
-    /** Indicates the loading progress. */
-    private JXBusyLabel     busyLabel;
+	/** Indicates the loading progress. */
+	private JXBusyLabel     busyLabel;
 
 	/**
 	 * Creates a new instance.
@@ -360,8 +348,8 @@ class LocationDialog extends JDialog implements ActionListener,
 	 *                 Option indicating which window to select
 	 */
 	LocationDialog(JFrame parent, TreeImageDisplay selectedContainer,
-			int importDataType, Collection<TreeImageDisplay> objects,
-			Importer model, long currentGroupId, boolean ijoption)
+				   int importDataType, Collection<TreeImageDisplay> objects,
+				   Importer model, long currentGroupId, boolean ijoption)
 	{
 		super(parent);
 		this.container = selectedContainer;
@@ -375,7 +363,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		initUIComponents();
 		layoutUI(ijoption);
 		populateUIWithDisplayData(findWithId(groups, currentGroupId),
-		        model.getImportFor());
+				model.getImportFor());
 
 		addPropertyChangeListener(this);
 
@@ -445,7 +433,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @return The DataObject in the list with matching id, <null> if not found.
 	 */
 	private <T extends DataObject> T findWithId(Collection<T> dataObjects,
-			long id) {
+												long id) {
 
 		for (T dataObject : dataObjects) {
 			if (dataObject.getId() == id)
@@ -492,11 +480,6 @@ class LocationDialog extends JDialog implements ActionListener,
 		refreshButton.setActionCommand("" + CMD_REFRESH_DISPLAY);
 		refreshButton.addActionListener(this);
 
-		basicAdvButton = new JButton(TEXT_BASIC);
-		basicAdvButton.setBackground(UIUtilities.BACKGROUND);
-		basicAdvButton.setActionCommand("" + CMD_SHOW_ADVANCED_PANEL);
-        basicAdvButton.addActionListener(this);
-
 		projectsBox = new JComboBox();
 		projectsBox.addItemListener(this);
 
@@ -505,20 +488,6 @@ class LocationDialog extends JDialog implements ActionListener,
 
 		screensBox = new JComboBox();
 		screensBox.addItemListener(this);
-
-		// Check box options for advanced panel
-		thumbGenCheckbox = new JCheckBox("Skip thumbnail generation");
-		thumbGenCheckbox.addItemListener(e -> {
-
-		});
-		minMaxCheckBox = new JCheckBox("Skip min/max compute");
-		minMaxCheckBox.addItemListener(e ->  {
-
-		});
-		checksumCheckBox = new JCheckBox("Skip checksum checking");
-		checksumCheckBox.addItemListener(e -> {
-
-		});
 
 		// main location panel buttons
 		newProjectButton = new JButton(TEXT_NEW);
@@ -548,16 +517,13 @@ class LocationDialog extends JDialog implements ActionListener,
 		closeButton.addActionListener(this);
 		closeButton.setActionCommand("" + CMD_CLOSE);
 
-        Dimension d = new Dimension(UIUtilities.DEFAULT_ICON_WIDTH,
-                UIUtilities.DEFAULT_ICON_HEIGHT);
-        busyLabel = new JXBusyLabel(d);
-        busyLabel.setVisible(true);
-        busyLabel.setBusy(true);
+		Dimension d = new Dimension(UIUtilities.DEFAULT_ICON_WIDTH,
+				UIUtilities.DEFAULT_ICON_HEIGHT);
+		busyLabel = new JXBusyLabel(d);
+		busyLabel.setVisible(true);
+		busyLabel.setBusy(true);
 
 		getRootPane().setDefaultButton(addButton);
-
-		// Advanced panel sits under tabbed panel
-		advOptsPanel = buildAdvancedOptionsPanel();
 	}
 
 	/**
@@ -573,15 +539,14 @@ class LocationDialog extends JDialog implements ActionListener,
 		buttonPanel.setLayout(lay);
 		int plugin = ImporterAgent.runAsPlugin();
 		if (plugin != LookupNames.IMAGE_J_IMPORT &&
-		        plugin != LookupNames.IMAGE_J) {
-		    buttonPanel.add(closeButton);
-	        buttonPanel.add(refreshButton);
-            buttonPanel.add(basicAdvButton);
+				plugin != LookupNames.IMAGE_J) {
+			buttonPanel.add(closeButton);
+			buttonPanel.add(refreshButton);
 		} else {
-		    if (!ijoption) {
-		        buttonPanel.add(closeButton);
-            }
-		    buttonPanel.add(refreshButton);
+			if (!ijoption) {
+				buttonPanel.add(closeButton);
+			}
+			buttonPanel.add(refreshButton);
 		}
 
 		buttonPanel.add(Box.createHorizontalGlue());
@@ -641,11 +606,11 @@ class LocationDialog extends JDialog implements ActionListener,
 		c.anchor = GridBagConstraints.WEST;
 
 		if (groups.size() > 1) {
-	        groupPanel.add(UIUtilities.setTextFont(TEXT_GROUP), c);
-	        c.gridx++;
-	        groupPanel.add(groupsBox,c);
-	        c.gridy++;
-	        c.gridx=0;
+			groupPanel.add(UIUtilities.setTextFont(TEXT_GROUP), c);
+			c.gridx++;
+			groupPanel.add(groupsBox,c);
+			c.gridy++;
+			c.gridx=0;
 		}
 		if (usersBox.isVisible()) {
 			groupPanel.add(UIUtilities.setTextFont(TEXT_IMPORT_AS), c);
@@ -668,113 +633,82 @@ class LocationDialog extends JDialog implements ActionListener,
 		return groupPanel;
 	}
 
-    /**
-     * Builds a JPanel holding the project selection section.
-     *
-     * @return JPanel holding the project selection UI elements
-     */
-    private JPanel buildProjectSelectionPanel() {
-        JPanel projectPanel = new JPanel(new GridBagLayout());
-
-        GridBagConstraints c = new GridBagConstraints();
-        c.insets = new Insets(1, 1, 1, 1);
-        c.gridx = 0;
-        c.gridy = 0;
-        c.fill = GridBagConstraints.NONE;
-        c.anchor = GridBagConstraints.WEST;
-        c.weightx = 0;
-        c.weighty = 0;
-
-        projectPanel.add(UIUtilities.setTextFont(TEXT_PROJECT), c);
-        c.gridx++;
-        c.fill = GridBagConstraints.HORIZONTAL;
-        c.weightx = 1;
-        projectPanel.add(projectsBox, c);
-        c.gridx++;
-        c.fill = GridBagConstraints.NONE;
-        c.weightx = 0;
-        projectPanel.add(newProjectButton, c);
-        c.gridy++;
-
-        c.gridx = 0;
-        projectPanel.add(UIUtilities.setTextFont(TEXT_DATASET), c);
-        c.gridx++;
-        c.fill = GridBagConstraints.HORIZONTAL;
-        c.weightx = 1;
-        projectPanel.add(datasetsBox, c);
-        c.gridx++;
-        c.fill = GridBagConstraints.NONE;
-        c.weightx = 0;
-        projectPanel.add(newDatasetButton, c);
-
-        projectPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
-                UI_GAP, UI_GAP));
-
-        return projectPanel;
-    }
-
-    /**
-     * Builds a JPanel holding the screen selection section.
-     *
-     * @return JPanel holding the screen selection UI elements
-     */
-    private JPanel buildScreenSelectionPanel() {
-        JPanel screenPanel = new JPanel(new GridBagLayout());
-
-        GridBagConstraints c = new GridBagConstraints();
-        c.insets = new Insets(1, 1, 1, 1);
-        c.gridx = 0;
-        c.gridy = 0;
-        c.fill = GridBagConstraints.NONE;
-        c.anchor = GridBagConstraints.WEST;
-        c.weightx = 0;
-        c.weighty = 0;
-
-        screenPanel.add(UIUtilities.setTextFont(TEXT_SCREEN), c);
-        c.gridx++;
-        c.fill = GridBagConstraints.HORIZONTAL;
-        c.weightx = 1;
-        screenPanel.add(screensBox, c);
-        c.gridx++;
-        c.fill = GridBagConstraints.NONE;
-        c.weightx = 0;
-        screenPanel.add(newScreenButton, c);
-
-        screenPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
-                UI_GAP, UI_GAP));
-
-        return screenPanel;
-    }
-
-    private JPanel buildAdvancedOptionsPanel() {
-    	// Create checkboxes
-		JPanel advPanel = new JPanel(new GridBagLayout());
-		// advPanel.setVisible(false);
+	/**
+	 * Builds a JPanel holding the project selection section.
+	 *
+	 * @return JPanel holding the project selection UI elements
+	 */
+	private JPanel buildProjectSelectionPanel() {
+		JPanel projectPanel = new JPanel(new GridBagLayout());
 
 		GridBagConstraints c = new GridBagConstraints();
 		c.insets = new Insets(1, 1, 1, 1);
+		c.gridx = 0;
+		c.gridy = 0;
 		c.fill = GridBagConstraints.NONE;
 		c.anchor = GridBagConstraints.WEST;
+		c.weightx = 0;
+		c.weighty = 0;
 
-		c.gridy = 0;
+		projectPanel.add(UIUtilities.setTextFont(TEXT_PROJECT), c);
+		c.gridx++;
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.weightx = 1;
-		advPanel.add(thumbGenCheckbox, c);
+		projectPanel.add(projectsBox, c);
+		c.gridx++;
+		c.fill = GridBagConstraints.NONE;
+		c.weightx = 0;
+		projectPanel.add(newProjectButton, c);
+		c.gridy++;
 
-		c.gridy = 1;
+		c.gridx = 0;
+		projectPanel.add(UIUtilities.setTextFont(TEXT_DATASET), c);
+		c.gridx++;
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.weightx = 1;
-		advPanel.add(minMaxCheckBox, c);
+		projectPanel.add(datasetsBox, c);
+		c.gridx++;
+		c.fill = GridBagConstraints.NONE;
+		c.weightx = 0;
+		projectPanel.add(newDatasetButton, c);
 
-		c.gridy = 2;
-		c.fill = GridBagConstraints.HORIZONTAL;
-		c.weightx = 1;
-		advPanel.add(checksumCheckBox, c);
-
-		advPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
+		projectPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
 				UI_GAP, UI_GAP));
 
-		return advPanel;
+		return projectPanel;
+	}
+
+	/**
+	 * Builds a JPanel holding the screen selection section.
+	 *
+	 * @return JPanel holding the screen selection UI elements
+	 */
+	private JPanel buildScreenSelectionPanel() {
+		JPanel screenPanel = new JPanel(new GridBagLayout());
+
+		GridBagConstraints c = new GridBagConstraints();
+		c.insets = new Insets(1, 1, 1, 1);
+		c.gridx = 0;
+		c.gridy = 0;
+		c.fill = GridBagConstraints.NONE;
+		c.anchor = GridBagConstraints.WEST;
+		c.weightx = 0;
+		c.weighty = 0;
+
+		screenPanel.add(UIUtilities.setTextFont(TEXT_SCREEN), c);
+		c.gridx++;
+		c.fill = GridBagConstraints.HORIZONTAL;
+		c.weightx = 1;
+		screenPanel.add(screensBox, c);
+		c.gridx++;
+		c.fill = GridBagConstraints.NONE;
+		c.weightx = 0;
+		screenPanel.add(newScreenButton, c);
+
+		screenPanel.setBorder(BorderFactory.createEmptyBorder(UI_GAP, UI_GAP,
+				UI_GAP, UI_GAP));
+
+		return screenPanel;
 	}
 
 	/**
@@ -785,19 +719,19 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @param userID The selected user.
 	 */
 	private void populateGroupBox(Collection<GroupData> availableGroups,
-			GroupData selectedGroup, long userID)
+								  GroupData selectedGroup, long userID)
 	{
 		groupsBox.removeItemListener(this);
 		groupsBox.removeAllItems();
 		JComboBoxImageObject selectedGroupItem = null;
 		JComboBoxImageObject item;
 		List<String> tooltips = new ArrayList<String>(availableGroups.size());
-        List<String> lines;
+		List<String> lines;
 		for (GroupData group : availableGroups) {
 			item = new JComboBoxImageObject(group, getGroupIcon(group));
 			lines = new ArrayList<String>();
-            lines.addAll(UIUtilities.wrapStyleWord(group.getName()));
-            tooltips.add(UIUtilities.formatToolTipText(lines));
+			lines.addAll(UIUtilities.wrapStyleWord(group.getName()));
+			tooltips.add(UIUtilities.formatToolTipText(lines));
 			groupsBox.addItem(item);
 			if (selectedGroup != null && selectedGroup.getId() == group.getId())
 				selectedGroupItem = item;
@@ -826,7 +760,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @return See above.
 	 */
 	private boolean canImportForUserInGroup(ExperimenterData user,
-			GroupData selectedGroup) {
+											GroupData selectedGroup) {
 		ExperimenterData loggedInUser = ImporterAgent.getUserDetails();
 		if (user.getId() == loggedInUser.getId()) return true;
 		if (ImporterAgent.isAdministrator()) return true;
@@ -847,18 +781,18 @@ class LocationDialog extends JDialog implements ActionListener,
 	private Icon getGroupIcon(GroupData group)
 	{
 		switch (group.getPermissions().getPermissionsLevel()) {
-		case GroupData.PERMISSIONS_PRIVATE:
-			return GROUP_PRIVATE_ICON;
-		case GroupData.PERMISSIONS_GROUP_READ:
-			return GROUP_READ_ONLY_ICON;
-		case GroupData.PERMISSIONS_GROUP_READ_LINK:
-			return GROUP_READ_LINK_ICON;
-		case GroupData.PERMISSIONS_GROUP_READ_WRITE:
-			return GROUP_READ_WRITE_ICON;
-		case GroupData.PERMISSIONS_PUBLIC_READ:
-			return GROUP_PUBLIC_READ_ICON;
-		case GroupData.PERMISSIONS_PUBLIC_READ_WRITE:
-			return GROUP_PUBLIC_READ_WRITE_ICON;
+			case GroupData.PERMISSIONS_PRIVATE:
+				return GROUP_PRIVATE_ICON;
+			case GroupData.PERMISSIONS_GROUP_READ:
+				return GROUP_READ_ONLY_ICON;
+			case GroupData.PERMISSIONS_GROUP_READ_LINK:
+				return GROUP_READ_LINK_ICON;
+			case GroupData.PERMISSIONS_GROUP_READ_WRITE:
+				return GROUP_READ_WRITE_ICON;
+			case GroupData.PERMISSIONS_PUBLIC_READ:
+				return GROUP_PUBLIC_READ_ICON;
+			case GroupData.PERMISSIONS_PUBLIC_READ_WRITE:
+				return GROUP_PUBLIC_READ_WRITE_ICON;
 		}
 		return null;
 	}
@@ -867,39 +801,40 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * Builds and lays out the UI.
 	 *
 	 * @param ijoption This is only used in imagej mode.
-     *                 Option indicating which window to select.
+	 *                 Option indicating which window to select.
 	 */
 	private void layoutUI(boolean ijoption)
 	{
-	    int plugin = ImporterAgent.runAsPlugin();
-        JComponent pane;
-        if (plugin == LookupNames.IMAGE_J_IMPORT ||plugin == LookupNames.IMAGE_J) {
-            activeWindow = true;
-            JPanel buttons = new JPanel();
-            buttons.setLayout(new BoxLayout(buttons, BoxLayout.Y_AXIS));
-            ButtonGroup group = new ButtonGroup();
-            JRadioButton b = new JRadioButton("Add Image from current window");
-            b.setSelected(activeWindow);
-            buttons.add(b);
-            group.add(b);
-            b.addItemListener(new ItemListener() {
-                @Override
-                public void itemStateChanged(ItemEvent e) {
-                    activeWindow = (e.getStateChange() == ItemEvent.SELECTED);
-                }
-            });
-            b = new JRadioButton("Add Images from all image windows");
-            buttons.add(b);
-            group.add(b);
-            pane = new JPanel();
-            pane.setLayout(new BorderLayout());
-            pane.add(buildDataTypeTabbedPane(), BorderLayout.CENTER);
-            if (ijoption) {
-                pane.add(UIUtilities.buildComponentPanel(buttons), BorderLayout.SOUTH);
-            }
-        } else {
-            pane = buildDataTypeTabbedPane();
-        }
+		int plugin = ImporterAgent.runAsPlugin();
+		JComponent pane;
+		if (plugin == LookupNames.IMAGE_J_IMPORT ||plugin == LookupNames.IMAGE_J) {
+			activeWindow = true;
+			JPanel buttons = new JPanel();
+			buttons.setLayout(new BoxLayout(buttons, BoxLayout.Y_AXIS));
+			ButtonGroup group = new ButtonGroup();
+			JRadioButton b = new JRadioButton("Add Image from current window");
+			b.setSelected(activeWindow);
+			buttons.add(b);
+			group.add(b);
+			b.addItemListener(new ItemListener() {
+
+				@Override
+				public void itemStateChanged(ItemEvent e) {
+					activeWindow = (e.getStateChange() == ItemEvent.SELECTED);
+				}
+			});
+			b = new JRadioButton("Add Images from all image windows");
+			buttons.add(b);
+			group.add(b);
+			pane = new JPanel();
+			pane.setLayout(new BorderLayout());
+			pane.add(buildDataTypeTabbedPane(), BorderLayout.CENTER);
+			if (ijoption) {
+				pane.add(UIUtilities.buildComponentPanel(buttons), BorderLayout.SOUTH);
+			}
+		} else {
+			pane = buildDataTypeTabbedPane();
+		}
 
 		BorderLayout layout = new BorderLayout();
 		layout.setHgap(UI_GAP);
@@ -908,16 +843,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		JPanel content = new JPanel();
 		content.setLayout(new BorderLayout());
 		content.add(buildGroupSelectionPanel(),BorderLayout.NORTH);
-
-		JPanel centerPanel = new JPanel();
-		centerPanel.setLayout(new BoxLayout(centerPanel, BoxLayout.Y_AXIS));
-		centerPanel.add(pane);
-
-		advOptsPanel = buildAdvancedOptionsPanel();
-		centerPanel.add(advOptsPanel);
-
-		content.add(centerPanel, BorderLayout.CENTER);
-
+		content.add(pane, BorderLayout.CENTER);
 		content.add(buildLowerButtonPanel(ijoption), BorderLayout.SOUTH);
 		content.setBorder(BorderFactory.createEmptyBorder(UI_GAP,UI_GAP,UI_GAP,UI_GAP));
 		this.getContentPane().setLayout(new BorderLayout());
@@ -953,13 +879,13 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @return The JPanel wrapping the container
 	 */
 	private <T extends Container> JPanel wrapInPaddedPanel(T container,
-			int top, int left, int bottom, int right)
+														   int top, int left, int bottom, int right)
 	{
-	    JPanel p = new JPanel();
-	    p.setLayout(new BorderLayout());
-	    p.setBorder(BorderFactory.createEmptyBorder(top, left, bottom, right));
-	    p.add(container, BorderLayout.CENTER);
-	    return p;
+		JPanel p = new JPanel();
+		p.setLayout(new BorderLayout());
+		p.setBorder(BorderFactory.createEmptyBorder(top, left, bottom, right));
+		p.add(container, BorderLayout.CENTER);
+		return p;
 	}
 
 	/**
@@ -967,11 +893,11 @@ class LocationDialog extends JDialog implements ActionListener,
 	 */
 	private void close()
 	{
-	    int plugin = ImporterAgent.runAsPlugin();
-        if (plugin == LookupNames.IMAGE_J
-                || plugin == LookupNames.IMAGE_J_IMPORT) {
-            return;
-        }
+		int plugin = ImporterAgent.runAsPlugin();
+		if (plugin == LookupNames.IMAGE_J
+				|| plugin == LookupNames.IMAGE_J_IMPORT) {
+			return;
+		}
 		setVisible(false);
 		dispose();
 	}
@@ -1031,19 +957,6 @@ class LocationDialog extends JDialog implements ActionListener,
 					storeCurrentSelections();
 					firePropertyChange(ImportDialog.REFRESH_LOCATION_PROPERTY,
 							null, new ImportLocationDetails(dataType));
-					break;
-				case CMD_SHOW_ADVANCED_PANEL:
-					basicAdvButton.setText(TEXT_BASIC);
-                    basicAdvButton.setActionCommand("" + CMD_HIDE_ADVANCED_PANEL);
-					advOptsPanel.setVisible(true);
-					pack();
-					break;
-                case CMD_HIDE_ADVANCED_PANEL:
-                    basicAdvButton.setText(TEXT_ADVANCED);
-                    basicAdvButton.setActionCommand("" + CMD_SHOW_ADVANCED_PANEL);
-					advOptsPanel.setVisible(false);
-					pack();
-                    break;
 			}
 
 			if (newDataObject != null) {
@@ -1056,14 +969,6 @@ class LocationDialog extends JDialog implements ActionListener,
 			}
 		} catch (NumberFormatException nfe) {
 		}
-	}
-
-	private void showAdvancedPanel() {
-
-	}
-
-	private void hideAdvancedPanel() {
-
 	}
 
 	/**
@@ -1142,7 +1047,7 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @param listItems The items to populate the box with
 	 */
 	private void displayItemsWithTooltips(JComboBox comboBox,
-			List<DataNode> listItems)
+										  List<DataNode> listItems)
 	{
 		displayItems(comboBox, listItems, null, null);
 	}
@@ -1156,9 +1061,9 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @param selected The item to select in the JComboBox
 	 */
 	private void displayItemsWithTooltips(JComboBox comboBox,
-			List<DataNode> listItems, DataNode selected)
+										  List<DataNode> listItems, DataNode selected)
 	{
-	    displayItems(comboBox, listItems, selected, null);
+		displayItems(comboBox, listItems, selected, null);
 	}
 
 	/**
@@ -1170,21 +1075,21 @@ class LocationDialog extends JDialog implements ActionListener,
 	 */
 	private boolean isAdmin(long userID)
 	{
-	    Iterator<GroupData> i = groups.iterator();
-	    GroupData g;
-	    Set<ExperimenterData> experimenters;
-	    while (i.hasNext()) {
-            g = i.next();
-            if (model.isSystemGroup(g.getId(), GroupData.SYSTEM)) {
-                experimenters = g.getExperimenters();
-                Iterator<ExperimenterData> j = experimenters.iterator();
-                while (j.hasNext()) {
-                    if (j.next().getId() == userID)
-                        return true;
-                }
-            }
-        }
-	    return false;
+		Iterator<GroupData> i = groups.iterator();
+		GroupData g;
+		Set<ExperimenterData> experimenters;
+		while (i.hasNext()) {
+			g = i.next();
+			if (model.isSystemGroup(g.getId(), GroupData.SYSTEM)) {
+				experimenters = g.getExperimenters();
+				Iterator<ExperimenterData> j = experimenters.iterator();
+				while (j.hasNext()) {
+					if (j.next().getId() == userID)
+						return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -1197,11 +1102,11 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @param itemListener An item listener to add for the JComboBox
 	 */
 	private void displayItems(JComboBox comboBox,
-			List<DataNode> listItems, DataNode select,
-			ItemListener itemListener)
+							  List<DataNode> listItems, DataNode select,
+							  ItemListener itemListener)
 	{
 		if (comboBox == null || listItems == null)
-		    return;
+			return;
 		//Only add the item the user can actually select
 		if (itemListener != null)
 			comboBox.removeItemListener(itemListener);
@@ -1217,7 +1122,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		ExperimenterData user = getSelectedUser();
 		long userID = -1;
 		if (user != null)
-		    userID = user.getId();
+			userID = user.getId();
 		ExperimenterData loggedIn = ImporterAgent.getUserDetails();
 		boolean isAdmin = ImporterAgent.isAdministrator();
 		long loggedInID = loggedIn.getId();
@@ -1240,16 +1145,16 @@ class LocationDialog extends JDialog implements ActionListener,
 			Selectable<DataNode> comboBoxItem =
 					new Selectable<DataNode>(node, selectable);
 			if (select != null) {
-			    if (node.getDataObject().getId() < 0
-			            && select.getDataObject().getId() < 0) {
-			        if (node.toString().trim().equals(select.toString().trim()))
-			            selected = comboBoxItem;
-			    } else {
-			        if (node.getDataObject().getId() ==
-			                select.getDataObject().getId()) {
-			            selected = comboBoxItem;
-			        }
-			    }
+				if (node.getDataObject().getId() < 0
+						&& select.getDataObject().getId() < 0) {
+					if (node.toString().trim().equals(select.toString().trim()))
+						selected = comboBoxItem;
+				} else {
+					if (node.getDataObject().getId() ==
+							select.getDataObject().getId()) {
+						selected = comboBoxItem;
+					}
+				}
 			}
 			model.addElement(comboBoxItem);
 		}
@@ -1277,33 +1182,33 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @param isAdmin Returns <code>true</code> if the logged in user is an
 	 *                administrator, <code>false</code> otherwise.
 	 * @param userIsAdmin Returns <code>true</code> if the selected user is an
-     *                administrator, <code>false</code> otherwise.
+	 *                administrator, <code>false</code> otherwise.
 	 * @return See above.
 	 */
 	private boolean canLink(DataObject node, long userID, GroupData group,
-			long loggedUserID, boolean isAdmin, boolean userIsAdmin)
+							long loggedUserID, boolean isAdmin, boolean userIsAdmin)
 	{
-	    //data owner
+		//data owner
 		if (node.getOwner().getId() == userID) return true;
 		if (!node.canLink()) return false; //handle private group case.
-        PermissionData permissions = group.getPermissions();
-        if (permissions.getPermissionsLevel() == GroupData.PERMISSIONS_PRIVATE)
-            return false;
-        if (permissions.isGroupWrite() || userIsAdmin) return true;
-        //read-only group and higher
-        //is the selected user a group owner.
-        Set leaders = group.getLeaders();
-        if (leaders != null) {
-            Iterator i = leaders.iterator();
-            ExperimenterData exp;
-            while (i.hasNext()) {
-                exp = (ExperimenterData) i.next();
-                if (exp.getId() == userID) return true;
-            }
-        }
-        if (userID != loggedUserID)
-            return false;
-        return isAdmin;
+		PermissionData permissions = group.getPermissions();
+		if (permissions.getPermissionsLevel() == GroupData.PERMISSIONS_PRIVATE)
+			return false;
+		if (permissions.isGroupWrite() || userIsAdmin) return true;
+		//read-only group and higher
+		//is the selected user a group owner.
+		Set leaders = group.getLeaders();
+		if (leaders != null) {
+			Iterator i = leaders.iterator();
+			ExperimenterData exp;
+			while (i.hasNext()) {
+				exp = (ExperimenterData) i.next();
+				if (exp.getId() == userID) return true;
+			}
+		}
+		if (userID != loggedUserID)
+			return false;
+		return isAdmin;
 	}
 
 	/**
@@ -1329,44 +1234,44 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @param userID The id of the user.
 	 */
 	private void displayUsers(JComboBox comboBox, GroupData group,
-	        ItemListener itemListener, long userID) {
+							  ItemListener itemListener, long userID) {
 
-	    if (comboBox == null || group == null) return;
+		if (comboBox == null || group == null) return;
 
-	    if (itemListener != null)
-	        comboBox.removeItemListener(itemListener);
-	    comboBox.removeAllItems();
+		if (itemListener != null)
+			comboBox.removeItemListener(itemListener);
+		comboBox.removeAllItems();
 
-	    DefaultComboBoxModel model = new SelectableComboBoxModel();
-	    Selectable<ExperimenterDisplay> selected = null;
+		DefaultComboBoxModel model = new SelectableComboBoxModel();
+		Selectable<ExperimenterDisplay> selected = null;
 
-	    List<ExperimenterData> members = sort(group.getExperimenters());
-	    boolean canImportAs;
-	    Selectable<ExperimenterDisplay> item;
-	    List<String> tooltips = new ArrayList<String>(members.size());
-	    List<String> lines;
-	    for (ExperimenterData user : members) {
-	        canImportAs = canImportForUserInGroup(user, group);
-	        item = new Selectable<ExperimenterDisplay>(
-	                new ExperimenterDisplay(user), canImportAs);
-	        if (user.getId() == userID)
-	            selected = item;
-	        lines = new ArrayList<String>();
-	        lines.addAll(UIUtilities.wrapStyleWord(
-	                EditorUtil.formatExperimenter(user)));
-	        tooltips.add(UIUtilities.formatToolTipText(lines));
-	        model.addElement(item);
-	    }
-	    ComboBoxToolTipRenderer renderer = createComboboxRenderer();
-	    renderer.setTooltips(tooltips);
-	    comboBox.setModel(model);
-	    comboBox.setRenderer(renderer);
+		List<ExperimenterData> members = sort(group.getExperimenters());
+		boolean canImportAs;
+		Selectable<ExperimenterDisplay> item;
+		List<String> tooltips = new ArrayList<String>(members.size());
+		List<String> lines;
+		for (ExperimenterData user : members) {
+			canImportAs = canImportForUserInGroup(user, group);
+			item = new Selectable<ExperimenterDisplay>(
+					new ExperimenterDisplay(user), canImportAs);
+			if (user.getId() == userID)
+				selected = item;
+			lines = new ArrayList<String>();
+			lines.addAll(UIUtilities.wrapStyleWord(
+					EditorUtil.formatExperimenter(user)));
+			tooltips.add(UIUtilities.formatToolTipText(lines));
+			model.addElement(item);
+		}
+		ComboBoxToolTipRenderer renderer = createComboboxRenderer();
+		renderer.setTooltips(tooltips);
+		comboBox.setModel(model);
+		comboBox.setRenderer(renderer);
 
-	    if (selected != null)
-	        comboBox.setSelectedItem(selected);
+		if (selected != null)
+			comboBox.setSelectedItem(selected);
 
-	    if (itemListener != null)
-	        comboBox.addItemListener(itemListener);
+		if (itemListener != null)
+			comboBox.addItemListener(itemListener);
 	}
 
 	/**
@@ -1491,23 +1396,23 @@ class LocationDialog extends JDialog implements ActionListener,
 			if (child != null) {
 				firePropertyChange(ImportDialog.CREATE_OBJECT_PROPERTY, null,
 						new ObjectToCreate(selectedGroup, child, parent,
-						getSelectedUser()));
+								getSelectedUser()));
 			}
 		}
 
-        if (ImportDialog.REFRESH_LOCATION_PROPERTY.equals(name)
-                || ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
-            busyLabel.setBusy(true);
-            busyLabel.setVisible(true);
-            addButton.setEnabled(false);
-            Object value = evt.getNewValue();
-            if(value != null && value instanceof ImportLocationDetails) {
-                ImportLocationDetails details = (ImportLocationDetails) evt
-                        .getNewValue();
-                if (details != null)
-                    dataType = (int) details.getDataType();
-            }
-        }
+		if (ImportDialog.REFRESH_LOCATION_PROPERTY.equals(name)
+				|| ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
+			busyLabel.setBusy(true);
+			busyLabel.setVisible(true);
+			addButton.setEnabled(false);
+			Object value = evt.getNewValue();
+			if(value != null && value instanceof ImportLocationDetails) {
+				ImportLocationDetails details = (ImportLocationDetails) evt
+						.getNewValue();
+				if (details != null)
+					dataType = (int) details.getDataType();
+			}
+		}
 	}
 
 	/**
@@ -1614,7 +1519,7 @@ class LocationDialog extends JDialog implements ActionListener,
 			if (hostObject instanceof ProjectData)
 			{
 				selectedProject = findDataNode(projects,
-					hostObject, ProjectData.class);
+						hostObject, ProjectData.class);
 			} else if (hostObject instanceof DatasetData)
 			{
 				Object parentNode = getParentUserObject(container);
@@ -1635,10 +1540,10 @@ class LocationDialog extends JDialog implements ActionListener,
 			selectedProject = findDataNode(projects, currentProject);
 			int index = 0;
 			switch (ImporterAgent.runAsPlugin()) {
-                case LookupNames.IMAGE_J:
-                case LookupNames.IMAGE_J_IMPORT:
-                    index = 1;
-            }
+				case LookupNames.IMAGE_J:
+				case LookupNames.IMAGE_J_IMPORT:
+					index = 1;
+			}
 			selectedDataset = findDataNode(datasets.get(selectedProject),
 					currentDataset, index);
 			selectedScreen = findDataNode(screens, currentScreen);
@@ -1647,9 +1552,9 @@ class LocationDialog extends JDialog implements ActionListener,
 		displayItems(projectsBox, sortByUser(projects),
 				selectedProject, this);
 		if (selectedProject != null) {
-		      displayItemsWithTooltips(datasetsBox,
-		                sortByUser(datasets.get(selectedProject)),
-		                selectedDataset);
+			displayItemsWithTooltips(datasetsBox,
+					sortByUser(datasets.get(selectedProject)),
+					selectedDataset);
 		}
 		displayItemsWithTooltips(screensBox,
 				sortByUser(screens), selectedScreen);
@@ -1669,10 +1574,10 @@ class LocationDialog extends JDialog implements ActionListener,
 		sorted.add(nodes.get(0)); //default node.
 		DataNode node;
 		if (nodes.size() > 1) {
-		    node = nodes.get(1);
-		    if (node.isNoDataset()) {
-		        sorted.add(node);
-		    }
+			node = nodes.get(1);
+			if (node.isNoDataset()) {
+				sorted.add(node);
+			}
 		}
 		Iterator<DataNode> i = nodes.iterator();
 		while (i.hasNext()) {
@@ -1685,7 +1590,7 @@ class LocationDialog extends JDialog implements ActionListener,
 		List<DataNode> l = null;
 		if (exp != null) l = map.get(exp.getId());
 		if (CollectionUtils.isNotEmpty(l))
-		    sorted.addAll(sort(l));
+			sorted.addAll(sort(l));
 		//items are ordered by users.
 		long id;
 		ExperimenterData user;
@@ -1694,9 +1599,9 @@ class LocationDialog extends JDialog implements ActionListener,
 			if (user != null && exp != null) {
 				id = user.getId();
 				if (id != exp.getId()) {
-				    l = map.get(id);
-				    if (l != null)
-				        sorted.addAll(sort(l));
+					l = map.get(id);
+					if (l != null)
+						sorted.addAll(sort(l));
 				}
 			}
 		}
@@ -1704,30 +1609,30 @@ class LocationDialog extends JDialog implements ActionListener,
 	}
 
 	/**
-     * Searches the list of nodes returning the entry with the same Id as
-     * the find parameter, returns <null> if the list is empty, or the first
-     * item in the list if the find parameter is not found or is null.
-     * @param nodes The list of nodes to scan.
-     * @param find The node to match Id against.
-     * @param index The default index if valid.
-     * @return The item, <null> if no list, first list item if find is <null>.
-     */
-    private DataNode findDataNode(List<DataNode> nodes, DataNode find, int index)
-    {
-        if (CollectionUtils.isEmpty(nodes)) return null;
+	 * Searches the list of nodes returning the entry with the same Id as
+	 * the find parameter, returns <null> if the list is empty, or the first
+	 * item in the list if the find parameter is not found or is null.
+	 * @param nodes The list of nodes to scan.
+	 * @param find The node to match Id against.
+	 * @param index The default index if valid.
+	 * @return The item, <null> if no list, first list item if find is <null>.
+	 */
+	private DataNode findDataNode(List<DataNode> nodes, DataNode find, int index)
+	{
+		if (CollectionUtils.isEmpty(nodes)) return null;
 
-        if (find == null) {
-            if (index >= nodes.size()) return nodes.get(0);
-            return nodes.get(index);
-        }
+		if (find == null) {
+			if (index >= nodes.size()) return nodes.get(0);
+			return nodes.get(index);
+		}
 
-        for (DataNode node : nodes) {
-            if (getIdOf(node) == getIdOf(find))
-                return node;
-        }
-        if (index >= nodes.size()) return nodes.get(0);
-        return nodes.get(index);
-    }
+		for (DataNode node : nodes) {
+			if (getIdOf(node) == getIdOf(find))
+				return node;
+		}
+		if (index >= nodes.size()) return nodes.get(0);
+		return nodes.get(index);
+	}
 
 	/**
 	 * Searches the list of nodes returning the entry with the same Id as
@@ -1786,17 +1691,17 @@ class LocationDialog extends JDialog implements ActionListener,
 	 * @param userID The id of the user.
 	 */
 	void reset(TreeImageDisplay container, int type,
-	        Collection<TreeImageDisplay> objects , long currentGroupId,
-	        long userID)
+			   Collection<TreeImageDisplay> objects , long currentGroupId,
+			   long userID)
 	{
-	    this.dataType = type;
-	    this.objects = objects;
-	    this.container = container;
-	    this.busyLabel.setBusy(false);
-	    this.busyLabel.setVisible(false);
-	    this.addButton.setEnabled(true);
-	    populateUIWithDisplayData(findWithId(groups, currentGroupId), userID);
-	    setInputsEnabled(true);
+		this.dataType = type;
+		this.objects = objects;
+		this.container = container;
+		this.busyLabel.setBusy(false);
+		this.busyLabel.setVisible(false);
+		this.addButton.setEnabled(true);
+		populateUIWithDisplayData(findWithId(groups, currentGroupId), userID);
+		setInputsEnabled(true);
 	}
 
 	/**
@@ -1869,22 +1774,22 @@ class LocationDialog extends JDialog implements ActionListener,
 	 */
 	public void itemStateChanged(ItemEvent ie)
 	{
-	    Object source = ie.getSource();
-	    if (ie.getStateChange() == ItemEvent.SELECTED) {
-	        if (source == groupsBox) {
-	            storeCurrentSelections();
-	            switchToSelectedGroup();
-	        } else if (source == usersBox) {
-	            switchToSelectedUser();
-	        } else if (source == projectsBox) {
-	            DataNode node = getSelectedItem(projectsBox);
-	            datasetsBox.setEnabled(true);
-	            newDatasetButton.setEnabled(true);
-	            if (node.isDefaultProject())
-	                newDatasetButton.setEnabled(true);
-	            populateDatasetsBox();
-	        }
-	    }
+		Object source = ie.getSource();
+		if (ie.getStateChange() == ItemEvent.SELECTED) {
+			if (source == groupsBox) {
+				storeCurrentSelections();
+				switchToSelectedGroup();
+			} else if (source == usersBox) {
+				switchToSelectedUser();
+			} else if (source == projectsBox) {
+				DataNode node = getSelectedItem(projectsBox);
+				datasetsBox.setEnabled(true);
+				newDatasetButton.setEnabled(true);
+				if (node.isDefaultProject())
+					newDatasetButton.setEnabled(true);
+				populateDatasetsBox();
+			}
+		}
 	}
 
 	/**
@@ -1917,8 +1822,8 @@ class LocationDialog extends JDialog implements ActionListener,
 	}
 
 	/**
-     * Returns <code>true</code> to import the image from the current window
-     * <code>false</code> to import the images from all windows.
-     */
-    boolean isActiveWindow() { return activeWindow; }
+	 * Returns <code>true</code> to import the image from the current window
+	 * <code>false</code> to import the images from all windows.
+	 */
+	boolean isActiveWindow() { return activeWindow; }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
@@ -1,0 +1,53 @@
+package org.openmicroscopy.shoola.agents.fsimporter.chooser;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Options panel to display a list of check boxes to enable skip
+ * compute flags in importer. Holds state of what options have been
+ * selected
+ */
+class SkipComputePanel extends JPanel {
+
+	private static final String TEXT_THUMBNAIL_GENERATION = "thumbnail generation";
+	private static final String TEXT_MIN_MAX_GENERATION = "min/max compute";
+	private static final String TEXT_CHECKSUM_GENERATION = "checksum checking";
+
+	private JCheckBox thumbGenCheckbox;
+	private JCheckBox minMaxCheckBox;
+	private JCheckBox checksumCheckBox;
+
+	// Store state of check boxs here
+
+	public SkipComputePanel() {
+		super(new GridLayout(0, 1));
+
+		// Check box options for advanced panel
+		thumbGenCheckbox = new JCheckBox(TEXT_THUMBNAIL_GENERATION);
+		thumbGenCheckbox.setToolTipText("Skips the generation of thumbnails on the server" +
+				" saving time taken to import images");
+		thumbGenCheckbox.addItemListener(e -> {
+
+		});
+		minMaxCheckBox = new JCheckBox(TEXT_MIN_MAX_GENERATION);
+		thumbGenCheckbox.setToolTipText("Skips the calculation of min and max of color values on the server" +
+				" saving time taken to import images");
+		minMaxCheckBox.addItemListener(e -> {
+
+		});
+		checksumCheckBox = new JCheckBox(TEXT_CHECKSUM_GENERATION);
+		checksumCheckBox.setToolTipText("Skips the calculation of min and max of color values on the server" +
+				" saving time taken to import images");
+		checksumCheckBox.addItemListener(e -> {
+
+		});
+
+		add(thumbGenCheckbox);
+		add(minMaxCheckBox);
+		add(checksumCheckBox);
+	}
+
+	// Get state of check boxes here
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
@@ -2,6 +2,10 @@ package org.openmicroscopy.shoola.agents.fsimporter.chooser;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Options panel to display a list of check boxes to enable skip
@@ -10,44 +14,99 @@ import java.awt.*;
  */
 class SkipComputePanel extends JPanel {
 
-	private static final String TEXT_THUMBNAIL_GENERATION = "thumbnail generation";
-	private static final String TEXT_MIN_MAX_GENERATION = "min/max compute";
-	private static final String TEXT_CHECKSUM_GENERATION = "checksum checking";
+    /**
+     * Text for checkboxes
+     */
+    private static final String TEXT_THUMBNAIL_GENERATION = "thumbnail generation";
+    private static final String TEXT_MIN_MAX_COMPUTE = "min/max compute";
+    private static final String TEXT_CHECKSUM_CHECKING = "checksum checking";
+    private static final String TEXT_UPGRADE_CHECK = "Upgrade check for Bio-Formats";
 
-	private JCheckBox thumbGenCheckbox;
-	private JCheckBox minMaxCheckBox;
-	private JCheckBox checksumCheckBox;
+    /**
+     * Tooltips for checkboxes
+     */
+    private static final String TEXT_TOOLTIP_THUMBNAIL_SKIP = "Skip generation of thumbnails\n" +
+            "Thumbnails will usually be generated when accessing the images post-import via the OMERO clients.";
 
-	// Store state of check boxs here
+    private static final String TEXT_TOOLTIP_MIN_MAX_SKIP = "Skip calculation of the minima and maxima pixel values\n" +
+            "This option will also skip the calculation of the pixels checksum. Recalculating minima and maxima pixel " +
+            "values post-import is currently not supported. See Calculation of minima and maxima pixel " +
+            "values for more information.";
 
-	public SkipComputePanel() {
-		super(new GridLayout(0, 1));
+    private static final String TEXT_TOOLTIP_CHECKSUM_SKIP = "Skip checksum calculation on image files before and " +
+            "after transfer\n" +
+            "This option effectively sets the --checksum_algorithm to use a fast algorithm, File-Size-64, that " +
+            "considers only file size, not the actual file contents.";
 
-		// Check box options for advanced panel
-		thumbGenCheckbox = new JCheckBox(TEXT_THUMBNAIL_GENERATION);
-		thumbGenCheckbox.setToolTipText("Skips the generation of thumbnails on the server" +
-				" saving time taken to import images");
-		thumbGenCheckbox.addItemListener(e -> {
+    private static final String TEXT_TOOLTIP_UPGRADE_SKIP = "Skip upgrade check for Bio-Formats";
 
-		});
-		minMaxCheckBox = new JCheckBox(TEXT_MIN_MAX_GENERATION);
-		thumbGenCheckbox.setToolTipText("Skips the calculation of min and max of color values on the server" +
-				" saving time taken to import images");
-		minMaxCheckBox.addItemListener(e -> {
 
-		});
-		checksumCheckBox = new JCheckBox(TEXT_CHECKSUM_GENERATION);
-		checksumCheckBox.setToolTipText("Skips the calculation of min and max of color values on the server" +
-				" saving time taken to import images");
-		checksumCheckBox.addItemListener(e -> {
+    private JCheckBox thumbGenCheckbox;
+    private JCheckBox minMaxCheckBox;
+    private JCheckBox checksumCheckBox;
+    private JCheckBox upgradeCheckCheckBox;
 
-		});
+    private Map<String, Object> choices = new HashMap<String, Object>();
 
-		add(thumbGenCheckbox);
-		add(minMaxCheckBox);
-		add(checksumCheckBox);
-	}
 
-	// Get state of check boxes here
+    public SkipComputePanel() {
+        super(new GridLayout(0, 1));
 
+        // Check box options for advanced panel
+        thumbGenCheckbox = new JCheckBox(TEXT_THUMBNAIL_GENERATION);
+        thumbGenCheckbox.setToolTipText(TEXT_TOOLTIP_THUMBNAIL_SKIP);
+        thumbGenCheckbox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                boolean doThumbnails = !thumbGenCheckbox.isSelected();
+                choices.put("doThumbnails", doThumbnails);
+            }
+        });
+        thumbGenCheckbox.setSelected(false);
+
+        minMaxCheckBox = new JCheckBox(TEXT_MIN_MAX_COMPUTE);
+        minMaxCheckBox.setToolTipText(TEXT_TOOLTIP_MIN_MAX_SKIP);
+        minMaxCheckBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                choices.put("noStatsInfo", thumbGenCheckbox.isSelected());
+            }
+        });
+        minMaxCheckBox.setSelected(false);
+
+        checksumCheckBox = new JCheckBox(TEXT_CHECKSUM_CHECKING);
+        checksumCheckBox.setToolTipText(TEXT_TOOLTIP_CHECKSUM_SKIP);
+        checksumCheckBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if (thumbGenCheckbox.isSelected()) {
+                    choices.put("checksumAlgorithm", "{}");
+                } else {
+                    choices.put("checksumAlgorithm", "File-Size-64");
+                }
+            }
+        });
+        checksumCheckBox.setSelected(false);
+
+        upgradeCheckCheckBox = new JCheckBox(TEXT_UPGRADE_CHECK);
+        upgradeCheckCheckBox.setToolTipText(TEXT_TOOLTIP_UPGRADE_SKIP);
+        upgradeCheckCheckBox.addItemListener(new ItemListener() {
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                if (thumbGenCheckbox.isSelected()) {
+                    choices.put("checksumAlgorithm", "{}");
+                } else {
+                    choices.put("checksumAlgorithm", "");
+                }
+            }
+        });
+
+        add(thumbGenCheckbox);
+        add(minMaxCheckBox);
+        add(checksumCheckBox);
+    }
+
+    public Map<String, Object> getChoices() {
+        return choices;
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
@@ -47,9 +47,8 @@ class SkipComputePanel extends JPanel {
      * Text for checkboxes
      */
     private static final String TEXT_THUMBNAIL_GENERATION = "Thumbnail generation";
-    private static final String TEXT_MIN_MAX_COMPUTE = "Min/max compute";
-    private static final String TEXT_CHECKSUM_CHECKING = "Checksum checking";
-    private static final String TEXT_UPGRADE_CHECK = "Upgrade check for Bio-Formats";
+    private static final String TEXT_MIN_MAX_COMPUTE = "Min/max calculation";
+    private static final String TEXT_CHECKSUM_CHECKING = "Checksum verification";
 
     /**
      * Tooltips for checkboxes
@@ -73,7 +72,6 @@ class SkipComputePanel extends JPanel {
     private JCheckBox thumbGenCheckbox;
     private JCheckBox minMaxCheckBox;
     private JCheckBox checksumCheckBox;
-    private JCheckBox upgradeCheckCheckBox;
 
     private Map<String, Object> choices = new HashMap<String, Object>();
 
@@ -117,19 +115,9 @@ class SkipComputePanel extends JPanel {
         });
         checksumCheckBox.setSelected(false);
 
-        upgradeCheckCheckBox = new JCheckBox(TEXT_UPGRADE_CHECK);
-        upgradeCheckCheckBox.setToolTipText(TEXT_TOOLTIP_UPGRADE_SKIP);
-        upgradeCheckCheckBox.addItemListener(new ItemListener() {
-            @Override
-            public void itemStateChanged(ItemEvent e) {
-                choices.put(ImportableObject.OPTION_UPGRADECHECK, !upgradeCheckCheckBox.isSelected());
-            }
-        });
-
         add(thumbGenCheckbox);
         add(minMaxCheckBox);
         add(checksumCheckBox);
-        add(upgradeCheckCheckBox);
     }
     
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
@@ -20,15 +20,17 @@
  */
 package org.openmicroscopy.shoola.agents.fsimporter.chooser;
 
-import javax.swing.*;
 
-import org.openmicroscopy.shoola.env.data.model.ImportableObject;
-
-import java.awt.*;
+import java.awt.GridLayout;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
+
+import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 
 /**
  * Options panel to display a list of check boxes to enable skip
@@ -107,9 +109,9 @@ class SkipComputePanel extends JPanel {
             @Override
             public void itemStateChanged(ItemEvent e) {
                 if (checksumCheckBox.isSelected()) {
-                    choices.put(ImportableObject.OPTION_CHECKSUMS, "File-Size-64"); // File-Size-64 fast
+                    choices.put(ImportableObject.OPTION_CHECKSUMS, omero.model.enums.ChecksumAlgorithmFileSize64.value); // File-Size-64 fast
                 } else {
-                    choices.put(ImportableObject.OPTION_CHECKSUMS, "SHA1-160");  // default SHA1-160
+                    choices.put(ImportableObject.OPTION_CHECKSUMS, omero.model.enums.ChecksumAlgorithmSHA1160.value);  // default SHA1-160
                 }
             }
         });

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/SkipComputePanel.java
@@ -1,6 +1,29 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2018 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
 package org.openmicroscopy.shoola.agents.fsimporter.chooser;
 
 import javax.swing.*;
+
+import org.openmicroscopy.shoola.env.data.model.ImportableObject;
+
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
@@ -11,15 +34,19 @@ import java.util.Map;
  * Options panel to display a list of check boxes to enable skip
  * compute flags in importer. Holds state of what options have been
  * selected
+ * 
+ * @author  Riad Gozim &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:r.gozim@dundee.ac.uk">r.gozim@dundee.ac.uk</a>
+ * 
  */
 class SkipComputePanel extends JPanel {
 
     /**
      * Text for checkboxes
      */
-    private static final String TEXT_THUMBNAIL_GENERATION = "thumbnail generation";
-    private static final String TEXT_MIN_MAX_COMPUTE = "min/max compute";
-    private static final String TEXT_CHECKSUM_CHECKING = "checksum checking";
+    private static final String TEXT_THUMBNAIL_GENERATION = "Thumbnail generation";
+    private static final String TEXT_MIN_MAX_COMPUTE = "Min/max compute";
+    private static final String TEXT_CHECKSUM_CHECKING = "Checksum checking";
     private static final String TEXT_UPGRADE_CHECK = "Upgrade check for Bio-Formats";
 
     /**
@@ -59,7 +86,7 @@ class SkipComputePanel extends JPanel {
             @Override
             public void itemStateChanged(ItemEvent e) {
                 boolean doThumbnails = !thumbGenCheckbox.isSelected();
-                choices.put("doThumbnails", doThumbnails);
+                choices.put(ImportableObject.OPTION_THUMBNAILS, doThumbnails);
             }
         });
         thumbGenCheckbox.setSelected(false);
@@ -69,7 +96,7 @@ class SkipComputePanel extends JPanel {
         minMaxCheckBox.addItemListener(new ItemListener() {
             @Override
             public void itemStateChanged(ItemEvent e) {
-                choices.put("noStatsInfo", thumbGenCheckbox.isSelected());
+                choices.put(ImportableObject.OPTION_SKIP_MINMAX, minMaxCheckBox.isSelected());
             }
         });
         minMaxCheckBox.setSelected(false);
@@ -79,10 +106,10 @@ class SkipComputePanel extends JPanel {
         checksumCheckBox.addItemListener(new ItemListener() {
             @Override
             public void itemStateChanged(ItemEvent e) {
-                if (thumbGenCheckbox.isSelected()) {
-                    choices.put("checksumAlgorithm", "{}");
+                if (checksumCheckBox.isSelected()) {
+                    choices.put(ImportableObject.OPTION_CHECKSUMS, "File-Size-64"); // File-Size-64 fast
                 } else {
-                    choices.put("checksumAlgorithm", "File-Size-64");
+                    choices.put(ImportableObject.OPTION_CHECKSUMS, "SHA1-160");  // default SHA1-160
                 }
             }
         });
@@ -93,19 +120,20 @@ class SkipComputePanel extends JPanel {
         upgradeCheckCheckBox.addItemListener(new ItemListener() {
             @Override
             public void itemStateChanged(ItemEvent e) {
-                if (thumbGenCheckbox.isSelected()) {
-                    choices.put("checksumAlgorithm", "{}");
-                } else {
-                    choices.put("checksumAlgorithm", "");
-                }
+                choices.put(ImportableObject.OPTION_UPGRADECHECK, !upgradeCheckCheckBox.isSelected());
             }
         });
 
         add(thumbGenCheckbox);
         add(minMaxCheckBox);
         add(checksumCheckBox);
+        add(upgradeCheckCheckBox);
     }
-
+    
+    /**
+     * Get the advanced import configuration choices
+     * @return See above
+     */
     public Map<String, Object> getChoices() {
         return choices;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/CheckSumDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/CheckSumDialog.java
@@ -44,7 +44,7 @@ import javax.swing.table.TableColumnModel;
 
 //Application-internal dependencies
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
-import org.openmicroscopy.shoola.env.data.util.StatusLabel;
+import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.util.ui.TitlePanel;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
@@ -76,7 +76,7 @@ public class CheckSumDialog
 	 * 
 	 * @param label The component hosting information about the checksums.
 	 */
-	private void initialize(StatusLabel label)
+	private void initialize(Status label)
 	{
 		IconManager icons = IconManager.getInstance();
 		ChecksumTableRenderer rnd = new ChecksumTableRenderer(
@@ -139,7 +139,7 @@ public class CheckSumDialog
 	 * @param owner The owner of the dialog.
 	 * @param label The component hosting information about the checksums.
 	 */
-	public CheckSumDialog(JFrame owner, StatusLabel label)
+	public CheckSumDialog(JFrame owner, Status label)
 	{
 		super(owner);
 		setTitle(TITLE);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/CheckSumDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/CheckSumDialog.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.fsimporter.util.CheckSumDialog
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+ *  Copyright (C) 2013-2018 University of Dundee & Open Microscopy Environment.
  *  All rights reserved.
  *
  *

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1401,7 +1401,9 @@ public class FileImportComponent
 		List<FileImportComponentI> l = null;
 		if (getFile().isFile()) {
 			if (hasFailuresToReupload() && !reimported) {
-				return Arrays.asList(this);
+			    ArrayList<FileImportComponentI> ret = new ArrayList<FileImportComponentI>();
+                ret.add(this);
+                return ret;
 			}
 		} else {
 			if (components != null) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -110,60 +110,10 @@ import omero.gateway.model.TagAnnotationData;
  */
 public class FileImportComponent
 	extends JPanel
-	implements PropertyChangeListener
+	implements PropertyChangeListener, FileImportComponentI
 {
-	/** Indicates that the container is of type <code>Project</code>. */
-	public static final int PROJECT_TYPE = 0;
-	
-	/** Indicates that the container is of type <code>Screen</code>. */
-	public static final int SCREEN_TYPE = 1;
-	
-	/** Indicates that the container is of type <code>Dataset</code>. */
-	public static final int DATASET_TYPE = 2;
-	
-	/** Indicates that no container specified. */
-	public static final int NO_CONTAINER = 3;
-	
-	/** Bound property indicating to retry an upload.*/
-	public static final String RETRY_PROPERTY = "retry";
-	
-	/** 
-	 * Bound property indicating that the error to submit is selected or not.
-	 */
-	public static final String SUBMIT_ERROR_PROPERTY = "submitError";
-	
-	/** Bound property indicating to display the error.*/
-	public static final String DISPLAY_ERROR_PROPERTY = "displayError";
-	
-	/** Bound property indicating to cancel the import.*/
-	public static final String CANCEL_IMPORT_PROPERTY = "cancelImport";
-	
-	/** Bound property indicating to browse the node. */
-	public static final String BROWSE_PROPERTY = "browse";
-	
-	/** Bound property indicating to increase the number of files to import. */
-	public static final String IMPORT_FILES_NUMBER_PROPERTY = "importFilesNumber";
-	
-	/**
-	 * Bound property indicating to load the content of the log file.
-	 */
-	public static final String LOAD_LOGFILEPROPERTY = "loadLogfile";
-
-	/**
-	 * Bound property indicating to retrieve the log file.
-	 */
-	public static final String RETRIEVE_LOGFILEPROPERTY = "retrieveLogfile";
-	
-	/**
-	 * Bound property indicating to show the checksums,
-	 */
-	public static final String CHECKSUM_DISPLAY_PROPERTY = "checksumDisplay";
-
 	/** The default size of the busy label. */
 	private static final Dimension SIZE = new Dimension(16, 16);
-
-	/** The number of extra labels for images to add. */
-	public static final int MAX_THUMBNAILS = 3;
 
 	/** Text indicating that the folder does not contain importable files.*/
 	private static final String EMPTY_FOLDER = "No data to import";
@@ -229,7 +179,7 @@ public class FileImportComponent
 	private JXTaskPane pane;
 	
 	/** The parent of the node. */
-	private FileImportComponent parent;
+	private FileImportComponentI parent;
 
 	/** 
 	 * Flag indicating that the container hosting the imported image
@@ -818,28 +768,23 @@ public class FileImportComponent
 				importable.getRefNode());
 	}
 	
-	/**
-	 * Returns the file hosted by this component.
-	 * 
-	 * @return See above.
-	 */
-	public FileObject getFile() { return importable.getFile(); }
-	
-	/**
-     * Returns the file hosted by this component.
-     * 
-     * @return See above.
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getFile()
      */
+	@Override
+    public FileObject getFile() { return importable.getFile(); }
+	
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getOriginalFile()
+     */
+    @Override
     public FileObject getOriginalFile() { return importable.getOriginalFile(); }
     
-	/**
-	 * Sets the location where to import the files.
-	 * 
-	 * @param data The data where to import the folder or screening data.
-	 * @param dataset The dataset if any.
-	 * @param refNode The node of reference.
-	 */
-	public void setLocation(DataObject data, DatasetData dataset, 
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#setLocation(omero.gateway.model.DataObject, omero.gateway.model.DatasetData, java.lang.Object)
+     */
+	@Override
+    public void setLocation(DataObject data, DatasetData dataset, 
 			Object refNode)
 	{
 		this.data = data;
@@ -863,29 +808,25 @@ public class FileImportComponent
 		}
 	}
 	
-	/**
-	 * Sets the log file annotation.
-	 * 
-	 * @param data The annotation associated to the file set.
-	 * @param id The id of the file set.
-	 */
-	public void setImportLogFile(Collection<FileAnnotationData> data, long id)
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#setImportLogFile(java.util.Collection, long)
+     */
+	@Override
+    public void setImportLogFile(Collection<FileAnnotationData> data, long id)
 	{
 	}
 
-	/**
-	 * Returns the dataset or <code>null</code>.
-	 * 
-	 * @return See above.
-	 */
-	public DatasetData getDataset() { return dataset; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getDataset()
+     */
+	@Override
+    public DatasetData getDataset() { return dataset; }
 	
-	/**
-	 * Returns the object or <code>null</code>.
-	 * 
-	 * @return See above.
-	 */
-	public DataObject getDataObject() { return data; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getDataObject()
+     */
+	@Override
+    public DataObject getDataObject() { return data; }
 	
 	/**
 	 * Replaces the initial status label.
@@ -906,25 +847,22 @@ public class FileImportComponent
 	 * 
 	 * @param parent The value to set.
 	 */
-	void setParent(FileImportComponent parent)
+	void setParent(FileImportComponentI parent)
 	{
 		this.parent = parent;
 	}
 	
-	/**
-	 * Returns <code>true</code> if the parent is set.
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasParent() { return parent != null; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasParent()
+     */
+	@Override
+    public boolean hasParent() { return parent != null; }
 	
-	/**
-	 * Returns the components displaying the status of an on-going import.
-	 * 
-	 * @return See above.
-	 */
-	public Status getStatus() { return status; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getStatus()
+     */
+	@Override
+    public Status getStatus() { return status; }
 
 	/**
 	 * Returns the associated file if any.
@@ -957,11 +895,11 @@ public class FileImportComponent
 	    return CollectionUtils.isNotEmpty(l);
 	}
 
-	/**
-	 * Sets the result of the import.
-	 * @param image The image.
-	 */
-	public void setStatus(Object image)
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#setStatus(java.lang.Object)
+     */
+	@Override
+    public void setStatus(Object image)
 	{
 		busyLabel.setVisible(false);
 		busyLabel.setBusy(false);
@@ -1047,18 +985,17 @@ public class FileImportComponent
 		repaint();
 	}
 
-	/**
-	 * Returns the files that failed to import.
-	 * 
-	 * @return See above.
-	 */
-	public List<FileImportComponent> getImportErrors()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getImportErrors()
+     */
+	@Override
+    public List<FileImportComponentI> getImportErrors()
 	{
-		List<FileImportComponent> l = null;
+		List<FileImportComponentI> l = null;
 		if (getFile().isFile()) {
 			Object r = status.getImportResult();
 			if (r instanceof Exception || image instanceof Exception) {
-				l = new ArrayList<FileImportComponent>();
+				l = new ArrayList<FileImportComponentI>();
 				l.add(this);
 				return l;
 			}
@@ -1067,9 +1004,9 @@ public class FileImportComponent
 			    Collection<FileImportComponent> values =  components.values();
                 synchronized (components) {
                     Iterator<FileImportComponent> i = values.iterator();
-    				FileImportComponent fc;
-    				l = new ArrayList<FileImportComponent>();
-    				List<FileImportComponent> list;
+    				FileImportComponentI fc;
+    				l = new ArrayList<FileImportComponentI>();
+    				List<FileImportComponentI> list;
     				while (i.hasNext()) {
     					fc = i.next();
     					list = fc.getImportErrors();
@@ -1082,26 +1019,23 @@ public class FileImportComponent
 		return l;
 	}
 	
-	/**
-	 * Returns the id of the group.
-	 * 
-	 * @return See above.
-	 */
-	public long getGroupID() { return importable.getGroup().getId(); }
-
-	/**
-     * Returns the id of the experimenter.
-     * 
-     * @return See above.
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getGroupID()
      */
+	@Override
+    public long getGroupID() { return importable.getGroup().getId(); }
+
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getExperimenterID()
+     */
+    @Override
     public long getExperimenterID() { return importable.getUser().getId(); }
 	
-	/**
-	 * Returns the import error object.
-	 * 
-	 * @return See above.
-	 */
-	public ImportErrorObject getImportErrorObject()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getImportErrorObject()
+     */
+	@Override
+    public ImportErrorObject getImportErrorObject()
 	{
 		Object r = status.getImportResult();
 		Exception e = null;
@@ -1123,38 +1057,32 @@ public class FileImportComponent
 		return object;
 	}
 	
-	/**
-	 * Returns <code>true</code> if the import has failed, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasImportFailed()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasImportFailed()
+     */
+	@Override
+    public boolean hasImportFailed()
 	{
 		return resultIndex == ImportStatus.FAILURE ||
 				resultIndex == ImportStatus.UPLOAD_FAILURE;
 	}
 	
-	/**
-	 * Returns <code>true</code> if it was a failure prior or during the
-	 * upload, <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasUploadFailed()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasUploadFailed()
+     */
+	@Override
+    public boolean hasUploadFailed()
 	{
 		return resultIndex == ImportStatus.UPLOAD_FAILURE ||
 				(resultIndex == ImportStatus.FAILURE &&
 				!status.didUploadStart());
 	}
 	
-	/**
-	 * Returns <code>true</code> if the import has been cancelled,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean isCancelled()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#isCancelled()
+     */
+	@Override
+    public boolean isCancelled()
 	{
 		boolean b = status.isMarkedAsCancel();
 		if (b || getFile().isFile()) return b;
@@ -1170,12 +1098,10 @@ public class FileImportComponent
 		return false;
 	}
 
-	/**
-	 * Returns <code>true</code> if the component has imports to cancel,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasImportToCancel()
+     */
+    @Override
     public boolean hasImportToCancel()
     {
         boolean b = status.isMarkedAsCancel();
@@ -1185,7 +1111,7 @@ public class FileImportComponent
         Collection<FileImportComponent> values =  components.values();
         synchronized (components) {
             Iterator<FileImportComponent> i = values.iterator();
-            FileImportComponent fc;
+            FileImportComponentI fc;
             while (i.hasNext()) {
                 fc = i.next();
                 if (!fc.isCancelled() && !fc.hasImportStarted())
@@ -1195,13 +1121,11 @@ public class FileImportComponent
         return false;
     }
     
-	/**
-	 * Returns <code>true</code> if the file can be re-imported,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasFailuresToReimport()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasFailuresToReimport()
+     */
+	@Override
+    public boolean hasFailuresToReimport()
 	{
 		if (getFile().isFile()) return hasUploadFailed() && !reimported;
 		if (components == null) return false;
@@ -1216,13 +1140,11 @@ public class FileImportComponent
 		return false;
 	}
 	
-	/**
-	 * Returns <code>true</code> if the file can be re-imported,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasFailuresToReupload()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasFailuresToReupload()
+     */
+	@Override
+    public boolean hasFailuresToReupload()
 	{
 		if (getFile().isFile()) return hasUploadFailed() && !reimported;
 		if (components == null) return false;
@@ -1237,13 +1159,11 @@ public class FileImportComponent
 		return false;
 	}
 	
-	/**
-	 * Returns <code>true</code> if the import has failed, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasImportStarted()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasImportStarted()
+     */
+	@Override
+    public boolean hasImportStarted()
 	{
 		if (getFile().isFile()) return resultIndex != ImportStatus.QUEUED;
 		if (components == null) return false;
@@ -1258,13 +1178,11 @@ public class FileImportComponent
 		return count == components.size();
 	}
 
-	/**
-	 * Returns <code>true</code> the error can be submitted, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasFailuresToSend()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasFailuresToSend()
+     */
+	@Override
+    public boolean hasFailuresToSend()
 	{
 		if (getFile().isFile()) return resultIndex == ImportStatus.FAILURE;
 		if (components == null) return false;
@@ -1279,24 +1197,16 @@ public class FileImportComponent
 		return false;
 	}
 	
-	/**
-	 * Returns <code>true</code> if the folder has components added,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasComponents()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasComponents()
+     */
+	@Override
+    public boolean hasComponents()
 	{
 		return components != null && components.size() > 0;
 	}
 	
-	/** 
-	 * Lays out the entries.
-	 * 
-	 * @param failure Pass <code>true</code> to display the failed import only,
-	 * <code>false</code> to display all the entries.
-	 */
-	public void layoutEntries(boolean failure)
+    public void layoutEntries(boolean failure)
 	{
 		JPanel p = new JPanel();
 		p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS));
@@ -1342,13 +1252,11 @@ public class FileImportComponent
 		pane.repaint();
 	}
 	
-	/**
-	 * Returns the status of the import process one of the
-	 * values defined in @see ImportStatus
-	 * 
-	 * @return See above.
-	 */
-	public ImportStatus getImportStatus()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getImportStatus()
+     */
+	@Override
+    public ImportStatus getImportStatus()
 	{
 		if (getFile().isFile()) {
 			if (hasImportFailed()) return ImportStatus.FAILURE;
@@ -1382,13 +1290,11 @@ public class FileImportComponent
 		return ImportStatus.SUCCESS;
 	}
 	
-	/**
-	 * Returns <code>true</code> if refresh whole tree, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasToRefreshTree()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasToRefreshTree()
+     */
+	@Override
+    public boolean hasToRefreshTree()
 	{
 		if (getFile().isFile()) {
 			if (hasImportFailed()) return false;
@@ -1415,13 +1321,11 @@ public class FileImportComponent
 		return true;
 	}
 	
-	/**
-	 * Returns <code>true</code> if some files were imported, 
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean toRefresh()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#toRefresh()
+     */
+	@Override
+    public boolean toRefresh()
 	{
 		/*
 		if (file.isFile()) {
@@ -1442,8 +1346,11 @@ public class FileImportComponent
 		return true;
 	}
 
-	/** Indicates the import has been cancelled. */
-	public void cancelLoading()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#cancelLoading()
+     */
+	@Override
+    public void cancelLoading()
 	{
 		if (components == null || components.isEmpty()) {
 			cancel(getFile().isFile());
@@ -1458,47 +1365,40 @@ public class FileImportComponent
         }
 	}
 	
-	/**
-	 * Sets the type. 
-	 * 
-	 * @param type One of the constants defined by this class.
-	 */
-	public void setType(int type) { this.type = type; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#setType(int)
+     */
+	@Override
+    public void setType(int type) { this.type = type; }
 	
-	/**
-	 * Returns the supported type. One of the constants defined by this class.
-	 * 
-	 * @return See above.
-	 */
-	public int getType() { return type; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getType()
+     */
+	@Override
+    public int getType() { return type; }
 	
-	/**
-	 * Returns <code>true</code> if the folder has been converted into a
-	 * container, <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean isFolderAsContainer()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#isFolderAsContainer()
+     */
+	@Override
+    public boolean isFolderAsContainer()
 	{
 		return importable.isFolderAsContainer();
 	}
 	
-	/**
-	 * Returns the object corresponding to the folder.
-	 * 
-	 * @return See above.
-	 */
-	public DataObject getContainerFromFolder() { return containerFromFolder; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getContainerFromFolder()
+     */
+	@Override
+    public DataObject getContainerFromFolder() { return containerFromFolder; }
 
-	/**
-	 * Returns <code>true</code> if the file has already been marked for
-	 * re-import, <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public List<FileImportComponent> getFilesToReupload()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getFilesToReupload()
+     */
+	@Override
+    public List<FileImportComponentI> getFilesToReupload()
 	{
-		List<FileImportComponent> l = null;
+		List<FileImportComponentI> l = null;
 		if (getFile().isFile()) {
 			if (hasFailuresToReupload() && !reimported) {
 				return Arrays.asList(this);
@@ -1508,9 +1408,9 @@ public class FileImportComponent
 			    Collection<FileImportComponent> values =  components.values();
 		        synchronized (components) {
 		            Iterator<FileImportComponent> i = values.iterator();
-    				FileImportComponent fc;
-    				l = new ArrayList<FileImportComponent>();
-    				List<FileImportComponent> list;
+    				FileImportComponentI fc;
+    				l = new ArrayList<FileImportComponentI>();
+    				List<FileImportComponentI> list;
     				while (i.hasNext()) {
     					fc = i.next();
     					list = fc.getFilesToReupload();
@@ -1523,95 +1423,77 @@ public class FileImportComponent
 		return l;
 	}
 	
-	/**
-	 * Sets to <code>true</code> to mark the file for reimport.
-	 * <code>false</code> otherwise.
-	 * 
-	 * @param reimported Pass <code>true</code> to mark the file for reimport,
-	 * <code>false</code> otherwise.
-	 */
-	public void setReimported(boolean reimported)
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#setReimported(boolean)
+     */
+	@Override
+    public void setReimported(boolean reimported)
 	{ 
 		this.reimported = reimported;
 		repaint();
 	}
 	
-	/**
-	 * Sets the result of the import for the specified file.
-	 * 
-	 * @param result The result.
-	 */
-	public void uploadComplete(Object result)
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#uploadComplete(java.lang.Object)
+     */
+	@Override
+    public void uploadComplete(Object result)
 	{
 		if (result instanceof CmdCallback)
 			callback = (CmdCallback) result;
 	}
 
-	/**
-	 * Returns the index associated to the main component.
-	 * 
-	 * @return See above.
-	 */
-	public int getIndex() { return index; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getIndex()
+     */
+	@Override
+    public int getIndex() { return index; }
 	
-	/**
-	 * Returns the result of the import either a collection of
-	 * <code>PixelsData</code> or an exception.
-	 * 
-	 * @return See above.
-	 */
-	public Object getImportResult() { return status.getImportResult(); }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getImportResult()
+     */
+	@Override
+    public Object getImportResult() { return status.getImportResult(); }
 	
-	/**
-	 * Returns <code>true</code> if it is a HCS file, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean isHCS() { return status.isHCS(); }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#isHCS()
+     */
+	@Override
+    public boolean isHCS() { return status.isHCS(); }
 	
-	/**
-	 * Returns the size of the upload.
-	 * 
-	 * @return See above.
-	 */
-	public long getImportSize() { return status.getSizeUpload(); }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getImportSize()
+     */
+	@Override
+    public long getImportSize() { return status.getSizeUpload(); }
 	
-	/**
-	 * Returns <code>true</code> if the result has already been set,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	public boolean hasResult() { return image != null; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasResult()
+     */
+	@Override
+    public boolean hasResult() { return image != null; }
 	
-	/**
-	 * Returns the importable object associated to the parent,
-	 * <code>null</code> if no parent.
-	 * 
-	 * @return See above.
-	 */
-	public ImportableFile getImportableFile() { return importable; }
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getImportableFile()
+     */
+	@Override
+    public ImportableFile getImportableFile() { return importable; }
 
-	/**
-	 * Indicates the results saving status.
-	 *
-	 * @param message The message to display
-	 * @param busy Pass <code>true</code> when saving,
-	 *             <code>false</code> otherwise.
-	 */
-	public void onResultsSaving(String message, boolean busy)
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#onResultsSaving(java.lang.String, boolean)
+     */
+	@Override
+    public void onResultsSaving(String message, boolean busy)
 	{
 	    busyLabel.setVisible(busy);
 	    busyLabel.setBusy(busy);
 	}
 
-	/**
-	 * Overridden to make sure that all the components have the correct 
-	 * background.
-	 * @see JPanel#setBackground(Color)
-	 */
-	public void setBackground(Color color)
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#setBackground(java.awt.Color)
+     */
+	@Override
+    public void setBackground(Color color)
 	{
 		if (busyLabel != null) busyLabel.setBackground(color);
 		if (namePane != null) {
@@ -1622,11 +1504,11 @@ public class FileImportComponent
 		super.setBackground(color);
 	}
 
-	/**
-	 * Listens to property fired by the <code>StatusLabel</code>.
-	 * @see PropertyChangeListener#propertyChange(PropertyChangeEvent)
-	 */
-	public void propertyChange(PropertyChangeEvent evt)
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#propertyChange(java.beans.PropertyChangeEvent)
+     */
+	@Override
+    public void propertyChange(PropertyChangeEvent evt)
 	{
 		String name = evt.getPropertyName();
 		if (Status.FILES_SET_PROPERTY.equals(name)) {
@@ -1701,11 +1583,11 @@ public class FileImportComponent
 		}
 	}
 
-	/**
-	 * Returns the name of the file and group's id and user's id.
-	 * @see #toString()
-	 */
-	public String toString()
+	/* (non-Javadoc)
+     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#toString()
+     */
+	@Override
+    public String toString()
 	{
 		StringBuffer buf = new StringBuffer();
 		buf.append(getFile().getAbsolutePath());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -797,7 +797,7 @@ public class FileImportComponent
 			containerObject = dataset;
 			return;
 		}
-		if (data != null && data instanceof ScreenData) {
+		if (data instanceof ScreenData) {
 			containerObject = data;
 		}
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -33,7 +33,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -97,8 +96,6 @@ import omero.gateway.model.ScreenData;
 import omero.gateway.model.TagAnnotationData;
 
 /** 
- * Component hosting the file to import and displaying the status of the 
- * import process.
  *
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
@@ -115,9 +112,6 @@ public class FileImportComponent
 	/** The default size of the busy label. */
 	private static final Dimension SIZE = new Dimension(16, 16);
 
-	/** Text indicating that the folder does not contain importable files.*/
-	private static final String EMPTY_FOLDER = "No data to import";
-	
 	/** The maximum width used for the component.*/
 	private static final int LENGTH = 350;
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -76,7 +76,6 @@ import org.openmicroscopy.shoola.env.data.ImportException;
 import org.openmicroscopy.shoola.env.data.model.FileObject;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
-
 import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.env.data.util.StatusLabel;
 import org.openmicroscopy.shoola.env.event.EventBus;
@@ -1541,4 +1540,20 @@ public class FileImportComponent
 						this);
 		}
 	}
+	
+    /**
+     * Returns the name of the file and group's id and user's id. 
+     * (This String is used as reference to find a specific FileImportComponent
+     * (see {@link FileImportComponent#components}) again, don't remove!)
+     */
+    @Override
+    public String toString() {
+        StringBuffer buf = new StringBuffer();
+        buf.append(getFile().getAbsolutePath());
+        if (importable.getGroup() != null)
+            buf.append("_" + importable.getGroup().getId());
+        if (importable.getUser() != null)
+            buf.append("_" + importable.getUser().getId());
+        return buf.toString();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1089,6 +1089,20 @@ public class FileImportComponent
         }
 		return false;
 	}
+	
+	@Override
+    public int cancelled() {
+        int c = 0;
+        Collection<FileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<FileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().isCancelled())
+                    c++;
+            }
+        }
+        return c;
+    }
 
 	/* (non-Javadoc)
      * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#hasImportToCancel()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1090,15 +1090,17 @@ public class FileImportComponent
 		return false;
 	}
 	
-	@Override
+    @Override
     public int cancelled() {
         int c = 0;
-        Collection<FileImportComponent> values = components.values();
-        synchronized (components) {
-            Iterator<FileImportComponent> i = values.iterator();
-            while (i.hasNext()) {
-                if (i.next().isCancelled())
-                    c++;
+        if (components != null) {
+            Collection<FileImportComponent> values = components.values();
+            synchronized (components) {
+                Iterator<FileImportComponent> i = values.iterator();
+                while (i.hasNext()) {
+                    if (i.next().isCancelled())
+                        c++;
+                }
             }
         }
         return c;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -77,14 +77,13 @@ import org.openmicroscopy.shoola.env.data.model.FileObject;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
 
-import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.env.data.util.StatusLabel;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
+import omero.gateway.SecurityContext;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.FileAnnotationData;
@@ -1161,15 +1160,12 @@ public class FileImportComponent
 	{
 		if (getFile().isFile()) return resultIndex != ImportStatus.QUEUED;
 		if (components == null) return false;
-		Collection<FileImportComponent> values =  components.values();
-		int count = 0;
         synchronized (components) {
-            Iterator<FileImportComponent> i = values.iterator();
-    		while (i.hasNext()) {
-    			if (i.next().hasImportStarted()) count++;
-    		}
+            for (FileImportComponent c : components.values()) 
+                if (!c.hasImportStarted())
+                    return false;
         }
-		return count == components.size();
+        return true;
 	}
 
 	/* (non-Javadoc)
@@ -1302,41 +1298,8 @@ public class FileImportComponent
 		}
 		if (components == null) return false;
 		if (importable.isFolderAsContainer() && type != ContainerType.PROJECT) {
-		    Collection<FileImportComponent> values =  components.values();
-            synchronized (components) {
-                Iterator<FileImportComponent> i = values.iterator();
-    			while (i.hasNext()) {
-    				if (i.next().toRefresh()) 
-    					return true;
-    			}
-            }
-			return false;
+		    return true;
 		}
-		return true;
-	}
-	
-	/* (non-Javadoc)
-     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#toRefresh()
-     */
-	@Override
-    public boolean toRefresh()
-	{
-		/*
-		if (file.isFile()) {
-			if (deleteButton.isVisible()) return false;
-			else if (errorBox.isVisible())
-				return !(errorBox.isEnabled() && errorBox.isSelected());
-			return true;
-		}
-		if (components == null) return false;
-		Iterator<FileImportComponent> i = components.values().iterator();
-		int count = 0;
-		while (i.hasNext()) {
-			if (i.next().hasFailuresToSend()) 
-				count++;
-		}
-		return components.size() != count;
-		*/
 		return true;
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -1578,20 +1578,4 @@ public class FileImportComponent
 						this);
 		}
 	}
-
-	/* (non-Javadoc)
-     * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#toString()
-     */
-	@Override
-    public String toString()
-	{
-		StringBuffer buf = new StringBuffer();
-		buf.append(getFile().getAbsolutePath());
-		if (importable.getGroup() != null)
-			buf.append("_"+importable.getGroup().getId());
-		if (importable.getUser() != null)
-			buf.append("_"+importable.getUser().getId());
-		return buf.toString();
-	}
-
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponent.java
@@ -119,7 +119,7 @@ public class FileImportComponent
 	private static final String EMPTY_DIRECTORY = "No data to import";
 	
 	/** One of the constants defined by this class. */
-	private int type;
+	private ContainerType type;
 
 	/** The component indicating the progress of the import. */
 	private JXBusyLabel busyLabel;
@@ -1293,15 +1293,15 @@ public class FileImportComponent
 		if (getFile().isFile()) {
 			if (hasImportFailed()) return false;
 			switch (type) {
-				case PROJECT_TYPE:
-				case NO_CONTAINER:
+				case PROJECT:
+				case NA:
 					return true;
 				default:
 					return false;
 			}
 		}
 		if (components == null) return false;
-		if (importable.isFolderAsContainer() && type != PROJECT_TYPE) {
+		if (importable.isFolderAsContainer() && type != ContainerType.PROJECT) {
 		    Collection<FileImportComponent> values =  components.values();
             synchronized (components) {
                 Iterator<FileImportComponent> i = values.iterator();
@@ -1363,13 +1363,13 @@ public class FileImportComponent
      * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#setType(int)
      */
 	@Override
-    public void setType(int type) { this.type = type; }
+    public void setType(ContainerType type) { this.type = type; }
 	
 	/* (non-Javadoc)
      * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#getType()
      */
 	@Override
-    public int getType() { return type; }
+    public ContainerType getType() { return type; }
 	
 	/* (non-Javadoc)
      * @see org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI#isFolderAsContainer()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -371,4 +371,5 @@ public interface FileImportComponentI {
      */
     public abstract String toString();
 
+    public abstract void addPropertyChangeListener(PropertyChangeListener l);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -1,0 +1,374 @@
+package org.openmicroscopy.shoola.agents.fsimporter.util;
+
+import java.awt.Color;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Collection;
+import java.util.List;
+
+import javax.swing.JPanel;
+
+import omero.gateway.model.DataObject;
+import omero.gateway.model.DatasetData;
+import omero.gateway.model.FileAnnotationData;
+
+import org.openmicroscopy.shoola.env.data.model.FileObject;
+import org.openmicroscopy.shoola.env.data.model.ImportableFile;
+import org.openmicroscopy.shoola.env.data.util.Status;
+import org.openmicroscopy.shoola.util.file.ImportErrorObject;
+
+public interface FileImportComponentI {
+
+    /** Indicates that the container is of type <code>Project</code>. */
+    public static final int PROJECT_TYPE = 0;
+    /** Indicates that the container is of type <code>Screen</code>. */
+    public static final int SCREEN_TYPE = 1;
+    /** Indicates that the container is of type <code>Dataset</code>. */
+    public static final int DATASET_TYPE = 2;
+    /** Indicates that no container specified. */
+    public static final int NO_CONTAINER = 3;
+    /** Bound property indicating to retry an upload.*/
+    public static final String RETRY_PROPERTY = "retry";
+    /** 
+     * Bound property indicating that the error to submit is selected or not.
+     */
+    public static final String SUBMIT_ERROR_PROPERTY = "submitError";
+    /** Bound property indicating to display the error.*/
+    public static final String DISPLAY_ERROR_PROPERTY = "displayError";
+    /** Bound property indicating to cancel the import.*/
+    public static final String CANCEL_IMPORT_PROPERTY = "cancelImport";
+    /** Bound property indicating to browse the node. */
+    public static final String BROWSE_PROPERTY = "browse";
+    /** Bound property indicating to increase the number of files to import. */
+    public static final String IMPORT_FILES_NUMBER_PROPERTY = "importFilesNumber";
+    /**
+     * Bound property indicating to load the content of the log file.
+     */
+    public static final String LOAD_LOGFILEPROPERTY = "loadLogfile";
+    /**
+     * Bound property indicating to retrieve the log file.
+     */
+    public static final String RETRIEVE_LOGFILEPROPERTY = "retrieveLogfile";
+    /**
+     * Bound property indicating to show the checksums,
+     */
+    public static final String CHECKSUM_DISPLAY_PROPERTY = "checksumDisplay";
+    /** The number of extra labels for images to add. */
+    public static final int MAX_THUMBNAILS = 3;
+
+    /**
+     * Returns the file hosted by this component.
+     * 
+     * @return See above.
+     */
+    public abstract FileObject getFile();
+
+    /**
+     * Returns the file hosted by this component.
+     * 
+     * @return See above.
+     */
+    public abstract FileObject getOriginalFile();
+
+    /**
+     * Sets the location where to import the files.
+     * 
+     * @param data The data where to import the folder or screening data.
+     * @param dataset The dataset if any.
+     * @param refNode The node of reference.
+     */
+    public abstract void setLocation(DataObject data, DatasetData dataset,
+            Object refNode);
+
+    /**
+     * Sets the log file annotation.
+     * 
+     * @param data The annotation associated to the file set.
+     * @param id The id of the file set.
+     */
+    public abstract void setImportLogFile(Collection<FileAnnotationData> data,
+            long id);
+
+    /**
+     * Returns the dataset or <code>null</code>.
+     * 
+     * @return See above.
+     */
+    public abstract DatasetData getDataset();
+
+    /**
+     * Returns the object or <code>null</code>.
+     * 
+     * @return See above.
+     */
+    public abstract DataObject getDataObject();
+
+    /**
+     * Returns <code>true</code> if the parent is set.
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasParent();
+
+    /**
+     * Returns the components displaying the status of an on-going import.
+     * 
+     * @return See above.
+     */
+    public abstract Status getStatus();
+
+    /**
+     * Sets the result of the import.
+     * @param image The image.
+     */
+    public abstract void setStatus(Object image);
+
+    /**
+     * Returns the files that failed to import.
+     * 
+     * @return See above.
+     */
+    public abstract List<FileImportComponentI> getImportErrors();
+
+    /**
+     * Returns the id of the group.
+     * 
+     * @return See above.
+     */
+    public abstract long getGroupID();
+
+    /**
+     * Returns the id of the experimenter.
+     * 
+     * @return See above.
+     */
+    public abstract long getExperimenterID();
+
+    /**
+     * Returns the import error object.
+     * 
+     * @return See above.
+     */
+    public abstract ImportErrorObject getImportErrorObject();
+
+    /**
+     * Returns <code>true</code> if the import has failed, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasImportFailed();
+
+    /**
+     * Returns <code>true</code> if it was a failure prior or during the
+     * upload, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasUploadFailed();
+
+    /**
+     * Returns <code>true</code> if the import has been cancelled,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean isCancelled();
+
+    /**
+     * Returns <code>true</code> if the component has imports to cancel,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasImportToCancel();
+
+    /**
+     * Returns <code>true</code> if the file can be re-imported,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasFailuresToReimport();
+
+    /**
+     * Returns <code>true</code> if the file can be re-imported,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasFailuresToReupload();
+
+    /**
+     * Returns <code>true</code> if the import has failed, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasImportStarted();
+
+    /**
+     * Returns <code>true</code> the error can be submitted, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasFailuresToSend();
+
+    /**
+     * Returns <code>true</code> if the folder has components added,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasComponents();
+
+    /**
+     * Returns the status of the import process one of the
+     * values defined in @see ImportStatus
+     * 
+     * @return See above.
+     */
+    public abstract ImportStatus getImportStatus();
+
+    /**
+     * Returns <code>true</code> if refresh whole tree, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasToRefreshTree();
+
+    /**
+     * Returns <code>true</code> if some files were imported, 
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean toRefresh();
+
+    /** Indicates the import has been cancelled. */
+    public abstract void cancelLoading();
+
+    /**
+     * Sets the type. 
+     * 
+     * @param type One of the constants defined by this class.
+     */
+    public abstract void setType(int type);
+
+    /**
+     * Returns the supported type. One of the constants defined by this class.
+     * 
+     * @return See above.
+     */
+    public abstract int getType();
+
+    /**
+     * Returns <code>true</code> if the folder has been converted into a
+     * container, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean isFolderAsContainer();
+
+    /**
+     * Returns the object corresponding to the folder.
+     * 
+     * @return See above.
+     */
+    public abstract DataObject getContainerFromFolder();
+
+    /**
+     * Returns <code>true</code> if the file has already been marked for
+     * re-import, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract List<FileImportComponentI> getFilesToReupload();
+
+    /**
+     * Sets to <code>true</code> to mark the file for reimport.
+     * <code>false</code> otherwise.
+     * 
+     * @param reimported Pass <code>true</code> to mark the file for reimport,
+     * <code>false</code> otherwise.
+     */
+    public abstract void setReimported(boolean reimported);
+
+    /**
+     * Sets the result of the import for the specified file.
+     * 
+     * @param result The result.
+     */
+    public abstract void uploadComplete(Object result);
+
+    /**
+     * Returns the index associated to the main component.
+     * 
+     * @return See above.
+     */
+    public abstract int getIndex();
+
+    /**
+     * Returns the result of the import either a collection of
+     * <code>PixelsData</code> or an exception.
+     * 
+     * @return See above.
+     */
+    public abstract Object getImportResult();
+
+    /**
+     * Returns <code>true</code> if it is a HCS file, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean isHCS();
+
+    /**
+     * Returns the size of the upload.
+     * 
+     * @return See above.
+     */
+    public abstract long getImportSize();
+
+    /**
+     * Returns <code>true</code> if the result has already been set,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public abstract boolean hasResult();
+
+    /**
+     * Returns the importable object associated to the parent,
+     * <code>null</code> if no parent.
+     * 
+     * @return See above.
+     */
+    public abstract ImportableFile getImportableFile();
+
+    /**
+     * Indicates the results saving status.
+     *
+     * @param message The message to display
+     * @param busy Pass <code>true</code> when saving,
+     *             <code>false</code> otherwise.
+     */
+    public abstract void onResultsSaving(String message, boolean busy);
+
+    /**
+     * Listens to property fired by the <code>StatusLabel</code>.
+     * @see PropertyChangeListener#propertyChange(PropertyChangeEvent)
+     */
+    public abstract void propertyChange(PropertyChangeEvent evt);
+
+    /**
+     * Returns the name of the file and group's id and user's id.
+     * @see #toString()
+     */
+    public abstract String toString();
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -254,7 +254,7 @@ public interface FileImportComponentI {
     public abstract boolean hasComponents();
 
     /**
-     * Returns the status of the import process one of the
+     * Returns the status of the import process. One of the
      * values defined in @see ImportStatus
      * 
      * @return See above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -230,7 +230,7 @@ public interface FileImportComponentI {
     public abstract boolean hasFailuresToReupload();
 
     /**
-     * Returns <code>true</code> if the import has failed, <code>false</code>
+     * Returns <code>true</code> if the import has started, <code>false</code>
      * otherwise.
      * 
      * @return See above.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -269,14 +269,6 @@ public interface FileImportComponentI {
      */
     public abstract boolean hasToRefreshTree();
 
-    /**
-     * Returns <code>true</code> if some files were imported, 
-     * <code>false</code> otherwise.
-     * 
-     * @return See above.
-     */
-    public abstract boolean toRefresh();
-
     /** Indicates the import has been cancelled. */
     public abstract void cancelLoading();
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -44,14 +44,18 @@ import org.openmicroscopy.shoola.util.file.ImportErrorObject;
  */
 public interface FileImportComponentI {
 
-    /** Indicates that the container is of type <code>Project</code>. */
-    public static final int PROJECT_TYPE = 0;
-    /** Indicates that the container is of type <code>Screen</code>. */
-    public static final int SCREEN_TYPE = 1;
-    /** Indicates that the container is of type <code>Dataset</code>. */
-    public static final int DATASET_TYPE = 2;
-    /** Indicates that no container specified. */
-    public static final int NO_CONTAINER = 3;
+    /** The container type */
+    public enum ContainerType {
+        /** Project type */
+        PROJECT,
+        /** Screen type */
+        SCREEN,
+        /** Dataset type */
+        DATASET,
+        /** No container type */
+        NA
+    }
+
     /** Bound property indicating to retry an upload.*/
     public static final String RETRY_PROPERTY = "retry";
     /** 
@@ -281,14 +285,14 @@ public interface FileImportComponentI {
      * 
      * @param type One of the constants defined by this class.
      */
-    public abstract void setType(int type);
+    public abstract void setType(ContainerType type);
 
     /**
      * Returns the supported type. One of the constants defined by this class.
      * 
      * @return See above.
      */
-    public abstract int getType();
+    public abstract ContainerType getType();
 
     /**
      * Returns <code>true</code> if the folder has been converted into a

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -387,12 +387,6 @@ public interface FileImportComponentI {
     public abstract void propertyChange(PropertyChangeEvent evt);
 
     /**
-     * Returns the name of the file and group's id and user's id.
-     * @see #toString()
-     */
-    public abstract String toString();
-
-    /**
      * Add a PropertyChangeListener
      * @param l The PropertyChangeListener
      */

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -206,6 +206,13 @@ public interface FileImportComponentI {
     public abstract boolean isCancelled();
 
     /**
+     * Returns the number of cancelled imports
+     * 
+     * @return See above.
+     */
+    public int cancelled();
+    
+    /**
      * Returns <code>true</code> if the component has imports to cancel,
      * <code>false</code> otherwise.
      * 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/FileImportComponentI.java
@@ -1,12 +1,30 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2018 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+
 package org.openmicroscopy.shoola.agents.fsimporter.util;
 
-import java.awt.Color;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collection;
 import java.util.List;
-
-import javax.swing.JPanel;
 
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
@@ -17,6 +35,13 @@ import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 
+/**
+ * Component hosting the file to import and displaying the status of the 
+ * import process.
+ * 
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
 public interface FileImportComponentI {
 
     /** Indicates that the container is of type <code>Project</code>. */
@@ -371,5 +396,9 @@ public interface FileImportComponentI {
      */
     public abstract String toString();
 
+    /**
+     * Add a PropertyChangeListener
+     * @param l The PropertyChangeListener
+     */
     public abstract void addPropertyChangeListener(PropertyChangeListener l);
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -1,0 +1,1168 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.fsimporter.util;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import omero.cmd.CmdCallback;
+import omero.cmd.CmdCallbackI;
+import omero.gateway.SecurityContext;
+import omero.gateway.model.DataObject;
+import omero.gateway.model.DatasetData;
+import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.FilesetData;
+import omero.gateway.model.PixelsData;
+import omero.gateway.model.ProjectData;
+import omero.gateway.model.ScreenData;
+import omero.gateway.model.TagAnnotationData;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.openmicroscopy.shoola.agents.events.iviewer.ViewImage;
+import org.openmicroscopy.shoola.agents.events.iviewer.ViewImageObject;
+import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
+import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
+import org.openmicroscopy.shoola.agents.util.ui.ThumbnailLabel;
+import org.openmicroscopy.shoola.env.data.ImportException;
+import org.openmicroscopy.shoola.env.data.model.FileObject;
+import org.openmicroscopy.shoola.env.data.model.ImportableFile;
+import org.openmicroscopy.shoola.env.data.util.Status;
+import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.util.file.ImportErrorObject;
+
+/**
+ * Component hosting the file to import and displaying the status of the import
+ * process.
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:donald@lifesci.dundee.ac.uk"
+ *         >donald@lifesci.dundee.ac.uk</a>
+ * @author Blazej Pindelski, bpindelski at dundee.ac.uk
+ * @version 3.0
+ * @since 3.0-Beta4
+ */
+public class LightFileImportComponent implements PropertyChangeListener,
+        FileImportComponentI {
+
+    /** Text indicating that the folder does not contain importable files. */
+    private static final String EMPTY_FOLDER = "No data to import";
+
+    /** The maximum width used for the component. */
+    private static final int LENGTH = 350;
+
+    /**
+     * private static final String EMPTY_DIRECTORY = "No data to import";
+     * 
+     * /** One of the constants defined by this class.
+     */
+    private int type;
+
+    /** The imported image. */
+    private Object image;
+
+    /** Set to <code>true</code> if attempt to re-import. */
+    private boolean reimported;
+
+    /** Indicates the status of the on-going import. */
+    private Status status;
+
+    /** Keep tracks of the components. */
+    private Map<File, LightFileImportComponent> components;
+
+    /** The data object corresponding to the folder. */
+    private DataObject containerFromFolder;
+
+    /** The node where to import the folder. */
+    private DataObject data;
+
+    /** The dataset if any. */
+    private DatasetData dataset;
+
+    /** The node of reference if any. */
+    private Object refNode;
+
+    /** The object where the data have been imported. */
+    private DataObject containerObject;
+
+    /** The parent of the node. */
+    private FileImportComponentI parent;
+
+    /** The state of the import */
+    private ImportStatus resultIndex;
+
+    /** The index associated to the main component. */
+    private int index;
+
+    /** Reference to the callback. */
+    private CmdCallback callback;
+
+    /** The importable object. */
+    private ImportableFile importable;
+
+    /** The collection of tags added to the imported images. */
+    private Collection<TagAnnotationData> tags;
+
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    
+    private void firePropertyChange(String name, Object oldValue,
+            Object newValue) {
+        this.pcs.firePropertyChange(name, oldValue, newValue);
+    }
+
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+         this.pcs.addPropertyChangeListener(listener);
+    }
+
+    public PropertyChangeListener[] getPropertyChangeListeners() {
+        return this.pcs.getPropertyChangeListeners();
+    }
+
+    /** Indicates that the import was successful or if it failed. */
+    private void formatResult() {
+        if (callback != null) {
+            try {
+                ((CmdCallbackI) callback).close(true);
+            } catch (Exception e) {
+            }
+        }
+        Object result = status.getImportResult();
+        if (image instanceof ImportException)
+            result = image;
+        if (result instanceof ImportException) {
+            ImportException e = (ImportException) result;
+            int status = e.getStatus();
+            if (status == ImportException.CHECKSUM_MISMATCH)
+                resultIndex = ImportStatus.UPLOAD_FAILURE;
+            else if (status == ImportException.MISSING_LIBRARY)
+                resultIndex = ImportStatus.FAILURE_LIBRARY;
+            else
+                resultIndex = ImportStatus.FAILURE;
+        } else if (result instanceof CmdCallback) {
+            callback = (CmdCallback) result;
+        } else {
+            resultIndex = ImportStatus.SUCCESS;
+        }
+    }
+
+    /**
+     * Indicates that the file will not be imported.
+     * 
+     * @param fire
+     *            Pass <code>true</code> to fire a property, <code>false</code>
+     *            otherwise.
+     */
+    private void cancel(boolean fire) {
+        boolean b = status.isCancellable() || getFile().isDirectory();
+        if (!isCancelled() && !hasImportFailed() && b
+                && !status.isMarkedAsDuplicate()) {
+            status.markedAsCancel();
+            firePropertyChange(CANCEL_IMPORT_PROPERTY, null, this);
+        }
+    }
+
+    /** Initializes the components. */
+    private void initComponents() {
+        status = new Status(importable.getFile());
+        status.addPropertyChangeListener(this);
+        image = null;
+    }
+
+    /**
+     * Attaches the listeners to the newly created component.
+     * 
+     * @param c
+     *            The component to handle.
+     */
+    private void attachListeners(LightFileImportComponent c) {
+        PropertyChangeListener[] listeners = getPropertyChangeListeners();
+        if (listeners != null && listeners.length > 0) {
+            for (int j = 0; j < listeners.length; j++) {
+                c.addPropertyChangeListener(listeners[j]);
+            }
+        }
+    }
+
+    /**
+     * Adds the specified files to the list of import data.
+     * 
+     * @param files
+     *            The files to import.
+     */
+    private void insertFiles(Map<File, Status> files) {
+        resultIndex = ImportStatus.SUCCESS;
+        if (files == null || files.size() == 0)
+            return;
+        components = Collections
+                .synchronizedMap(new HashMap<File, LightFileImportComponent>());
+
+        Entry<File, Status> entry;
+        Iterator<Entry<File, Status>> i = files.entrySet().iterator();
+        LightFileImportComponent c;
+        File f;
+        DatasetData d = dataset;
+        Object node = refNode;
+        if (importable.isFolderAsContainer()) {
+            node = null;
+            d = new DatasetData();
+            d.setName(getFile().getName());
+        }
+        ImportableFile copy;
+        while (i.hasNext()) {
+            entry = i.next();
+            f = entry.getKey();
+            copy = importable.copy();
+            copy.setFile(f);
+            c = new LightFileImportComponent(copy, getIndex(), tags);
+            if (f.isFile()) {
+                c.setLocation(data, d, node);
+                c.setParent(this);
+            }
+            c.setType(getType());
+            attachListeners(c);
+            c.setStatusLabel(entry.getValue());
+            entry.getValue().addPropertyChangeListener(this);
+            components.put((File) entry.getKey(), c);
+        }
+    }
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param importable
+     *            The component hosting information about the file.
+     * @param browsable
+     *            Flag indicating that the container can be browsed or not.
+     * @param singleGroup
+     *            Passes <code>true</code> if the user is member of only one
+     *            group, <code>false</code> otherwise.
+     * @param index
+     *            The index of the parent.
+     * @param tags
+     *            The tags that will be linked to the objects.
+     */
+    public LightFileImportComponent(ImportableFile importable, int index,
+            Collection<TagAnnotationData> tags) {
+        if (importable == null)
+            throw new IllegalArgumentException("No file specified.");
+        if (importable.getGroup() == null)
+            throw new IllegalArgumentException("No group specified.");
+        this.index = index;
+        this.tags = tags;
+        this.importable = importable;
+        resultIndex = ImportStatus.QUEUED;
+        initComponents();
+        setLocation(importable.getParent(), importable.getDataset(),
+                importable.getRefNode());
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getFile()
+     */
+    @Override
+    public FileObject getFile() {
+        return importable.getFile();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getOriginalFile()
+     */
+    @Override
+    public FileObject getOriginalFile() {
+        return importable.getOriginalFile();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #setLocation(omero.gateway.model.DataObject,
+     * omero.gateway.model.DatasetData, java.lang.Object)
+     */
+    @Override
+    public void setLocation(DataObject data, DatasetData dataset, Object refNode) {
+        this.data = data;
+        this.dataset = dataset;
+        this.refNode = refNode;
+        if (refNode != null && refNode instanceof TreeImageDisplay) {
+            TreeImageDisplay n = (TreeImageDisplay) refNode;
+            Object ho = n.getUserObject();
+            if (ho instanceof DatasetData || ho instanceof ProjectData
+                    || ho instanceof ScreenData) {
+                containerObject = (DataObject) ho;
+            }
+            return;
+        }
+        if (dataset != null) {
+            containerObject = dataset;
+            return;
+        }
+        if (data != null && data instanceof ScreenData) {
+            containerObject = data;
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #setImportLogFile(java.util.Collection, long)
+     */
+    @Override
+    public void setImportLogFile(Collection<FileAnnotationData> data, long id) {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getDataset()
+     */
+    @Override
+    public DatasetData getDataset() {
+        return dataset;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getDataObject()
+     */
+    @Override
+    public DataObject getDataObject() {
+        return data;
+    }
+
+    /**
+     * Replaces the initial status label.
+     * 
+     * @param label
+     *            The value to replace.
+     */
+    void setStatusLabel(Status label) {
+        status = label;
+        status.addPropertyChangeListener(this);
+    }
+
+    /**
+     * Sets the parent of the component.
+     * 
+     * @param parent
+     *            The value to set.
+     */
+    void setParent(FileImportComponentI parent) {
+        this.parent = parent;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasParent()
+     */
+    @Override
+    public boolean hasParent() {
+        return parent != null;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getStatus()
+     */
+    @Override
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Returns the associated file if any.
+     *
+     * @param series
+     *            See above.
+     * @return See above.
+     */
+    private FileObject getAssociatedFile(int series) {
+        List<FileObject> l = getFile().getAssociatedFiles();
+        Iterator<FileObject> i = l.iterator();
+        FileObject f;
+        while (i.hasNext()) {
+            f = i.next();
+            if (f.getIndex() == series) {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns <code>true</code> if the file has some associated files,
+     * <code>false</code> otherwise.
+     *
+     * @return See above.
+     */
+    private boolean hasAssociatedFiles() {
+        List<FileObject> l = getFile().getAssociatedFiles();
+        return CollectionUtils.isNotEmpty(l);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #setStatus(java.lang.Object)
+     */
+    @Override
+    public void setStatus(Object image) {
+        this.image = image;
+        if (image instanceof Collection) {
+            Collection<?> c = (Collection) image;
+            if (!c.isEmpty()) {
+                Object obj = c.iterator().next();
+                if (obj instanceof PixelsData) {
+                    // Result from the import itself
+                    this.image = null;
+                    formatResult();
+                }
+            }
+        } else if (image instanceof ImportException) {
+            if (getFile().isDirectory()) {
+                this.image = null;
+            } else
+                formatResult();
+        } else if (image instanceof Boolean) {
+            if (status.isMarkedAsCancel() || status.isMarkedAsDuplicate()) {
+                resultIndex = ImportStatus.IGNORED;
+                this.image = null;
+            }
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getImportErrors()
+     */
+    @Override
+    public List<FileImportComponentI> getImportErrors() {
+        List<FileImportComponentI> l = null;
+        if (getFile().isFile()) {
+            Object r = status.getImportResult();
+            if (r instanceof Exception || image instanceof Exception) {
+                l = new ArrayList<FileImportComponentI>();
+                l.add(this);
+                return l;
+            }
+        } else {
+            if (components != null) {
+                Collection<LightFileImportComponent> values = components
+                        .values();
+                synchronized (components) {
+                    Iterator<LightFileImportComponent> i = values.iterator();
+                    FileImportComponentI fc;
+                    l = new ArrayList<FileImportComponentI>();
+                    List<FileImportComponentI> list;
+                    while (i.hasNext()) {
+                        fc = i.next();
+                        list = fc.getImportErrors();
+                        if (!CollectionUtils.isEmpty(list))
+                            l.addAll(list);
+                    }
+                }
+            }
+        }
+        return l;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getGroupID()
+     */
+    @Override
+    public long getGroupID() {
+        return importable.getGroup().getId();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getExperimenterID()
+     */
+    @Override
+    public long getExperimenterID() {
+        return importable.getUser().getId();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getImportErrorObject()
+     */
+    @Override
+    public ImportErrorObject getImportErrorObject() {
+        Object r = status.getImportResult();
+        Exception e = null;
+        if (r instanceof Exception)
+            e = (Exception) r;
+        else if (image instanceof Exception)
+            e = (Exception) image;
+        if (e == null)
+            return null;
+        ImportErrorObject object = new ImportErrorObject(getFile()
+                .getTrueFile(), e, getGroupID());
+        object.setImportContainer(status.getImportContainer());
+        long id = status.getLogFileID();
+        if (id <= 0) {
+            FilesetData data = status.getFileset();
+            if (data != null) {
+                id = data.getId();
+                object.setRetrieveFromAnnotation(true);
+            }
+        }
+        object.setLogFileID(id);
+        return object;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasImportFailed()
+     */
+    @Override
+    public boolean hasImportFailed() {
+        return resultIndex == ImportStatus.FAILURE
+                || resultIndex == ImportStatus.UPLOAD_FAILURE;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasUploadFailed()
+     */
+    @Override
+    public boolean hasUploadFailed() {
+        return resultIndex == ImportStatus.UPLOAD_FAILURE
+                || (resultIndex == ImportStatus.FAILURE && !status
+                        .didUploadStart());
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #isCancelled()
+     */
+    @Override
+    public boolean isCancelled() {
+        boolean b = status.isMarkedAsCancel();
+        if (b || getFile().isFile())
+            return b;
+        if (components == null)
+            return false;
+        Collection<LightFileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().isCancelled())
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasImportToCancel()
+     */
+    @Override
+    public boolean hasImportToCancel() {
+        boolean b = status.isMarkedAsCancel();
+        if (b)
+            return false;
+        if (getFile().isFile() && !hasImportStarted())
+            return true;
+        if (components == null)
+            return false;
+        Collection<LightFileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            FileImportComponentI fc;
+            while (i.hasNext()) {
+                fc = i.next();
+                if (!fc.isCancelled() && !fc.hasImportStarted())
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasFailuresToReimport()
+     */
+    @Override
+    public boolean hasFailuresToReimport() {
+        if (getFile().isFile())
+            return hasUploadFailed() && !reimported;
+        if (components == null)
+            return false;
+        Collection<LightFileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().hasUploadFailed())
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasFailuresToReupload()
+     */
+    @Override
+    public boolean hasFailuresToReupload() {
+        if (getFile().isFile())
+            return hasUploadFailed() && !reimported;
+        if (components == null)
+            return false;
+        Collection<LightFileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().hasFailuresToReupload())
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasImportStarted()
+     */
+    @Override
+    public boolean hasImportStarted() {
+        if (getFile().isFile())
+            return resultIndex != ImportStatus.QUEUED;
+        if (components == null)
+            return false;
+        Collection<LightFileImportComponent> values = components.values();
+        int count = 0;
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().hasImportStarted())
+                    count++;
+            }
+        }
+        return count == components.size();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasFailuresToSend()
+     */
+    @Override
+    public boolean hasFailuresToSend() {
+        if (getFile().isFile())
+            return resultIndex == ImportStatus.FAILURE;
+        if (components == null)
+            return false;
+        Collection<LightFileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().hasFailuresToSend())
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasComponents()
+     */
+    @Override
+    public boolean hasComponents() {
+        return components != null && components.size() > 0;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getImportStatus()
+     */
+    @Override
+    public ImportStatus getImportStatus() {
+        if (getFile().isFile()) {
+            if (hasImportFailed())
+                return ImportStatus.FAILURE;
+            return resultIndex;
+        }
+        if (components == null || components.size() == 0) {
+            if (image instanceof Boolean) {
+                if (getFile().isDirectory()) {
+                    return ImportStatus.SUCCESS;
+                } else {
+                    if (!status.isMarkedAsCancel()
+                            && !status.isMarkedAsDuplicate())
+                        return ImportStatus.FAILURE;
+                }
+            }
+            return resultIndex;
+        }
+
+        Collection<LightFileImportComponent> values = components.values();
+        int n = components.size();
+        int count = 0;
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().hasImportFailed())
+                    count++;
+            }
+        }
+        if (count == n)
+            return ImportStatus.FAILURE;
+        if (count > 0)
+            return ImportStatus.PARTIAL;
+        return ImportStatus.SUCCESS;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasToRefreshTree()
+     */
+    @Override
+    public boolean hasToRefreshTree() {
+        if (getFile().isFile()) {
+            if (hasImportFailed())
+                return false;
+            switch (type) {
+            case PROJECT_TYPE:
+            case NO_CONTAINER:
+                return true;
+            default:
+                return false;
+            }
+        }
+        if (components == null)
+            return false;
+        if (importable.isFolderAsContainer() && type != PROJECT_TYPE) {
+            Collection<LightFileImportComponent> values = components.values();
+            synchronized (components) {
+                Iterator<LightFileImportComponent> i = values.iterator();
+                while (i.hasNext()) {
+                    if (i.next().toRefresh())
+                        return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #toRefresh()
+     */
+    @Override
+    public boolean toRefresh() {
+        /*
+         * if (file.isFile()) { if (deleteButton.isVisible()) return false; else
+         * if (errorBox.isVisible()) return !(errorBox.isEnabled() &&
+         * errorBox.isSelected()); return true; } if (components == null) return
+         * false; Iterator<FileImportComponent> i =
+         * components.values().iterator(); int count = 0; while (i.hasNext()) {
+         * if (i.next().hasFailuresToSend()) count++; } return components.size()
+         * != count;
+         */
+        return true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #cancelLoading()
+     */
+    @Override
+    public void cancelLoading() {
+        if (components == null || components.isEmpty()) {
+            cancel(getFile().isFile());
+            return;
+        }
+        Collection<LightFileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                i.next().cancelLoading();
+            }
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #setType(int)
+     */
+    @Override
+    public void setType(int type) {
+        this.type = type;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getType()
+     */
+    @Override
+    public int getType() {
+        return type;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #isFolderAsContainer()
+     */
+    @Override
+    public boolean isFolderAsContainer() {
+        return importable.isFolderAsContainer();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getContainerFromFolder()
+     */
+    @Override
+    public DataObject getContainerFromFolder() {
+        return containerFromFolder;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getFilesToReupload()
+     */
+    @Override
+    public List<FileImportComponentI> getFilesToReupload() {
+        List<FileImportComponentI> l = null;
+        if (getFile().isFile()) {
+            if (hasFailuresToReupload() && !reimported) {
+                return Arrays.asList(this);
+            }
+        } else {
+            if (components != null) {
+                Collection<LightFileImportComponent> values = components
+                        .values();
+                synchronized (components) {
+                    Iterator<LightFileImportComponent> i = values.iterator();
+                    FileImportComponentI fc;
+                    l = new ArrayList<FileImportComponentI>();
+                    List<FileImportComponentI> list;
+                    while (i.hasNext()) {
+                        fc = i.next();
+                        list = fc.getFilesToReupload();
+                        if (!CollectionUtils.isEmpty(list))
+                            l.addAll(list);
+                    }
+                }
+            }
+        }
+        return l;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #setReimported(boolean)
+     */
+    @Override
+    public void setReimported(boolean reimported) {
+        this.reimported = reimported;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #uploadComplete(java.lang.Object)
+     */
+    @Override
+    public void uploadComplete(Object result) {
+        if (result instanceof CmdCallback)
+            callback = (CmdCallback) result;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getIndex()
+     */
+    @Override
+    public int getIndex() {
+        return index;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getImportResult()
+     */
+    @Override
+    public Object getImportResult() {
+        return status.getImportResult();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #isHCS()
+     */
+    @Override
+    public boolean isHCS() {
+        return status.isHCS();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getImportSize()
+     */
+    @Override
+    public long getImportSize() {
+        return status.getSizeUpload();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #hasResult()
+     */
+    @Override
+    public boolean hasResult() {
+        return image != null;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #getImportableFile()
+     */
+    @Override
+    public ImportableFile getImportableFile() {
+        return importable;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #onResultsSaving(java.lang.String, boolean)
+     */
+    @Override
+    public void onResultsSaving(String message, boolean busy) {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #propertyChange(java.beans.PropertyChangeEvent)
+     */
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        String name = evt.getPropertyName();
+        if (Status.FILES_SET_PROPERTY.equals(name)) {
+            if (isCancelled()) {
+                return;
+            }
+            Map<File, Status> files = (Map<File, Status>) evt.getNewValue();
+            int n = files.size();
+            insertFiles(files);
+            firePropertyChange(IMPORT_FILES_NUMBER_PROPERTY, null, n);
+        } else if (Status.FILE_IMPORT_STARTED_PROPERTY.equals(name)) {
+            resultIndex = ImportStatus.STARTED;
+            Status sl = (Status) evt.getNewValue();
+            if (sl.equals(status)) {
+                firePropertyChange(Status.FILE_IMPORT_STARTED_PROPERTY, null,
+                        this);
+            }
+        } else if (Status.UPLOAD_DONE_PROPERTY.equals(name)) {
+            Status sl = (Status) evt.getNewValue();
+            if (sl.equals(status) && hasParent()) {
+                if (sl.isMarkedAsCancel())
+                    cancel(true);
+                else {
+                    formatResult();
+                    firePropertyChange(Status.UPLOAD_DONE_PROPERTY, null, this);
+                }
+            }
+        } else if (Status.FILE_RESET_PROPERTY.equals(name)) {
+            importable.setFile((File) evt.getNewValue());
+        } else if (ThumbnailLabel.BROWSE_PLATE_PROPERTY.equals(name)) {
+            firePropertyChange(BROWSE_PROPERTY, evt.getOldValue(),
+                    evt.getNewValue());
+        } else if (Status.CONTAINER_FROM_FOLDER_PROPERTY.equals(name)) {
+            containerFromFolder = (DataObject) evt.getNewValue();
+            if (containerFromFolder instanceof DatasetData) {
+                containerObject = containerFromFolder;
+            } else if (containerFromFolder instanceof ScreenData) {
+                containerObject = containerFromFolder;
+            }
+        } else if (Status.DEBUG_TEXT_PROPERTY.equals(name)) {
+            firePropertyChange(name, evt.getOldValue(), evt.getNewValue());
+        } else if (ThumbnailLabel.VIEW_IMAGE_PROPERTY.equals(name)) {
+            // use the group
+            SecurityContext ctx = new SecurityContext(importable.getGroup()
+                    .getId());
+            EventBus bus = ImporterAgent.getRegistry().getEventBus();
+            Long id = (Long) evt.getNewValue();
+            bus.post(new ViewImage(ctx, new ViewImageObject(id), null));
+        } else if (Status.IMPORT_DONE_PROPERTY.equals(name)
+                || Status.PROCESSING_ERROR_PROPERTY.equals(name)) {
+            Status sl = (Status) evt.getNewValue();
+            if (sl.equals(status))
+                firePropertyChange(Status.IMPORT_DONE_PROPERTY, null, this);
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
+     * #toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer buf = new StringBuffer();
+        buf.append(getFile().getAbsolutePath());
+        if (importable.getGroup() != null)
+            buf.append("_" + importable.getGroup().getId());
+        if (importable.getUser() != null)
+            buf.append("_" + importable.getUser().getId());
+        return buf.toString();
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -952,7 +952,9 @@ public class LightFileImportComponent implements PropertyChangeListener,
         List<FileImportComponentI> l = null;
         if (getFile().isFile()) {
             if (hasFailuresToReupload() && !reimported) {
-                return Arrays.asList(this);
+                ArrayList<FileImportComponentI> ret = new ArrayList<FileImportComponentI>();
+                ret.add(this);
+                return ret;
             }
         } else {
             if (components != null) {
@@ -1144,6 +1146,9 @@ public class LightFileImportComponent implements PropertyChangeListener,
             Status sl = (Status) evt.getNewValue();
             if (sl.equals(status))
                 firePropertyChange(Status.IMPORT_DONE_PROPERTY, null, this);
+        }
+        else if (Status.STEP_PROPERTY.equals(name)) {
+            firePropertyChange(Status.STEP_PROPERTY, evt.getOldValue(), evt.getNewValue());
         }
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -247,11 +247,6 @@ public class LightFileImportComponent implements PropertyChangeListener,
      * 
      * @param importable
      *            The component hosting information about the file.
-     * @param browsable
-     *            Flag indicating that the container can be browsed or not.
-     * @param singleGroup
-     *            Passes <code>true</code> if the user is member of only one
-     *            group, <code>false</code> otherwise.
      * @param index
      *            The index of the parent.
      * @param tags

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,7 +25,6 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,26 +59,13 @@ import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 
 /**
- * Component hosting the file to import and displaying the status of the import
- * process.
- *
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:donald@lifesci.dundee.ac.uk"
- *         >donald@lifesci.dundee.ac.uk</a>
- * @author Blazej Pindelski, bpindelski at dundee.ac.uk
- * @version 3.0
- * @since 3.0-Beta4
+ * A light-weight FileImportComponentI which doesn't use any heavy GUI elements.
+ * 
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
 public class LightFileImportComponent implements PropertyChangeListener,
         FileImportComponentI {
-
-    /** Text indicating that the folder does not contain importable files. */
-    private static final String EMPTY_FOLDER = "No data to import";
-
-    /** The maximum width used for the component. */
-    private static final int LENGTH = 350;
 
     /**
      * private static final String EMPTY_DIRECTORY = "No data to import";

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -596,7 +596,7 @@ public class LightFileImportComponent implements PropertyChangeListener,
     @Override
     public int cancelled() {
         int c = 0;
-        if (components != null) {
+        if (components != null && !components.isEmpty()) {
             Collection<LightFileImportComponent> values = components.values();
             synchronized (components) {
                 Iterator<LightFileImportComponent> i = values.iterator();
@@ -605,6 +605,8 @@ public class LightFileImportComponent implements PropertyChangeListener,
                         c++;
                 }
             }
+        } else if (isCancelled()) {
+            c++;
         }
         return c;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -1132,23 +1132,4 @@ public class LightFileImportComponent implements PropertyChangeListener,
             firePropertyChange(Status.STEP_PROPERTY, evt.getOldValue(), evt.getNewValue());
         }
     }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI
-     * #toString()
-     */
-    @Override
-    public String toString() {
-        StringBuffer buf = new StringBuffer();
-        buf.append(getFile().getAbsolutePath());
-        if (importable.getGroup() != null)
-            buf.append("_" + importable.getGroup().getId());
-        if (importable.getUser() != null)
-            buf.append("_" + importable.getUser().getId());
-        return buf.toString();
-    }
-
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -1075,4 +1075,20 @@ public class LightFileImportComponent implements PropertyChangeListener,
             firePropertyChange(Status.STEP_PROPERTY, evt.getOldValue(), evt.getNewValue());
         }
     }
+    
+    /**
+     * Returns the name of the file and group's id and user's id. 
+     * (This String is used as reference to find a specific LightFileImportComponent
+     * (see {@link LightFileImportComponent#components}) again, don't remove!)
+     */
+    @Override
+    public String toString() {
+        StringBuffer buf = new StringBuffer();
+        buf.append(getFile().getAbsolutePath());
+        if (importable.getGroup() != null)
+            buf.append("_" + importable.getGroup().getId());
+        if (importable.getUser() != null)
+            buf.append("_" + importable.getUser().getId());
+        return buf.toString();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -596,12 +596,14 @@ public class LightFileImportComponent implements PropertyChangeListener,
     @Override
     public int cancelled() {
         int c = 0;
-        Collection<LightFileImportComponent> values = components.values();
-        synchronized (components) {
-            Iterator<LightFileImportComponent> i = values.iterator();
-            while (i.hasNext()) {
-                if (i.next().isCancelled())
-                    c++;
+        if (components != null) {
+            Collection<LightFileImportComponent> values = components.values();
+            synchronized (components) {
+                Iterator<LightFileImportComponent> i = values.iterator();
+                while (i.hasNext()) {
+                    if (i.next().isCancelled())
+                        c++;
+                }
             }
         }
         return c;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -592,6 +592,20 @@ public class LightFileImportComponent implements PropertyChangeListener,
         }
         return false;
     }
+    
+    @Override
+    public int cancelled() {
+        int c = 0;
+        Collection<LightFileImportComponent> values = components.values();
+        synchronized (components) {
+            Iterator<LightFileImportComponent> i = values.iterator();
+            while (i.hasNext()) {
+                if (i.next().isCancelled())
+                    c++;
+            }
+        }
+        return c;
+    }
 
     /*
      * (non-Javadoc)

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -317,7 +317,7 @@ public class LightFileImportComponent implements PropertyChangeListener,
             containerObject = dataset;
             return;
         }
-        if (data != null && data instanceof ScreenData) {
+        if (data instanceof ScreenData) {
             containerObject = data;
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -72,7 +72,7 @@ public class LightFileImportComponent implements PropertyChangeListener,
      * 
      * /** One of the constants defined by this class.
      */
-    private int type;
+    private ContainerType type;
 
     /** The imported image. */
     private Object image;
@@ -807,8 +807,8 @@ public class LightFileImportComponent implements PropertyChangeListener,
             if (hasImportFailed())
                 return false;
             switch (type) {
-            case PROJECT_TYPE:
-            case NO_CONTAINER:
+            case PROJECT:
+            case NA:
                 return true;
             default:
                 return false;
@@ -816,7 +816,7 @@ public class LightFileImportComponent implements PropertyChangeListener,
         }
         if (components == null)
             return false;
-        if (importable.isFolderAsContainer() && type != PROJECT_TYPE) {
+        if (importable.isFolderAsContainer() && type != ContainerType.PROJECT) {
             Collection<LightFileImportComponent> values = components.values();
             synchronized (components) {
                 Iterator<LightFileImportComponent> i = values.iterator();
@@ -881,7 +881,7 @@ public class LightFileImportComponent implements PropertyChangeListener,
      * #setType(int)
      */
     @Override
-    public void setType(int type) {
+    public void setType(ContainerType type) {
         this.type = type;
     }
 
@@ -893,7 +893,7 @@ public class LightFileImportComponent implements PropertyChangeListener,
      * #getType()
      */
     @Override
-    public int getType() {
+    public ContainerType getType() {
         return type;
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
@@ -26,9 +26,7 @@ import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
@@ -55,6 +55,9 @@ public class FailedImportDialog extends JDialog {
     /** Holds the error logs (key: file name) */
     private Map<String, String> errors = new HashMap<String, String>();
 
+    /** Maximum broken import files to list */
+    private final int MAX_ENTRIES = 50;
+    
     /**
      * Create new instance
      * 
@@ -94,15 +97,15 @@ public class FailedImportDialog extends JDialog {
         con.add(new JLabel("File:"), c);
 
         String[] tmp = null;
-        if (errors.keySet().size() < 50) {
+        if (errors.keySet().size() < MAX_ENTRIES) {
             tmp = new String[errors.keySet().size()];
             tmp = errors.keySet().toArray(tmp);
         } else {
-            tmp = new String[51];
+            tmp = new String[MAX_ENTRIES + 1];
             Iterator<String> it = errors.keySet().iterator();
-            for (int i = 0; i < 50; i++)
+            for (int i = 0; i < MAX_ENTRIES; i++)
                 tmp[i] = it.next();
-            tmp[50] = "... and " + (errors.keySet().size() - 50) + " more.";
+            tmp[50] = "... and " + (errors.keySet().size() - MAX_ENTRIES) + " more.";
         }
         String selected = tmp[0];
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
@@ -1,0 +1,168 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2018 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.fsimporter.view;
+
+import java.awt.BorderLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
+import org.openmicroscopy.shoola.util.file.ImportErrorObject;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
+/**
+ * A dialog for displaying the error logs for files which failed to import.
+ * 
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class FailedImportDialog extends JDialog {
+
+    /** Holds the error logs (key: file name) */
+    private Map<String, String> errors = new HashMap<String, String>();
+
+    /**
+     * Create new instance
+     * 
+     * @param owner
+     *            The dialog owner
+     * @param components
+     *            The failed imports
+     */
+    public FailedImportDialog(JFrame owner,
+            Collection<FileImportComponentI> components) {
+        super(owner);
+
+        for (FileImportComponentI c : components) {
+            ImportErrorObject obj = c.getImportErrorObject();
+            errors.put(UIUtilities.formatPartialName(obj.getFile()
+                    .getAbsolutePath(), 60), UIUtilities.printErrorText(obj
+                    .getException()));
+        }
+
+        buildUI();
+    }
+
+    private void buildUI() {
+        setTitle("Failed imports");
+
+        JPanel con = new JPanel();
+        con.setBorder(BorderFactory.createEmptyBorder(4, 4, 4, 4));
+        con.setLayout(new GridBagLayout());
+
+        GridBagConstraints c = new GridBagConstraints();
+        c.ipadx = 2;
+        c.ipady = 2;
+
+        c.gridx = 0;
+        c.gridy = 0;
+        c.fill = GridBagConstraints.NONE;
+        con.add(new JLabel("File:"), c);
+
+        String[] tmp = null;
+        if (errors.keySet().size() < 50) {
+            tmp = new String[errors.keySet().size()];
+            tmp = errors.keySet().toArray(tmp);
+        } else {
+            tmp = new String[51];
+            Iterator<String> it = errors.keySet().iterator();
+            for (int i = 0; i < 50; i++)
+                tmp[i] = it.next();
+            tmp[50] = "... and " + (errors.keySet().size() - 50) + " more.";
+        }
+        String selected = tmp[0];
+
+        final JComboBox<String> filesBox = new JComboBox<String>(tmp);
+        filesBox.setSelectedItem(selected);
+
+        c.gridx = 1;
+        c.gridy = 0;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        con.add(filesBox, c);
+
+        selected = errors.get(selected);
+        final JTextArea errorText = new JTextArea(20, 60);
+        errorText.setEditable(false);
+        errorText.setText(selected);
+
+        c.gridx = 0;
+        c.gridy = 1;
+        c.gridwidth = 2;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        con.add(new JLabel("Error log:"), c);
+
+        c.gridx = 0;
+        c.gridy = 2;
+        c.gridwidth = 2;
+        c.fill = GridBagConstraints.BOTH;
+        final JScrollPane sp = new JScrollPane(errorText);
+        con.add(sp, c);
+
+        filesBox.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                String sel = (String) filesBox.getSelectedItem();
+                String text = errors.get(sel);
+                errorText.setText(text != null ? text : "");
+                errorText.setCaretPosition(0);
+            }
+        });
+
+        final JButton close = new JButton("Close");
+        c.gridx = 1;
+        c.gridy = 3;
+        c.gridwidth = 1;
+        c.fill = GridBagConstraints.BOTH;
+        c.anchor = GridBagConstraints.LAST_LINE_END;
+        c.fill = GridBagConstraints.NONE;
+        con.add(close, c);
+        close.addActionListener(new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                FailedImportDialog.this.dispose();
+            }
+        });
+
+        getRootPane().setLayout(new BorderLayout());
+        getRootPane().add(con, BorderLayout.CENTER);
+
+        pack();
+
+        errorText.setCaretPosition(0);
+    }
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
@@ -27,7 +27,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Map;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 import javax.swing.BorderFactory;
@@ -53,11 +53,11 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
 public class FailedImportDialog extends JDialog {
 
     /** Holds the error logs (key: file name) */
-    private Map<String, String> errors = new TreeMap<String, String>();
+    private SortedMap<String, String> errors = new TreeMap<String, String>();
 
     /** Maximum broken import files to list */
     private final int MAX_ENTRIES = 50;
-    
+
     /**
      * Create new instance
      * 
@@ -76,7 +76,7 @@ public class FailedImportDialog extends JDialog {
                     .getAbsolutePath(), 60), UIUtilities.printErrorText(obj
                     .getException()));
         }
-        
+
         buildUI();
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
@@ -28,7 +28,9 @@ import java.awt.event.ActionListener;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -53,7 +55,7 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
 public class FailedImportDialog extends JDialog {
 
     /** Holds the error logs (key: file name) */
-    private Map<String, String> errors = new HashMap<String, String>();
+    private Map<String, String> errors = new TreeMap<String, String>();
 
     /** Maximum broken import files to list */
     private final int MAX_ENTRIES = 50;
@@ -76,7 +78,7 @@ public class FailedImportDialog extends JDialog {
                     .getAbsolutePath(), 60), UIUtilities.printErrorText(obj
                     .getException()));
         }
-
+        
         buildUI();
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
@@ -28,6 +28,7 @@ import javax.swing.JFrame;
 
 import org.openmicroscopy.shoola.agents.events.treeviewer.BrowserSelectionEvent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.ObjectToCreate;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.env.data.model.DiskQuota;
@@ -220,7 +221,7 @@ public interface Importer
      * 
      * @param fc The file to upload or <code>null</code>.
      */
-    public void retryUpload(FileImportComponent fc);
+    public void retryUpload(FileImportComponentI fc);
 
     /**
      * Returns <code>true</code> if it is the last file to import,
@@ -336,14 +337,14 @@ public interface Importer
      * 
      * @param component The component to handle.
      */
-    void onImportComplete(FileImportComponent component);
+    void onImportComplete(FileImportComponentI component);
 
     /**
      * Indicates that the import is complete for the specified component.
      * 
      * @param component The component to handle.
      */
-    void onUploadComplete(FileImportComponent component);
+    void onUploadComplete(FileImportComponentI component);
 
     /**
      * Sets the result e.g. thumbnails corresponding to the images imported.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/Importer.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -27,7 +27,6 @@ import java.util.Collection;
 import javax.swing.JFrame;
 
 import org.openmicroscopy.shoola.agents.events.treeviewer.BrowserSelectionEvent;
-import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.ObjectToCreate;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -36,6 +36,7 @@ import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.chooser.ImportDialog;
 import org.openmicroscopy.shoola.agents.fsimporter.chooser.ImportLocationSettings;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.ObjectToCreate;
 import org.openmicroscopy.shoola.agents.treeviewer.view.TreeViewer;
 import org.openmicroscopy.shoola.agents.util.ViewerSorter;
@@ -50,7 +51,9 @@ import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.model.ResultsObject;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
@@ -544,18 +547,18 @@ class ImporterComponent
 	 * Implemented as specified by the {@link Importer} interface.
 	 * @see Importer#retryUpload(FileImportComponent)
 	 */
-	public void retryUpload(FileImportComponent fc)
+	public void retryUpload(FileImportComponentI fc)
 	{
 		if (model.getState() == DISCARDED) return;
 		ImporterUIElement element = view.getSelectedPane();
 		if (element == null) return;
-		List<FileImportComponent> l;
+		List<FileImportComponentI> l;
 		if (fc != null) {
-			l = new ArrayList<FileImportComponent>(1);
+			l = new ArrayList<FileImportComponentI>(1);
 			l.add(fc);
 		} else l = element.getFilesToReupload();
 		if (CollectionUtils.isEmpty(l)) return;
-		Iterator<FileImportComponent> i = l.iterator();
+		Iterator<FileImportComponentI> i = l.iterator();
 		ImportableObject object = element.getData();
 		List<ImportableFile> list = new ArrayList<ImportableFile>();
 		while (i.hasNext()) {
@@ -837,7 +840,7 @@ class ImporterComponent
 	 * Implemented as specified by the {@link TreeViewer} interface.
 	 * @see Importer#onImportComplete(FileImportComponent)
 	 */
-	public void onImportComplete(FileImportComponent component)
+	public void onImportComplete(FileImportComponentI component)
 	{
 		if (component == null || model.getState() == DISCARDED) return;
 		ImporterUIElement element = view.getUIElement(component.getIndex());
@@ -876,8 +879,8 @@ class ImporterComponent
 		}
 		model.saveROI(component, ids);
         if (l.size() > 0 && !PlateData.class.equals(klass)) {
-            if (l.size() > FileImportComponent.MAX_THUMBNAILS) {
-                l = l.subList(0, FileImportComponent.MAX_THUMBNAILS);
+            if (l.size() > FileImportComponentI.MAX_THUMBNAILS) {
+                l = l.subList(0, FileImportComponentI.MAX_THUMBNAILS);
             }
             model.fireImportResultLoading(l, klass, component,
                     component.getImportableFile().getUser());
@@ -888,7 +891,7 @@ class ImporterComponent
 	 * Implemented as specified by the {@link Importer} interface.
 	 * @see Importer#onUploadComplete(FileImportComponent)
 	 */
-	public void onUploadComplete(FileImportComponent component)
+	public void onUploadComplete(FileImportComponentI component)
 	{
 		if (model.getState() == DISCARDED) return;
 		if (component == null || model.getState() == DISCARDED) return;
@@ -911,7 +914,7 @@ class ImporterComponent
 	public void setImportResult(Object result, Object component)
 	{
 		if (component == null || model.getState() == DISCARDED) return;
-		FileImportComponent c = (FileImportComponent) component;
+		FileImportComponentI c = (FileImportComponentI) component;
 		ImporterUIElement element = view.getUIElement(c.getIndex());
 		if (element == null) return;
 		c.setStatus(result);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -51,7 +51,6 @@ import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.model.ResultsObject;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
-
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -827,8 +827,9 @@ class ImporterComponent
 			ImporterUIElement element;
 			while (i.hasNext()) {
 				element = i.next();
-				if (!element.isUploadComplete())
+				if (!element.isUploadComplete()) {
 					return true;
+				}
 			}
 		}
 		return false;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -52,13 +52,12 @@ import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.model.ResultsObject;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
 
-import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 import org.openmicroscopy.shoola.util.ui.component.AbstractComponent;
 
+import omero.gateway.SecurityContext;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.FileAnnotationData;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
@@ -63,7 +63,7 @@ import org.openmicroscopy.shoola.agents.util.ViewerSorter;
 import org.openmicroscopy.shoola.agents.util.ui.JComboBoxImageObject;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
-import org.openmicroscopy.shoola.env.data.util.StatusLabel;
+import org.openmicroscopy.shoola.env.data.util.Status;
 import omero.log.Logger;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
@@ -404,7 +404,7 @@ class ImporterControl
             } else if (ImportDialog.CREATE_OBJECT_PROPERTY.equals(name)) {
                     ObjectToCreate l = (ObjectToCreate) evt.getNewValue();
                     model.createDataObject(l);
-            } else if (StatusLabel.DEBUG_TEXT_PROPERTY.equals(name)) {
+            } else if (Status.DEBUG_TEXT_PROPERTY.equals(name)) {
                     view.appendDebugText((String) evt.getNewValue());
             } else if (MacOSMenuHandler.QUIT_APPLICATION_PROPERTY.equals(name)) {
                     Action a = getAction(EXIT);
@@ -414,12 +414,12 @@ class ImporterControl
             } else if (ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
                     GroupData newGroup = (GroupData) evt.getNewValue();
                     model.setUserGroup(newGroup);
-            } else if (StatusLabel.FILE_IMPORT_STARTED_PROPERTY.equals(name) ||
+            } else if (Status.FILE_IMPORT_STARTED_PROPERTY.equals(name) ||
                     FileImportComponent.CANCEL_IMPORT_PROPERTY.equals(name)) {
                 checkDisableCancelAllButtons();
-            } else if (StatusLabel.IMPORT_DONE_PROPERTY.equals(name)) {
+            } else if (Status.IMPORT_DONE_PROPERTY.equals(name)) {
                     model.onImportComplete((FileImportComponent) evt.getNewValue());
-            } else if (StatusLabel.UPLOAD_DONE_PROPERTY.equals(name)) {
+            } else if (Status.UPLOAD_DONE_PROPERTY.equals(name)) {
                     model.onUploadComplete((FileImportComponent) evt.getNewValue());
             }
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
@@ -391,7 +391,6 @@ class ImporterControl
          */
         private void handlePropertyChangedEvent(PropertyChangeEvent evt) {
             String name = evt.getPropertyName();
-            System.out.println("ImporterControl <- "+name);
             if (ImportDialog.IMPORT_PROPERTY.equals(name)) {
                 actionsMap.get(CANCEL_BUTTON).setEnabled(true);
                 model.importData((ImportableObject) evt.getNewValue());

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
@@ -58,13 +58,16 @@ import org.openmicroscopy.shoola.agents.fsimporter.actions.RetryImportAction;
 import org.openmicroscopy.shoola.agents.fsimporter.actions.SubmitFilesAction;
 import org.openmicroscopy.shoola.agents.fsimporter.chooser.ImportDialog;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.ObjectToCreate;
 import org.openmicroscopy.shoola.agents.util.ViewerSorter;
 import org.openmicroscopy.shoola.agents.util.ui.JComboBoxImageObject;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.util.Status;
+
 import omero.log.Logger;
+
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 import org.openmicroscopy.shoola.util.ui.ClosableTabbedPane;
@@ -120,7 +123,7 @@ class ImporterControl
 	private ImporterUI		view;
 
 	/** Collection of files to submit. */
-	private List<FileImportComponent> markedFailed;
+	private List<FileImportComponentI> markedFailed;
 	
 	/** Maps actions identifiers onto actual <code>Action</code> object. */
 	private Map<Integer, ImporterAction>	actionsMap;
@@ -260,11 +263,11 @@ class ImporterControl
 	 * 
 	 * @param fc The component to handle or <code>null</code>.
 	 */
-	void submitFiles(FileImportComponent fc)
+	void submitFiles(FileImportComponentI fc)
 	{
-		List<FileImportComponent> list;
+		List<FileImportComponentI> list;
 		if (fc != null) {
-			list = new ArrayList<FileImportComponent>();
+			list = new ArrayList<FileImportComponentI>();
 			list.add(fc);
 		} else {
 			list = view.getMarkedFiles();
@@ -272,7 +275,7 @@ class ImporterControl
 		
 		markedFailed = list;
 		//Now prepare the list of object to send.
-		Iterator<FileImportComponent> i = list.iterator();
+		Iterator<FileImportComponentI> i = list.iterator();
 		ImportErrorObject object;
 		List<ImportErrorObject> toSubmit = new ArrayList<ImportErrorObject>();
 		while (i.hasNext()) {
@@ -388,6 +391,7 @@ class ImporterControl
          */
         private void handlePropertyChangedEvent(PropertyChangeEvent evt) {
             String name = evt.getPropertyName();
+            System.out.println("ImporterControl <- "+name);
             if (ImportDialog.IMPORT_PROPERTY.equals(name)) {
                 actionsMap.get(CANCEL_BUTTON).setEnabled(true);
                 model.importData((ImportableObject) evt.getNewValue());
@@ -397,7 +401,7 @@ class ImporterControl
                     model.close();
             } else if (ClosableTabbedPane.CLOSE_TAB_PROPERTY.equals(name)) {
                     model.removeImportElement(evt.getNewValue());
-            } else if (FileImportComponent.SUBMIT_ERROR_PROPERTY.equals(name)) {
+            } else if (FileImportComponentI.SUBMIT_ERROR_PROPERTY.equals(name)) {
                     submitFiles((FileImportComponent) evt.getNewValue());
             } else if (ImportDialog.REFRESH_LOCATION_PROPERTY.equals(name)) {
                     model.refreshContainers((ImportLocationDetails) evt.getNewValue());
@@ -415,12 +419,12 @@ class ImporterControl
                     GroupData newGroup = (GroupData) evt.getNewValue();
                     model.setUserGroup(newGroup);
             } else if (Status.FILE_IMPORT_STARTED_PROPERTY.equals(name) ||
-                    FileImportComponent.CANCEL_IMPORT_PROPERTY.equals(name)) {
+                    FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
                 checkDisableCancelAllButtons();
             } else if (Status.IMPORT_DONE_PROPERTY.equals(name)) {
-                    model.onImportComplete((FileImportComponent) evt.getNewValue());
+                    model.onImportComplete((FileImportComponentI) evt.getNewValue());
             } else if (Status.UPLOAD_DONE_PROPERTY.equals(name)) {
-                    model.onUploadComplete((FileImportComponent) evt.getNewValue());
+                    model.onUploadComplete((FileImportComponentI) evt.getNewValue());
             }
         }
 
@@ -439,7 +443,7 @@ class ImporterControl
 	 * 
 	 * @param fc The file to upload.
 	 */
-	void cancel(FileImportComponent fc)
+	void cancel(FileImportComponentI fc)
 	{
 		model.onUploadComplete(fc);
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
@@ -65,7 +65,6 @@ import org.openmicroscopy.shoola.agents.util.ui.JComboBoxImageObject;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.util.Status;
-
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
 import org.openmicroscopy.shoola.util.ui.ClosableTabbedPane;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -65,8 +65,6 @@ import org.openmicroscopy.shoola.agents.util.ui.JComboBoxImageObject;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.util.Status;
-
-import omero.log.Logger;
 
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -49,7 +49,7 @@ import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.MeasurementsSaver;
 import org.openmicroscopy.shoola.agents.fsimporter.ROISaver;
 import org.openmicroscopy.shoola.agents.fsimporter.TagsLoader;
-import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.ObjectToCreate;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.FileObject;
@@ -620,7 +620,7 @@ class ImporterModel
      * @param c The component to handle.
      * @param images The images to handle.
      */
-    void saveROI(FileImportComponent c, List<ImageData> images)
+    void saveROI(FileImportComponentI c, List<ImageData> images)
     {
         FileObject object = c.getOriginalFile();
         if (object.isImagePlus() && CollectionUtils.isNotEmpty(images)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -66,6 +66,7 @@ import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
+
 //Third-party libraries
 import info.clearthought.layout.TableLayout;
 
@@ -79,10 +80,13 @@ import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.actions.GroupSelectionAction;
 import org.openmicroscopy.shoola.agents.fsimporter.chooser.ImportDialog;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
+
 import omero.gateway.SecurityContext;
+
 import org.openmicroscopy.shoola.env.ui.TaskBar;
 import org.openmicroscopy.shoola.env.ui.TopWindow;
 import org.openmicroscopy.shoola.util.ui.ClosableTabbedPane;
@@ -448,12 +452,12 @@ class ImporterUI extends TopWindow
 	 * 
 	 * @return See above.
 	 */
-	List<FileImportComponent> getMarkedFiles()
+	List<FileImportComponentI> getMarkedFiles()
 	{
 		Component[] comps = tabs.getComponents();
 		if (comps == null || comps.length == 0) return null;
-		List<FileImportComponent> list = new ArrayList<FileImportComponent>();
-		List<FileImportComponent> l;
+		List<FileImportComponentI> list = new ArrayList<FileImportComponentI>();
+		List<FileImportComponentI> l;
 		ImporterUIElement element = getSelectedPane();
 		if(element == null)
 			return null;
@@ -474,8 +478,14 @@ class ImporterUI extends TopWindow
 		if (object == null) return null;
 		int n = tabs.getComponentCount();
 		String title = "Import #"+total;
-		ImporterUIElement element = new ImporterUIElement(controller, model,
-				this, uiElementID, n, title, object);
+		ImporterUIElement element = null;
+        if (object.getFiles().size() > 200) {
+            element = new ImporterUIElement(controller, model, this,
+                    uiElementID, n, title, object);
+        } else {
+            element = new ImporterUIElementDetailed(controller, model, this,
+                    uiElementID, n, title, object);
+        }
 		tabs.insertTab(title, element.getImportIcon(), element, "", total);
 		total++;
 		uiElements.put(uiElementID, element);
@@ -715,7 +725,7 @@ class ImporterUI extends TopWindow
 	 * 
 	 * @return See above.
 	 */
-	List<FileImportComponent> getFilesToReimport()
+	List<FileImportComponentI> getFilesToReimport()
 	{
 		ImporterUIElement pane = getSelectedPane();
     	if (pane == null) return null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -479,8 +479,8 @@ class ImporterUI extends TopWindow
 		int n = tabs.getComponentCount();
 		String title = "Import #"+total;
 		ImporterUIElement element = null;
-        if (object.getFiles().size() > 200) {
-            element = new ImporterUIElement(controller, model, this,
+        if (object.getFiles().size() > 0) {
+            element = new ImporterUIElementLight(controller, model, this,
                     uiElementID, n, title, object);
         } else {
             element = new ImporterUIElementDetailed(controller, model, this,

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -36,6 +36,7 @@ import java.awt.Toolkit;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.awt.event.KeyEvent;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -65,6 +66,8 @@ import javax.swing.event.ChangeListener;
 import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
+
+
 
 
 //Third-party libraries
@@ -475,11 +478,16 @@ class ImporterUI extends TopWindow
 	 */
 	ImporterUIElement addImporterElement(ImportableObject object)
 	{
-		if (object == null) return null;
+		if (object == null) 
+		    return null;
+		
+		int maxFiles = (Integer) ImporterAgent.getRegistry().lookup(
+                "/options/DetailedImportFileLimit");
+		
 		int n = tabs.getComponentCount();
 		String title = "Import #"+total;
 		ImporterUIElement element = null;
-        if (object.getFiles().size() > 0) {
+        if (fileCount(object) > maxFiles) {
             element = new ImporterUIElementLight(controller, model, this,
                     uiElementID, n, title, object);
         } else {
@@ -496,6 +504,28 @@ class ImporterUI extends TopWindow
 		}
 		return element;
 	}
+	
+    private int fileCount(ImportableObject obj) {
+        int count = 0;
+        for (ImportableFile f : obj.getFiles()) {
+            count += fileCount(f.getOriginalFile().getTrueFile());
+        }
+        return count;
+    }
+
+    private int fileCount(File file) {
+        if (file == null)
+            return 0;
+
+        if (file.isDirectory()) {
+            int count = 0;
+            for (File f : file.listFiles()) {
+                count += fileCount(f);
+            }
+            return count;
+        }
+        return 1;
+    }
 	
 	/** Resets the import.*/
 	void reset()

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -67,9 +67,6 @@ import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
-
-
-
 //Third-party libraries
 import info.clearthought.layout.TableLayout;
 
@@ -78,18 +75,15 @@ import org.jdesktop.swingx.JXLabel;
 import org.jdesktop.swingx.JXPanel;
 
 //Application-internal dependencies
+import omero.gateway.SecurityContext;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
 import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.actions.GroupSelectionAction;
 import org.openmicroscopy.shoola.agents.fsimporter.chooser.ImportDialog;
-import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.imviewer.view.ImViewer;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
-
-import omero.gateway.SecurityContext;
-
 import org.openmicroscopy.shoola.env.ui.TaskBar;
 import org.openmicroscopy.shoola.env.ui.TopWindow;
 import org.openmicroscopy.shoola.util.ui.ClosableTabbedPane;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -567,8 +567,9 @@ class ImporterUI extends TopWindow
 	void setSelectedPane(ImporterUIElement element, boolean startImport)
 	{
 		int n = tabs.getComponentCount();
+		
 		if (n == 0 || element == null) return;
-		if (tabs.getSelectedComponent() == element) return;
+		
 		Component[] components = tabs.getComponents();
 		int index = -1;
 		for (int i = 0; i < components.length; i++) {
@@ -577,6 +578,7 @@ class ImporterUI extends TopWindow
 				tabs.setSelectedComponent(element);
 			}
 		}
+		
 		if (startImport) {
 			Icon icon = element.startImport(tabs);
 			if (index >=0) tabs.setIconAt(index, icon);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUI.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.agents.fsimporter.view.ImporterUI 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -134,22 +134,26 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
     LinkedHashMap<String, FileImportComponentI> components;
 
     /** The number of cancellation. */
-    private int countCancelled;
+    int countCancelled;
 
     /** The number of uploaded files. */
-    private int countUploaded;
+    int countUploaded;
 
     /** The number of files/folder imported. */
-    private int countImported;
+    int countImported;
 
     /** The number of files uploaded. */
-    private int countUploadFailure;
+    int countUploadFailure;
 
+    int countMetadata = 0;
+    
+    int countThumbs = 0;
+    
     /**
      * The number of failures that occurred during scanning, uploading or
      * processing.
      */
-    private int countFailure;
+    int countFailure;
 
     /** The total number of files or folder to import. */
     int totalToImport;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -69,7 +69,7 @@ import org.openmicroscopy.shoola.env.data.model.DownloadAndLaunchActivityParam;
 import org.openmicroscopy.shoola.env.data.model.FileObject;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
-import org.openmicroscopy.shoola.env.data.util.StatusLabel;
+import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
@@ -418,7 +418,7 @@ class ImporterUIElement
 					} else if (
 						FileImportComponent.CHECKSUM_DISPLAY_PROPERTY.equals(
 							name)) {
-						StatusLabel label = (StatusLabel) evt.getNewValue();
+						Status label = (Status) evt.getNewValue();
 						CheckSumDialog d = new CheckSumDialog(view, label);
 						UIUtilities.centerAndShow(d);
 					} else if (FileImportComponent.RETRY_PROPERTY.equals(name)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -21,17 +21,12 @@
 package org.openmicroscopy.shoola.agents.fsimporter.view;
 
 import info.clearthought.layout.TableLayout;
-import info.clearthought.layout.TableLayoutConstraints;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,23 +40,26 @@ import java.util.Map.Entry;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.Icon;
-import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.border.LineBorder;
+
+import omero.gateway.model.DataObject;
+import omero.gateway.model.DatasetData;
+import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.ProjectData;
+import omero.gateway.model.ScreenData;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.jdesktop.swingx.JXBusyLabel;
-import org.openmicroscopy.shoola.agents.events.importer.BrowseContainer;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
 import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
-import org.openmicroscopy.shoola.agents.fsimporter.util.CheckSumDialog;
-import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.ImportStatus;
+import org.openmicroscopy.shoola.agents.fsimporter.util.LightFileImportComponent;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.env.Environment;
 import org.openmicroscopy.shoola.env.LookupNames;
@@ -69,8 +67,6 @@ import org.openmicroscopy.shoola.env.data.model.DownloadAndLaunchActivityParam;
 import org.openmicroscopy.shoola.env.data.model.FileObject;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
-import org.openmicroscopy.shoola.env.data.util.Status;
-import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.file.ImportErrorObject;
@@ -78,1146 +74,985 @@ import org.openmicroscopy.shoola.util.ui.ClosableTabbedPaneComponent;
 import org.openmicroscopy.shoola.util.ui.RotationIcon;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
-import omero.gateway.model.DataObject;
-import omero.gateway.model.DatasetData;
-import omero.gateway.model.FileAnnotationData;
-import omero.gateway.model.FilesetData;
-import omero.gateway.model.ProjectData;
-import omero.gateway.model.ScreenData;
-
-/** 
+/**
  * Component displaying an import.
  *
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:donald@lifesci.dundee.ac.uk"
+ *         >donald@lifesci.dundee.ac.uk</a>
  * @version 3.0
  * @since 3.0-Beta4
  */
-class ImporterUIElement 
-	extends ClosableTabbedPaneComponent
-{
-	
-	/** Description of the component. */
-	private static final String DESCRIPTION = 
-		"Closing will cancel imports that have not yet started.";
-	
-	/** Text indicating to only show the failure.*/
-	private static final String SHOW_FAILURE = "Show Failed";
-	
-	/** Text indicating to show all the imports.*/
-	private static final String SHOW_ALL = "Show All";
-	
-	/** The columns for the layout of the {@link #entries}. */
-	private static final double[] COLUMNS = {TableLayout.FILL};
-	
-	/** The default size of the icon. */
-	private static final Dimension ICON_SIZE = new Dimension(16, 16);
-	
-	/** Icon used when the import is completed successfully. */
-	private static final Icon IMPORT_SUCCESS;
-	
-	/** Icon used when the import failed. */
-	private static final Icon IMPORT_FAIL;
-	
-	/** Icon used when the import is completed. */
-	private static final Icon IMPORT_PARTIAL;
-	
-	static {
-		IconManager icons = IconManager.getInstance();
-		IMPORT_SUCCESS = icons.getIcon(IconManager.APPLY);
-		IMPORT_FAIL = icons.getIcon(IconManager.DELETE);
-		IMPORT_PARTIAL = icons.getIcon(IconManager.APPLY_CANCEL);
-	}
-	
-	/** The message to display in the header.*/
-	private static final String MESSAGE = 
-			"When upload is complete, the import" +CommonsLangUtils.LINE_SEPARATOR+
-			"window and OMERO session can be closed." +CommonsLangUtils.LINE_SEPARATOR+
-			"Reading will continue on the server.";
-	
-	/** The object hosting information about files to import. */
-	private ImportableObject object;
-	
-	/** The components to lay out. */
-	private LinkedHashMap<String, FileImportComponent>	components;
+class ImporterUIElement extends ClosableTabbedPaneComponent {
 
-	/** Component hosting the entries. */
-	private JPanel	entries;
+    /** Description of the component. */
+    private static final String DESCRIPTION = "Closing will cancel imports that have not yet started.";
 
-	/** The number of cancellation.*/
-	private int countCancelled;
-	
-	/** The number of uploaded files.*/
-	private int countUploaded;
-	
-	/** The number of files/folder imported. */
-	private int countImported;
-	
-	/** The number of files uploaded. */
-	private int countUploadFailure;
-	
-	/** 
-	 * The number of failures that occurred during scanning, uploading
-	 * or processing.
-	 */
-	private int countFailure;
-	
-	/** The total number of files or folder to import. */
-	private int totalToImport;
-	
-	/** The size of the import. */
-	private long sizeImport;
-	
-	/** The component displaying the size the import. */
-	private JLabel sizeLabel;
-	
-	/** The component displaying the number of files to import. */
-	private JLabel numberOfImportLabel;
+    /** Text indicating to only show the failure. */
+    private static final String SHOW_FAILURE = "Show Failed";
 
-	/** Label for report display */
-	private JLabel reportLabel;
+    /** Text indicating to show all the imports. */
+    private static final String SHOW_ALL = "Show All";
 
-	/** Label for import size display */
-	private JLabel importSizeLabel;
-			
-	/** The identifier of the component. */
-	private int id;
-	
-	/** The collection of folders' name used as dataset. */
-	private Map<JLabel, Object> foldersName;
+    /** The columns for the layout of the {@link #entries}. */
+    private static final double[] COLUMNS = { TableLayout.FILL };
 
-	/** Reference to the view. */
-	private ImporterUI view;
-	
-	/** Reference to the controller. */
-	private ImporterControl controller;
-	
-	/** Reference to the controller. */
-	private ImporterModel model;
+    /** The default size of the icon. */
+    private static final Dimension ICON_SIZE = new Dimension(16, 16);
 
-	/** The type of container to handle. */
-	private int type;
-	
-	/** The existing containers. */
-	private List<DataObject> existingContainers;
+    /** Icon used when the import is completed successfully. */
+    private static final Icon IMPORT_SUCCESS;
 
-	/** The busy label. */
-	private JXBusyLabel busyLabel;
-	
-	/**The icon used to indicate an on-going import.*/
-	private RotationIcon rotationIcon;
-	
-	/** Controls used to filter the result.*/
-	private JButton filterButton;
-	
-	/** Flag indicating if the upload has started or not.*/
-	private boolean uploadStarted;
-	
-	/**
-	 * Returns the object found by identifier.
-	 * 
-	 * @param data The object to handle.
-	 * @param result The collection of element to check.
-	 * @return See above.
-	 */
-	private DataObject getObjectFromID(DataObject data, Collection result)
-	{
-		Iterator i = result.iterator();
-		DataObject object;
-		while (i.hasNext()) {
-			object = (DataObject) i.next();
-			if (object.getClass().equals(data.getClass()) 
-					&& object.getId() == data.getId()) {
-				return object;
-			}
-		}
-		return null;
-	}
-	
-	/**
-	 * Returns the object found by name.
-	 * 
-	 * @param data The object to handle.
-	 * @param result The collection of element to check.
-	 * @return See above.
-	 */
-	private DataObject getObject(DataObject data, Collection result)
-	{
-		String name = "";
-		if (data instanceof ProjectData) {
-			name = ((ProjectData) data).getName();
-		} else if (data instanceof ScreenData) {
-			name = ((ScreenData) data).getName();
-		} else if (data instanceof DatasetData) {
-			name = ((DatasetData) data).getName();
-		}
-		Iterator i = result.iterator();
-		DataObject object;
-		String n = "";
-		while (i.hasNext()) {
-			object = (DataObject) i.next();
-			if (object.getClass().equals(data.getClass())) {
-				if (object instanceof ProjectData) {
-					n = ((ProjectData) object).getName();
-				} else if (object instanceof ScreenData) {
-					n = ((ScreenData) object).getName();
-				} else if (object instanceof DatasetData) {
-					n = ((DatasetData) object).getName();
-				}
-				if (n.equals(name)) return object;
-			}
-		}
-		return null;
-	}
-	
-	/** Sets the text of indicating the number of imports. */
-	private void setNumberOfImport()
-	{
-		StringBuffer buffer = new StringBuffer();
-		int n = countUploaded-countUploadFailure-countCancelled;
-		if (n < 0) n = 0;
-		buffer.append(n);
-		buffer.append(" out of ");
-		buffer.append(totalToImport);
-		buffer.append(" uploaded");
-		numberOfImportLabel.setText(buffer.toString());
-	}
-	
-	/**
-	 * Browses the specified object.
-	 * 
-	 * @param data The object to handle.
-	 * @param node The node hosting the object to browse or <code>null</code>.
-	 */ 
-	private void browse(Object data, Object node)
-	{
-		EventBus bus = ImporterAgent.getRegistry().getEventBus();
-		if (data instanceof TreeImageDisplay || data instanceof DataObject) {
-			bus.post(new BrowseContainer(data, node));
-		} else if (data instanceof FileImportComponent) {
-			FileImportComponent fc = (FileImportComponent) data;
-			if (fc.getContainerFromFolder() != null)
-				bus.post(new BrowseContainer(fc.getContainerFromFolder(), 
-						node));
-		}
-	}
+    /** Icon used when the import failed. */
+    private static final Icon IMPORT_FAIL;
 
-	/**
-	 * Displays only the failures or all the results.
-	 */
-	private void filterFailures()
-	{
-		String v = filterButton.getText();
-		if (SHOW_FAILURE.equals(v)) {
-			filterButton.setText(SHOW_ALL);
-			layoutEntries(true);
-		} else {
-			filterButton.setText(SHOW_FAILURE);
-			layoutEntries(false);
-		}
-	}
-	
-	/** Initializes the components. */
-	private void initialize()
-	{
-		filterButton = new JButton(SHOW_FAILURE);
-		filterButton.setEnabled(false);
-		filterButton.addActionListener(new ActionListener() {
-			
-			/**
-			 * Filters or not the import that did not fail.
-			 */
-			public void actionPerformed(ActionEvent evt) {
-				filterFailures();
-			}
-		});
-		sizeImport = 0;
-		busyLabel = new JXBusyLabel(ICON_SIZE);
-		numberOfImportLabel = UIUtilities.createComponent(null);
-		foldersName = new LinkedHashMap<JLabel, Object>();
-		countUploadFailure = 0;
-		countFailure = 0;
-		countUploaded = 0;
-		addPropertyChangeListener(controller);
-		entries = new JPanel();
-		entries.setBackground(UIUtilities.BACKGROUND);
-		components = new LinkedHashMap<String, FileImportComponent>();
-		List<ImportableFile> files = object.getFiles();
-		FileImportComponent c;
-		
-		Iterator<ImportableFile> i = files.iterator();
-		ImportableFile importable;
-		type = -1;
-		List<Object> containers = object.getRefNodes();
-		if (containers != null && containers.size() > 0) {
-			Iterator<Object> j = containers.iterator();
-			TreeImageDisplay node;
-			Object h;
-			while (j.hasNext()) {
-				node = (TreeImageDisplay) j.next();
-				h = node.getUserObject();
-				if (h instanceof DatasetData) {
-					type = FileImportComponent.DATASET_TYPE;
-				} else if (h instanceof ScreenData) {
-					type = FileImportComponent.SCREEN_TYPE;
-				} else if (h instanceof ProjectData) {
-					type = FileImportComponent.PROJECT_TYPE;
-				}
-				break;
-			}
-		} else {
-			type = FileImportComponent.NO_CONTAINER;
-		}
-		JLabel l;
-		boolean single = model.isSingleGroup();
-		FileObject f;
-		while (i.hasNext()) {
-			importable = i.next();
-			f = (FileObject) importable.getFile();
-			c = new FileImportComponent(importable,
-					!controller.isMaster(), single, getID(), object.getTags());
-			c.setType(type);
-			c.addPropertyChangeListener(controller);
-			c.addPropertyChangeListener(new PropertyChangeListener() {
-				
-				public void propertyChange(PropertyChangeEvent evt) {
-					String name = evt.getPropertyName();
-					if (FileImportComponent.BROWSE_PROPERTY.equals(name)) {
-						List<Object> refNodes = object.getRefNodes();
-						Object node = null;
-						if (refNodes != null && refNodes.size() > 0)
-							node = refNodes.get(0);
-						browse(evt.getNewValue(), node);
-					} else if (
-						FileImportComponent.IMPORT_FILES_NUMBER_PROPERTY.equals(
-								name)) {
-						//-1 to remove the entry for the folder.
-						Integer v = (Integer) evt.getNewValue()-1;
-						totalToImport += v;
-						setNumberOfImport();
-					} else if (FileImportComponent.LOAD_LOGFILEPROPERTY.equals(
-							name)) {
-						FileImportComponent fc = (FileImportComponent)
-								evt.getNewValue();
-						if (fc == null) return;
-						long logFileID = fc.getStatus().getLogFileID();
-						if (logFileID <= 0) {
-							FilesetData data = fc.getStatus().getFileset();
-							if (data == null) return;
-							model.fireImportLogFileLoading(data.getId(),
-									fc.getIndex());
-						} else downloadLogFile(logFileID);
-					} else if (
-						FileImportComponent.RETRIEVE_LOGFILEPROPERTY.equals(
-							name)) {
-						FilesetData data = (FilesetData) evt.getNewValue();
-						if (data != null)
-							model.fireImportLogFileLoading(data.getId(), id);
-					} else if (
-						FileImportComponent.CHECKSUM_DISPLAY_PROPERTY.equals(
-							name)) {
-						Status label = (Status) evt.getNewValue();
-						CheckSumDialog d = new CheckSumDialog(view, label);
-						UIUtilities.centerAndShow(d);
-					} else if (FileImportComponent.RETRY_PROPERTY.equals(name)) {
-						controller.retryUpload(
-								(FileImportComponent) evt.getNewValue());
-					} else if (
-						FileImportComponent.CANCEL_IMPORT_PROPERTY.equals(name)) {
-						controller.cancel(
-								(FileImportComponent) evt.getNewValue());
-					}
-				}
-			});
-			if (f.isDirectory()) {
-				if (importable.isFolderAsContainer()) {
-					l = new JLabel(f.getName());
-					foldersName.put(l, c);
-				}
-			} else {
-				if (importable.isFolderAsContainer()) {
-					String name = f.getParentName();
-					//first check if the name is already there.
-					Entry<JLabel, Object> entry;
-					Iterator<Entry<JLabel, Object>>
-					k = foldersName.entrySet().iterator();
-					boolean exist = false;
-					while (k.hasNext()) {
-						entry = k.next();
-						l = entry.getKey();
-						if (l.getText().equals(name)) {
-							exist = true;
-							break;
-						}
-					}
-					if (name == null) {
-					    name = f.getName();
-					}
-					if (!exist) {
-						foldersName.put(new JLabel(name), c);
-					}
-				}
-			}
-			importable.setStatus(c.getStatus());
-			components.put(c.toString(), c);
-		}
-		totalToImport = files.size();
-	}
-	
-	/**
-	 * Downloads the log file.
-	 * 
-	 * @param logFileID
-	 */
-	void downloadLogFile(long logFileID)
-	{
-		if (logFileID < 0) return;
-		Environment env = (Environment) 
-				ImporterAgent.getRegistry().lookup(
-						LookupNames.ENV);
-		String path = env.getOmeroFilesHome();
-		File f = new File(path, "importLog_"+logFileID);
-		DownloadAndLaunchActivityParam
-		activity = new DownloadAndLaunchActivityParam(logFileID,
-				DownloadAndLaunchActivityParam.ORIGINAL_FILE,
-				f, null);
-		activity.setUIRegister(false);
-		UserNotifier un =
-				ImporterAgent.getRegistry().getUserNotifier();
-		un.notifyActivity(model.getSecurityContext(), activity);
-	}
-	
-	/** 
-	 * Builds a row.
-	 * 
-	 * @return See above.
-	 */
-	private JPanel createRow()
-	{
-		JPanel p = new JPanel();
-		p.setLayout(new FlowLayout(FlowLayout.LEFT));
-		p.setBackground(UIUtilities.BACKGROUND_COLOR);
-		return p;
-	}
-	
-	/**
-	 * Make the JTextArea represent a multiline label.
-	 * 
-	 * @param textArea The component to handle.
-	 */
-	private void makeLabelStyle(JTextArea textArea)
-	{
-		if (textArea == null) return;
-		textArea.setEditable(false);
-		textArea.setCursor(null);
-		textArea.setOpaque(false);
-		textArea.setFocusable(false);
-	}
-	
-	/** 
-	 * Builds and lays out the header.
-	 * 
-	 * @return See above.
-	 */
-	private JPanel buildHeader()
-	{
-		sizeLabel = UIUtilities.createComponent(null);
-		sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
-		reportLabel = UIUtilities.setTextFont("Report:", Font.BOLD);
-		importSizeLabel = UIUtilities.setTextFont("Import Size:", Font.BOLD);
-		double[][] design = new double[][]{
-					{TableLayout.PREFERRED},
-					{TableLayout.PREFERRED, TableLayout.PREFERRED}
-				};
-		TableLayout layout = new TableLayout(design);
-		JPanel detailsPanel = new JPanel(layout);
-		detailsPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
-		JPanel p = createRow();
-		p.add(reportLabel);
-		p.add(numberOfImportLabel);
-		detailsPanel.add(p, "0, 0");
-		p = createRow();
-		p.add(importSizeLabel);
-		p.add(sizeLabel);
-		detailsPanel.add(p, "0, 1");
-		
-		JPanel middlePanel = new JPanel();
-		middlePanel.setBackground(UIUtilities.BACKGROUND_COLOR);
-		middlePanel.add(filterButton);
-		
-    	JTextArea description = new JTextArea(MESSAGE);
-    	makeLabelStyle(description);
-    	description.setBackground(UIUtilities.BACKGROUND_COLOR);
-    	
-		JPanel descriptionPanel = new JPanel();
-		descriptionPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
-		descriptionPanel.add(description);
-		
-		JPanel header = new JPanel();
-		header.setBackground(UIUtilities.BACKGROUND_COLOR);
-		header.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
-		header.setLayout(new BorderLayout());
-		
-		header.add(Box.createVerticalStrut(10), BorderLayout.NORTH);
-		header.add(detailsPanel, BorderLayout.WEST);
-		header.add(middlePanel, BorderLayout.CENTER);
-		header.add(descriptionPanel, BorderLayout.EAST);
-		header.add(Box.createVerticalStrut(10), BorderLayout.SOUTH);
-		
-		return header;
-	}
-	
-	/** Builds and lays out the UI. */
-	private void buildGUI()
-	{
-		layoutEntries(false);
-		JScrollPane pane = new JScrollPane(entries);
-		pane.setOpaque(false);
-		pane.setBorder(new LineBorder(Color.LIGHT_GRAY));
-		setLayout(new BorderLayout(0, 0));
-		add(buildHeader(), BorderLayout.NORTH);
-		add(pane, BorderLayout.CENTER);
-	}
-	
-	/** 
-	 * Lays out the entries.
-	 * 
-	 * @param failure Pass <code>true</code> to display the failed import only,
-	 * <code>false</code> to display all the entries.
-	 */
-	private void layoutEntries(boolean failure)
-	{
-		entries.removeAll();
-		TableLayout layout = new TableLayout();
-		layout.setColumn(COLUMNS);
-		entries.setLayout(layout);
-		int index = 0;
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		if (failure) {
-			while (i.hasNext()) {
-				entry = i.next();
-				fc = entry.getValue();
-				if (fc.hasComponents()) {
-					addRow(layout, index, entry.getValue());
-					fc.layoutEntries(failure);
-					index++;
-				} else {
-					if (fc.hasImportFailed()) {
-						addRow(layout, index, entry.getValue());
-						index++;
-					}
-				}
-			}
-		} else {
-			while (i.hasNext()) {
-				entry = i.next();
-				fc = entry.getValue();
-				addRow(layout, index, fc);
-				fc.layoutEntries(failure);
-				index++;
-			}
-		}
-		
-		entries.revalidate();
-		repaint();
-		setNumberOfImport();
-	}
-	
-	/**
-	 * Adds a new row.
-	 * 
-	 * @param layout The layout.
-	 * @param index	 The index of the row.
-	 * @param c		 The component to add.
-	 */
-	private void addRow(TableLayout layout, int index, FileImportComponent c)
-	{
-		layout.insertRow(index, TableLayout.PREFERRED);
-		if (index%2 == 0)
-			c.setBackground(UIUtilities.BACKGROUND_COLOUR_EVEN);
-		else 
-			c.setBackground(UIUtilities.BACKGROUND_COLOUR_ODD);
-		entries.add(c, new TableLayoutConstraints(0, index));
-	}
-	
-	/**
-	 * Creates a new instance.
-	 * 
-	 * @param controller Reference to the control. Mustn't be <code>null</code>.
-	 * @param model Reference to the model. Mustn't be <code>null</code>.
-	 * @param view Reference to the model. Mustn't be <code>null</code>.
-	 * @param id The identifier of the component.
-	 * @param index The index of the component.
-	 * @param name The name of the component.
-	 * @param object the object to handle. Mustn't be <code>null</code>.
-	 */
-	ImporterUIElement(ImporterControl controller, ImporterModel model,
-			ImporterUI view, int id, int index, String name,
-			ImportableObject object)
-	{
-		super(index, name, DESCRIPTION);
-		if (object == null) 
-			throw new IllegalArgumentException("No object specified.");
-		if (controller == null)
-			throw new IllegalArgumentException("No Control.");
-		if (model == null)
-			throw new IllegalArgumentException("No Model.");
-		if (view == null)
-			throw new IllegalArgumentException("No View.");
-		this.controller = controller;
-		this.model = model;
-		this.view = view;
-		this.id = id;
-		this.object = object;
-		initialize();
-		buildGUI();
-	}
+    /** Icon used when the import is completed. */
+    private static final Icon IMPORT_PARTIAL;
 
-	/**
-	 * Returns the identifier of the component.
-	 * 
-	 * @return See above.
-	 */
-	int getID() { return id; }
-	
-	/**
-	 * Returns the formatted result.
-	 * 
-	 * @param f The imported file.
-	 * @return See above.
-	 */
-	Object getFormattedResult(ImportableFile f)
-	{
-		FileImportComponent c = components.get(f.toString());
-		if (c == null) return null;
-		ImportErrorObject object = c.getImportErrorObject();
-		if (object != null) return object;
-		
-		return null;
-	}
-	
+    static {
+        IconManager icons = IconManager.getInstance();
+        IMPORT_SUCCESS = icons.getIcon(IconManager.APPLY);
+        IMPORT_FAIL = icons.getIcon(IconManager.DELETE);
+        IMPORT_PARTIAL = icons.getIcon(IconManager.APPLY_CANCEL);
+    }
 
-	/**
-	 * Sets the result of the import for the specified file.
-	 * 
-	 * @param f The imported file.
-	 * @param result The result.
-	 * @result Returns the formatted result or <code>null</code>.
-	 */
-	Object uploadComplete(ImportableFile f, Object result)
-	{
-		FileImportComponent c = components.get(f.toString());
-		return uploadComplete(c, result);
-	}
-	
-	/**
-	 * Sets the result of the import for the specified file.
-	 * 
-	 * @param f The imported file.
-	 * @param result The result.
-	 * @param index The index corresponding to the component
-	 * @result Returns the formatted result or <code>null</code>.
-	 */
-	Object uploadComplete(FileImportComponent c, Object result)
-	{
-		if (c == null) return null;
-		c.uploadComplete(result);
-		FileObject file = c.getFile();
-		Object r = null;
-		if (file.isFile()) {
-			countUploaded++;
-			sizeImport += c.getImportSize();
-			sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
-			//handle error that occurred during the scanning or upload.
-			//Check that the result has not been set.
-			//if (!c.hasResult()) {
-			if (result instanceof Exception) {
-				r = new ImportErrorObject(file.getTrueFile(), (Exception) result,
-						c.getGroupID());
-				if (c.hasResult()) return null;
-				setImportResult(c, result);
-			} else if (result instanceof Boolean) {
-				Boolean b = (Boolean) result;
-				if (!b && c.isCancelled()) {
-					countUploaded--;
-					if (isDone() && rotationIcon != null)
-						rotationIcon.stopRotation();
-				} else
-				setImportResult(c, result);
-			} else {
-				if (c.isCancelled()) {
-					if (result == null) {
-						countCancelled++;
-						countImported++;
-						if (isDone() && rotationIcon != null)
-							rotationIcon.stopRotation();
-					} else {
-						countCancelled--;
-						countUploaded--;
-					}
-				}
-			}
-			//}
-		} else {//empty folder
-			if (result instanceof Exception) {
-				countUploaded++;
-				//Check if no files
-				if (!c.hasComponents()) {
-					countImported++;
-					countUploadFailure++;
-					c.setStatus(result);
-				}
-				if (isDone() && rotationIcon != null)
-					rotationIcon.stopRotation();
-			} else if (result instanceof Boolean) {
-				Boolean b = (Boolean) result;
-				if (!b && c.isCancelled()) {
-					countUploaded++;
-					countCancelled++;
-					countImported++;
-					if (isDone() && rotationIcon != null)
-						rotationIcon.stopRotation();
-				}
-			}
-		}
-		setNumberOfImport();
-		setClosable(isUploadComplete());
-		return r;
-	}
-	
-	/**
-	 * Sets the result of the import for the specified file.
-	 * 
-	 * @param fc The component hosting the file to import.
-	 * @param result The result.
-	 * @result Returns the formatted result or <code>null</code>.
-	 */
-	void setImportResult(FileImportComponent fc, Object result)
-	{
-		if (fc == null) return;
-		FileObject file = fc.getFile();
-		if (file.isFile()) {
-			fc.setStatus(result);
-			countImported++;
-			if (fc.isCancelled() && result != null &&
-				!(result instanceof Boolean))
-				countImported--;
-			if (isDone() && rotationIcon != null)
-				rotationIcon.stopRotation();
-			if (fc.hasUploadFailed()) {
-				countUploadFailure++;
-				sizeImport -= fc.getImportSize();
-				sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
-			}
-			if (fc.hasImportFailed()) countFailure++;
-			setNumberOfImport();
-			setClosable(isDone());
-			filterButton.setEnabled(countFailure > 0 &&
-					countFailure != totalToImport);
-		} else { //empty folder
-			if (result instanceof Exception) {
-				fc.setStatus(result);
-				countImported++;
-				countFailure++;
-				countUploadFailure++;
-				if (isDone() && rotationIcon != null)
-					rotationIcon.stopRotation();
-				setNumberOfImport();
-				setClosable(isDone());
-			}
-		}
-	}
+    /** The message to display in the header. */
+    private static final String MESSAGE = "When upload is complete, the import"
+            + CommonsLangUtils.LINE_SEPARATOR
+            + "window and OMERO session can be closed."
+            + CommonsLangUtils.LINE_SEPARATOR
+            + "Reading will continue on the server.";
 
-	/**
-	 * Returns <code>true</code> if the upload is finished, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean isUploadComplete() { 
-	    return (countFailure + countUploaded) == totalToImport;
-	}
-	
-	/**
-	 * Returns <code>true</code> if the import is finished, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean isDone() { return countImported == totalToImport; }
-	
-	/**
-	 * Returns <code>true</code> if there is one remaining import,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean isLastImport() { return countImported == (totalToImport-1); }
-	
-	/** 
-	 * Indicates that the import has started. 
-	 * 
-	 * @param component The component of reference of the rotation icon.
-	 */
-	Icon startImport(JComponent component)
-	{
-		uploadStarted = true;
-		setClosable(false);
-		busyLabel.setBusy(true);
-		repaint();
-		return new RotationIcon(busyLabel.getIcon(), component, true);
-	}
-	
-	/**
-	 * Returns <code>true</code> if the import has started, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasStarted() { return uploadStarted; }
-	
-	/**
-	 * Manually sets the uploadStarted flag
-	 * @param uploadStarted
-	 */
-	void setUploadStarted(boolean uploadStarted) {
-	    this.uploadStarted = uploadStarted;
-	}
-	
-	/**
-	 * Returns <code>true</code> if the component has imports in the queue that
-	 * have not yet started or been cancelled, <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasImportToCancel()
-	{
-	    for (final FileImportComponent fic : components.values()) {
-	    	if (fic.hasImportToCancel()) {
-	            return true;
-	        }
-	    }
-	    return false;
-	}
+    /** The object hosting information about files to import. */
+    ImportableObject object;
 
-	/**
-	 * Returns the collection of files that could not be imported.
-	 * 
-	 * @return See above.
-	 */
-	List<FileImportComponent> getMarkedFiles()
-	{
-		List<FileImportComponent> list = new ArrayList<FileImportComponent>();
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		List<FileImportComponent> l;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			l = fc.getImportErrors();
-			if (l != null && l.size() > 0)
-				list.addAll(l);
-		}
-		return list;
-	}
-	
-	/**
-	 * Returns the collection of files that could not be imported.
-	 * 
-	 * @return See above.
-	 */
-	List<FileImportComponent> getFilesToReupload()
-	{
-		List<FileImportComponent> list = new ArrayList<FileImportComponent>();
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		List<FileImportComponent> l;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			l = fc.getFilesToReupload();
-			if (!CollectionUtils.isEmpty(l))
-				list.addAll(l);
-		}
-		return list;
-	}
-	
-	/**
-	 * Returns the object to import.
-	 * 
-	 * @return See above.
-	 */
-	ImportableObject getData() { return object; }
-	
-	/**
-	 * Returns the existing containers.
-	 * 
-	 * @return See above.
-	 */
-	List<DataObject> getExistingContainers()
-	{
-		if (existingContainers != null) return existingContainers;
-		existingContainers = new ArrayList<DataObject>();
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		Map<Long, DatasetData> datasets = new HashMap<Long, DatasetData>();
-		Map<Long, DataObject> projects = new HashMap<Long, DataObject>();
-		Map<Long, DataObject> screens = new HashMap<Long, DataObject>();
-		DatasetData d;
-		DataObject object;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			d = fc.getDataset();
-			if (d != null && d.getId() > 0)
-				datasets.put(d.getId(), d);
-			object = fc.getDataObject();
-			if (object instanceof ScreenData && object.getId() > 0)
-				screens.put(object.getId(), object);
-			if (object instanceof ProjectData && object.getId() > 0) {
-				if (d != null && d.getId() <= 0)
-					projects.put(object.getId(), object);
-			}
-		}
-		existingContainers.addAll(datasets.values());
-		existingContainers.addAll(projects.values());
-		existingContainers.addAll(screens.values());
-		return existingContainers;
-	}
+    /** The components to lay out. */
+    private LinkedHashMap<String, LightFileImportComponent> components;
 
-	/**
-	 * Sets the import log file for each import component.
-	 *
-	 * @param data Collection of file annotations linked to the file set.
-	 * @param id The id of the file set.
-	 */
-	void setImportLogFile(Collection<FileAnnotationData> data, long id)
-	{
-	    if (CollectionUtils.isEmpty(data)) return;
-	    Entry<String, FileImportComponent> entry;
-	    Iterator<Entry<String, FileImportComponent>>
-	    i = components.entrySet().iterator();
-	    FileImportComponent fc;
-	    Iterator<FileAnnotationData> j;
-	    FileAnnotationData fa;
-	    while (i.hasNext()) {
-	        entry = i.next();
-	        fc = entry.getValue();
-	        if (fc.getIndex() == id) {
-	            j = data.iterator();
-	            while (j.hasNext()) {
-	                fa = j.next();
-	                if (FileAnnotationData.LOG_FILE_NS.equals(
-	                        fa.getNameSpace())) {
-	                    downloadLogFile(fa.getFileID());
-	                    break;
-	                }
-	            }
-	        }
-	    }
-	}
+    /** The number of cancellation. */
+    private int countCancelled;
 
-	/**
-	 * Returns <code>true</code> if errors to send, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasFailuresToSend()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasFailuresToSend())
-				return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Returns <code>true</code> if files to reimport, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasFailuresToReimport()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasFailuresToReimport())
-				return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Returns <code>true</code> if files to re-upload, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasFailuresToReupload()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasFailuresToReupload())
-				return true;
-		}
-		return false;
-	}
-	
-	/** Indicates that the import has been cancelled. */
-	void cancelLoading()
-	{
-		if (components == null || components.size() == 0) return;
-		Iterator<FileImportComponent> i = components.values().iterator();
-		while (i.hasNext()) {
-			i.next().cancelLoading();
-		}
-	}
+    /** The number of uploaded files. */
+    private int countUploaded;
 
-	/**
-	 * Returns <code>true</code> if the view should be refreshed,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasToRefreshTree()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponent fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasToRefreshTree())
-				return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Returns the icon indicating the status of the import.
-	 * 
-	 * @return See above.
-	 */
-	Icon getImportIcon()
-	{ 
-		if (isDone()) {
-			Iterator<Entry<String, FileImportComponent>>
-			i = components.entrySet().iterator();
-			FileImportComponent fc;
-			Entry<String, FileImportComponent> entry;
-			int failure = 0;
-			ImportStatus v;
-			while (i.hasNext()) {
-				entry = i.next();
-				fc = entry.getValue();
-				v = fc.getImportStatus();
-				if (v == ImportStatus.PARTIAL)
-					return IMPORT_PARTIAL;
-				if (v == ImportStatus.FAILURE) failure++;
-			}
-			if (failure == components.size()) return IMPORT_FAIL;
-			else if (failure > 0) return IMPORT_PARTIAL;
-			return IMPORT_SUCCESS;
-		}
-		return busyLabel.getIcon();
-	}
-	
-	/** Invokes when the import is finished. */
-	void onImportEnded()
-	{ 
-		busyLabel.setBusy(false);
-		setClosable(true);
-	}
+    /** The number of files/folder imported. */
+    private int countImported;
 
-	/**
-	 * Resets the containers in the file to load.
-	 * 
-	 * @param result The containers to reset.
-	 */
-	void resetContainers(Collection result)
-	{
-		if (result == null || result.size() == 0) return;
-		List<ImportableFile> files = getData().getFiles();
-		if (files == null || files.size() == 0) return;
-		Iterator<ImportableFile> i = files.iterator();
-		ImportableFile f;
-		DataObject parent;
-		DatasetData dataset;
-		DataObject data;
-		ProjectData p;
-		DatasetData r;
-		while (i.hasNext()) {
-			f = i.next();
-			parent = f.getParent();
-			dataset = f.getDataset();
-			if (parent != null) {
-				if (parent.getId() <= 0) { //new project or screen
-					data = getObject(parent, result);
-					r = null;
-					if (dataset != null) {
-						if (dataset.getId() <= 0) {
-							//data is a project
-							r = dataset;
-							p = (ProjectData) data;
-							r = (DatasetData) 
-								getObject(dataset, p.getDatasets());
-						}
-					} 
-					f.setLocation(data, r);
-				} else { //was already created.
-					if (dataset != null) {
-						if (dataset.getId() <= 0) {
-							data = getObjectFromID(parent, result);
-							//data is a project
-							r = dataset;
-							p = (ProjectData) data;
-							r = (DatasetData) 
-								getObject(dataset, p.getDatasets());
-							f.setLocation(data, r);
-						}
-					}
-				}
-			} else { //no parent
-				if (dataset != null) {
-					if (dataset.getId() <= 0) {
-						//data is a project
-						r = dataset;
-						r = (DatasetData) 
-							getObject(dataset, result);
-						f.setLocation(null, r);
-					}
-				}
-			}
-		}
-	}
+    /** The number of files uploaded. */
+    private int countUploadFailure;
+
+    /**
+     * The number of failures that occurred during scanning, uploading or
+     * processing.
+     */
+    private int countFailure;
+
+    /** The total number of files or folder to import. */
+    private int totalToImport;
+
+    /** The size of the import. */
+    private long sizeImport;
+
+    /** The component displaying the size the import. */
+    private JLabel sizeLabel;
+
+    /** The component displaying the number of files to import. */
+    private JLabel numberOfImportLabel;
+
+    /** Label for report display */
+    private JLabel reportLabel;
+
+    /** Label for import size display */
+    private JLabel importSizeLabel;
+
+    /** The identifier of the component. */
+    int id;
+
+    /** The collection of folders' name used as dataset. */
+    private Map<JLabel, Object> foldersName;
+
+    /** Reference to the view. */
+    ImporterUI view;
+
+    /** Reference to the controller. */
+    ImporterControl controller;
+
+    /** Reference to the controller. */
+    ImporterModel model;
+
+    /** The type of container to handle. */
+    private int type;
+
+    /** The existing containers. */
+    private List<DataObject> existingContainers;
+
+    /** The busy label. */
+    private JXBusyLabel busyLabel;
+
+    /** The icon used to indicate an on-going import. */
+    private RotationIcon rotationIcon;
+
+    /** Flag indicating if the upload has started or not. */
+    private boolean uploadStarted;
+
+    /**
+     * Returns the object found by identifier.
+     * 
+     * @param data
+     *            The object to handle.
+     * @param result
+     *            The collection of element to check.
+     * @return See above.
+     */
+    private DataObject getObjectFromID(DataObject data, Collection result) {
+        Iterator i = result.iterator();
+        DataObject object;
+        while (i.hasNext()) {
+            object = (DataObject) i.next();
+            if (object.getClass().equals(data.getClass())
+                    && object.getId() == data.getId()) {
+                return object;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the object found by name.
+     * 
+     * @param data
+     *            The object to handle.
+     * @param result
+     *            The collection of element to check.
+     * @return See above.
+     */
+    private DataObject getObject(DataObject data, Collection result) {
+        String name = "";
+        if (data instanceof ProjectData) {
+            name = ((ProjectData) data).getName();
+        } else if (data instanceof ScreenData) {
+            name = ((ScreenData) data).getName();
+        } else if (data instanceof DatasetData) {
+            name = ((DatasetData) data).getName();
+        }
+        Iterator i = result.iterator();
+        DataObject object;
+        String n = "";
+        while (i.hasNext()) {
+            object = (DataObject) i.next();
+            if (object.getClass().equals(data.getClass())) {
+                if (object instanceof ProjectData) {
+                    n = ((ProjectData) object).getName();
+                } else if (object instanceof ScreenData) {
+                    n = ((ScreenData) object).getName();
+                } else if (object instanceof DatasetData) {
+                    n = ((DatasetData) object).getName();
+                }
+                if (n.equals(name))
+                    return object;
+            }
+        }
+        return null;
+    }
+
+    /** Sets the text of indicating the number of imports. */
+    private void setNumberOfImport() {
+        StringBuffer buffer = new StringBuffer();
+        int n = countUploaded - countUploadFailure - countCancelled;
+        if (n < 0)
+            n = 0;
+        buffer.append(n);
+        buffer.append(" out of ");
+        buffer.append(totalToImport);
+        buffer.append(" uploaded");
+        numberOfImportLabel.setText(buffer.toString());
+    }
+
+    /** Initializes the components. */
+    private void initialize() {
+        sizeImport = 0;
+        busyLabel = new JXBusyLabel(ICON_SIZE);
+        numberOfImportLabel = UIUtilities.createComponent(null);
+        foldersName = new LinkedHashMap<JLabel, Object>();
+        countUploadFailure = 0;
+        countFailure = 0;
+        countUploaded = 0;
+        addPropertyChangeListener(controller);
+        components = new LinkedHashMap<String, LightFileImportComponent>();
+        List<ImportableFile> files = object.getFiles();
+        LightFileImportComponent c;
+
+        Iterator<ImportableFile> i = files.iterator();
+        ImportableFile importable;
+        type = -1;
+        List<Object> containers = object.getRefNodes();
+        if (containers != null && containers.size() > 0) {
+            Iterator<Object> j = containers.iterator();
+            TreeImageDisplay node;
+            Object h;
+            while (j.hasNext()) {
+                node = (TreeImageDisplay) j.next();
+                h = node.getUserObject();
+                if (h instanceof DatasetData) {
+                    type = FileImportComponentI.DATASET_TYPE;
+                } else if (h instanceof ScreenData) {
+                    type = FileImportComponentI.SCREEN_TYPE;
+                } else if (h instanceof ProjectData) {
+                    type = FileImportComponentI.PROJECT_TYPE;
+                }
+                break;
+            }
+        } else {
+            type = FileImportComponentI.NO_CONTAINER;
+        }
+        JLabel l;
+        boolean single = model.isSingleGroup();
+        FileObject f;
+        while (i.hasNext()) {
+            importable = i.next();
+            f = (FileObject) importable.getFile();
+            c = new LightFileImportComponent(importable, getID(),
+                    object.getTags());
+            c.setType(type);
+            c.addPropertyChangeListener(controller);
+            if (f.isDirectory()) {
+                if (importable.isFolderAsContainer()) {
+                    l = new JLabel(f.getName());
+                    foldersName.put(l, c);
+                }
+            } else {
+                if (importable.isFolderAsContainer()) {
+                    String name = f.getParentName();
+                    // first check if the name is already there.
+                    Entry<JLabel, Object> entry;
+                    Iterator<Entry<JLabel, Object>> k = foldersName.entrySet()
+                            .iterator();
+                    boolean exist = false;
+                    while (k.hasNext()) {
+                        entry = k.next();
+                        l = entry.getKey();
+                        if (l.getText().equals(name)) {
+                            exist = true;
+                            break;
+                        }
+                    }
+                    if (name == null) {
+                        name = f.getName();
+                    }
+                    if (!exist) {
+                        foldersName.put(new JLabel(name), c);
+                    }
+                }
+            }
+            importable.setStatus(c.getStatus());
+            components.put(c.toString(), c);
+        }
+        totalToImport = files.size();
+    }
+
+    /**
+     * Downloads the log file.
+     * 
+     * @param logFileID
+     */
+    void downloadLogFile(long logFileID) {
+        if (logFileID < 0)
+            return;
+        Environment env = (Environment) ImporterAgent.getRegistry().lookup(
+                LookupNames.ENV);
+        String path = env.getOmeroFilesHome();
+        File f = new File(path, "importLog_" + logFileID);
+        DownloadAndLaunchActivityParam activity = new DownloadAndLaunchActivityParam(
+                logFileID, DownloadAndLaunchActivityParam.ORIGINAL_FILE, f,
+                null);
+        activity.setUIRegister(false);
+        UserNotifier un = ImporterAgent.getRegistry().getUserNotifier();
+        un.notifyActivity(model.getSecurityContext(), activity);
+    }
+
+    /**
+     * Builds a row.
+     * 
+     * @return See above.
+     */
+    private JPanel createRow() {
+        JPanel p = new JPanel();
+        p.setLayout(new FlowLayout(FlowLayout.LEFT));
+        p.setBackground(UIUtilities.BACKGROUND_COLOR);
+        return p;
+    }
+
+    /**
+     * Make the JTextArea represent a multiline label.
+     * 
+     * @param textArea
+     *            The component to handle.
+     */
+    private void makeLabelStyle(JTextArea textArea) {
+        if (textArea == null)
+            return;
+        textArea.setEditable(false);
+        textArea.setCursor(null);
+        textArea.setOpaque(false);
+        textArea.setFocusable(false);
+    }
+
+    /**
+     * Builds and lays out the header.
+     * 
+     * @return See above.
+     */
+    private JPanel buildHeader() {
+        sizeLabel = UIUtilities.createComponent(null);
+        sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+        reportLabel = UIUtilities.setTextFont("Report:", Font.BOLD);
+        importSizeLabel = UIUtilities.setTextFont("Import Size:", Font.BOLD);
+        double[][] design = new double[][] { { TableLayout.PREFERRED },
+                { TableLayout.PREFERRED, TableLayout.PREFERRED } };
+        TableLayout layout = new TableLayout(design);
+        JPanel detailsPanel = new JPanel(layout);
+        detailsPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
+        JPanel p = createRow();
+        p.add(reportLabel);
+        p.add(numberOfImportLabel);
+        detailsPanel.add(p, "0, 0");
+        p = createRow();
+        p.add(importSizeLabel);
+        p.add(sizeLabel);
+        detailsPanel.add(p, "0, 1");
+
+        JPanel middlePanel = new JPanel();
+        middlePanel.setBackground(UIUtilities.BACKGROUND_COLOR);
+
+        JTextArea description = new JTextArea(MESSAGE);
+        makeLabelStyle(description);
+        description.setBackground(UIUtilities.BACKGROUND_COLOR);
+
+        JPanel descriptionPanel = new JPanel();
+        descriptionPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
+        descriptionPanel.add(description);
+
+        JPanel header = new JPanel();
+        header.setBackground(UIUtilities.BACKGROUND_COLOR);
+        header.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        header.setLayout(new BorderLayout());
+
+        header.add(Box.createVerticalStrut(10), BorderLayout.NORTH);
+        header.add(detailsPanel, BorderLayout.WEST);
+        header.add(middlePanel, BorderLayout.CENTER);
+        header.add(descriptionPanel, BorderLayout.EAST);
+        header.add(Box.createVerticalStrut(10), BorderLayout.SOUTH);
+
+        return header;
+    }
+
+    /** Builds and lays out the UI. */
+    private void buildGUI() {
+        JPanel info = new JPanel();
+        info.setOpaque(false);
+        info.setBorder(new LineBorder(Color.LIGHT_GRAY));
+
+        setLayout(new BorderLayout(0, 0));
+        add(buildHeader(), BorderLayout.NORTH);
+        add(info, BorderLayout.CENTER);
+    }
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param controller
+     *            Reference to the control. Mustn't be <code>null</code>.
+     * @param model
+     *            Reference to the model. Mustn't be <code>null</code>.
+     * @param view
+     *            Reference to the model. Mustn't be <code>null</code>.
+     * @param id
+     *            The identifier of the component.
+     * @param index
+     *            The index of the component.
+     * @param name
+     *            The name of the component.
+     * @param object
+     *            the object to handle. Mustn't be <code>null</code>.
+     */
+    ImporterUIElement(ImporterControl controller, ImporterModel model,
+            ImporterUI view, int id, int index, String name,
+            ImportableObject object) {
+        super(index, name, DESCRIPTION);
+        if (object == null)
+            throw new IllegalArgumentException("No object specified.");
+        if (controller == null)
+            throw new IllegalArgumentException("No Control.");
+        if (model == null)
+            throw new IllegalArgumentException("No Model.");
+        if (view == null)
+            throw new IllegalArgumentException("No View.");
+        this.controller = controller;
+        this.model = model;
+        this.view = view;
+        this.id = id;
+        this.object = object;
+        initialize();
+        buildGUI();
+    }
+
+    /**
+     * Returns the identifier of the component.
+     * 
+     * @return See above.
+     */
+    int getID() {
+        return id;
+    }
+
+    /**
+     * Returns the formatted result.
+     * 
+     * @param f
+     *            The imported file.
+     * @return See above.
+     */
+    Object getFormattedResult(ImportableFile f) {
+        FileImportComponentI c = components.get(f.toString());
+        if (c == null)
+            return null;
+        ImportErrorObject object = c.getImportErrorObject();
+        if (object != null)
+            return object;
+
+        return null;
+    }
+
+    /**
+     * Sets the result of the import for the specified file.
+     * 
+     * @param f
+     *            The imported file.
+     * @param result
+     *            The result.
+     * @result Returns the formatted result or <code>null</code>.
+     */
+    Object uploadComplete(ImportableFile f, Object result) {
+        FileImportComponentI c = components.get(f.toString());
+        return uploadComplete(c, result);
+    }
+
+    /**
+     * Sets the result of the import for the specified file.
+     * 
+     * @param f
+     *            The imported file.
+     * @param result
+     *            The result.
+     * @param index
+     *            The index corresponding to the component
+     * @result Returns the formatted result or <code>null</code>.
+     */
+    Object uploadComplete(FileImportComponentI c, Object result) {
+        if (c == null)
+            return null;
+        c.uploadComplete(result);
+        FileObject file = c.getFile();
+        Object r = null;
+        if (file.isFile()) {
+            countUploaded++;
+            sizeImport += c.getImportSize();
+            sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+            // handle error that occurred during the scanning or upload.
+            // Check that the result has not been set.
+            // if (!c.hasResult()) {
+            if (result instanceof Exception) {
+                r = new ImportErrorObject(file.getTrueFile(),
+                        (Exception) result, c.getGroupID());
+                if (c.hasResult())
+                    return null;
+                setImportResult(c, result);
+            } else if (result instanceof Boolean) {
+                Boolean b = (Boolean) result;
+                if (!b && c.isCancelled()) {
+                    countUploaded--;
+                    if (isDone() && rotationIcon != null)
+                        rotationIcon.stopRotation();
+                } else
+                    setImportResult(c, result);
+            } else {
+                if (c.isCancelled()) {
+                    if (result == null) {
+                        countCancelled++;
+                        countImported++;
+                        if (isDone() && rotationIcon != null)
+                            rotationIcon.stopRotation();
+                    } else {
+                        countCancelled--;
+                        countUploaded--;
+                    }
+                }
+            }
+            // }
+        } else {// empty folder
+            if (result instanceof Exception) {
+                countUploaded++;
+                // Check if no files
+                if (!c.hasComponents()) {
+                    countImported++;
+                    countUploadFailure++;
+                    c.setStatus(result);
+                }
+                if (isDone() && rotationIcon != null)
+                    rotationIcon.stopRotation();
+            } else if (result instanceof Boolean) {
+                Boolean b = (Boolean) result;
+                if (!b && c.isCancelled()) {
+                    countUploaded++;
+                    countCancelled++;
+                    countImported++;
+                    if (isDone() && rotationIcon != null)
+                        rotationIcon.stopRotation();
+                }
+            }
+        }
+        setNumberOfImport();
+        setClosable(isUploadComplete());
+        return r;
+    }
+
+    /**
+     * Sets the result of the import for the specified file.
+     * 
+     * @param fc
+     *            The component hosting the file to import.
+     * @param result
+     *            The result.
+     * @result Returns the formatted result or <code>null</code>.
+     */
+    void setImportResult(FileImportComponentI fc, Object result) {
+        if (fc == null)
+            return;
+        FileObject file = fc.getFile();
+        if (file.isFile()) {
+            fc.setStatus(result);
+            countImported++;
+            if (fc.isCancelled() && result != null
+                    && !(result instanceof Boolean))
+                countImported--;
+            if (isDone() && rotationIcon != null)
+                rotationIcon.stopRotation();
+            if (fc.hasUploadFailed()) {
+                countUploadFailure++;
+                sizeImport -= fc.getImportSize();
+                sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+            }
+            if (fc.hasImportFailed())
+                countFailure++;
+            setNumberOfImport();
+            setClosable(isDone());
+        } else { // empty folder
+            if (result instanceof Exception) {
+                fc.setStatus(result);
+                countImported++;
+                countFailure++;
+                countUploadFailure++;
+                if (isDone() && rotationIcon != null)
+                    rotationIcon.stopRotation();
+                setNumberOfImport();
+                setClosable(isDone());
+            }
+        }
+    }
+
+    /**
+     * Returns <code>true</code> if the upload is finished, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    boolean isUploadComplete() {
+        return (countFailure + countUploaded) == totalToImport;
+    }
+
+    /**
+     * Returns <code>true</code> if the import is finished, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    boolean isDone() {
+        return countImported == totalToImport;
+    }
+
+    /**
+     * Returns <code>true</code> if there is one remaining import,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    boolean isLastImport() {
+        return countImported == (totalToImport - 1);
+    }
+
+    /**
+     * Indicates that the import has started.
+     * 
+     * @param component
+     *            The component of reference of the rotation icon.
+     */
+    Icon startImport(JComponent component) {
+        uploadStarted = true;
+        setClosable(false);
+        busyLabel.setBusy(true);
+        repaint();
+        return new RotationIcon(busyLabel.getIcon(), component, true);
+    }
+
+    /**
+     * Returns <code>true</code> if the import has started, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    boolean hasStarted() {
+        return uploadStarted;
+    }
+
+    /**
+     * Manually sets the uploadStarted flag
+     * 
+     * @param uploadStarted
+     */
+    void setUploadStarted(boolean uploadStarted) {
+        this.uploadStarted = uploadStarted;
+    }
+
+    /**
+     * Returns <code>true</code> if the component has imports in the queue that
+     * have not yet started or been cancelled, <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    boolean hasImportToCancel() {
+        for (final FileImportComponentI fic : components.values()) {
+            if (fic.hasImportToCancel()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the collection of files that could not be imported.
+     * 
+     * @return See above.
+     */
+    List<FileImportComponentI> getMarkedFiles() {
+        List<FileImportComponentI> list = new ArrayList<FileImportComponentI>();
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        List<FileImportComponentI> l;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            l = fc.getImportErrors();
+            if (l != null && l.size() > 0)
+                list.addAll(l);
+        }
+        return list;
+    }
+
+    /**
+     * Returns the collection of files that could not be imported.
+     * 
+     * @return See above.
+     */
+    List<FileImportComponentI> getFilesToReupload() {
+        List<FileImportComponentI> list = new ArrayList<FileImportComponentI>();
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        List<FileImportComponentI> l;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            l = fc.getFilesToReupload();
+            if (!CollectionUtils.isEmpty(l))
+                list.addAll(l);
+        }
+        return list;
+    }
+
+    /**
+     * Returns the object to import.
+     * 
+     * @return See above.
+     */
+    ImportableObject getData() {
+        return object;
+    }
+
+    /**
+     * Returns the existing containers.
+     * 
+     * @return See above.
+     */
+    List<DataObject> getExistingContainers() {
+        if (existingContainers != null)
+            return existingContainers;
+        existingContainers = new ArrayList<DataObject>();
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        Map<Long, DatasetData> datasets = new HashMap<Long, DatasetData>();
+        Map<Long, DataObject> projects = new HashMap<Long, DataObject>();
+        Map<Long, DataObject> screens = new HashMap<Long, DataObject>();
+        DatasetData d;
+        DataObject object;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            d = fc.getDataset();
+            if (d != null && d.getId() > 0)
+                datasets.put(d.getId(), d);
+            object = fc.getDataObject();
+            if (object instanceof ScreenData && object.getId() > 0)
+                screens.put(object.getId(), object);
+            if (object instanceof ProjectData && object.getId() > 0) {
+                if (d != null && d.getId() <= 0)
+                    projects.put(object.getId(), object);
+            }
+        }
+        existingContainers.addAll(datasets.values());
+        existingContainers.addAll(projects.values());
+        existingContainers.addAll(screens.values());
+        return existingContainers;
+    }
+
+    /**
+     * Sets the import log file for each import component.
+     *
+     * @param data
+     *            Collection of file annotations linked to the file set.
+     * @param id
+     *            The id of the file set.
+     */
+    void setImportLogFile(Collection<FileAnnotationData> data, long id) {
+        if (CollectionUtils.isEmpty(data))
+            return;
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        Iterator<FileAnnotationData> j;
+        FileAnnotationData fa;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            if (fc.getIndex() == id) {
+                j = data.iterator();
+                while (j.hasNext()) {
+                    fa = j.next();
+                    if (FileAnnotationData.LOG_FILE_NS
+                            .equals(fa.getNameSpace())) {
+                        downloadLogFile(fa.getFileID());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns <code>true</code> if errors to send, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    boolean hasFailuresToSend() {
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            if (fc.hasFailuresToSend())
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns <code>true</code> if files to reimport, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    boolean hasFailuresToReimport() {
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            if (fc.hasFailuresToReimport())
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns <code>true</code> if files to re-upload, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    boolean hasFailuresToReupload() {
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            if (fc.hasFailuresToReupload())
+                return true;
+        }
+        return false;
+    }
+
+    /** Indicates that the import has been cancelled. */
+    void cancelLoading() {
+        if (components == null || components.size() == 0)
+            return;
+        Iterator<LightFileImportComponent> i = components.values().iterator();
+        while (i.hasNext()) {
+            i.next().cancelLoading();
+        }
+    }
+
+    /**
+     * Returns <code>true</code> if the view should be refreshed,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    boolean hasToRefreshTree() {
+        Entry<String, LightFileImportComponent> entry;
+        Iterator<Entry<String, LightFileImportComponent>> i = components
+                .entrySet().iterator();
+        FileImportComponentI fc;
+        while (i.hasNext()) {
+            entry = i.next();
+            fc = entry.getValue();
+            if (fc.hasToRefreshTree())
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the icon indicating the status of the import.
+     * 
+     * @return See above.
+     */
+    Icon getImportIcon() {
+        if (isDone()) {
+            Iterator<Entry<String, LightFileImportComponent>> i = components
+                    .entrySet().iterator();
+            FileImportComponentI fc;
+            Entry<String, LightFileImportComponent> entry;
+            int failure = 0;
+            ImportStatus v;
+            while (i.hasNext()) {
+                entry = i.next();
+                fc = entry.getValue();
+                v = fc.getImportStatus();
+                if (v == ImportStatus.PARTIAL)
+                    return IMPORT_PARTIAL;
+                if (v == ImportStatus.FAILURE)
+                    failure++;
+            }
+            if (failure == components.size())
+                return IMPORT_FAIL;
+            else if (failure > 0)
+                return IMPORT_PARTIAL;
+            return IMPORT_SUCCESS;
+        }
+        return busyLabel.getIcon();
+    }
+
+    /** Invokes when the import is finished. */
+    void onImportEnded() {
+        busyLabel.setBusy(false);
+        setClosable(true);
+    }
+
+    /**
+     * Resets the containers in the file to load.
+     * 
+     * @param result
+     *            The containers to reset.
+     */
+    void resetContainers(Collection result) {
+        if (result == null || result.size() == 0)
+            return;
+        List<ImportableFile> files = getData().getFiles();
+        if (files == null || files.size() == 0)
+            return;
+        Iterator<ImportableFile> i = files.iterator();
+        ImportableFile f;
+        DataObject parent;
+        DatasetData dataset;
+        DataObject data;
+        ProjectData p;
+        DatasetData r;
+        while (i.hasNext()) {
+            f = i.next();
+            parent = f.getParent();
+            dataset = f.getDataset();
+            if (parent != null) {
+                if (parent.getId() <= 0) { // new project or screen
+                    data = getObject(parent, result);
+                    r = null;
+                    if (dataset != null) {
+                        if (dataset.getId() <= 0) {
+                            // data is a project
+                            r = dataset;
+                            p = (ProjectData) data;
+                            r = (DatasetData) getObject(dataset,
+                                    p.getDatasets());
+                        }
+                    }
+                    f.setLocation(data, r);
+                } else { // was already created.
+                    if (dataset != null) {
+                        if (dataset.getId() <= 0) {
+                            data = getObjectFromID(parent, result);
+                            // data is a project
+                            r = dataset;
+                            p = (ProjectData) data;
+                            r = (DatasetData) getObject(dataset,
+                                    p.getDatasets());
+                            f.setLocation(data, r);
+                        }
+                    }
+                }
+            } else { // no parent
+                if (dataset != null) {
+                    if (dataset.getId() <= 0) {
+                        // data is a project
+                        r = dataset;
+                        r = (DatasetData) getObject(dataset, result);
+                        f.setLocation(null, r);
+                    }
+                }
+            }
+        }
+    }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -61,6 +61,7 @@ import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
 import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI.ContainerType;
 import org.openmicroscopy.shoola.agents.fsimporter.util.ImportStatus;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.env.Environment;
@@ -191,7 +192,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
     ImporterModel model;
 
     /** The type of container to handle. */
-    private int type;
+    private ContainerType type;
 
     /** The existing containers. */
     private List<DataObject> existingContainers;
@@ -300,7 +301,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
         
         Iterator<ImportableFile> i = files.iterator();
         ImportableFile importable;
-        type = -1;
+        type = ContainerType.NA;
         List<Object> containers = object.getRefNodes();
         if (containers != null && containers.size() > 0) {
             Iterator<Object> j = containers.iterator();
@@ -310,16 +311,14 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
                 node = (TreeImageDisplay) j.next();
                 h = node.getUserObject();
                 if (h instanceof DatasetData) {
-                    type = FileImportComponentI.DATASET_TYPE;
+                    type = ContainerType.DATASET;
                 } else if (h instanceof ScreenData) {
-                    type = FileImportComponentI.SCREEN_TYPE;
+                    type = ContainerType.SCREEN;
                 } else if (h instanceof ProjectData) {
-                    type = FileImportComponentI.PROJECT_TYPE;
+                    type = ContainerType.PROJECT;
                 }
                 break;
             }
-        } else {
-            type = FileImportComponentI.NO_CONTAINER;
         }
         JLabel l;
         boolean single = model.isSingleGroup();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -91,13 +91,13 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
 abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements PropertyChangeListener {
 
     /** Description of the component. */
-    private static final String DESCRIPTION = "Closing will cancel imports that have not yet started.";
+    static final String DESCRIPTION = "Closing will cancel imports that have not yet started.";
 
     /** Text indicating to only show the failure. */
-    private static final String SHOW_FAILURE = "Show Failed";
+    static final String SHOW_FAILURE = "Show Failed";
 
     /** Text indicating to show all the imports. */
-    private static final String SHOW_ALL = "Show All";
+    static final String SHOW_ALL = "Show All";
 
     /** The columns for the layout of the {@link #entries}. */
     private static final double[] COLUMNS = { TableLayout.FILL };
@@ -122,7 +122,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
     }
 
     /** The message to display in the header. */
-    private static final String MESSAGE = "When upload is complete, the import"
+    static final String MESSAGE = "When upload is complete, the import"
             + CommonsLangUtils.LINE_SEPARATOR
             + "window and OMERO session can be closed."
             + CommonsLangUtils.LINE_SEPARATOR
@@ -456,7 +456,6 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
     {
         StringBuffer buffer = new StringBuffer();
         int n = countUploaded-countUploadFailure-countCancelled;
-        if (n < 0) n = 0;
         buffer.append(n);
         buffer.append(" out of ");
         buffer.append(totalToImport);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -772,6 +772,15 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
         }
         return false;
     }
+    
+    int cancelled() {
+        int i = 0;
+        for (final FileImportComponentI fic : components.values()) {
+            if (fic.isCancelled())
+                i++;
+        }
+        return i;
+    }
 
     /**
      * Returns the collection of files that could not be imported.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -264,7 +264,22 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
         }
         return null;
     }
+    
+    /**
+     * Show the failures
+     */
+    abstract void showFailures();
 
+    /**
+     * Build the UI
+     * @param importable The component hosting information about the file.
+     * @param browsable Flag indicating that the container can be browsed or not.
+     * @param singleGroup Passes <code>true</code> if the user is member of
+     * only one group, <code>false</code> otherwise.
+     * @param index The index of the parent.
+     * @param tags The tags that will be linked to the objects.
+     * @return The FileImportComponent
+     */
     abstract FileImportComponentI buildComponent(ImportableFile importable, boolean
             browsable, boolean singleGroup, int index,
             Collection<TagAnnotationData> tags);
@@ -450,10 +465,6 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
         numberOfImportLabel.setText(buffer.toString());
     }
     
-    void filterFailures() {
-        
-    }
-    
     /** 
      * Builds and lays out the header.
      * 
@@ -475,7 +486,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
              * Filters or not the import that did not fail.
              */
             public void actionPerformed(ActionEvent evt) {
-                filterFailures();
+                showFailures();
             }
         });
         
@@ -693,7 +704,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
      * @return See above.
      */
     boolean isUploadComplete() {
-        return (countFailure + countUploaded) == totalToImport;
+        return countUploaded == totalToImport;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -702,7 +702,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
      * @return See above.
      */
     boolean isUploadComplete() {
-        return countUploaded == totalToImport;
+        return (countUploaded + countUploadFailure) == totalToImport;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -702,7 +702,7 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
      * @return See above.
      */
     boolean isUploadComplete() {
-        return (countUploaded + countUploadFailure) == totalToImport;
+        return (countUploaded + countUploadFailure + cancelled()) >= totalToImport;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElement.java
@@ -773,11 +773,14 @@ abstract class ImporterUIElement extends ClosableTabbedPaneComponent implements 
         return false;
     }
     
+    /**
+     * Get the number of cancelled imports.
+     * @return See above.
+     */
     int cancelled() {
         int i = 0;
         for (final FileImportComponentI fic : components.values()) {
-            if (fic.isCancelled())
-                i++;
+            i += fic.cancelled();
         }
         return i;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
@@ -85,6 +85,7 @@ import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.FilesetData;
 import omero.gateway.model.ProjectData;
 import omero.gateway.model.ScreenData;
+import omero.gateway.model.TagAnnotationData;
 
 /** 
  * Component displaying an import.
@@ -113,163 +114,14 @@ class ImporterUIElementDetailed
 	/** The columns for the layout of the {@link #entries}. */
 	private static final double[] COLUMNS = {TableLayout.FILL};
 	
-	/** The default size of the icon. */
-	private static final Dimension ICON_SIZE = new Dimension(16, 16);
-	
-	/** Icon used when the import is completed successfully. */
-	private static final Icon IMPORT_SUCCESS;
-	
-	/** Icon used when the import failed. */
-	private static final Icon IMPORT_FAIL;
-	
-	/** Icon used when the import is completed. */
-	private static final Icon IMPORT_PARTIAL;
-	
-	static {
-		IconManager icons = IconManager.getInstance();
-		IMPORT_SUCCESS = icons.getIcon(IconManager.APPLY);
-		IMPORT_FAIL = icons.getIcon(IconManager.DELETE);
-		IMPORT_PARTIAL = icons.getIcon(IconManager.APPLY_CANCEL);
-	}
-	
 	/** The message to display in the header.*/
 	private static final String MESSAGE = 
 			"When upload is complete, the import" +CommonsLangUtils.LINE_SEPARATOR+
 			"window and OMERO session can be closed." +CommonsLangUtils.LINE_SEPARATOR+
 			"Reading will continue on the server.";
-	
-	/** The components to lay out. */
-	private LinkedHashMap<String, FileImportComponent>	components;
 
 	/** Component hosting the entries. */
 	private JPanel	entries;
-
-	/** The number of cancellation.*/
-	private int countCancelled;
-	
-	/** The number of uploaded files.*/
-	private int countUploaded;
-	
-	/** The number of files/folder imported. */
-	private int countImported;
-	
-	/** The number of files uploaded. */
-	private int countUploadFailure;
-	
-	/** 
-	 * The number of failures that occurred during scanning, uploading
-	 * or processing.
-	 */
-	private int countFailure;
-	
-	/** The total number of files or folder to import. */
-	private int totalToImport;
-	
-	/** The size of the import. */
-	private long sizeImport;
-	
-	/** The component displaying the size the import. */
-	private JLabel sizeLabel;
-	
-	/** The component displaying the number of files to import. */
-	private JLabel numberOfImportLabel;
-
-	/** Label for report display */
-	private JLabel reportLabel;
-
-	/** Label for import size display */
-	private JLabel importSizeLabel;
-	
-	/** The collection of folders' name used as dataset. */
-	private Map<JLabel, Object> foldersName;
-
-	/** The type of container to handle. */
-	private int type;
-	
-	/** The existing containers. */
-	private List<DataObject> existingContainers;
-
-	/** The busy label. */
-	private JXBusyLabel busyLabel;
-	
-	/**The icon used to indicate an on-going import.*/
-	private RotationIcon rotationIcon;
-	
-	/** Controls used to filter the result.*/
-	private JButton filterButton;
-	
-	/** Flag indicating if the upload has started or not.*/
-	private boolean uploadStarted;
-	
-	/**
-	 * Returns the object found by identifier.
-	 * 
-	 * @param data The object to handle.
-	 * @param result The collection of element to check.
-	 * @return See above.
-	 */
-	private DataObject getObjectFromID(DataObject data, Collection result)
-	{
-		Iterator i = result.iterator();
-		DataObject object;
-		while (i.hasNext()) {
-			object = (DataObject) i.next();
-			if (object.getClass().equals(data.getClass()) 
-					&& object.getId() == data.getId()) {
-				return object;
-			}
-		}
-		return null;
-	}
-	
-	/**
-	 * Returns the object found by name.
-	 * 
-	 * @param data The object to handle.
-	 * @param result The collection of element to check.
-	 * @return See above.
-	 */
-	private DataObject getObject(DataObject data, Collection result)
-	{
-		String name = "";
-		if (data instanceof ProjectData) {
-			name = ((ProjectData) data).getName();
-		} else if (data instanceof ScreenData) {
-			name = ((ScreenData) data).getName();
-		} else if (data instanceof DatasetData) {
-			name = ((DatasetData) data).getName();
-		}
-		Iterator i = result.iterator();
-		DataObject object;
-		String n = "";
-		while (i.hasNext()) {
-			object = (DataObject) i.next();
-			if (object.getClass().equals(data.getClass())) {
-				if (object instanceof ProjectData) {
-					n = ((ProjectData) object).getName();
-				} else if (object instanceof ScreenData) {
-					n = ((ScreenData) object).getName();
-				} else if (object instanceof DatasetData) {
-					n = ((DatasetData) object).getName();
-				}
-				if (n.equals(name)) return object;
-			}
-		}
-		return null;
-	}
-	
-	/** Sets the text of indicating the number of imports. */
-	private void setNumberOfImport()
-	{
-		StringBuffer buffer = new StringBuffer();
-		int n = countUploaded-countUploadFailure-countCancelled;
-		if (n < 0) n = 0;
-		buffer.append(n);
-		buffer.append(" out of ");
-		buffer.append(totalToImport);
-		buffer.append(" uploaded");
-		numberOfImportLabel.setText(buffer.toString());
-	}
 	
 	/**
 	 * Browses the specified object.
@@ -293,7 +145,7 @@ class ImporterUIElementDetailed
 	/**
 	 * Displays only the failures or all the results.
 	 */
-	private void filterFailures()
+	void filterFailures()
 	{
 		String v = filterButton.getText();
 		if (SHOW_FAILURE.equals(v)) {
@@ -305,151 +157,12 @@ class ImporterUIElementDetailed
 		}
 	}
 	
-	/** Initializes the components. */
-	private void initialize()
-	{
-		filterButton = new JButton(SHOW_FAILURE);
-		filterButton.setEnabled(false);
-		filterButton.addActionListener(new ActionListener() {
-			
-			/**
-			 * Filters or not the import that did not fail.
-			 */
-			public void actionPerformed(ActionEvent evt) {
-				filterFailures();
-			}
-		});
-		sizeImport = 0;
-		busyLabel = new JXBusyLabel(ICON_SIZE);
-		numberOfImportLabel = UIUtilities.createComponent(null);
-		foldersName = new LinkedHashMap<JLabel, Object>();
-		countUploadFailure = 0;
-		countFailure = 0;
-		countUploaded = 0;
-		addPropertyChangeListener(controller);
-		entries = new JPanel();
-		entries.setBackground(UIUtilities.BACKGROUND);
-		components = new LinkedHashMap<String, FileImportComponent>();
-		List<ImportableFile> files = object.getFiles();
-		FileImportComponent c;
-		
-		Iterator<ImportableFile> i = files.iterator();
-		ImportableFile importable;
-		type = -1;
-		List<Object> containers = object.getRefNodes();
-		if (containers != null && containers.size() > 0) {
-			Iterator<Object> j = containers.iterator();
-			TreeImageDisplay node;
-			Object h;
-			while (j.hasNext()) {
-				node = (TreeImageDisplay) j.next();
-				h = node.getUserObject();
-				if (h instanceof DatasetData) {
-					type = FileImportComponentI.DATASET_TYPE;
-				} else if (h instanceof ScreenData) {
-					type = FileImportComponentI.SCREEN_TYPE;
-				} else if (h instanceof ProjectData) {
-					type = FileImportComponentI.PROJECT_TYPE;
-				}
-				break;
-			}
-		} else {
-			type = FileImportComponentI.NO_CONTAINER;
-		}
-		JLabel l;
-		boolean single = model.isSingleGroup();
-		FileObject f;
-		while (i.hasNext()) {
-			importable = i.next();
-			f = (FileObject) importable.getFile();
-			c = new FileImportComponent(importable,
-					!controller.isMaster(), single, getID(), object.getTags());
-			c.setType(type);
-			c.addPropertyChangeListener(controller);
-			c.addPropertyChangeListener(new PropertyChangeListener() {
-				
-				public void propertyChange(PropertyChangeEvent evt) {
-					String name = evt.getPropertyName();
-					if (FileImportComponentI.BROWSE_PROPERTY.equals(name)) {
-						List<Object> refNodes = object.getRefNodes();
-						Object node = null;
-						if (refNodes != null && refNodes.size() > 0)
-							node = refNodes.get(0);
-						browse(evt.getNewValue(), node);
-					} else if (
-						FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(
-								name)) {
-						//-1 to remove the entry for the folder.
-						Integer v = (Integer) evt.getNewValue()-1;
-						totalToImport += v;
-						setNumberOfImport();
-					} else if (FileImportComponentI.LOAD_LOGFILEPROPERTY.equals(
-							name)) {
-						FileImportComponentI fc = (FileImportComponentI)
-								evt.getNewValue();
-						if (fc == null) return;
-						long logFileID = fc.getStatus().getLogFileID();
-						if (logFileID <= 0) {
-							FilesetData data = fc.getStatus().getFileset();
-							if (data == null) return;
-							model.fireImportLogFileLoading(data.getId(),
-									fc.getIndex());
-						} else downloadLogFile(logFileID);
-					} else if (
-						FileImportComponentI.RETRIEVE_LOGFILEPROPERTY.equals(
-							name)) {
-						FilesetData data = (FilesetData) evt.getNewValue();
-						if (data != null)
-							model.fireImportLogFileLoading(data.getId(), id);
-					} else if (
-						FileImportComponentI.CHECKSUM_DISPLAY_PROPERTY.equals(
-							name)) {
-						Status label = (Status) evt.getNewValue();
-						CheckSumDialog d = new CheckSumDialog(view, label);
-						UIUtilities.centerAndShow(d);
-					} else if (FileImportComponentI.RETRY_PROPERTY.equals(name)) {
-						controller.retryUpload(
-								(FileImportComponent) evt.getNewValue());
-					} else if (
-						FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
-						controller.cancel(
-								(FileImportComponentI) evt.getNewValue());
-					}
-				}
-			});
-			if (f.isDirectory()) {
-				if (importable.isFolderAsContainer()) {
-					l = new JLabel(f.getName());
-					foldersName.put(l, c);
-				}
-			} else {
-				if (importable.isFolderAsContainer()) {
-					String name = f.getParentName();
-					//first check if the name is already there.
-					Entry<JLabel, Object> entry;
-					Iterator<Entry<JLabel, Object>>
-					k = foldersName.entrySet().iterator();
-					boolean exist = false;
-					while (k.hasNext()) {
-						entry = k.next();
-						l = entry.getKey();
-						if (l.getText().equals(name)) {
-							exist = true;
-							break;
-						}
-					}
-					if (name == null) {
-					    name = f.getName();
-					}
-					if (!exist) {
-						foldersName.put(new JLabel(name), c);
-					}
-				}
-			}
-			importable.setStatus(c.getStatus());
-			components.put(c.toString(), c);
-		}
-		totalToImport = files.size();
+	@Override
+	FileImportComponentI buildComponent(ImportableFile importable, boolean
+            browsable, boolean singleGroup, int index,
+            Collection<TagAnnotationData> tags) {
+	    return new FileImportComponent(importable,
+                !controller.isMaster(), singleGroup, getID(), object.getTags());
 	}
 	
 	/**
@@ -475,95 +188,19 @@ class ImporterUIElementDetailed
 		un.notifyActivity(model.getSecurityContext(), activity);
 	}
 	
-	/** 
-	 * Builds a row.
-	 * 
-	 * @return See above.
-	 */
-	private JPanel createRow()
-	{
-		JPanel p = new JPanel();
-		p.setLayout(new FlowLayout(FlowLayout.LEFT));
-		p.setBackground(UIUtilities.BACKGROUND_COLOR);
-		return p;
-	}
-	
-	/**
-	 * Make the JTextArea represent a multiline label.
-	 * 
-	 * @param textArea The component to handle.
-	 */
-	private void makeLabelStyle(JTextArea textArea)
-	{
-		if (textArea == null) return;
-		textArea.setEditable(false);
-		textArea.setCursor(null);
-		textArea.setOpaque(false);
-		textArea.setFocusable(false);
-	}
-	
-	/** 
-	 * Builds and lays out the header.
-	 * 
-	 * @return See above.
-	 */
-	private JPanel buildHeader()
-	{
-		sizeLabel = UIUtilities.createComponent(null);
-		sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
-		reportLabel = UIUtilities.setTextFont("Report:", Font.BOLD);
-		importSizeLabel = UIUtilities.setTextFont("Import Size:", Font.BOLD);
-		double[][] design = new double[][]{
-					{TableLayout.PREFERRED},
-					{TableLayout.PREFERRED, TableLayout.PREFERRED}
-				};
-		TableLayout layout = new TableLayout(design);
-		JPanel detailsPanel = new JPanel(layout);
-		detailsPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
-		JPanel p = createRow();
-		p.add(reportLabel);
-		p.add(numberOfImportLabel);
-		detailsPanel.add(p, "0, 0");
-		p = createRow();
-		p.add(importSizeLabel);
-		p.add(sizeLabel);
-		detailsPanel.add(p, "0, 1");
-		
-		JPanel middlePanel = new JPanel();
-		middlePanel.setBackground(UIUtilities.BACKGROUND_COLOR);
-		middlePanel.add(filterButton);
-		
-    	JTextArea description = new JTextArea(MESSAGE);
-    	makeLabelStyle(description);
-    	description.setBackground(UIUtilities.BACKGROUND_COLOR);
-    	
-		JPanel descriptionPanel = new JPanel();
-		descriptionPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
-		descriptionPanel.add(description);
-		
-		JPanel header = new JPanel();
-		header.setBackground(UIUtilities.BACKGROUND_COLOR);
-		header.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
-		header.setLayout(new BorderLayout());
-		
-		header.add(Box.createVerticalStrut(10), BorderLayout.NORTH);
-		header.add(detailsPanel, BorderLayout.WEST);
-		header.add(middlePanel, BorderLayout.CENTER);
-		header.add(descriptionPanel, BorderLayout.EAST);
-		header.add(Box.createVerticalStrut(10), BorderLayout.SOUTH);
-		
-		return header;
-	}
-	
 	/** Builds and lays out the UI. */
 	private void buildGUI()
 	{
+	    setLayout(new BorderLayout(0, 0));
+	    
+	    add(buildHeader(), BorderLayout.NORTH);
+	    
+        entries = new JPanel();
+        entries.setBackground(UIUtilities.BACKGROUND);
 		layoutEntries(false);
 		JScrollPane pane = new JScrollPane(entries);
 		pane.setOpaque(false);
 		pane.setBorder(new LineBorder(Color.LIGHT_GRAY));
-		setLayout(new BorderLayout(0, 0));
-		add(buildHeader(), BorderLayout.NORTH);
 		add(pane, BorderLayout.CENTER);
 	}
 	
@@ -580,21 +217,21 @@ class ImporterUIElementDetailed
 		layout.setColumn(COLUMNS);
 		entries.setLayout(layout);
 		int index = 0;
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
+		Entry<String, FileImportComponentI> entry;
+		Iterator<Entry<String, FileImportComponentI>>
 		i = components.entrySet().iterator();
 		FileImportComponent fc;
 		if (failure) {
 			while (i.hasNext()) {
 				entry = i.next();
-				fc = entry.getValue();
+				fc = (FileImportComponent) entry.getValue();
 				if (fc.hasComponents()) {
-					addRow(layout, index, entry.getValue());
+					addRow(layout, index, fc);
 					fc.layoutEntries(failure);
 					index++;
 				} else {
 					if (fc.hasImportFailed()) {
-						addRow(layout, index, entry.getValue());
+						addRow(layout, index, fc);
 						index++;
 					}
 				}
@@ -602,7 +239,7 @@ class ImporterUIElementDetailed
 		} else {
 			while (i.hasNext()) {
 				entry = i.next();
-				fc = entry.getValue();
+				fc = (FileImportComponent) entry.getValue();
 				addRow(layout, index, fc);
 				fc.layoutEntries(failure);
 				index++;
@@ -649,552 +286,57 @@ class ImporterUIElementDetailed
 		super(controller, model,
 	            view, id, index, name,
 	            object);
-		initialize();
 		buildGUI();
 	}
 
-	/**
-	 * Returns the identifier of the component.
-	 * 
-	 * @return See above.
-	 */
-	int getID() { return id; }
-	
-	/**
-	 * Returns the formatted result.
-	 * 
-	 * @param f The imported file.
-	 * @return See above.
-	 */
-	Object getFormattedResult(ImportableFile f)
-	{
-		FileImportComponentI c = components.get(f.toString());
-		if (c == null) return null;
-		ImportErrorObject object = c.getImportErrorObject();
-		if (object != null) return object;
-		
-		return null;
-	}
-	
-
-	/**
-	 * Sets the result of the import for the specified file.
-	 * 
-	 * @param f The imported file.
-	 * @param result The result.
-	 * @result Returns the formatted result or <code>null</code>.
-	 */
-	Object uploadComplete(ImportableFile f, Object result)
-	{
-		FileImportComponentI c = components.get(f.toString());
-		return uploadComplete(c, result);
-	}
-	
-	/**
-	 * Sets the result of the import for the specified file.
-	 * 
-	 * @param f The imported file.
-	 * @param result The result.
-	 * @param index The index corresponding to the component
-	 * @result Returns the formatted result or <code>null</code>.
-	 */
-	Object uploadComplete(FileImportComponentI c, Object result)
-	{
-		if (c == null) return null;
-		c.uploadComplete(result);
-		FileObject file = c.getFile();
-		Object r = null;
-		if (file.isFile()) {
-			countUploaded++;
-			sizeImport += c.getImportSize();
-			sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
-			//handle error that occurred during the scanning or upload.
-			//Check that the result has not been set.
-			//if (!c.hasResult()) {
-			if (result instanceof Exception) {
-				r = new ImportErrorObject(file.getTrueFile(), (Exception) result,
-						c.getGroupID());
-				if (c.hasResult()) return null;
-				setImportResult(c, result);
-			} else if (result instanceof Boolean) {
-				Boolean b = (Boolean) result;
-				if (!b && c.isCancelled()) {
-					countUploaded--;
-					if (isDone() && rotationIcon != null)
-						rotationIcon.stopRotation();
-				} else
-				setImportResult(c, result);
-			} else {
-				if (c.isCancelled()) {
-					if (result == null) {
-						countCancelled++;
-						countImported++;
-						if (isDone() && rotationIcon != null)
-							rotationIcon.stopRotation();
-					} else {
-						countCancelled--;
-						countUploaded--;
-					}
-				}
-			}
-			//}
-		} else {//empty folder
-			if (result instanceof Exception) {
-				countUploaded++;
-				//Check if no files
-				if (!c.hasComponents()) {
-					countImported++;
-					countUploadFailure++;
-					c.setStatus(result);
-				}
-				if (isDone() && rotationIcon != null)
-					rotationIcon.stopRotation();
-			} else if (result instanceof Boolean) {
-				Boolean b = (Boolean) result;
-				if (!b && c.isCancelled()) {
-					countUploaded++;
-					countCancelled++;
-					countImported++;
-					if (isDone() && rotationIcon != null)
-						rotationIcon.stopRotation();
-				}
-			}
-		}
-		setNumberOfImport();
-		setClosable(isUploadComplete());
-		return r;
-	}
-	
-	/**
-	 * Sets the result of the import for the specified file.
-	 * 
-	 * @param fc The component hosting the file to import.
-	 * @param result The result.
-	 * @result Returns the formatted result or <code>null</code>.
-	 */
-	void setImportResult(FileImportComponentI fc, Object result)
-	{
-		if (fc == null) return;
-		FileObject file = fc.getFile();
-		if (file.isFile()) {
-			fc.setStatus(result);
-			countImported++;
-			if (fc.isCancelled() && result != null &&
-				!(result instanceof Boolean))
-				countImported--;
-			if (isDone() && rotationIcon != null)
-				rotationIcon.stopRotation();
-			if (fc.hasUploadFailed()) {
-				countUploadFailure++;
-				sizeImport -= fc.getImportSize();
-				sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
-			}
-			if (fc.hasImportFailed()) countFailure++;
-			setNumberOfImport();
-			setClosable(isDone());
-			filterButton.setEnabled(countFailure > 0 &&
-					countFailure != totalToImport);
-		} else { //empty folder
-			if (result instanceof Exception) {
-				fc.setStatus(result);
-				countImported++;
-				countFailure++;
-				countUploadFailure++;
-				if (isDone() && rotationIcon != null)
-					rotationIcon.stopRotation();
-				setNumberOfImport();
-				setClosable(isDone());
-			}
-		}
-	}
-
-	/**
-	 * Returns <code>true</code> if the upload is finished, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean isUploadComplete() { 
-	    return (countFailure + countUploaded) == totalToImport;
-	}
-	
-    /**
-     * Returns <code>true</code> if the import is finished, <code>false</code>
-     * otherwise.
-     * 
-     * @return See above.
-     */
-    boolean isDone() {
-        return countImported == totalToImport;
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        String name = evt.getPropertyName();
+        if (FileImportComponentI.BROWSE_PROPERTY.equals(name)) {
+            List<Object> refNodes = object.getRefNodes();
+            Object node = null;
+            if (refNodes != null && refNodes.size() > 0)
+                node = refNodes.get(0);
+            browse(evt.getNewValue(), node);
+        } else if (
+            FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(
+                    name)) {
+            //-1 to remove the entry for the folder.
+            Integer v = (Integer) evt.getNewValue()-1;
+            totalToImport += v;
+            setNumberOfImport();
+        } else if (FileImportComponentI.LOAD_LOGFILEPROPERTY.equals(
+                name)) {
+            FileImportComponentI fc = (FileImportComponentI)
+                    evt.getNewValue();
+            if (fc == null) return;
+            long logFileID = fc.getStatus().getLogFileID();
+            if (logFileID <= 0) {
+                FilesetData data = fc.getStatus().getFileset();
+                if (data == null) return;
+                model.fireImportLogFileLoading(data.getId(),
+                        fc.getIndex());
+            } else downloadLogFile(logFileID);
+        } else if (
+            FileImportComponentI.RETRIEVE_LOGFILEPROPERTY.equals(
+                name)) {
+            FilesetData data = (FilesetData) evt.getNewValue();
+            if (data != null)
+                model.fireImportLogFileLoading(data.getId(), id);
+        } else if (
+            FileImportComponentI.CHECKSUM_DISPLAY_PROPERTY.equals(
+                name)) {
+            Status label = (Status) evt.getNewValue();
+            CheckSumDialog d = new CheckSumDialog(view, label);
+            UIUtilities.centerAndShow(d);
+        } else if (FileImportComponentI.RETRY_PROPERTY.equals(name)) {
+            controller.retryUpload(
+                    (FileImportComponent) evt.getNewValue());
+        } else if (
+            FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
+            controller.cancel(
+                    (FileImportComponentI) evt.getNewValue());
+        }
     }
-	
-	/**
-	 * Returns <code>true</code> if there is one remaining import,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean isLastImport() { return countImported == (totalToImport-1); }
-	
-	/** 
-	 * Indicates that the import has started. 
-	 * 
-	 * @param component The component of reference of the rotation icon.
-	 */
-	Icon startImport(JComponent component)
-	{
-		uploadStarted = true;
-		setClosable(false);
-		busyLabel.setBusy(true);
-		repaint();
-		return new RotationIcon(busyLabel.getIcon(), component, true);
-	}
-	
-	/**
-	 * Returns <code>true</code> if the import has started, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasStarted() { return uploadStarted; }
-	
-	/**
-	 * Manually sets the uploadStarted flag
-	 * @param uploadStarted
-	 */
-	void setUploadStarted(boolean uploadStarted) {
-	    this.uploadStarted = uploadStarted;
-	}
-	
-	/**
-	 * Returns <code>true</code> if the component has imports in the queue that
-	 * have not yet started or been cancelled, <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasImportToCancel()
-	{
-	    for (final FileImportComponentI fic : components.values()) {
-	    	if (fic.hasImportToCancel()) {
-	            return true;
-	        }
-	    }
-	    return false;
-	}
-
-	/**
-	 * Returns the collection of files that could not be imported.
-	 * 
-	 * @return See above.
-	 */
-	List<FileImportComponentI> getMarkedFiles()
-	{
-		List<FileImportComponentI> list = new ArrayList<FileImportComponentI>();
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponentI fc;
-		List<FileImportComponentI> l;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			l = fc.getImportErrors();
-			if (l != null && l.size() > 0)
-				list.addAll(l);
-		}
-		return list;
-	}
-	
-	/**
-	 * Returns the collection of files that could not be imported.
-	 * 
-	 * @return See above.
-	 */
-	List<FileImportComponentI> getFilesToReupload()
-	{
-		List<FileImportComponentI> list = new ArrayList<FileImportComponentI>();
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponentI fc;
-		List<FileImportComponentI> l;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			l = fc.getFilesToReupload();
-			if (!CollectionUtils.isEmpty(l))
-				list.addAll(l);
-		}
-		return list;
-	}
-	
-	/**
-	 * Returns the object to import.
-	 * 
-	 * @return See above.
-	 */
-	ImportableObject getData() { return object; }
-	
-	/**
-	 * Returns the existing containers.
-	 * 
-	 * @return See above.
-	 */
-	List<DataObject> getExistingContainers()
-	{
-		if (existingContainers != null) return existingContainers;
-		existingContainers = new ArrayList<DataObject>();
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponentI fc;
-		Map<Long, DatasetData> datasets = new HashMap<Long, DatasetData>();
-		Map<Long, DataObject> projects = new HashMap<Long, DataObject>();
-		Map<Long, DataObject> screens = new HashMap<Long, DataObject>();
-		DatasetData d;
-		DataObject object;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			d = fc.getDataset();
-			if (d != null && d.getId() > 0)
-				datasets.put(d.getId(), d);
-			object = fc.getDataObject();
-			if (object instanceof ScreenData && object.getId() > 0)
-				screens.put(object.getId(), object);
-			if (object instanceof ProjectData && object.getId() > 0) {
-				if (d != null && d.getId() <= 0)
-					projects.put(object.getId(), object);
-			}
-		}
-		existingContainers.addAll(datasets.values());
-		existingContainers.addAll(projects.values());
-		existingContainers.addAll(screens.values());
-		return existingContainers;
-	}
-
-	/**
-	 * Sets the import log file for each import component.
-	 *
-	 * @param data Collection of file annotations linked to the file set.
-	 * @param id The id of the file set.
-	 */
-	void setImportLogFile(Collection<FileAnnotationData> data, long id)
-	{
-	    if (CollectionUtils.isEmpty(data)) return;
-	    Entry<String, FileImportComponent> entry;
-	    Iterator<Entry<String, FileImportComponent>>
-	    i = components.entrySet().iterator();
-	    FileImportComponentI fc;
-	    Iterator<FileAnnotationData> j;
-	    FileAnnotationData fa;
-	    while (i.hasNext()) {
-	        entry = i.next();
-	        fc = entry.getValue();
-	        if (fc.getIndex() == id) {
-	            j = data.iterator();
-	            while (j.hasNext()) {
-	                fa = j.next();
-	                if (FileAnnotationData.LOG_FILE_NS.equals(
-	                        fa.getNameSpace())) {
-	                    downloadLogFile(fa.getFileID());
-	                    break;
-	                }
-	            }
-	        }
-	    }
-	}
-
-	/**
-	 * Returns <code>true</code> if errors to send, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasFailuresToSend()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponentI fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasFailuresToSend())
-				return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Returns <code>true</code> if files to reimport, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasFailuresToReimport()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponentI fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasFailuresToReimport())
-				return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Returns <code>true</code> if files to re-upload, <code>false</code>
-	 * otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasFailuresToReupload()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponentI fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasFailuresToReupload())
-				return true;
-		}
-		return false;
-	}
-	
-	/** Indicates that the import has been cancelled. */
-	void cancelLoading()
-	{
-		if (components == null || components.size() == 0) return;
-		Iterator<FileImportComponent> i = components.values().iterator();
-		while (i.hasNext()) {
-			i.next().cancelLoading();
-		}
-	}
-
-	/**
-	 * Returns <code>true</code> if the view should be refreshed,
-	 * <code>false</code> otherwise.
-	 * 
-	 * @return See above.
-	 */
-	boolean hasToRefreshTree()
-	{
-		Entry<String, FileImportComponent> entry;
-		Iterator<Entry<String, FileImportComponent>>
-		i = components.entrySet().iterator();
-		FileImportComponentI fc;
-		while (i.hasNext()) {
-			entry = i.next();
-			fc = entry.getValue();
-			if (fc.hasToRefreshTree())
-				return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Returns the icon indicating the status of the import.
-	 * 
-	 * @return See above.
-	 */
-	Icon getImportIcon()
-	{ 
-		if (isDone()) {
-			Iterator<Entry<String, FileImportComponent>>
-			i = components.entrySet().iterator();
-			FileImportComponentI fc;
-			Entry<String, FileImportComponent> entry;
-			int failure = 0;
-			ImportStatus v;
-			while (i.hasNext()) {
-				entry = i.next();
-				fc = entry.getValue();
-				v = fc.getImportStatus();
-				if (v == ImportStatus.PARTIAL)
-					return IMPORT_PARTIAL;
-				if (v == ImportStatus.FAILURE) failure++;
-			}
-			if (failure == components.size()) return IMPORT_FAIL;
-			else if (failure > 0) return IMPORT_PARTIAL;
-			return IMPORT_SUCCESS;
-		}
-		return busyLabel.getIcon();
-	}
-	
-	/** Invokes when the import is finished. */
-	void onImportEnded()
-	{ 
-		busyLabel.setBusy(false);
-		setClosable(true);
-	}
-
-	/**
-	 * Resets the containers in the file to load.
-	 * 
-	 * @param result The containers to reset.
-	 */
-	void resetContainers(Collection result)
-	{
-		if (result == null || result.size() == 0) return;
-		List<ImportableFile> files = getData().getFiles();
-		if (files == null || files.size() == 0) return;
-		Iterator<ImportableFile> i = files.iterator();
-		ImportableFile f;
-		DataObject parent;
-		DatasetData dataset;
-		DataObject data;
-		ProjectData p;
-		DatasetData r;
-		while (i.hasNext()) {
-			f = i.next();
-			parent = f.getParent();
-			dataset = f.getDataset();
-			if (parent != null) {
-				if (parent.getId() <= 0) { //new project or screen
-					data = getObject(parent, result);
-					r = null;
-					if (dataset != null) {
-						if (dataset.getId() <= 0) {
-							//data is a project
-							r = dataset;
-							p = (ProjectData) data;
-							r = (DatasetData) 
-								getObject(dataset, p.getDatasets());
-						}
-					} 
-					f.setLocation(data, r);
-				} else { //was already created.
-					if (dataset != null) {
-						if (dataset.getId() <= 0) {
-							data = getObjectFromID(parent, result);
-							//data is a project
-							r = dataset;
-							p = (ProjectData) data;
-							r = (DatasetData) 
-								getObject(dataset, p.getDatasets());
-							f.setLocation(data, r);
-						}
-					}
-				}
-			} else { //no parent
-				if (dataset != null) {
-					if (dataset.getId() <= 0) {
-						//data is a project
-						r = dataset;
-						r = (DatasetData) 
-							getObject(dataset, result);
-						f.setLocation(null, r);
-					}
-				}
-			}
-		}
-	}
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
@@ -1,0 +1,1200 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.fsimporter.view;
+
+import info.clearthought.layout.TableLayout;
+import info.clearthought.layout.TableLayoutConstraints;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.border.LineBorder;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.jdesktop.swingx.JXBusyLabel;
+import org.openmicroscopy.shoola.agents.events.importer.BrowseContainer;
+import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
+import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.CheckSumDialog;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
+import org.openmicroscopy.shoola.agents.fsimporter.util.ImportStatus;
+import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
+import org.openmicroscopy.shoola.env.Environment;
+import org.openmicroscopy.shoola.env.LookupNames;
+import org.openmicroscopy.shoola.env.data.model.DownloadAndLaunchActivityParam;
+import org.openmicroscopy.shoola.env.data.model.FileObject;
+import org.openmicroscopy.shoola.env.data.model.ImportableFile;
+import org.openmicroscopy.shoola.env.data.model.ImportableObject;
+import org.openmicroscopy.shoola.env.data.util.Status;
+import org.openmicroscopy.shoola.env.event.EventBus;
+import org.openmicroscopy.shoola.env.ui.UserNotifier;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.file.ImportErrorObject;
+import org.openmicroscopy.shoola.util.ui.ClosableTabbedPaneComponent;
+import org.openmicroscopy.shoola.util.ui.RotationIcon;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
+import omero.gateway.model.DataObject;
+import omero.gateway.model.DatasetData;
+import omero.gateway.model.FileAnnotationData;
+import omero.gateway.model.FilesetData;
+import omero.gateway.model.ProjectData;
+import omero.gateway.model.ScreenData;
+
+/** 
+ * Component displaying an import.
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
+ * @version 3.0
+ * @since 3.0-Beta4
+ */
+class ImporterUIElementDetailed 
+	extends ImporterUIElement
+{
+	
+	/** Description of the component. */
+	private static final String DESCRIPTION = 
+		"Closing will cancel imports that have not yet started.";
+	
+	/** Text indicating to only show the failure.*/
+	private static final String SHOW_FAILURE = "Show Failed";
+	
+	/** Text indicating to show all the imports.*/
+	private static final String SHOW_ALL = "Show All";
+	
+	/** The columns for the layout of the {@link #entries}. */
+	private static final double[] COLUMNS = {TableLayout.FILL};
+	
+	/** The default size of the icon. */
+	private static final Dimension ICON_SIZE = new Dimension(16, 16);
+	
+	/** Icon used when the import is completed successfully. */
+	private static final Icon IMPORT_SUCCESS;
+	
+	/** Icon used when the import failed. */
+	private static final Icon IMPORT_FAIL;
+	
+	/** Icon used when the import is completed. */
+	private static final Icon IMPORT_PARTIAL;
+	
+	static {
+		IconManager icons = IconManager.getInstance();
+		IMPORT_SUCCESS = icons.getIcon(IconManager.APPLY);
+		IMPORT_FAIL = icons.getIcon(IconManager.DELETE);
+		IMPORT_PARTIAL = icons.getIcon(IconManager.APPLY_CANCEL);
+	}
+	
+	/** The message to display in the header.*/
+	private static final String MESSAGE = 
+			"When upload is complete, the import" +CommonsLangUtils.LINE_SEPARATOR+
+			"window and OMERO session can be closed." +CommonsLangUtils.LINE_SEPARATOR+
+			"Reading will continue on the server.";
+	
+	/** The components to lay out. */
+	private LinkedHashMap<String, FileImportComponent>	components;
+
+	/** Component hosting the entries. */
+	private JPanel	entries;
+
+	/** The number of cancellation.*/
+	private int countCancelled;
+	
+	/** The number of uploaded files.*/
+	private int countUploaded;
+	
+	/** The number of files/folder imported. */
+	private int countImported;
+	
+	/** The number of files uploaded. */
+	private int countUploadFailure;
+	
+	/** 
+	 * The number of failures that occurred during scanning, uploading
+	 * or processing.
+	 */
+	private int countFailure;
+	
+	/** The total number of files or folder to import. */
+	private int totalToImport;
+	
+	/** The size of the import. */
+	private long sizeImport;
+	
+	/** The component displaying the size the import. */
+	private JLabel sizeLabel;
+	
+	/** The component displaying the number of files to import. */
+	private JLabel numberOfImportLabel;
+
+	/** Label for report display */
+	private JLabel reportLabel;
+
+	/** Label for import size display */
+	private JLabel importSizeLabel;
+	
+	/** The collection of folders' name used as dataset. */
+	private Map<JLabel, Object> foldersName;
+
+	/** The type of container to handle. */
+	private int type;
+	
+	/** The existing containers. */
+	private List<DataObject> existingContainers;
+
+	/** The busy label. */
+	private JXBusyLabel busyLabel;
+	
+	/**The icon used to indicate an on-going import.*/
+	private RotationIcon rotationIcon;
+	
+	/** Controls used to filter the result.*/
+	private JButton filterButton;
+	
+	/** Flag indicating if the upload has started or not.*/
+	private boolean uploadStarted;
+	
+	/**
+	 * Returns the object found by identifier.
+	 * 
+	 * @param data The object to handle.
+	 * @param result The collection of element to check.
+	 * @return See above.
+	 */
+	private DataObject getObjectFromID(DataObject data, Collection result)
+	{
+		Iterator i = result.iterator();
+		DataObject object;
+		while (i.hasNext()) {
+			object = (DataObject) i.next();
+			if (object.getClass().equals(data.getClass()) 
+					&& object.getId() == data.getId()) {
+				return object;
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * Returns the object found by name.
+	 * 
+	 * @param data The object to handle.
+	 * @param result The collection of element to check.
+	 * @return See above.
+	 */
+	private DataObject getObject(DataObject data, Collection result)
+	{
+		String name = "";
+		if (data instanceof ProjectData) {
+			name = ((ProjectData) data).getName();
+		} else if (data instanceof ScreenData) {
+			name = ((ScreenData) data).getName();
+		} else if (data instanceof DatasetData) {
+			name = ((DatasetData) data).getName();
+		}
+		Iterator i = result.iterator();
+		DataObject object;
+		String n = "";
+		while (i.hasNext()) {
+			object = (DataObject) i.next();
+			if (object.getClass().equals(data.getClass())) {
+				if (object instanceof ProjectData) {
+					n = ((ProjectData) object).getName();
+				} else if (object instanceof ScreenData) {
+					n = ((ScreenData) object).getName();
+				} else if (object instanceof DatasetData) {
+					n = ((DatasetData) object).getName();
+				}
+				if (n.equals(name)) return object;
+			}
+		}
+		return null;
+	}
+	
+	/** Sets the text of indicating the number of imports. */
+	private void setNumberOfImport()
+	{
+		StringBuffer buffer = new StringBuffer();
+		int n = countUploaded-countUploadFailure-countCancelled;
+		if (n < 0) n = 0;
+		buffer.append(n);
+		buffer.append(" out of ");
+		buffer.append(totalToImport);
+		buffer.append(" uploaded");
+		numberOfImportLabel.setText(buffer.toString());
+	}
+	
+	/**
+	 * Browses the specified object.
+	 * 
+	 * @param data The object to handle.
+	 * @param node The node hosting the object to browse or <code>null</code>.
+	 */ 
+	private void browse(Object data, Object node)
+	{
+		EventBus bus = ImporterAgent.getRegistry().getEventBus();
+		if (data instanceof TreeImageDisplay || data instanceof DataObject) {
+			bus.post(new BrowseContainer(data, node));
+		} else if (data instanceof FileImportComponent) {
+			FileImportComponentI fc = (FileImportComponentI) data;
+			if (fc.getContainerFromFolder() != null)
+				bus.post(new BrowseContainer(fc.getContainerFromFolder(), 
+						node));
+		}
+	}
+
+	/**
+	 * Displays only the failures or all the results.
+	 */
+	private void filterFailures()
+	{
+		String v = filterButton.getText();
+		if (SHOW_FAILURE.equals(v)) {
+			filterButton.setText(SHOW_ALL);
+			layoutEntries(true);
+		} else {
+			filterButton.setText(SHOW_FAILURE);
+			layoutEntries(false);
+		}
+	}
+	
+	/** Initializes the components. */
+	private void initialize()
+	{
+		filterButton = new JButton(SHOW_FAILURE);
+		filterButton.setEnabled(false);
+		filterButton.addActionListener(new ActionListener() {
+			
+			/**
+			 * Filters or not the import that did not fail.
+			 */
+			public void actionPerformed(ActionEvent evt) {
+				filterFailures();
+			}
+		});
+		sizeImport = 0;
+		busyLabel = new JXBusyLabel(ICON_SIZE);
+		numberOfImportLabel = UIUtilities.createComponent(null);
+		foldersName = new LinkedHashMap<JLabel, Object>();
+		countUploadFailure = 0;
+		countFailure = 0;
+		countUploaded = 0;
+		addPropertyChangeListener(controller);
+		entries = new JPanel();
+		entries.setBackground(UIUtilities.BACKGROUND);
+		components = new LinkedHashMap<String, FileImportComponent>();
+		List<ImportableFile> files = object.getFiles();
+		FileImportComponent c;
+		
+		Iterator<ImportableFile> i = files.iterator();
+		ImportableFile importable;
+		type = -1;
+		List<Object> containers = object.getRefNodes();
+		if (containers != null && containers.size() > 0) {
+			Iterator<Object> j = containers.iterator();
+			TreeImageDisplay node;
+			Object h;
+			while (j.hasNext()) {
+				node = (TreeImageDisplay) j.next();
+				h = node.getUserObject();
+				if (h instanceof DatasetData) {
+					type = FileImportComponentI.DATASET_TYPE;
+				} else if (h instanceof ScreenData) {
+					type = FileImportComponentI.SCREEN_TYPE;
+				} else if (h instanceof ProjectData) {
+					type = FileImportComponentI.PROJECT_TYPE;
+				}
+				break;
+			}
+		} else {
+			type = FileImportComponentI.NO_CONTAINER;
+		}
+		JLabel l;
+		boolean single = model.isSingleGroup();
+		FileObject f;
+		while (i.hasNext()) {
+			importable = i.next();
+			f = (FileObject) importable.getFile();
+			c = new FileImportComponent(importable,
+					!controller.isMaster(), single, getID(), object.getTags());
+			c.setType(type);
+			c.addPropertyChangeListener(controller);
+			c.addPropertyChangeListener(new PropertyChangeListener() {
+				
+				public void propertyChange(PropertyChangeEvent evt) {
+					String name = evt.getPropertyName();
+					if (FileImportComponentI.BROWSE_PROPERTY.equals(name)) {
+						List<Object> refNodes = object.getRefNodes();
+						Object node = null;
+						if (refNodes != null && refNodes.size() > 0)
+							node = refNodes.get(0);
+						browse(evt.getNewValue(), node);
+					} else if (
+						FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(
+								name)) {
+						//-1 to remove the entry for the folder.
+						Integer v = (Integer) evt.getNewValue()-1;
+						totalToImport += v;
+						setNumberOfImport();
+					} else if (FileImportComponentI.LOAD_LOGFILEPROPERTY.equals(
+							name)) {
+						FileImportComponentI fc = (FileImportComponentI)
+								evt.getNewValue();
+						if (fc == null) return;
+						long logFileID = fc.getStatus().getLogFileID();
+						if (logFileID <= 0) {
+							FilesetData data = fc.getStatus().getFileset();
+							if (data == null) return;
+							model.fireImportLogFileLoading(data.getId(),
+									fc.getIndex());
+						} else downloadLogFile(logFileID);
+					} else if (
+						FileImportComponentI.RETRIEVE_LOGFILEPROPERTY.equals(
+							name)) {
+						FilesetData data = (FilesetData) evt.getNewValue();
+						if (data != null)
+							model.fireImportLogFileLoading(data.getId(), id);
+					} else if (
+						FileImportComponentI.CHECKSUM_DISPLAY_PROPERTY.equals(
+							name)) {
+						Status label = (Status) evt.getNewValue();
+						CheckSumDialog d = new CheckSumDialog(view, label);
+						UIUtilities.centerAndShow(d);
+					} else if (FileImportComponentI.RETRY_PROPERTY.equals(name)) {
+						controller.retryUpload(
+								(FileImportComponent) evt.getNewValue());
+					} else if (
+						FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
+						controller.cancel(
+								(FileImportComponentI) evt.getNewValue());
+					}
+				}
+			});
+			if (f.isDirectory()) {
+				if (importable.isFolderAsContainer()) {
+					l = new JLabel(f.getName());
+					foldersName.put(l, c);
+				}
+			} else {
+				if (importable.isFolderAsContainer()) {
+					String name = f.getParentName();
+					//first check if the name is already there.
+					Entry<JLabel, Object> entry;
+					Iterator<Entry<JLabel, Object>>
+					k = foldersName.entrySet().iterator();
+					boolean exist = false;
+					while (k.hasNext()) {
+						entry = k.next();
+						l = entry.getKey();
+						if (l.getText().equals(name)) {
+							exist = true;
+							break;
+						}
+					}
+					if (name == null) {
+					    name = f.getName();
+					}
+					if (!exist) {
+						foldersName.put(new JLabel(name), c);
+					}
+				}
+			}
+			importable.setStatus(c.getStatus());
+			components.put(c.toString(), c);
+		}
+		totalToImport = files.size();
+	}
+	
+	/**
+	 * Downloads the log file.
+	 * 
+	 * @param logFileID
+	 */
+	void downloadLogFile(long logFileID)
+	{
+		if (logFileID < 0) return;
+		Environment env = (Environment) 
+				ImporterAgent.getRegistry().lookup(
+						LookupNames.ENV);
+		String path = env.getOmeroFilesHome();
+		File f = new File(path, "importLog_"+logFileID);
+		DownloadAndLaunchActivityParam
+		activity = new DownloadAndLaunchActivityParam(logFileID,
+				DownloadAndLaunchActivityParam.ORIGINAL_FILE,
+				f, null);
+		activity.setUIRegister(false);
+		UserNotifier un =
+				ImporterAgent.getRegistry().getUserNotifier();
+		un.notifyActivity(model.getSecurityContext(), activity);
+	}
+	
+	/** 
+	 * Builds a row.
+	 * 
+	 * @return See above.
+	 */
+	private JPanel createRow()
+	{
+		JPanel p = new JPanel();
+		p.setLayout(new FlowLayout(FlowLayout.LEFT));
+		p.setBackground(UIUtilities.BACKGROUND_COLOR);
+		return p;
+	}
+	
+	/**
+	 * Make the JTextArea represent a multiline label.
+	 * 
+	 * @param textArea The component to handle.
+	 */
+	private void makeLabelStyle(JTextArea textArea)
+	{
+		if (textArea == null) return;
+		textArea.setEditable(false);
+		textArea.setCursor(null);
+		textArea.setOpaque(false);
+		textArea.setFocusable(false);
+	}
+	
+	/** 
+	 * Builds and lays out the header.
+	 * 
+	 * @return See above.
+	 */
+	private JPanel buildHeader()
+	{
+		sizeLabel = UIUtilities.createComponent(null);
+		sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+		reportLabel = UIUtilities.setTextFont("Report:", Font.BOLD);
+		importSizeLabel = UIUtilities.setTextFont("Import Size:", Font.BOLD);
+		double[][] design = new double[][]{
+					{TableLayout.PREFERRED},
+					{TableLayout.PREFERRED, TableLayout.PREFERRED}
+				};
+		TableLayout layout = new TableLayout(design);
+		JPanel detailsPanel = new JPanel(layout);
+		detailsPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
+		JPanel p = createRow();
+		p.add(reportLabel);
+		p.add(numberOfImportLabel);
+		detailsPanel.add(p, "0, 0");
+		p = createRow();
+		p.add(importSizeLabel);
+		p.add(sizeLabel);
+		detailsPanel.add(p, "0, 1");
+		
+		JPanel middlePanel = new JPanel();
+		middlePanel.setBackground(UIUtilities.BACKGROUND_COLOR);
+		middlePanel.add(filterButton);
+		
+    	JTextArea description = new JTextArea(MESSAGE);
+    	makeLabelStyle(description);
+    	description.setBackground(UIUtilities.BACKGROUND_COLOR);
+    	
+		JPanel descriptionPanel = new JPanel();
+		descriptionPanel.setBackground(UIUtilities.BACKGROUND_COLOR);
+		descriptionPanel.add(description);
+		
+		JPanel header = new JPanel();
+		header.setBackground(UIUtilities.BACKGROUND_COLOR);
+		header.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+		header.setLayout(new BorderLayout());
+		
+		header.add(Box.createVerticalStrut(10), BorderLayout.NORTH);
+		header.add(detailsPanel, BorderLayout.WEST);
+		header.add(middlePanel, BorderLayout.CENTER);
+		header.add(descriptionPanel, BorderLayout.EAST);
+		header.add(Box.createVerticalStrut(10), BorderLayout.SOUTH);
+		
+		return header;
+	}
+	
+	/** Builds and lays out the UI. */
+	private void buildGUI()
+	{
+		layoutEntries(false);
+		JScrollPane pane = new JScrollPane(entries);
+		pane.setOpaque(false);
+		pane.setBorder(new LineBorder(Color.LIGHT_GRAY));
+		setLayout(new BorderLayout(0, 0));
+		add(buildHeader(), BorderLayout.NORTH);
+		add(pane, BorderLayout.CENTER);
+	}
+	
+	/** 
+	 * Lays out the entries.
+	 * 
+	 * @param failure Pass <code>true</code> to display the failed import only,
+	 * <code>false</code> to display all the entries.
+	 */
+	private void layoutEntries(boolean failure)
+	{
+		entries.removeAll();
+		TableLayout layout = new TableLayout();
+		layout.setColumn(COLUMNS);
+		entries.setLayout(layout);
+		int index = 0;
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponent fc;
+		if (failure) {
+			while (i.hasNext()) {
+				entry = i.next();
+				fc = entry.getValue();
+				if (fc.hasComponents()) {
+					addRow(layout, index, entry.getValue());
+					fc.layoutEntries(failure);
+					index++;
+				} else {
+					if (fc.hasImportFailed()) {
+						addRow(layout, index, entry.getValue());
+						index++;
+					}
+				}
+			}
+		} else {
+			while (i.hasNext()) {
+				entry = i.next();
+				fc = entry.getValue();
+				addRow(layout, index, fc);
+				fc.layoutEntries(failure);
+				index++;
+			}
+		}
+		
+		entries.revalidate();
+		repaint();
+		setNumberOfImport();
+	}
+	
+	/**
+	 * Adds a new row.
+	 * 
+	 * @param layout The layout.
+	 * @param index	 The index of the row.
+	 * @param c		 The component to add.
+	 */
+	private void addRow(TableLayout layout, int index, FileImportComponent c)
+	{
+		layout.insertRow(index, TableLayout.PREFERRED);
+		if (index%2 == 0)
+			c.setBackground(UIUtilities.BACKGROUND_COLOUR_EVEN);
+		else 
+			c.setBackground(UIUtilities.BACKGROUND_COLOUR_ODD);
+		entries.add(c, new TableLayoutConstraints(0, index));
+	}
+	
+	/**
+	 * Creates a new instance.
+	 * 
+	 * @param controller Reference to the control. Mustn't be <code>null</code>.
+	 * @param model Reference to the model. Mustn't be <code>null</code>.
+	 * @param view Reference to the model. Mustn't be <code>null</code>.
+	 * @param id The identifier of the component.
+	 * @param index The index of the component.
+	 * @param name The name of the component.
+	 * @param object the object to handle. Mustn't be <code>null</code>.
+	 */
+	ImporterUIElementDetailed(ImporterControl controller, ImporterModel model,
+			ImporterUI view, int id, int index, String name,
+			ImportableObject object)
+	{
+		super(controller, model,
+	            view, id, index, name,
+	            object);
+		initialize();
+		buildGUI();
+	}
+
+	/**
+	 * Returns the identifier of the component.
+	 * 
+	 * @return See above.
+	 */
+	int getID() { return id; }
+	
+	/**
+	 * Returns the formatted result.
+	 * 
+	 * @param f The imported file.
+	 * @return See above.
+	 */
+	Object getFormattedResult(ImportableFile f)
+	{
+		FileImportComponentI c = components.get(f.toString());
+		if (c == null) return null;
+		ImportErrorObject object = c.getImportErrorObject();
+		if (object != null) return object;
+		
+		return null;
+	}
+	
+
+	/**
+	 * Sets the result of the import for the specified file.
+	 * 
+	 * @param f The imported file.
+	 * @param result The result.
+	 * @result Returns the formatted result or <code>null</code>.
+	 */
+	Object uploadComplete(ImportableFile f, Object result)
+	{
+		FileImportComponentI c = components.get(f.toString());
+		return uploadComplete(c, result);
+	}
+	
+	/**
+	 * Sets the result of the import for the specified file.
+	 * 
+	 * @param f The imported file.
+	 * @param result The result.
+	 * @param index The index corresponding to the component
+	 * @result Returns the formatted result or <code>null</code>.
+	 */
+	Object uploadComplete(FileImportComponentI c, Object result)
+	{
+		if (c == null) return null;
+		c.uploadComplete(result);
+		FileObject file = c.getFile();
+		Object r = null;
+		if (file.isFile()) {
+			countUploaded++;
+			sizeImport += c.getImportSize();
+			sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+			//handle error that occurred during the scanning or upload.
+			//Check that the result has not been set.
+			//if (!c.hasResult()) {
+			if (result instanceof Exception) {
+				r = new ImportErrorObject(file.getTrueFile(), (Exception) result,
+						c.getGroupID());
+				if (c.hasResult()) return null;
+				setImportResult(c, result);
+			} else if (result instanceof Boolean) {
+				Boolean b = (Boolean) result;
+				if (!b && c.isCancelled()) {
+					countUploaded--;
+					if (isDone() && rotationIcon != null)
+						rotationIcon.stopRotation();
+				} else
+				setImportResult(c, result);
+			} else {
+				if (c.isCancelled()) {
+					if (result == null) {
+						countCancelled++;
+						countImported++;
+						if (isDone() && rotationIcon != null)
+							rotationIcon.stopRotation();
+					} else {
+						countCancelled--;
+						countUploaded--;
+					}
+				}
+			}
+			//}
+		} else {//empty folder
+			if (result instanceof Exception) {
+				countUploaded++;
+				//Check if no files
+				if (!c.hasComponents()) {
+					countImported++;
+					countUploadFailure++;
+					c.setStatus(result);
+				}
+				if (isDone() && rotationIcon != null)
+					rotationIcon.stopRotation();
+			} else if (result instanceof Boolean) {
+				Boolean b = (Boolean) result;
+				if (!b && c.isCancelled()) {
+					countUploaded++;
+					countCancelled++;
+					countImported++;
+					if (isDone() && rotationIcon != null)
+						rotationIcon.stopRotation();
+				}
+			}
+		}
+		setNumberOfImport();
+		setClosable(isUploadComplete());
+		return r;
+	}
+	
+	/**
+	 * Sets the result of the import for the specified file.
+	 * 
+	 * @param fc The component hosting the file to import.
+	 * @param result The result.
+	 * @result Returns the formatted result or <code>null</code>.
+	 */
+	void setImportResult(FileImportComponentI fc, Object result)
+	{
+		if (fc == null) return;
+		FileObject file = fc.getFile();
+		if (file.isFile()) {
+			fc.setStatus(result);
+			countImported++;
+			if (fc.isCancelled() && result != null &&
+				!(result instanceof Boolean))
+				countImported--;
+			if (isDone() && rotationIcon != null)
+				rotationIcon.stopRotation();
+			if (fc.hasUploadFailed()) {
+				countUploadFailure++;
+				sizeImport -= fc.getImportSize();
+				sizeLabel.setText(FileUtils.byteCountToDisplaySize(sizeImport));
+			}
+			if (fc.hasImportFailed()) countFailure++;
+			setNumberOfImport();
+			setClosable(isDone());
+			filterButton.setEnabled(countFailure > 0 &&
+					countFailure != totalToImport);
+		} else { //empty folder
+			if (result instanceof Exception) {
+				fc.setStatus(result);
+				countImported++;
+				countFailure++;
+				countUploadFailure++;
+				if (isDone() && rotationIcon != null)
+					rotationIcon.stopRotation();
+				setNumberOfImport();
+				setClosable(isDone());
+			}
+		}
+	}
+
+	/**
+	 * Returns <code>true</code> if the upload is finished, <code>false</code>
+	 * otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean isUploadComplete() { 
+	    return (countFailure + countUploaded) == totalToImport;
+	}
+	
+    /**
+     * Returns <code>true</code> if the import is finished, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    boolean isDone() {
+        return countImported == totalToImport;
+    }
+	
+	/**
+	 * Returns <code>true</code> if there is one remaining import,
+	 * <code>false</code> otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean isLastImport() { return countImported == (totalToImport-1); }
+	
+	/** 
+	 * Indicates that the import has started. 
+	 * 
+	 * @param component The component of reference of the rotation icon.
+	 */
+	Icon startImport(JComponent component)
+	{
+		uploadStarted = true;
+		setClosable(false);
+		busyLabel.setBusy(true);
+		repaint();
+		return new RotationIcon(busyLabel.getIcon(), component, true);
+	}
+	
+	/**
+	 * Returns <code>true</code> if the import has started, <code>false</code>
+	 * otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean hasStarted() { return uploadStarted; }
+	
+	/**
+	 * Manually sets the uploadStarted flag
+	 * @param uploadStarted
+	 */
+	void setUploadStarted(boolean uploadStarted) {
+	    this.uploadStarted = uploadStarted;
+	}
+	
+	/**
+	 * Returns <code>true</code> if the component has imports in the queue that
+	 * have not yet started or been cancelled, <code>false</code> otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean hasImportToCancel()
+	{
+	    for (final FileImportComponentI fic : components.values()) {
+	    	if (fic.hasImportToCancel()) {
+	            return true;
+	        }
+	    }
+	    return false;
+	}
+
+	/**
+	 * Returns the collection of files that could not be imported.
+	 * 
+	 * @return See above.
+	 */
+	List<FileImportComponentI> getMarkedFiles()
+	{
+		List<FileImportComponentI> list = new ArrayList<FileImportComponentI>();
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponentI fc;
+		List<FileImportComponentI> l;
+		while (i.hasNext()) {
+			entry = i.next();
+			fc = entry.getValue();
+			l = fc.getImportErrors();
+			if (l != null && l.size() > 0)
+				list.addAll(l);
+		}
+		return list;
+	}
+	
+	/**
+	 * Returns the collection of files that could not be imported.
+	 * 
+	 * @return See above.
+	 */
+	List<FileImportComponentI> getFilesToReupload()
+	{
+		List<FileImportComponentI> list = new ArrayList<FileImportComponentI>();
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponentI fc;
+		List<FileImportComponentI> l;
+		while (i.hasNext()) {
+			entry = i.next();
+			fc = entry.getValue();
+			l = fc.getFilesToReupload();
+			if (!CollectionUtils.isEmpty(l))
+				list.addAll(l);
+		}
+		return list;
+	}
+	
+	/**
+	 * Returns the object to import.
+	 * 
+	 * @return See above.
+	 */
+	ImportableObject getData() { return object; }
+	
+	/**
+	 * Returns the existing containers.
+	 * 
+	 * @return See above.
+	 */
+	List<DataObject> getExistingContainers()
+	{
+		if (existingContainers != null) return existingContainers;
+		existingContainers = new ArrayList<DataObject>();
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponentI fc;
+		Map<Long, DatasetData> datasets = new HashMap<Long, DatasetData>();
+		Map<Long, DataObject> projects = new HashMap<Long, DataObject>();
+		Map<Long, DataObject> screens = new HashMap<Long, DataObject>();
+		DatasetData d;
+		DataObject object;
+		while (i.hasNext()) {
+			entry = i.next();
+			fc = entry.getValue();
+			d = fc.getDataset();
+			if (d != null && d.getId() > 0)
+				datasets.put(d.getId(), d);
+			object = fc.getDataObject();
+			if (object instanceof ScreenData && object.getId() > 0)
+				screens.put(object.getId(), object);
+			if (object instanceof ProjectData && object.getId() > 0) {
+				if (d != null && d.getId() <= 0)
+					projects.put(object.getId(), object);
+			}
+		}
+		existingContainers.addAll(datasets.values());
+		existingContainers.addAll(projects.values());
+		existingContainers.addAll(screens.values());
+		return existingContainers;
+	}
+
+	/**
+	 * Sets the import log file for each import component.
+	 *
+	 * @param data Collection of file annotations linked to the file set.
+	 * @param id The id of the file set.
+	 */
+	void setImportLogFile(Collection<FileAnnotationData> data, long id)
+	{
+	    if (CollectionUtils.isEmpty(data)) return;
+	    Entry<String, FileImportComponent> entry;
+	    Iterator<Entry<String, FileImportComponent>>
+	    i = components.entrySet().iterator();
+	    FileImportComponentI fc;
+	    Iterator<FileAnnotationData> j;
+	    FileAnnotationData fa;
+	    while (i.hasNext()) {
+	        entry = i.next();
+	        fc = entry.getValue();
+	        if (fc.getIndex() == id) {
+	            j = data.iterator();
+	            while (j.hasNext()) {
+	                fa = j.next();
+	                if (FileAnnotationData.LOG_FILE_NS.equals(
+	                        fa.getNameSpace())) {
+	                    downloadLogFile(fa.getFileID());
+	                    break;
+	                }
+	            }
+	        }
+	    }
+	}
+
+	/**
+	 * Returns <code>true</code> if errors to send, <code>false</code>
+	 * otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean hasFailuresToSend()
+	{
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponentI fc;
+		while (i.hasNext()) {
+			entry = i.next();
+			fc = entry.getValue();
+			if (fc.hasFailuresToSend())
+				return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Returns <code>true</code> if files to reimport, <code>false</code>
+	 * otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean hasFailuresToReimport()
+	{
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponentI fc;
+		while (i.hasNext()) {
+			entry = i.next();
+			fc = entry.getValue();
+			if (fc.hasFailuresToReimport())
+				return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Returns <code>true</code> if files to re-upload, <code>false</code>
+	 * otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean hasFailuresToReupload()
+	{
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponentI fc;
+		while (i.hasNext()) {
+			entry = i.next();
+			fc = entry.getValue();
+			if (fc.hasFailuresToReupload())
+				return true;
+		}
+		return false;
+	}
+	
+	/** Indicates that the import has been cancelled. */
+	void cancelLoading()
+	{
+		if (components == null || components.size() == 0) return;
+		Iterator<FileImportComponent> i = components.values().iterator();
+		while (i.hasNext()) {
+			i.next().cancelLoading();
+		}
+	}
+
+	/**
+	 * Returns <code>true</code> if the view should be refreshed,
+	 * <code>false</code> otherwise.
+	 * 
+	 * @return See above.
+	 */
+	boolean hasToRefreshTree()
+	{
+		Entry<String, FileImportComponent> entry;
+		Iterator<Entry<String, FileImportComponent>>
+		i = components.entrySet().iterator();
+		FileImportComponentI fc;
+		while (i.hasNext()) {
+			entry = i.next();
+			fc = entry.getValue();
+			if (fc.hasToRefreshTree())
+				return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Returns the icon indicating the status of the import.
+	 * 
+	 * @return See above.
+	 */
+	Icon getImportIcon()
+	{ 
+		if (isDone()) {
+			Iterator<Entry<String, FileImportComponent>>
+			i = components.entrySet().iterator();
+			FileImportComponentI fc;
+			Entry<String, FileImportComponent> entry;
+			int failure = 0;
+			ImportStatus v;
+			while (i.hasNext()) {
+				entry = i.next();
+				fc = entry.getValue();
+				v = fc.getImportStatus();
+				if (v == ImportStatus.PARTIAL)
+					return IMPORT_PARTIAL;
+				if (v == ImportStatus.FAILURE) failure++;
+			}
+			if (failure == components.size()) return IMPORT_FAIL;
+			else if (failure > 0) return IMPORT_PARTIAL;
+			return IMPORT_SUCCESS;
+		}
+		return busyLabel.getIcon();
+	}
+	
+	/** Invokes when the import is finished. */
+	void onImportEnded()
+	{ 
+		busyLabel.setBusy(false);
+		setClosable(true);
+	}
+
+	/**
+	 * Resets the containers in the file to load.
+	 * 
+	 * @param result The containers to reset.
+	 */
+	void resetContainers(Collection result)
+	{
+		if (result == null || result.size() == 0) return;
+		List<ImportableFile> files = getData().getFiles();
+		if (files == null || files.size() == 0) return;
+		Iterator<ImportableFile> i = files.iterator();
+		ImportableFile f;
+		DataObject parent;
+		DatasetData dataset;
+		DataObject data;
+		ProjectData p;
+		DatasetData r;
+		while (i.hasNext()) {
+			f = i.next();
+			parent = f.getParent();
+			dataset = f.getDataset();
+			if (parent != null) {
+				if (parent.getId() <= 0) { //new project or screen
+					data = getObject(parent, result);
+					r = null;
+					if (dataset != null) {
+						if (dataset.getId() <= 0) {
+							//data is a project
+							r = dataset;
+							p = (ProjectData) data;
+							r = (DatasetData) 
+								getObject(dataset, p.getDatasets());
+						}
+					} 
+					f.setLocation(data, r);
+				} else { //was already created.
+					if (dataset != null) {
+						if (dataset.getId() <= 0) {
+							data = getObjectFromID(parent, result);
+							//data is a project
+							r = dataset;
+							p = (ProjectData) data;
+							r = (DatasetData) 
+								getObject(dataset, p.getDatasets());
+							f.setLocation(data, r);
+						}
+					}
+				}
+			} else { //no parent
+				if (dataset != null) {
+					if (dataset.getId() <= 0) {
+						//data is a project
+						r = dataset;
+						r = (DatasetData) 
+							getObject(dataset, result);
+						f.setLocation(null, r);
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,70 +25,40 @@ import info.clearthought.layout.TableLayoutConstraints;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.Font;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.Icon;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 import javax.swing.border.LineBorder;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FileUtils;
-import org.jdesktop.swingx.JXBusyLabel;
 import org.openmicroscopy.shoola.agents.events.importer.BrowseContainer;
-import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
 import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.CheckSumDialog;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
-import org.openmicroscopy.shoola.agents.fsimporter.util.ImportStatus;
 import org.openmicroscopy.shoola.agents.util.browser.TreeImageDisplay;
 import org.openmicroscopy.shoola.env.Environment;
 import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.model.DownloadAndLaunchActivityParam;
-import org.openmicroscopy.shoola.env.data.model.FileObject;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.env.event.EventBus;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
-import org.openmicroscopy.shoola.util.file.ImportErrorObject;
-import org.openmicroscopy.shoola.util.ui.ClosableTabbedPaneComponent;
-import org.openmicroscopy.shoola.util.ui.RotationIcon;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 import omero.gateway.model.DataObject;
-import omero.gateway.model.DatasetData;
-import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.FilesetData;
-import omero.gateway.model.ProjectData;
-import omero.gateway.model.ScreenData;
 import omero.gateway.model.TagAnnotationData;
 
 /** 
- * Component displaying an import.
+ * A GUI heavy version of the ImporterUIElement.
  *
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
@@ -71,24 +71,8 @@ class ImporterUIElementDetailed
 	extends ImporterUIElement
 {
 	
-	/** Description of the component. */
-	private static final String DESCRIPTION = 
-		"Closing will cancel imports that have not yet started.";
-	
-	/** Text indicating to only show the failure.*/
-	private static final String SHOW_FAILURE = "Show Failed";
-	
-	/** Text indicating to show all the imports.*/
-	private static final String SHOW_ALL = "Show All";
-	
 	/** The columns for the layout of the {@link #entries}. */
 	private static final double[] COLUMNS = {TableLayout.FILL};
-	
-	/** The message to display in the header.*/
-	private static final String MESSAGE = 
-			"When upload is complete, the import" +CommonsLangUtils.LINE_SEPARATOR+
-			"window and OMERO session can be closed." +CommonsLangUtils.LINE_SEPARATOR+
-			"Reading will continue on the server.";
 
 	/** Component hosting the entries. */
 	private JPanel	entries;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementDetailed.java
@@ -115,7 +115,7 @@ class ImporterUIElementDetailed
 	/**
 	 * Displays only the failures or all the results.
 	 */
-	void filterFailures()
+	void showFailures()
 	{
 		String v = filterButton.getText();
 		if (SHOW_FAILURE.equals(v)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -20,32 +20,32 @@
  */
 package org.openmicroscopy.shoola.agents.fsimporter.view;
 
-import info.clearthought.layout.TableLayout;
-
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.FlowLayout;
 import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import javax.swing.BorderFactory;
-import javax.swing.Box;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
 import javax.swing.border.LineBorder;
 
 import omero.gateway.model.TagAnnotationData;
 
-import org.apache.commons.io.FileUtils;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.LightFileImportComponent;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
+import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
-import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /**
  * Component displaying an import.
@@ -60,19 +60,44 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
  */
 class ImporterUIElementLight extends ImporterUIElement {
 
-    /** The message to display in the header. */
-    private static final String MESSAGE = "When upload is complete, the import"
-            + CommonsLangUtils.LINE_SEPARATOR
-            + "window and OMERO session can be closed."
-            + CommonsLangUtils.LINE_SEPARATOR
-            + "Reading will continue on the server.";
+    JLabel lTotal = new JLabel("0");
+    JLabel lRemaining = new JLabel("0");
+    JLabel lError = new JLabel("0");
 
+    Map<Integer, JLabel> stepLabel = new HashMap<Integer, JLabel>();
+    Map<Integer, JLabel> stepValues = new HashMap<Integer, JLabel>();
+
+    Map<Integer, Integer> importStatus = new ConcurrentHashMap<Integer, Integer>();
+    
     @Override
     FileImportComponentI buildComponent(ImportableFile importable,
             boolean browsable, boolean singleGroup, int index,
             Collection<TagAnnotationData> tags) {
-        return new LightFileImportComponent(importable, getID(),
-                object.getTags());
+        LightFileImportComponent fc = new LightFileImportComponent(importable,
+                getID(), object.getTags());
+        
+        fc.addPropertyChangeListener(new PropertyChangeListener() {
+
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                String name = evt.getPropertyName();
+                if (Status.STEP_PROPERTY.equals(name)) {
+                    String[] tmp = ((String) evt.getNewValue()).split("_");
+                    int id = Integer.parseInt(tmp[0]);
+                    int step = Integer.parseInt(tmp[1]);
+                    
+                    importStatus.put(id, step);
+
+                    SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            updateDisplay();
+                        }
+                    });
+                }
+            }
+        });
+        return fc;
     }
 
     /**
@@ -100,30 +125,111 @@ class ImporterUIElementLight extends ImporterUIElement {
         buildGUI();
     }
 
+    private JLabel boldLabel(String text) {
+        JLabel l = new JLabel(text);
+        l.setFont(l.getFont().deriveFont(Font.BOLD));
+        return l;
+    }
+    
     /** Builds and lays out the UI. */
     private void buildGUI() {
+        for (int i = 1; i < 7; i++) {
+            JLabel l = new JLabel(Status.STEPS.get(i));
+            stepLabel.put(i, l);
+            stepValues.put(i, new JLabel("0"));
+        }
+
         setLayout(new BorderLayout(0, 0));
-        
+
         add(buildHeader(), BorderLayout.NORTH);
-        
-        
+
         JPanel info = new JPanel();
         info.setOpaque(false);
         info.setBorder(new LineBorder(Color.LIGHT_GRAY));
+
+        info.setLayout(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        c.insets = new Insets(2, 2, 2, 2);
+
+        c.gridx = 0;
+        c.gridy = 0;
+        info.add(boldLabel("Total images"), c);
+        c.gridx = 1;
+        info.add(lTotal, c);
+        
+        c.gridx = 0;
+        c.gridy = 1;
+        c.insets = new Insets(10, 2, 2, 2);
+        info.add(boldLabel("Import Queue"), c);
+        c.gridx = 1;
+        info.add(lRemaining, c);
+        
+        c.gridx = 0;
+        c.gridy = 2;
+        c.gridwidth = 2;
+        c.insets = new Insets(10, 2, 2, 2);
+        info.add(boldLabel("Processing Queues"), c);
+        c.gridwidth = 1;
+        c.insets = new Insets(2, 2, 2, 2);
+        
+        for (int i = 1; i < 6; i++) {
+            c.gridx = 0;
+            c.gridy = i+2;
+            info.add(stepLabel.get(i), c);
+            c.gridx = 1;
+            info.add(stepValues.get(i), c);
+        }
+        
+        c.gridx = 0;
+        c.gridy = 8;
+        c.gridwidth = 2;
+        c.insets = new Insets(10, 2, 2, 2);
+        info.add(boldLabel("Result"), c);
+        c.gridwidth = 1;
+        c.insets = new Insets(2, 2, 2, 2);
+
+        c.gridx = 0;
+        c.gridy = 9;
+        info.add(stepLabel.get(6), c);
+        c.gridx = 1;
+        info.add(stepValues.get(6), c);
+        
+        c.gridx = 0;
+        c.gridy = 10;
+        info.add(new JLabel("Errors"), c);
+        c.gridx = 1;
+        info.add(lError, c);
+
         add(info, BorderLayout.CENTER);
+    }
+
+    private void updateDisplay() {
+        lTotal.setText("" + super.totalToImport);
+        int complete = 0;
+        for (int i = 1; i < 7; i++) {
+            int c = 0;
+            for (int step : importStatus.values()) {
+                if (i == step)
+                    c++;
+            }
+            stepValues.get(i).setText("" + c);
+            if(i == 6)
+                complete = c;
+        }
+        lError.setText("" + super.countFailure);
+        lRemaining.setText(""+(super.totalToImport-super.countFailure-complete));
     }
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         String name = evt.getPropertyName();
-        if (
-            FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(
-                    name)) {
-            //-1 to remove the entry for the folder.
-            Integer v = (Integer) evt.getNewValue()-1;
+        if (FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(name)) {
+            // -1 to remove the entry for the folder.
+            Integer v = (Integer) evt.getNewValue() - 1;
             totalToImport += v;
             setNumberOfImport();
-        } 
+        }
+        updateDisplay();
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -1,0 +1,129 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.agents.fsimporter.view;
+
+import info.clearthought.layout.TableLayout;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.beans.PropertyChangeEvent;
+import java.util.Collection;
+import java.util.List;
+
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.border.LineBorder;
+
+import omero.gateway.model.TagAnnotationData;
+
+import org.apache.commons.io.FileUtils;
+import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
+import org.openmicroscopy.shoola.agents.fsimporter.util.LightFileImportComponent;
+import org.openmicroscopy.shoola.env.data.model.ImportableFile;
+import org.openmicroscopy.shoola.env.data.model.ImportableObject;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
+/**
+ * Component displaying an import.
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:donald@lifesci.dundee.ac.uk"
+ *         >donald@lifesci.dundee.ac.uk</a>
+ * @version 3.0
+ * @since 3.0-Beta4
+ */
+class ImporterUIElementLight extends ImporterUIElement {
+
+    /** The message to display in the header. */
+    private static final String MESSAGE = "When upload is complete, the import"
+            + CommonsLangUtils.LINE_SEPARATOR
+            + "window and OMERO session can be closed."
+            + CommonsLangUtils.LINE_SEPARATOR
+            + "Reading will continue on the server.";
+
+    @Override
+    FileImportComponentI buildComponent(ImportableFile importable,
+            boolean browsable, boolean singleGroup, int index,
+            Collection<TagAnnotationData> tags) {
+        return new LightFileImportComponent(importable, getID(),
+                object.getTags());
+    }
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param controller
+     *            Reference to the control. Mustn't be <code>null</code>.
+     * @param model
+     *            Reference to the model. Mustn't be <code>null</code>.
+     * @param view
+     *            Reference to the model. Mustn't be <code>null</code>.
+     * @param id
+     *            The identifier of the component.
+     * @param index
+     *            The index of the component.
+     * @param name
+     *            The name of the component.
+     * @param object
+     *            the object to handle. Mustn't be <code>null</code>.
+     */
+    ImporterUIElementLight(ImporterControl controller, ImporterModel model,
+            ImporterUI view, int id, int index, String name,
+            ImportableObject object) {
+        super(controller, model, view, id, index, name, object);
+        buildGUI();
+    }
+
+    /** Builds and lays out the UI. */
+    private void buildGUI() {
+        setLayout(new BorderLayout(0, 0));
+        
+        add(buildHeader(), BorderLayout.NORTH);
+        
+        
+        JPanel info = new JPanel();
+        info.setOpaque(false);
+        info.setBorder(new LineBorder(Color.LIGHT_GRAY));
+        add(info, BorderLayout.CENTER);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        String name = evt.getPropertyName();
+        if (
+            FileImportComponentI.IMPORT_FILES_NUMBER_PROPERTY.equals(
+                    name)) {
+            //-1 to remove the entry for the folder.
+            Integer v = (Integer) evt.getNewValue()-1;
+            totalToImport += v;
+            setNumberOfImport();
+        } 
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -73,31 +73,8 @@ class ImporterUIElementLight extends ImporterUIElement {
     FileImportComponentI buildComponent(ImportableFile importable,
             boolean browsable, boolean singleGroup, int index,
             Collection<TagAnnotationData> tags) {
-        LightFileImportComponent fc = new LightFileImportComponent(importable,
+        return new LightFileImportComponent(importable,
                 getID(), object.getTags());
-
-        fc.addPropertyChangeListener(new PropertyChangeListener() {
-
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                String name = evt.getPropertyName();
-                if (Status.STEP_PROPERTY.equals(name)) {
-                    String[] tmp = ((String) evt.getNewValue()).split("_");
-                    int id = Integer.parseInt(tmp[0]);
-                    int step = Integer.parseInt(tmp[1]);
-
-                    importStatus.put(id, step);
-
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            updateDisplay();
-                        }
-                    });
-                }
-            }
-        });
-        return fc;
     }
 
     /**
@@ -265,6 +242,12 @@ class ImporterUIElementLight extends ImporterUIElement {
             setNumberOfImport();
         } else if (FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
             controller.cancel((FileImportComponentI) evt.getNewValue());
+        } else if (Status.STEP_PROPERTY.equals(name)) {
+            String[] tmp = ((String) evt.getNewValue()).split("_");
+            int id = Integer.parseInt(tmp[0]);
+            int step = Integer.parseInt(tmp[1]);
+
+            importStatus.put(id, step);
         }
         
         SwingUtilities.invokeLater(new Runnable() {
@@ -273,6 +256,7 @@ class ImporterUIElementLight extends ImporterUIElement {
                 updateDisplay();
             }
         });
+        
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -68,7 +68,10 @@ class ImporterUIElementLight extends ImporterUIElement {
     private JXBusyLabel processedBusy = new JXBusyLabel();
 
     private JLabel errors = new JLabel("0");
-
+    
+    private JLabel cancelled = new JLabel("0");
+    private JLabel cancelledLabel = new JLabel("Cancelled:")
+    ;
     @Override
     FileImportComponentI buildComponent(ImportableFile importable,
             boolean browsable, boolean singleGroup, int index,
@@ -164,10 +167,24 @@ class ImporterUIElementLight extends ImporterUIElement {
         c.gridx = 0;
         c.gridy = 3;
         c.fill = GridBagConstraints.NONE;
+        cancelledLabel.setVisible(false);
+        info.add(cancelledLabel, c);
+        
+        c.gridx = 1;
+        c.gridy = 3;
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.gridwidth = 2;
+        c.anchor = GridBagConstraints.WEST;
+        cancelled.setVisible(false);
+        info.add(cancelled, c);
+        
+        c.gridx = 0;
+        c.gridy = 4;
+        c.fill = GridBagConstraints.NONE;
         info.add(new JLabel("Errors:"), c);
 
         c.gridx = 1;
-        c.gridy = 3;
+        c.gridy = 4;
         c.fill = GridBagConstraints.HORIZONTAL;
         c.gridwidth = 2;
         c.anchor = GridBagConstraints.WEST;
@@ -196,29 +213,30 @@ class ImporterUIElementLight extends ImporterUIElement {
         upload.setValue(uploaded);
         upload.setMaximum(super.totalToImport);
         uploadBusy.setText(+uploaded + "/" + super.totalToImport);
-        if (uploaded == super.totalToImport) {
+        if (uploaded + cancelled + super.countFailure == super.totalToImport) {
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
-        } else if (uploaded + cancelled + super.countFailure == super.totalToImport) {
-            uploadBusy.setBusy(false);
-            uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
-        } else {
+        }  else {
             uploadBusy.setBusy(true);
         }
         
         processed.setValue(complete);
-        processed.setMaximum(super.totalToImport);
-        processedBusy.setText(complete + "/" + super.totalToImport);
-        if (complete == super.totalToImport) {
+        processed.setMaximum(uploaded);
+        processedBusy.setText(complete + "/" + uploaded);
+        if (complete + cancelled + super.countFailure == super.totalToImport) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
-        } else if (complete + cancelled + super.countFailure == super.totalToImport) {
-            processedBusy.setBusy(false);
-            processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         } else {
             processedBusy.setBusy(true);
         }
+        
         errors.setText("" + super.countFailure);
+        
+        if (cancelled > 0) {
+            this.cancelledLabel.setVisible(true);
+            this.cancelled.setText(""+cancelled);
+            this.cancelled.setVisible(true);
+        }
         
         if (super.countFailure > 0) {
             super.filterButton.setEnabled(true);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -218,34 +218,30 @@ class ImporterUIElementLight extends ImporterUIElement {
         
         upload.setValue(uploaded);
         upload.setMaximum(super.totalToImport);
+        uploadBusy.setText(+uploaded + "/" + super.totalToImport);
         if (uploaded == super.totalToImport) {
-            uploadBusy.setText("Finished");
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         } else if (complete + cancelled == super.totalToImport) {
-            uploadBusy.setText(uploaded + "/" + super.totalToImport);
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         } else {
-            uploadBusy.setText(uploaded + "/" + super.totalToImport);
             uploadBusy.setBusy(true);
         }
         
         processed.setValue(complete);
         processed.setMaximum(super.totalToImport);
+        processedBusy.setText(complete + "/" + super.totalToImport);
         if (complete == super.totalToImport) {
-            processedBusy.setText("Finished");
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         } else if (complete+super.countFailure == super.totalToImport) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         } else if (complete + cancelled == super.totalToImport) {
-            processedBusy.setText(complete + "/" + super.totalToImport);
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         } else {
-            processedBusy.setText(complete + "/" + super.totalToImport);
             processedBusy.setBusy(true);
         }
         errors.setText("" + super.countFailure);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -42,6 +42,7 @@ import javax.swing.border.LineBorder;
 import omero.gateway.model.TagAnnotationData;
 
 import org.jdesktop.swingx.JXBusyLabel;
+import org.openmicroscopy.shoola.agents.fsimporter.IconManager;
 import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.LightFileImportComponent;
@@ -210,6 +211,7 @@ class ImporterUIElementLight extends ImporterUIElement {
         if (uploaded == super.totalToImport) {
             upload.setString("Finished");
             uploadBusy.setBusy(false);
+            uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         } else
             upload.setString(uploaded + "/" + super.totalToImport);
 
@@ -218,7 +220,11 @@ class ImporterUIElementLight extends ImporterUIElement {
         if (complete == super.totalToImport) {
             processed.setString("Finished");
             processedBusy.setBusy(false);
-        } else
+            processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
+        } else if (complete+super.countFailure == super.totalToImport) {
+            processedBusy.setBusy(false);
+            processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
+        }else 
             processed.setString(complete + "/" + super.totalToImport);
 
         errors.setText("" + super.countFailure);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -63,7 +63,7 @@ class ImporterUIElementLight extends ImporterUIElement {
 
     private JProgressBar upload = new JProgressBar(SwingConstants.HORIZONTAL);
     private JProgressBar processed = new JProgressBar(SwingConstants.HORIZONTAL);
-
+    
     private JXBusyLabel uploadBusy = new JXBusyLabel();
     private JXBusyLabel processedBusy = new JXBusyLabel();
 
@@ -127,6 +127,19 @@ class ImporterUIElementLight extends ImporterUIElement {
 
     /** Builds and lays out the UI. */
     private void buildGUI() {
+        
+        // init
+        upload.setBorderPainted(true);
+        upload.setMinimum(0);
+        upload.setStringPainted(false);
+        
+        processed.setBorderPainted(true);
+        processed.setMinimum(0);
+        processed.setStringPainted(false);
+        
+        uploadBusy.setBusy(true);
+        processedBusy.setBusy(true);
+        
         setLayout(new BorderLayout(0, 0));
 
         add(buildHeader(), BorderLayout.NORTH);
@@ -149,14 +162,11 @@ class ImporterUIElementLight extends ImporterUIElement {
         c.gridy = 0;
         c.fill = GridBagConstraints.HORIZONTAL;
         info.add(upload, c);
-        upload.setMinimum(0);
-        upload.setStringPainted(true);
 
         c.gridx = 2;
         c.gridy = 0;
         c.fill = GridBagConstraints.NONE;
         info.add(uploadBusy, c);
-        uploadBusy.setBusy(true);
 
         c.gridx = 0;
         c.gridy = 1;
@@ -167,14 +177,11 @@ class ImporterUIElementLight extends ImporterUIElement {
         c.gridy = 1;
         c.fill = GridBagConstraints.HORIZONTAL;
         info.add(processed, c);
-        processed.setMinimum(0);
-        processed.setStringPainted(true);
 
         c.gridx = 2;
         c.gridy = 1;
         c.fill = GridBagConstraints.NONE;
         info.add(processedBusy, c);
-        processedBusy.setBusy(true);
 
         c.gridx = 0;
         c.gridy = 3;
@@ -209,23 +216,23 @@ class ImporterUIElementLight extends ImporterUIElement {
         upload.setValue(uploaded);
         upload.setMaximum(super.totalToImport);
         if (uploaded == super.totalToImport) {
-            upload.setString("Finished");
+            uploadBusy.setText("Finished");
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         } else
-            upload.setString(uploaded + "/" + super.totalToImport);
+            uploadBusy.setText(uploaded + "/" + super.totalToImport);
 
         processed.setValue(complete);
         processed.setMaximum(super.totalToImport);
         if (complete == super.totalToImport) {
-            processed.setString("Finished");
+            processedBusy.setText("Finished");
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         } else if (complete+super.countFailure == super.totalToImport) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         }else 
-            processed.setString(complete + "/" + super.totalToImport);
+            processedBusy.setText(complete + "/" + super.totalToImport);
 
         errors.setText("" + super.countFailure);
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -40,11 +41,13 @@ import javax.swing.border.LineBorder;
 
 import omero.gateway.model.TagAnnotationData;
 
+import org.openmicroscopy.shoola.agents.fsimporter.ImporterAgent;
 import org.openmicroscopy.shoola.agents.fsimporter.util.FileImportComponentI;
 import org.openmicroscopy.shoola.agents.fsimporter.util.LightFileImportComponent;
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.util.Status;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
 /**
  * A lightweight version of the ImporterUIElement.
@@ -212,7 +215,19 @@ class ImporterUIElementLight extends ImporterUIElement {
         }
         lError.setText("" + super.countFailure);
         lRemaining.setText(""+(super.totalToImport-super.countFailure-complete));
+        
+        if (super.countFailure > 0) {
+            super.filterButton.setEnabled(true);
+        }
     }
+    
+    @Override
+    void showFailures() {
+        JFrame f = ImporterAgent.getRegistry().getTaskBar().getFrame();
+        FailedImportDialog d = new FailedImportDialog(f, getMarkedFiles());
+        UIUtilities.centerAndShow(d);
+    }
+
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -238,7 +238,8 @@ class ImporterUIElementLight extends ImporterUIElement {
 
         if (super.countFailure > 0) {
             super.filterButton.setEnabled(true);
-        }    }
+        }
+    }
 
     @Override
     void showFailures() {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2016 University of Dundee. All rights reserved.
+ *  Copyright (C) 2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -45,18 +45,12 @@ import org.openmicroscopy.shoola.agents.fsimporter.util.LightFileImportComponent
 import org.openmicroscopy.shoola.env.data.model.ImportableFile;
 import org.openmicroscopy.shoola.env.data.model.ImportableObject;
 import org.openmicroscopy.shoola.env.data.util.Status;
-import org.openmicroscopy.shoola.util.CommonsLangUtils;
 
 /**
- * Component displaying an import.
- *
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
- *         href="mailto:donald@lifesci.dundee.ac.uk"
- *         >donald@lifesci.dundee.ac.uk</a>
- * @version 3.0
- * @since 3.0-Beta4
+ * A lightweight version of the ImporterUIElement.
+ * 
+ * @author Domink Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
  */
 class ImporterUIElementLight extends ImporterUIElement {
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -137,8 +137,8 @@ class ImporterUIElementLight extends ImporterUIElement {
         processed.setMinimum(0);
         processed.setStringPainted(false);
         
-        uploadBusy.setBusy(true);
-        processedBusy.setBusy(true);
+        uploadBusy.setBusy(false);
+        processedBusy.setBusy(false);
         
         setLayout(new BorderLayout(0, 0));
 
@@ -152,6 +152,7 @@ class ImporterUIElementLight extends ImporterUIElement {
         info.setLayout(new GridBagLayout());
         GridBagConstraints c = new GridBagConstraints();
         c.insets = new Insets(2, 2, 2, 2);
+        c.anchor = GridBagConstraints.ABOVE_BASELINE_LEADING;
 
         c.gridx = 0;
         c.gridy = 0;
@@ -219,9 +220,11 @@ class ImporterUIElementLight extends ImporterUIElement {
             uploadBusy.setText("Finished");
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
-        } else
+        } else {
             uploadBusy.setText(uploaded + "/" + super.totalToImport);
-
+            uploadBusy.setBusy(true);
+        }
+        
         processed.setValue(complete);
         processed.setMaximum(super.totalToImport);
         if (complete == super.totalToImport) {
@@ -231,9 +234,10 @@ class ImporterUIElementLight extends ImporterUIElement {
         } else if (complete+super.countFailure == super.totalToImport) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
-        }else 
+        }else  {
             processedBusy.setText(complete + "/" + super.totalToImport);
-
+            processedBusy.setBusy(true);
+        }
         errors.setText("" + super.countFailure);
 
         if (super.countFailure > 0) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -214,12 +214,18 @@ class ImporterUIElementLight extends ImporterUIElement {
                 complete = c;
         }
 
+        int cancelled = super.cancelled();
+        
         upload.setValue(uploaded);
         upload.setMaximum(super.totalToImport);
         if (uploaded == super.totalToImport) {
             uploadBusy.setText("Finished");
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
+        } else if (complete + cancelled == super.totalToImport) {
+            uploadBusy.setText(uploaded + "/" + super.totalToImport);
+            uploadBusy.setBusy(false);
+            uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         } else {
             uploadBusy.setText(uploaded + "/" + super.totalToImport);
             uploadBusy.setBusy(true);
@@ -234,7 +240,11 @@ class ImporterUIElementLight extends ImporterUIElement {
         } else if (complete+super.countFailure == super.totalToImport) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
-        }else  {
+        } else if (complete + cancelled == super.totalToImport) {
+            processedBusy.setText(complete + "/" + super.totalToImport);
+            processedBusy.setBusy(false);
+            processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
+        } else {
             processedBusy.setText(complete + "/" + super.totalToImport);
             processedBusy.setBusy(true);
         }
@@ -260,6 +270,8 @@ class ImporterUIElementLight extends ImporterUIElement {
             Integer v = (Integer) evt.getNewValue() - 1;
             totalToImport += v;
             setNumberOfImport();
+        } else if (FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
+            controller.cancel((FileImportComponentI) evt.getNewValue());
         }
         updateDisplay();
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -222,7 +222,7 @@ class ImporterUIElementLight extends ImporterUIElement {
         if (uploaded == super.totalToImport) {
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
-        } else if (complete + cancelled == super.totalToImport) {
+        } else if (uploaded + cancelled + super.countFailure == super.totalToImport) {
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         } else {
@@ -235,17 +235,14 @@ class ImporterUIElementLight extends ImporterUIElement {
         if (complete == super.totalToImport) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
-        } else if (complete+super.countFailure == super.totalToImport) {
-            processedBusy.setBusy(false);
-            processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
-        } else if (complete + cancelled == super.totalToImport) {
+        } else if (complete + cancelled + super.countFailure == super.totalToImport) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY_CANCEL));
         } else {
             processedBusy.setBusy(true);
         }
         errors.setText("" + super.countFailure);
-
+        
         if (super.countFailure > 0) {
             super.filterButton.setEnabled(true);
         }
@@ -269,7 +266,13 @@ class ImporterUIElementLight extends ImporterUIElement {
         } else if (FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
             controller.cancel((FileImportComponentI) evt.getNewValue());
         }
-        updateDisplay();
+        
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                updateDisplay();
+            }
+        });
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -79,7 +79,7 @@ import omero.gateway.model.SearchParameters;
 import omero.gateway.model.TableResult;
 import omero.gateway.util.Requests;
 
-import org.openmicroscopy.shoola.env.data.util.StatusLabel;
+import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.env.rnd.PixelsServicesFactory;
 import org.openmicroscopy.shoola.env.rnd.RndProxyDef;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
@@ -5872,7 +5872,7 @@ class OMEROGateway
 	 * @throws ImportException If an error occurred while importing.
 	 */
     Object importImageFile(SecurityContext ctx, ImportableObject object,
-            IObject container, ImportContainer ic, StatusLabel status,
+            IObject container, ImportContainer ic, Status status,
             boolean close, String userName)
         throws ImportException, DSAccessException, DSOutOfServiceException
 	{
@@ -5966,7 +5966,7 @@ class OMEROGateway
 	 * @throws ImportException If an error occurred while importing.
 	 */
 	ImportCandidates getImportCandidates(SecurityContext ctx,
-			ImportableObject object, File file, StatusLabel status)
+			ImportableObject object, File file, Status status)
 		throws ImportException
 	{
 		OMEROWrapper reader = null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5973,7 +5973,6 @@ class OMEROGateway
 		try {
             ImportConfig config = new ImportConfig();
             config.checksumAlgorithm.set(object.getChecksumAlgorithm());
-            config.checkUpgrade.set(object.getUpgradeCheck());
             if (object.skipThumbnails()) {
                 config.doThumbnails.set(Boolean.FALSE);
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5881,8 +5881,12 @@ class OMEROGateway
         //FIXME: unclear why we would need to set these values on
         // both the ImportConfig and the ImportContainer.
         if (container != null) {
-             config.target.set("omero.model.Dataset:"+container.getId().getValue());
-             ic.setTarget(container);
+            String name = container.getClass().getName();
+            if (name.endsWith("I")) {
+                name = name.substring(0, name.length()-1);
+            }
+            config.target.set(name+":"+container.getId().getValue());
+            ic.setTarget(container);
         }
 
         ic.setUserPixels(object.getPixelsSize());

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5881,8 +5881,7 @@ class OMEROGateway
         //FIXME: unclear why we would need to set these values on
         // both the ImportConfig and the ImportContainer.
         if (container != null) {
-        	 config.targetClass.set(container.getClass().getSimpleName());
-             config.targetId.set(container.getId().getValue());
+             config.target.set("omero.model.Dataset:"+container.getId().getValue());
              ic.setTarget(container);
         }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5977,10 +5977,10 @@ class OMEROGateway
             ImportConfig config = new ImportConfig();
             config.checksumAlgorithm.set(object.getChecksumAlgorithm());
             if (object.skipThumbnails()) {
-                config.doThumbnails.set(Boolean.FALSE);
+                config.doThumbnails.set(false);
             }
             if (object.skipMinMax()) {
-                config.noStatsInfo.set(Boolean.TRUE);
+                config.noStatsInfo.set(true);
             }
 
 			reader = new OMEROWrapper(config);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -5971,19 +5971,33 @@ class OMEROGateway
 	{
 		OMEROWrapper reader = null;
 		try {
-			ImportConfig config = new ImportConfig();
+            ImportConfig config = new ImportConfig();
+            config.checksumAlgorithm.set(object.getChecksumAlgorithm());
+            config.checkUpgrade.set(object.getUpgradeCheck());
+            if (object.skipThumbnails()) {
+                config.doThumbnails.set(Boolean.FALSE);
+            }
+            if (object.skipMinMax()) {
+                config.noStatsInfo.set(Boolean.TRUE);
+            }
+
 			reader = new OMEROWrapper(config);
 			String[] paths = new String[1];
 			paths[0] = file.getAbsolutePath();
 			ImportCandidates icans = new ImportCandidates(reader, paths, status);
 			
-			if(object.isOverrideName()) {
-			    String name = UIUtilities.getDisplayedFileName(file.getAbsolutePath(), object.getDepthForName());
-			    for(ImportContainer ic : icans.getContainers()) {
+			for(ImportContainer ic : icans.getContainers()) {
+			    if(object.isOverrideName()) {
+			        String name = UIUtilities.getDisplayedFileName(file.getAbsolutePath(), object.getDepthForName());
 			        ic.setUserSpecifiedName(name);
 			    }
-			}
-			
+			    if (object.skipThumbnails()) {
+	                ic.setDoThumbnails(false);
+	            }
+	            if (object.skipMinMax()) {
+	                ic.setNoStatsInfo(true);
+	            }
+            }
 			return icans;
 		} catch (Throwable e) {
 			throw new ImportException(e);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -993,9 +993,8 @@ class OmeroImageServiceImpl
 	 * ImportableFile, long, long, boolean)
 	 */
 	public Object importFile(ImportableObject object,
-		ImportableFile importable, boolean close) 
-		throws ImportException, DSAccessException, DSOutOfServiceException
-	{
+							 ImportableFile importable, boolean close)
+			throws ImportException, DSAccessException, DSOutOfServiceException {
 		if (importable == null || importable.getFile() == null)
 			throw new IllegalArgumentException("No images to import.");
 		Status status = importable.getStatus();
@@ -1010,10 +1009,10 @@ class OmeroImageServiceImpl
 			if (exp.getId() != loggedIn.getId())
 				userName = exp.getUserName();
 		}
-	      if (status.isMarkedAsCancel()) {
-	            if (close) gateway.closeImport(ctx, userName);
-	            return Boolean.valueOf(false);
-	        }
+		if (status.isMarkedAsCancel()) {
+			if (close) gateway.closeImport(ctx, userName);
+			return Boolean.valueOf(false);
+		}
 		Collection<TagAnnotationData> tags = object.getTags();
 		List<Annotation> customAnnotationList = new ArrayList<Annotation>();
 		List<IObject> l;
@@ -1033,9 +1032,9 @@ class OmeroImageServiceImpl
 			}
 			//save the tag.
 			try {
-			    if (l.size() > 0) {
-			        l = gateway.saveAndReturnObject(ctx, l, parameters, userName);
-			    }
+				if (l.size() > 0) {
+					l = gateway.saveAndReturnObject(ctx, l, parameters, userName);
+				}
 				Iterator<IObject> j = l.iterator();
 				Annotation a;
 				while (j.hasNext()) {
@@ -1045,10 +1044,10 @@ class OmeroImageServiceImpl
 				}
 				object.setTags(values);
 			} catch (Exception e) {
-			    LogMessage msg = new LogMessage();
-			    msg.print("Cannot create the tags.");
-			    msg.print(e);
-			    context.getLogger().error(this, msg);
+				LogMessage msg = new LogMessage();
+				msg.print("Cannot create the tags.");
+				msg.print(e);
+				context.getLogger().error(this, msg);
 			}
 		}
 		IObject link;
@@ -1059,7 +1058,7 @@ class OmeroImageServiceImpl
 		DatasetData dataset = importable.getDataset();
 		DataObject container = importable.getParent();
 		IObject ioContainer = null;
-		
+
 		DataObject createdData;
 		IObject project = null;
 		DataObject folder = null;
@@ -1070,33 +1069,33 @@ class OmeroImageServiceImpl
 		if (file.isFile()) {
 			ic = gateway.getImportCandidates(ctx, object, file, status);
 			if (CollectionUtils.isEmpty(ic.getContainers())) {
-			    Object o = status.getImportResult();
-                if (o instanceof ImportException) {
-                    return o;
-                }
-                ImportException e = new ImportException(
-                        ImportException.FILE_NOT_VALID_TEXT);
-                status.setCallback(e);
-                return e;
+				Object o = status.getImportResult();
+				if (o instanceof ImportException) {
+					return o;
+				}
+				ImportException e = new ImportException(
+						ImportException.FILE_NOT_VALID_TEXT);
+				status.setCallback(e);
+				return e;
 			}
 			hcsFile = isHCS(ic.getContainers());
 			//Create the container if required.
 			if (hcsFile) {
 				if (ic != null) {
-                    candidates = ic.getPaths();
-                    if (candidates.size() == 1) { 
-                        String value = candidates.get(0);
-                        if (!file.getAbsolutePath().equals(value) && 
-                            object.isFileinQueue(value)) {
-                            if (close) gateway.closeImport(ctx, userName);
-                            status.markedAsDuplicate();
-                            return Boolean.valueOf(true);
-                        }
-                    }
-                }
+					candidates = ic.getPaths();
+					if (candidates.size() == 1) {
+						String value = candidates.get(0);
+						if (!file.getAbsolutePath().equals(value) &&
+								object.isFileinQueue(value)) {
+							if (close) gateway.closeImport(ctx, userName);
+							status.markedAsDuplicate();
+							return Boolean.valueOf(true);
+						}
+					}
+				}
 				dataset = null;
-                if (!(container instanceof ScreenData))
-                    container = null;
+				if (!(container instanceof ScreenData))
+					container = null;
 			}
 
 			//remove hcs check if we want to create screen from folder.
@@ -1165,19 +1164,18 @@ class OmeroImageServiceImpl
 				candidates = ic.getPaths();
 				int size = candidates.size();
 				if (size == 0) {
-				    Object o = status.getImportResult();
-                    if (o instanceof ImportException) {
-                        return o;
-                    }
-                    ImportException e = new ImportException(
-                            ImportException.FILE_NOT_VALID_TEXT);
-                    status.setCallback(e);
-                    return e;
-				}
-				else if (size == 1) {
+					Object o = status.getImportResult();
+					if (o instanceof ImportException) {
+						return o;
+					}
+					ImportException e = new ImportException(
+							ImportException.FILE_NOT_VALID_TEXT);
+					status.setCallback(e);
+					return e;
+				} else if (size == 1) {
 					String value = candidates.get(0);
-					if (!file.getAbsolutePath().equals(value) && 
-						object.isFileinQueue(value)) {
+					if (!file.getAbsolutePath().equals(value) &&
+							object.isFileinQueue(value)) {
 						if (close) gateway.closeImport(ctx, userName);
 						status.markedAsDuplicate();
 						return Boolean.valueOf(true);
@@ -1196,20 +1194,20 @@ class OmeroImageServiceImpl
 				} else {
 					List<ImportContainer> containers = ic.getContainers();
 					hcs = isHCS(containers);
-					Map<File, Status> files = 
-						new HashMap<File, Status>();
+					Map<File, Status> files =
+							new HashMap<File, Status>();
 					Iterator<String> i = candidates.iterator();
 					Status label;
 					int index = 0;
 					File f;
 					while (i.hasNext()) {
-					    f = new File(i.next());
+						f = new File(i.next());
 						label = new Status(new FileObject(f));
 						label.setUsedFiles(containers.get(index).getUsedFiles());
 						files.put(f, label);
 						index++;
 					}
-						
+
 					status.setFiles(files);
 					Object v = importCandidates(ctx, files, status, object,
 							ioContainer, customAnnotationList, userID, close,
@@ -1222,10 +1220,10 @@ class OmeroImageServiceImpl
 				ic = gateway.getImportCandidates(ctx, object, file, status);
 				icContainers = ic.getContainers();
 				if (icContainers.size() == 0) {
-				    Object o = status.getImportResult();
-				    if (o instanceof ImportException) {
-				        return o;
-				    }
+					Object o = status.getImportResult();
+					if (o instanceof ImportException) {
+						return o;
+					}
 					return new ImportException(
 							ImportException.FILE_NOT_VALID_TEXT);
 				}
@@ -1243,11 +1241,11 @@ class OmeroImageServiceImpl
 		ic = gateway.getImportCandidates(ctx, object, file, status);
 		List<ImportContainer> lic = ic.getContainers();
 		if (lic.size() == 0) {
-            Object o = status.getImportResult();
-            if (o instanceof ImportException) {
-                return o;
-            }
-            return new ImportException(ImportException.FILE_NOT_VALID_TEXT);
+			Object o = status.getImportResult();
+			if (o instanceof ImportException) {
+				return o;
+			}
+			return new ImportException(ImportException.FILE_NOT_VALID_TEXT);
 		}
 		if (status.isMarkedAsCancel()) {
 			return Boolean.valueOf(false);
@@ -1255,11 +1253,11 @@ class OmeroImageServiceImpl
 		Map<File, Status> hcsFiles = new HashMap<File, Status>();
 		Map<File, Status> otherFiles = new HashMap<File, Status>();
 		Map<File, Status> files = new HashMap<File, Status>();
-		
+
 		File f;
 		Status sl;
 		int n = lic.size();
-		
+
 		Iterator<ImportContainer> j = lic.iterator();
 		ImportContainer c;
 		while (j.hasNext()) {
@@ -1322,7 +1320,7 @@ class OmeroImageServiceImpl
 						if (container != null) {
 							try {
 								Project p;
-								if (container.getId() <= 0) { 
+								if (container.getId() <= 0) {
 									//project needs to be created to.
 									createdData = object.hasObjectBeenCreated(
 											container, ctx);
@@ -1331,7 +1329,7 @@ class OmeroImageServiceImpl
 												ctx, container.asIObject(),
 												parameters, userName);
 										object.addNewDataObject(
-											PojoMapper.asDataObject(project));
+												PojoMapper.asDataObject(project));
 										p = (Project) project;
 									} else {
 										p = (Project) createdData.asProject();
@@ -1339,10 +1337,10 @@ class OmeroImageServiceImpl
 								} else { //project already exists.
 									p = (Project) container.asProject();
 								}
-								link = (ProjectDatasetLink) 
+								link = (ProjectDatasetLink)
 										ModelMapper.linkParentToChild(
 												(Dataset) ioContainer, p);
-										link = (ProjectDatasetLink) 
+								link = (ProjectDatasetLink)
 										gateway.saveAndReturnObject(ctx, link,
 												parameters, userName);
 							} catch (Exception e) {
@@ -1372,7 +1370,7 @@ class OmeroImageServiceImpl
 			}
 			//import the files that are not hcs files.
 			importCandidates(ctx, otherFiles, status, object,
-				ioContainer, customAnnotationList, userID, close, false, userName);
+					ioContainer, customAnnotationList, userID, close, false, userName);
 		}
 		return Boolean.valueOf(true);
 	}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroImageServiceImpl.java
@@ -101,7 +101,7 @@ import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.exception.RenderingServiceException;
 import omero.gateway.facility.BrowseFacility;
 
-import org.openmicroscopy.shoola.env.data.util.StatusLabel;
+import org.openmicroscopy.shoola.env.data.util.Status;
 import org.openmicroscopy.shoola.env.data.util.Target;
 
 import omero.log.LogMessage;
@@ -189,7 +189,7 @@ class OmeroImageServiceImpl
 	 * @param userName The login name of the user to import for.
 	 */
 	private Object importCandidates(SecurityContext ctx,
-		Map<File, StatusLabel> files, StatusLabel status,
+		Map<File, Status> files, Status status,
 		ImportableObject object, IObject ioContainer,
 		List<Annotation> list, long userID, boolean close, boolean hcs,
 		String userName)
@@ -199,9 +199,9 @@ class OmeroImageServiceImpl
 			if (close) gateway.closeImport(ctx, userName);
 			return Boolean.valueOf(false);
 		}
-		Entry<File, StatusLabel> entry;
-		Iterator<Entry<File, StatusLabel>> jj = files.entrySet().iterator();
-		StatusLabel label = null;
+		Entry<File, Status> entry;
+		Iterator<Entry<File, Status>> jj = files.entrySet().iterator();
+		Status label = null;
 		File file;
 		boolean toClose = false;
 		int n = files.size()-1;
@@ -217,7 +217,7 @@ class OmeroImageServiceImpl
 					!(ioContainer.getClass().equals(Screen.class) ||
 					ioContainer.getClass().equals(ScreenI.class)))
 					ioContainer = null;
-			label = (StatusLabel) entry.getValue();
+			label = (Status) entry.getValue();
 			if (close) {
 				toClose = index == n;
 				index++;
@@ -998,7 +998,7 @@ class OmeroImageServiceImpl
 	{
 		if (importable == null || importable.getFile() == null)
 			throw new IllegalArgumentException("No images to import.");
-		StatusLabel status = importable.getStatus();
+		Status status = importable.getStatus();
 		SecurityContext ctx = new SecurityContext(importable.getGroup().getId());
 		//If import as.
 		ExperimenterData loggedIn = context.getAdminService().getUserDetails();
@@ -1077,7 +1077,6 @@ class OmeroImageServiceImpl
                 ImportException e = new ImportException(
                         ImportException.FILE_NOT_VALID_TEXT);
                 status.setCallback(e);
-                status.setText(ImportException.FILE_NOT_VALID_TEXT);
                 return e;
 			}
 			hcsFile = isHCS(ic.getContainers());
@@ -1173,7 +1172,6 @@ class OmeroImageServiceImpl
                     ImportException e = new ImportException(
                             ImportException.FILE_NOT_VALID_TEXT);
                     status.setCallback(e);
-                    status.setText(ImportException.FILE_NOT_VALID_TEXT);
                     return e;
 				}
 				else if (size == 1) {
@@ -1198,15 +1196,15 @@ class OmeroImageServiceImpl
 				} else {
 					List<ImportContainer> containers = ic.getContainers();
 					hcs = isHCS(containers);
-					Map<File, StatusLabel> files = 
-						new HashMap<File, StatusLabel>();
+					Map<File, Status> files = 
+						new HashMap<File, Status>();
 					Iterator<String> i = candidates.iterator();
-					StatusLabel label;
+					Status label;
 					int index = 0;
 					File f;
 					while (i.hasNext()) {
 					    f = new File(i.next());
-						label = new StatusLabel(new FileObject(f));
+						label = new Status(new FileObject(f));
 						label.setUsedFiles(containers.get(index).getUsedFiles());
 						files.put(f, label);
 						index++;
@@ -1254,12 +1252,12 @@ class OmeroImageServiceImpl
 		if (status.isMarkedAsCancel()) {
 			return Boolean.valueOf(false);
 		}
-		Map<File, StatusLabel> hcsFiles = new HashMap<File, StatusLabel>();
-		Map<File, StatusLabel> otherFiles = new HashMap<File, StatusLabel>();
-		Map<File, StatusLabel> files = new HashMap<File, StatusLabel>();
+		Map<File, Status> hcsFiles = new HashMap<File, Status>();
+		Map<File, Status> otherFiles = new HashMap<File, Status>();
+		Map<File, Status> files = new HashMap<File, Status>();
 		
 		File f;
-		StatusLabel sl;
+		Status sl;
 		int n = lic.size();
 		
 		Iterator<ImportContainer> j = lic.iterator();
@@ -1268,7 +1266,7 @@ class OmeroImageServiceImpl
 			c = j.next();
 			hcs = c.getIsSPW();
 			f = c.getFile();
-			sl = new StatusLabel(new FileObject(f));
+			sl = new Status(new FileObject(f));
 			sl.setUsedFiles(c.getUsedFiles());
 			if (hcs) {
 				if (n == 1 && file.list().length > 1)

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
@@ -22,7 +22,7 @@ package org.openmicroscopy.shoola.env.data.model;
 
 import java.io.File;
 
-import org.openmicroscopy.shoola.env.data.util.StatusLabel;
+import org.openmicroscopy.shoola.env.data.util.Status;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ExperimenterData;
 import omero.gateway.model.GroupData;
@@ -50,7 +50,7 @@ public class ImportableFile
 	private boolean folderAsContainer;
 	
 	/** Object used to find result back. */
-	private StatusLabel status;
+	private Status status;
 	
 	/** Indicate where to import the file, either a project or screen. */
 	private omero.gateway.model.DataObject parent;
@@ -150,14 +150,14 @@ public class ImportableFile
 	 * 
 	 * @param status The component to set.
 	 */
-	public void setStatus(StatusLabel status) { this.status = status; }
+	public void setStatus(Status status) { this.status = status; }
 	
 	/**
 	 * Returns the component used to notify of the progress.
 	 * 
 	 * @return See above.
 	 */
-	public StatusLabel getStatus() { return status; }
+	public Status getStatus() { return status; }
 	
 	/**
 	 * Returns the node of reference if set.
@@ -223,7 +223,7 @@ public class ImportableFile
 		newObject.refNode = this.refNode;
 		newObject.group = this.group;
 		newObject.user = this.user;
-		newObject.status = new StatusLabel(this.file);
+		newObject.status = new Status(this.file);
 		return newObject;
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableFile.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2011 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -206,6 +206,9 @@ public class ImportableObject
 	/** The collection of new object. */
 	private Map<Long, List<DatasetData>> projectDatasetMap;
 
+	/** Map of skip options mapping to ImportConfig functions */
+	private Map<String, Object> skipChoices;
+
 	/**
 	 * Returns the object corresponding to the passed file.
 	 * 
@@ -262,6 +265,14 @@ public class ImportableObject
 		loadThumbnail = true;
 		newObjects = new ArrayList<DataObject>();
 		projectDatasetMap = new HashMap<Long, List<DatasetData>>();
+	}
+
+	public void setSkipChioces(Map<String, Object> choices) {
+		if (skipChoices == null) {
+			skipChoices = new HashMap<>(choices);
+		} else {
+			skipChoices.putAll(choices);
+		}
 	}
 	
 	/**
@@ -431,6 +442,8 @@ public class ImportableObject
 		}
 		return null; 
 	}
+
+
 	
 	/**
 	 * Returns the collection of tags.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -460,8 +460,6 @@ public class ImportableObject
 		}
 		return null; 
 	}
-
-
 	
 	/**
 	 * Returns the collection of tags.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -285,7 +285,7 @@ public class ImportableObject
      * @param choices
      *            The options
      */
-    public void setSkipChioces(Map<String, Object> choices) {
+    public void setSkipChoices(Map<String, Object> choices) {
         if (skipChoices == null) {
             skipChoices = new HashMap<>(choices);
         } else {
@@ -686,7 +686,7 @@ public class ImportableObject
      */
     public String getChecksumAlgorithm() {
         String option = (String) skipChoices.get(OPTION_CHECKSUMS);
-        return option != null ? option : "File-Size-64";
+        return option != null ? option : omero.model.enums.ChecksumAlgorithmFileSize64.value;
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -180,9 +180,6 @@ public class ImportableObject
 	/** Option for calculating checksums, if not set default: true */
 	public static String OPTION_CHECKSUMS = "checksumAlgorithm";
 	
-	/** Option for checking for upgrades, if not set default: true */
-	public static String OPTION_UPGRADECHECK = "checkUpgrade";
-	
 	/** The collection of files to import. */
 	private List<ImportableFile> files;
 	
@@ -705,16 +702,6 @@ public class ImportableObject
     public boolean skipThumbnails() {
         Boolean option = (Boolean) skipChoices.get(OPTION_THUMBNAILS);
         return option != null && !option;
-    }
-
-    /**
-     * Check for upgrade, default: true
-     * 
-     * @return See above
-     */
-    public boolean getUpgradeCheck() {
-        Boolean option = (Boolean) skipChoices.get(OPTION_UPGRADECHECK);
-        return option == null || option;
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ImportableObject.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -171,6 +171,18 @@ public class ImportableObject
 		return ARBITRARY_FILES_EXTENSION.contains(ext);
 	}
 	
+	/** Option for generating thumbnails, if not set default: true */
+	public static String OPTION_THUMBNAILS = "doThumbnails";
+	
+	/** Option for skipping min/max calculation, if not set default: false */
+	public static String OPTION_SKIP_MINMAX = "noStatsInfo";
+	
+	/** Option for calculating checksums, if not set default: true */
+	public static String OPTION_CHECKSUMS = "checksumAlgorithm";
+	
+	/** Option for checking for upgrades, if not set default: true */
+	public static String OPTION_UPGRADECHECK = "checkUpgrade";
+	
 	/** The collection of files to import. */
 	private List<ImportableFile> files;
 	
@@ -267,13 +279,19 @@ public class ImportableObject
 		projectDatasetMap = new HashMap<Long, List<DatasetData>>();
 	}
 
-	public void setSkipChioces(Map<String, Object> choices) {
-		if (skipChoices == null) {
-			skipChoices = new HashMap<>(choices);
-		} else {
-			skipChoices.putAll(choices);
-		}
-	}
+    /**
+     * Set the advanced import configuration options
+     * 
+     * @param choices
+     *            The options
+     */
+    public void setSkipChioces(Map<String, Object> choices) {
+        if (skipChoices == null) {
+            skipChoices = new HashMap<>(choices);
+        } else {
+            skipChoices.putAll(choices);
+        }
+    }
 	
 	/**
 	 * Sets to <code>true</code> if the thumbnail has to be loaded when 
@@ -660,5 +678,45 @@ public class ImportableObject
 		if (CollectionUtils.isEmpty(files)) return;
 		this.files = files;
 	}
+
+    /**
+     * Get the checksum algorithm, default: 'File-Size-64'
+     * 
+     * @return See above
+     */
+    public String getChecksumAlgorithm() {
+        String option = (String) skipChoices.get(OPTION_CHECKSUMS);
+        return option != null ? option : "File-Size-64";
+    }
+
+    /**
+     * Skip Min/Max calculation, default: false
+     * 
+     * @return See above
+     */
+    public boolean skipMinMax() {
+        Boolean option = (Boolean) skipChoices.get(OPTION_SKIP_MINMAX);
+        return option != null && option;
+    }
+
+    /**
+     * Skip thumbnail generation, default: false
+     * 
+     * @return See above
+     */
+    public boolean skipThumbnails() {
+        Boolean option = (Boolean) skipChoices.get(OPTION_THUMBNAILS);
+        return option != null && !option;
+    }
+
+    /**
+     * Check for upgrade, default: true
+     * 
+     * @return See above
+     */
+    public boolean getUpgradeCheck() {
+        Boolean option = (Boolean) skipChoices.get(OPTION_UPGRADECHECK);
+        return option == null || option;
+    }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
@@ -1,0 +1,659 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *  
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package org.openmicroscopy.shoola.env.data.util;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import ome.formats.importer.IObservable;
+import ome.formats.importer.IObserver;
+import ome.formats.importer.ImportCandidates;
+import ome.formats.importer.ImportContainer;
+import ome.formats.importer.ImportEvent;
+import ome.formats.importer.ImportEvent.FILESET_UPLOAD_END;
+import ome.formats.importer.util.ErrorHandler;
+import omero.cmd.CmdCallback;
+import omero.gateway.model.DataObject;
+import omero.gateway.model.FilesetData;
+import omero.gateway.model.PixelsData;
+import omero.gateway.util.PojoMapper;
+
+import org.apache.commons.io.FileUtils;
+import org.openmicroscopy.shoola.env.data.ImportException;
+import org.openmicroscopy.shoola.env.data.model.FileObject;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.ui.UIUtilities;
+
+/**
+ * Component tracking the status of a specific import.
+ *
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ */
+public class Status implements IObserver {
+
+    /** The text displayed when the file is already selected. */
+    public static final String DUPLICATE = "Already processed, skipping";
+
+    /** The text indicating the scanning steps. */
+    public static final String SCANNING_TEXT = "Scanning...";
+
+    /** Pass through of IObserver events **/
+    public static final String IMPORT_EVENT = "importEvenPassThrough";
+    
+    /**
+     * Bound property indicating that the original container has been reset.
+     * */
+    public static final String NO_CONTAINER_PROPERTY = "noContainer";
+
+    /** Bound property indicating that children files have been set. */
+    public static final String FILES_SET_PROPERTY = "filesSet";
+
+    /**
+     * Bound property indicating that the file has to be reset This should be
+     * invoked if the log file for example has been selected.
+     */
+    public static final String FILE_RESET_PROPERTY = "fileReset";
+
+    /** Bound property indicating that the import of the file has started. */
+    public static final String FILE_IMPORT_STARTED_PROPERTY = "fileImportStarted";
+
+    /**
+     * Bound property indicating that the container corresponding to the folder
+     * has been created.
+     * */
+    public static final String CONTAINER_FROM_FOLDER_PROPERTY = "containerFromFolder";
+
+    /** Bound property indicating that the status has changed. */
+    public static final String CANCELLABLE_IMPORT_PROPERTY = "cancellableImport";
+
+    /** Bound property indicating that the debug text has been sent. */
+    public static final String DEBUG_TEXT_PROPERTY = "debugText";
+
+    /** Bound property indicating that the import is done. */
+    public static final String IMPORT_DONE_PROPERTY = "importDone";
+
+    /** Bound property indicating that the upload is done. */
+    public static final String UPLOAD_DONE_PROPERTY = "uploadDone";
+
+    /** Bound property indicating that the scanning has started. */
+    public static final String SCANNING_PROPERTY = "scanning";
+
+    /** Bound property indicating that the scanning has started. */
+    public static final String PROCESSING_ERROR_PROPERTY = "processingError";
+
+    /** The default text of the component. */
+    public static final String DEFAULT_TEXT = "Pending...";
+
+    /**
+     * The number of processing sets. 1. Importing Metadata 2. Processing Pixels
+     * 3. Generating Thumbnails 4. Processing Metadata 5. Generating Objects
+     */
+    /** Map hosting the description of each step. */
+    public static final Map<Integer, String> STEPS;
+
+    /** Map hosting the description of the failure at a each step. */
+    public static final Map<Integer, String> STEP_FAILURES;
+
+    static {
+        STEPS = new HashMap<Integer, String>();
+        STEPS.put(1, "Importing Metadata");
+        STEPS.put(2, "Reading Pixels");
+        STEPS.put(3, "Generating Thumbnails");
+        STEPS.put(4, "Reading Metadata");
+        STEPS.put(5, "Generating Objects");
+        STEPS.put(6, "Complete");
+        STEP_FAILURES = new HashMap<Integer, String>();
+        STEP_FAILURES.put(1, "Failed to Import Metadata");
+        STEP_FAILURES.put(2, "Failed to Read Pixels");
+        STEP_FAILURES.put(3, "Failed to Generate Thumbnails");
+        STEP_FAILURES.put(4, "Failed to Read Metadata");
+        STEP_FAILURES.put(5, "Failed to Generate Objects");
+    }
+
+    /** The container. */
+    private ImportContainer ic;
+
+    /** The number of images in a series. */
+    private int seriesCount;
+
+    /** Flag indicating that the import has been cancelled. */
+    private boolean markedAsCancel;
+
+    /** Flag indicating that the import can or not be cancelled. */
+    private boolean cancellable;
+
+    /**
+     * Flag indicating that the file has already been imported or already in the
+     * queue.
+     */
+    private boolean markedAsDuplicate;
+
+    /** The size of the file. */
+    private String fileSize;
+
+    /** The size units. */
+    private String units;
+
+    /** The total size of uploaded files. */
+    private long totalUploadedSize;
+
+    /** The size of the upload, */
+    private long sizeUpload;
+
+    /** Checksum event stored for later retrieval */
+    private FILESET_UPLOAD_END checksumEvent;
+
+    /** The exception if an error occurred. */
+    private ImportException exception;
+
+    /** The list of pixels' identifiers returned when the import is complete. */
+    private Collection<PixelsData> pixels;
+
+    /** The file associated to that import. */
+    private FilesetData fileset;
+
+    /** The callback. This should only be set when importing a directory. */
+    private Object callback;
+
+    /** Indicates that the file scanned is a directory. */
+    // private boolean directory;
+
+    /** The id of the log file. */
+    private long logFileID;
+
+    /** The processing step. */
+    private int step;
+
+    /** Indicates if the upload ever started. */
+    private boolean uploadStarted;
+
+    /** The file or folder this component is for. */
+    private FileObject sourceFile;
+
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.addPropertyChangeListener(listener);
+    }
+
+    public void firePropertyChange(String name, Object oldValue, Object newValue) {
+        this.pcs.firePropertyChange(name, oldValue, newValue);
+    }
+
+    /**
+     * Formats the size of the uploaded data.
+     * 
+     * @param value
+     *            The value to display.
+     * @return See above.
+     */
+    private String formatUpload(long value) {
+        StringBuffer buffer = new StringBuffer();
+        String v = FileUtils.byteCountToDisplaySize(value);
+        String[] values = v.split(" ");
+        if (values.length > 1) {
+            String u = values[1];
+            if (units.equals(u))
+                buffer.append(values[0]);
+            else
+                buffer.append(v);
+        } else
+            buffer.append(v);
+        buffer.append("/");
+        buffer.append(fileSize);
+        return buffer.toString();
+    }
+
+    /** Initializes the components. */
+    private void initialize() {
+        step = 0;
+        sizeUpload = 0;
+        fileSize = "";
+        seriesCount = 0;
+        markedAsCancel = false;
+        cancellable = true;
+        totalUploadedSize = 0;
+    }
+
+    /**
+     * Handles error that occurred during the processing.
+     * 
+     * @param text
+     *            The text to display if any.
+     * @param fire
+     *            Indicate to fire a property.
+     */
+    private void handleProcessingError(String text, boolean fire) {
+        if (isMarkedAsCancel())
+            return;
+        cancellable = false;
+    }
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param sourceFile
+     *            The file associated to that label.
+     */
+    public Status(FileObject sourceFile) {
+        this.sourceFile = sourceFile;
+        initialize();
+    }
+
+    /**
+     * Sets the file set when the upload is complete. To be modified.
+     * 
+     * @param fileset
+     *            The value to set.
+     */
+    public void setFilesetData(final FilesetData fileset) {
+        this.fileset = fileset;
+    }
+
+    /**
+     * Returns <code>true</code> if it is a HCS file, <code>false</code>
+     * otherwise.
+     *
+     * @return See above.
+     */
+    public boolean isHCS() {
+        if (ic == null)
+            return false;
+        Boolean b = ic.getIsSPW();
+        if (b == null)
+            return false;
+        return b.booleanValue();
+    }
+
+    /**
+     * Returns the file set associated to the import.
+     * 
+     * @return See above.
+     */
+    public FilesetData getFileset() {
+        return fileset;
+    }
+
+    /**
+     * Sets the collection of files to import.
+     * 
+     * @param usedFiles
+     *            The value to set.
+     */
+    public void setUsedFiles(String[] usedFiles) {
+        if (usedFiles == null)
+            return;
+        for (int i = 0; i < usedFiles.length; i++) {
+            sizeUpload += (new File(usedFiles[i])).length();
+        }
+        fileSize = FileUtils.byteCountToDisplaySize(sizeUpload);
+        String[] values = fileSize.split(" ");
+        if (values.length > 1)
+            units = values[1];
+    }
+
+    /**
+     * Sets the callback. This method should only be invoked when the file is
+     * imported from a folder.
+     * 
+     * @param cmd
+     *            The object to handle.
+     */
+    public void setCallback(Object cmd) {
+        if (cmd instanceof ImportException)
+            exception = (ImportException) cmd;
+        else if (cmd instanceof CmdCallback || cmd instanceof Boolean)
+            callback = cmd;
+        firePropertyChange(UPLOAD_DONE_PROPERTY, null, this);
+    }
+
+    /** Marks the import has cancelled. */
+    public void markedAsCancel() {
+        this.markedAsCancel = true;
+    }
+
+    /**
+     * Returns <code>true</code> if the import is marked as cancel,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean isMarkedAsCancel() {
+        return markedAsCancel;
+    }
+
+    /** Marks the import has duplicate. */
+    public void markedAsDuplicate() {
+        this.markedAsDuplicate = true;
+    }
+
+    /**
+     * Returns <code>true</code> if the import is marked as duplicate,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean isMarkedAsDuplicate() {
+        return markedAsDuplicate;
+    }
+
+    /**
+     * Returns the text if an error occurred.
+     * 
+     * @return See above.
+     */
+    public String getErrorText() {
+        return "";
+    }
+
+    /**
+     * Returns the source files that have checksum values or <code>null</code>
+     * if no event stored.
+     * 
+     * @return See above.
+     */
+    public List<String> getChecksums() {
+        if (!hasChecksum())
+            return null;
+        return checksumEvent.checksums;
+    }
+
+    /**
+     * Returns the checksum values or <code>null</code> if no event stored.
+     * 
+     * @return See above.
+     */
+    public Map<Integer, String> getFailingChecksums() {
+        if (!hasChecksum())
+            return null;
+        return checksumEvent.failingChecksums;
+    }
+
+    /**
+     * Returns the source files that have checksum values or <code>null</code>
+     * if no event stored.
+     * 
+     * @return See above.
+     */
+    public String[] getChecksumFiles() {
+        if (!hasChecksum())
+            return null;
+        return checksumEvent.srcFiles;
+    }
+
+    /**
+     * Returns <code>true</code> if the checksums have been calculated,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean hasChecksum() {
+        return checksumEvent != null;
+    }
+
+    /**
+     * Fires a property indicating to import the files.
+     * 
+     * @param files
+     *            The file to handle.
+     */
+    public void setFiles(Map<File, Status> files) {
+        if (isMarkedAsCancel())
+            return;
+        firePropertyChange(FILES_SET_PROPERTY, null, files);
+    }
+
+    /**
+     * Indicates that the original container has been reset.
+     */
+    public void setNoContainer() {
+        firePropertyChange(NO_CONTAINER_PROPERTY, Boolean.valueOf(false),
+                Boolean.valueOf(true));
+    }
+
+    /**
+     * Sets the container corresponding to the folder.
+     * 
+     * @param container
+     *            The container to set.
+     */
+    public void setContainerFromFolder(DataObject container) {
+        firePropertyChange(CONTAINER_FROM_FOLDER_PROPERTY, null, container);
+    }
+
+    /**
+     * Replaces the initial file by the specified one. This should only be
+     * invoked if the original file was an arbitrary one requiring to use the
+     * import candidate e.g. <code>.log</code>.
+     * 
+     * @param file
+     *            The new file.
+     */
+    public void resetFile(File file) {
+        firePropertyChange(FILE_RESET_PROPERTY, null, file);
+    }
+
+    /**
+     * Returns the number of series.
+     * 
+     * @return See above.
+     */
+    public int getSeriesCount() {
+        return seriesCount;
+    }
+
+    /**
+     * Returns <code>true</code> if the import can be cancelled,
+     * <code>false</code> otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean isCancellable() {
+        return cancellable;
+    }
+
+    /**
+     * Returns the result of the import either a collection of
+     * <code>PixelsData</code> or an exception.
+     * 
+     * @return See above.
+     */
+    public Object getImportResult() {
+        if (exception != null)
+            return exception;
+        if (pixels != null)
+            return pixels;
+        return callback;
+    }
+
+    /**
+     * Returns the number of pixels objects created or <code>0</code>.
+     * 
+     * @return See above.
+     */
+    public int getNumberOfImportedFiles() {
+        if (pixels != null)
+            return pixels.size();
+        return 0;
+    }
+
+    /**
+     * Returns the size of the upload.
+     * 
+     * @return See above.
+     */
+    public long getSizeUpload() {
+        return sizeUpload;
+    }
+
+    /**
+     * Returns the ID associated to the log file.
+     * 
+     * @return See above.
+     */
+    public long getLogFileID() {
+        return logFileID;
+    }
+
+    /**
+     * Returns <code>true</code> if the upload ever started, <code>false</code>
+     * otherwise.
+     * 
+     * @return See above.
+     */
+    public boolean didUploadStart() {
+        return uploadStarted;
+    }
+
+    /**
+     * Returns the container.
+     *
+     * @return See above.
+     */
+    public ImportContainer getImportContainer() {
+        return ic;
+    }
+
+    /**
+     * Sets the import container.
+     *
+     * @param ic
+     *            The value to set.
+     */
+    public void setImportContainer(ImportContainer ic) {
+        this.ic = ic;
+    }
+
+    /**
+     * Displays the status of an on-going import.
+     * 
+     * @see IObserver#update(IObservable, ImportEvent)
+     */
+    public void update(IObservable observable, ImportEvent event) {
+        if (event == null)
+            return;
+        cancellable = false;
+        if (event instanceof ImportEvent.IMPORT_DONE) {
+            step = 6;
+            pixels = PojoMapper
+                    .<PixelsData> convertToDataObjects(((ImportEvent.IMPORT_DONE) event).pixels);
+            firePropertyChange(IMPORT_DONE_PROPERTY, null, this);
+        } else if (event instanceof ImportCandidates.SCANNING) {
+            if (!markedAsCancel)
+                cancellable = true;
+            if (exception == null)
+                firePropertyChange(SCANNING_PROPERTY, null, this);
+        } else if (event instanceof ErrorHandler.MISSING_LIBRARY) {
+            exception = new ImportException(
+                    ImportException.MISSING_LIBRARY_TEXT,
+                    ((ErrorHandler.MISSING_LIBRARY) event).exception);
+            handleProcessingError(ImportException.MISSING_LIBRARY_TEXT, false);
+        } else if (event instanceof ErrorHandler.UNKNOWN_FORMAT) {
+            exception = new ImportException(
+                    ImportException.UNKNOWN_FORMAT_TEXT,
+                    ((ErrorHandler.UNKNOWN_FORMAT) event).exception);
+            if (sourceFile != null && !sourceFile.isDirectory())
+                handleProcessingError(ImportException.UNKNOWN_FORMAT_TEXT, true);
+        } else if (event instanceof ErrorHandler.FILE_EXCEPTION) {
+            ErrorHandler.FILE_EXCEPTION e = (ErrorHandler.FILE_EXCEPTION) event;
+            exception = new ImportException(e.exception);
+            String text = ImportException.FILE_NOT_VALID_TEXT;
+            if (sourceFile != null && sourceFile.isDirectory())
+                text = "";
+            handleProcessingError(text, false);
+        } else if (event instanceof ErrorHandler.INTERNAL_EXCEPTION) {
+            ErrorHandler.INTERNAL_EXCEPTION e = (ErrorHandler.INTERNAL_EXCEPTION) event;
+            exception = new ImportException(e.exception);
+            handleProcessingError("", true);
+        } else if (event instanceof ImportEvent.FILE_UPLOAD_BYTES) {
+            ImportEvent.FILE_UPLOAD_BYTES e = (ImportEvent.FILE_UPLOAD_BYTES) event;
+            long v = totalUploadedSize + e.uploadedBytes;
+            StringBuffer buffer = new StringBuffer();
+            if (v != sizeUpload)
+                buffer.append(formatUpload(v));
+            else
+                buffer.append(fileSize);
+            buffer.append(" ");
+            if (e.timeLeft != 0) {
+                String s = UIUtilities.calculateHMSFromMilliseconds(e.timeLeft,
+                        true);
+                buffer.append(s);
+                if (CommonsLangUtils.isNotBlank(s))
+                    buffer.append(" Left");
+                else
+                    buffer.append("complete");
+            }
+        } else if (event instanceof ImportEvent.FILE_UPLOAD_COMPLETE) {
+            ImportEvent.FILE_UPLOAD_COMPLETE e = (ImportEvent.FILE_UPLOAD_COMPLETE) event;
+            totalUploadedSize += e.uploadedBytes;
+        } else if (event instanceof ImportEvent.FILESET_UPLOAD_END) {
+            checksumEvent = (ImportEvent.FILESET_UPLOAD_END) event;
+            if (exception == null) {
+                step = 1;
+            }
+        } else if (event instanceof ImportEvent.METADATA_IMPORTED) {
+            step = 2;
+        } else if (event instanceof ImportEvent.PIXELDATA_PROCESSED) {
+            step = 3;
+        } else if (event instanceof ImportEvent.THUMBNAILS_GENERATED) {
+            step = 4;
+        } else if (event instanceof ImportEvent.METADATA_PROCESSED) {
+            step = 5;
+        } else if (event instanceof ImportEvent.FILESET_UPLOAD_START) {
+            uploadStarted = true;
+            firePropertyChange(FILE_IMPORT_STARTED_PROPERTY, null, this);
+        } else if (event instanceof ImportEvent.IMPORT_STARTED) {
+            ImportEvent.IMPORT_STARTED e = (ImportEvent.IMPORT_STARTED) event;
+            if (e.logFileId != null) {
+                logFileID = e.logFileId;
+            }
+        } else if (event instanceof ImportEvent.POST_UPLOAD_EVENT) {
+            ImportEvent.POST_UPLOAD_EVENT e = (ImportEvent.POST_UPLOAD_EVENT) event;
+            ic = e.container;
+
+        }
+        
+        firePropertyChange(IMPORT_EVENT, null, event);
+    }
+
+    public String getUnits() {
+        return units;
+    }
+
+    public String getFileSize() {
+        return fileSize;
+    }
+
+    public int getStep() {
+        return step;
+    }
+
+    public long getTotalUploadedSize() {
+        return totalUploadedSize;
+    }
+    
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
@@ -104,6 +104,8 @@ public class Status implements IObserver {
 
     /** Bound property indicating that the scanning has started. */
     public static final String PROCESSING_ERROR_PROPERTY = "processingError";
+    
+    public static final String STEP_PROPERTY = "step";
 
     /** The default text of the component. */
     public static final String DEFAULT_TEXT = "Pending...";
@@ -558,7 +560,7 @@ public class Status implements IObserver {
             return;
         cancellable = false;
         if (event instanceof ImportEvent.IMPORT_DONE) {
-            step = 6;
+            setStep(6);
             pixels = PojoMapper
                     .<PixelsData> convertToDataObjects(((ImportEvent.IMPORT_DONE) event).pixels);
             firePropertyChange(IMPORT_DONE_PROPERTY, null, this);
@@ -613,16 +615,16 @@ public class Status implements IObserver {
         } else if (event instanceof ImportEvent.FILESET_UPLOAD_END) {
             checksumEvent = (ImportEvent.FILESET_UPLOAD_END) event;
             if (exception == null) {
-                step = 1;
+                setStep(1);
             }
         } else if (event instanceof ImportEvent.METADATA_IMPORTED) {
-            step = 2;
+            setStep(2);
         } else if (event instanceof ImportEvent.PIXELDATA_PROCESSED) {
-            step = 3;
+            setStep(3);
         } else if (event instanceof ImportEvent.THUMBNAILS_GENERATED) {
-            step = 4;
+            setStep(4);
         } else if (event instanceof ImportEvent.METADATA_PROCESSED) {
-            step = 5;
+            setStep(5);
         } else if (event instanceof ImportEvent.FILESET_UPLOAD_START) {
             uploadStarted = true;
             firePropertyChange(FILE_IMPORT_STARTED_PROPERTY, null, this);
@@ -638,6 +640,13 @@ public class Status implements IObserver {
         }
         
         firePropertyChange(IMPORT_EVENT, null, event);
+    }
+    
+    public void setStep(int step) {
+        int old = this.step;
+        this.step = step;
+        int id = sourceFile.hashCode();
+        firePropertyChange(STEP_PROPERTY, id+"_"+old, id+"_"+this.step);
     }
 
     public String getUnits() {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
@@ -182,9 +182,6 @@ public class Status implements IObserver {
     /** The callback. This should only be set when importing a directory. */
     private Object callback;
 
-    /** Indicates that the file scanned is a directory. */
-    // private boolean directory;
-
     /** The id of the log file. */
     private long logFileID;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
@@ -346,7 +346,7 @@ public class Status implements IObserver {
         firePropertyChange(UPLOAD_DONE_PROPERTY, null, this);
     }
 
-    /** Marks the import has cancelled. */
+    /** Marks the import as cancelled. */
     public void markedAsCancel() {
         this.markedAsCancel = true;
     }
@@ -361,7 +361,7 @@ public class Status implements IObserver {
         return markedAsCancel;
     }
 
-    /** Marks the import has duplicate. */
+    /** Marks the import as duplicate. */
     public void markedAsDuplicate() {
         this.markedAsDuplicate = true;
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
@@ -265,6 +265,7 @@ public class Status implements IObserver {
         if (isMarkedAsCancel())
             return;
         cancellable = false;
+        firePropertyChange(PROCESSING_ERROR_PROPERTY, null, this);
     }
 
     /**

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/Status.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -105,6 +105,7 @@ public class Status implements IObserver {
     /** Bound property indicating that the scanning has started. */
     public static final String PROCESSING_ERROR_PROPERTY = "processingError";
     
+    /** Bound property indicating that the current import step has changed. */
     public static final String STEP_PROPERTY = "step";
 
     /** The default text of the component. */
@@ -196,12 +197,23 @@ public class Status implements IObserver {
     /** The file or folder this component is for. */
     private FileObject sourceFile;
 
+    /** PropertyChangeSupport **/
     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
+    /**
+     * Add PropertyChangeListener
+     * @param listener  The PropertyChangeListener
+     */
     public void addPropertyChangeListener(PropertyChangeListener listener) {
         this.pcs.addPropertyChangeListener(listener);
     }
 
+    /**
+     * Fire a PropertyChangeEvent
+     * @param name The name of the event
+     * @param oldValue  The old value
+     * @param newValue  The new value
+     */
     public void firePropertyChange(String name, Object oldValue, Object newValue) {
         this.pcs.firePropertyChange(name, oldValue, newValue);
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
@@ -20,67 +20,51 @@
  */
 package org.openmicroscopy.shoola.env.data.util;
 
-
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.Font;
-import java.io.File;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import javax.swing.Box;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 
-import ome.formats.importer.IObservable;
-import ome.formats.importer.IObserver;
 import ome.formats.importer.ImportCandidates;
-import ome.formats.importer.ImportContainer;
 import ome.formats.importer.ImportEvent;
-import ome.formats.importer.ImportEvent.FILESET_UPLOAD_END;
 import ome.formats.importer.util.ErrorHandler;
-import omero.cmd.CmdCallback;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
-import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.env.data.ImportException;
-import org.openmicroscopy.shoola.env.data.model.FileObject;
+import org.openmicroscopy.shoola.util.CommonsLangUtils;
 import org.openmicroscopy.shoola.util.ui.UIUtilities;
 
-import omero.gateway.util.PojoMapper;
-import omero.gateway.model.DataObject;
-import omero.gateway.model.FilesetData;
-import omero.gateway.model.PixelsData;
 
 /**
  * Component displaying the status of a specific import.
  *
- * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp;
- * <a href="mailto:donald@lifesci.dundee.ac.uk">donald@lifesci.dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author Donald MacDonald &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:donald@lifesci.dundee.ac.uk"
+ *         >donald@lifesci.dundee.ac.uk</a>
  * @author Blazej Pindelski, bpindelski at dundee.ac.uk
  * @version 3.0
  * @since 3.0-Beta4
  */
-public class StatusLabel
-    extends JPanel
-    implements IObserver
-{
+public class StatusLabel extends JPanel implements PropertyChangeListener {
 
-    /** The text displayed when the file is already selected.*/
+    /** The text displayed when the file is already selected. */
     public static final String DUPLICATE = "Already processed, skipping";
 
     /** The text indicating the scanning steps. */
     public static final String SCANNING_TEXT = "Scanning...";
 
-    /** 
+    /**
      * Bound property indicating that the original container has been reset.
      * */
     public static final String NO_CONTAINER_PROPERTY = "noContainer";
@@ -88,28 +72,25 @@ public class StatusLabel
     /** Bound property indicating that children files have been set. */
     public static final String FILES_SET_PROPERTY = "filesSet";
 
-    /** 
-     * Bound property indicating that the file has to be reset
-     * This should be invoked if the log file for example has been selected.
+    /**
+     * Bound property indicating that the file has to be reset This should be
+     * invoked if the log file for example has been selected.
      */
     public static final String FILE_RESET_PROPERTY = "fileReset";
 
     /** Bound property indicating that the import of the file has started. */
-    public static final String FILE_IMPORT_STARTED_PROPERTY =
-            "fileImportStarted";
+    public static final String FILE_IMPORT_STARTED_PROPERTY = "fileImportStarted";
 
-    /** 
-     * Bound property indicating that the container corresponding to the
-     * folder has been created. 
+    /**
+     * Bound property indicating that the container corresponding to the folder
+     * has been created.
      * */
-    public static final String CONTAINER_FROM_FOLDER_PROPERTY =
-            "containerFromFolder";
+    public static final String CONTAINER_FROM_FOLDER_PROPERTY = "containerFromFolder";
 
-    /** Bound property indicating that the status has changed.*/
-    public static final String CANCELLABLE_IMPORT_PROPERTY =
-            "cancellableImport";
+    /** Bound property indicating that the status has changed. */
+    public static final String CANCELLABLE_IMPORT_PROPERTY = "cancellableImport";
 
-    /** Bound property indicating that the debug text has been sent.*/
+    /** Bound property indicating that the debug text has been sent. */
     public static final String DEBUG_TEXT_PROPERTY = "debugText";
 
     /** Bound property indicating that the import is done. */
@@ -124,147 +105,58 @@ public class StatusLabel
     /** Bound property indicating that the scanning has started. */
     public static final String PROCESSING_ERROR_PROPERTY = "processingError";
 
-    /** The default text of the component.*/
+    /** The default text of the component. */
     public static final String DEFAULT_TEXT = "Pending...";
 
-    /** Text to indicate that the import is cancelled. */
-    private static final String CANCEL_TEXT = "Cancelled";
-
-    /** Text to indicate that no files to import. */
-    private static final String NO_FILES_TEXT = "No Files to Import.";
-
-    /** The width of the upload bar.*/
+    /** The width of the upload bar. */
     private static final int WIDTH = 200;
 
-    /** The maximum number of value for upload.*/
+    /** The maximum number of value for upload. */
     private static final int MAX = 100;
-
-    /** 
-     * The number of processing sets.
-     * 1. Importing Metadata
-     * 2. Processing Pixels
-     * 3. Generating Thumbnails
-     * 4. Processing Metadata
-     * 5. Generating Objects
-     */
-    /** Map hosting the description of each step.*/
-    private static final Map<Integer, String> STEPS;
-
-    /** Map hosting the description of the failure at a each step.*/
-    private static final Map<Integer, String> STEP_FAILURES;
-
-    static {
-        STEPS = new HashMap<Integer, String>();
-        STEPS.put(1, "Importing Metadata");
-        STEPS.put(2, "Reading Pixels");
-        STEPS.put(3, "Generating Thumbnails");
-        STEPS.put(4, "Reading Metadata");
-        STEPS.put(5, "Generating Objects");
-        STEPS.put(6, "Complete");
-        STEP_FAILURES = new HashMap<Integer, String>();
-        STEP_FAILURES.put(1, "Failed to Import Metadata");
-        STEP_FAILURES.put(2, "Failed to Read Pixels");
-        STEP_FAILURES.put(3, "Failed to Generate Thumbnails");
-        STEP_FAILURES.put(4, "Failed to Read Metadata");
-        STEP_FAILURES.put(5, "Failed to Generate Objects");
-    }
-
-    /** The container.*/
-    private ImportContainer ic;
-
-    /** The number of images in a series. */
-    private int seriesCount;
-
-    /** Flag indicating that the import has been cancelled. */
-    private boolean markedAsCancel;
-
-    /** Flag indicating that the import can or not be cancelled.*/
-    private boolean cancellable;
-
-    /** 
-     * Flag indicating that the file has already been imported or already
-     * in the queue.
-     */
-    private boolean markedAsDuplicate;
-
-    /** The size of the file.*/
-    private String fileSize;
-
-    /** The size units.*/
-    private String units;
-
-    /** The total size of uploaded files.*/
-    private long totalUploadedSize;
-
-    /** The label displaying the general import information.*/
+    
+    /** The label displaying the general import information. */
     private JLabel generalLabel;
 
-    /** Indicate the progress of the upload.*/
+    /** Indicate the progress of the upload. */
     private JProgressBar uploadBar;
 
-    /** Indicate the progress of the processing.*/
+    /** Indicate the progress of the processing. */
     private JProgressBar processingBar;
-
-    /** The size of the upload,*/
-    private long sizeUpload;
-
-    /** The labels displaying information before the progress bars.*/
+    
+    /** The labels displaying information before the progress bars. */
     private List<JLabel> labels;
 
-    /** Checksum event stored for later retrieval */
-    private FILESET_UPLOAD_END checksumEvent;
-
-    /** The exception if an error occurred.*/
+    /** The exception if an error occurred. */
     private ImportException exception;
 
-    /** The list of pixels' identifiers returned when the import is complete.*/
-    private Collection<PixelsData> pixels;
-
-    /** The file associated to that import.*/
-    private FilesetData fileset;
-
-    /** The callback. This should only be set when importing a directory.*/
-    private Object callback;
-
-    /** Indicates that the file scanned is a directory.*/
-    //private boolean directory;
-
-    /** The id of the log file.*/
-    private long logFileID;
-
-    /** The processing step.*/
-    private int step;
-
-    /** Indicates if the upload ever started.*/
-    private boolean uploadStarted;
-
-    /** The file or folder this component is for.*/
-    private FileObject sourceFile;
-
-    /** 
+    private Status status;
+    
+    /**
      * Formats the size of the uploaded data.
      * 
-     * @param value The value to display.
+     * @param value
+     *            The value to display.
      * @return See above.
      */
-    private String formatUpload(long value)
-    {
+    private String formatUpload(long value) {
         StringBuffer buffer = new StringBuffer();
         String v = FileUtils.byteCountToDisplaySize(value);
         String[] values = v.split(" ");
         if (values.length > 1) {
             String u = values[1];
-            if (units.equals(u)) buffer.append(values[0]);
-            else buffer.append(v);
-        } else buffer.append(v);
+            if (status.getUnits().equals(u))
+                buffer.append(values[0]);
+            else
+                buffer.append(v);
+        } else
+            buffer.append(v);
         buffer.append("/");
-        buffer.append(fileSize);
+        buffer.append(status.getFileSize());
         return buffer.toString();
     }
 
-    /** Builds and lays out the UI.*/
-    private void buildUI()
-    {
+    /** Builds and lays out the UI. */
+    private void buildUI() {
         labels = new ArrayList<JLabel>();
         setLayout(new FlowLayout(FlowLayout.LEFT));
         add(generalLabel);
@@ -282,25 +174,17 @@ public class StatusLabel
         setOpaque(false);
     }
 
-    /** Initializes the components.*/
-    private void initialize()
-    {
-        step = 0;
-        sizeUpload = 0;
-        fileSize = "";
-        seriesCount = 0;
-        markedAsCancel = false;
-        cancellable = true;
-        totalUploadedSize = 0;
+    /** Initializes the components. */
+    private void initialize() {
         generalLabel = new JLabel(DEFAULT_TEXT);
         Font f = generalLabel.getFont();
-        Font derived = f.deriveFont(f.getStyle(), f.getSize()-2);
+        Font derived = f.deriveFont(f.getStyle(), f.getSize() - 2);
         uploadBar = new JProgressBar(0, MAX);
         uploadBar.setFont(derived);
         uploadBar.setStringPainted(true);
         Dimension d = uploadBar.getPreferredSize();
         uploadBar.setPreferredSize(new Dimension(WIDTH, d.height));
-        processingBar = new JProgressBar(0, STEPS.size());
+        processingBar = new JProgressBar(0, Status.STEPS.size());
         processingBar.setStringPainted(true);
         processingBar.setString(DEFAULT_TEXT);
         processingBar.setFont(derived);
@@ -309,444 +193,79 @@ public class StatusLabel
     }
 
     /**
-     * Handles error that occurred during the processing.
-     * 
-     * @param text The text to display if any.
-     * @param fire Indicate to fire a property.
-     */
-    private void handleProcessingError(String text, boolean fire)
-    {
-        if (isMarkedAsCancel()) return;
-        generalLabel.setText(text);
-        cancellable = false;
-        if (step > 0)
-            processingBar.setString(STEP_FAILURES.get(step));
-        if (fire)
-            firePropertyChange(PROCESSING_ERROR_PROPERTY, null, this);
-    }
-
-    /**
      * Creates a new instance.
      * 
-     * @param sourceFile The file associated to that label.
+     * @param sourceFile
+     *            The file associated to that label.
      */
-    public StatusLabel(FileObject sourceFile)
-    {
-        this.sourceFile = sourceFile;
+    public StatusLabel(Status status) {
+        this.status = status;
+        status.addPropertyChangeListener(this);
         initialize();
         buildUI();
     }
 
-    /** 
-     * Sets the file set when the upload is complete.
-     * To be modified.
-     * 
-     * @param fileset The value to set.
-     */
-    public void setFilesetData(final FilesetData fileset)
-    {
-        this.fileset = fileset;
-    }
-
-    /**
-     * Returns <code>true</code> if it is a HCS file, <code>false</code>
-     * otherwise.
-     *
-     * @return See above.
-     */
-    public boolean isHCS()
-    {
-        if (ic == null) return false;
-        Boolean b = ic.getIsSPW();
-        if (b == null) return false;
-        return b.booleanValue();
-    }
-
-    /**
-     * Returns the file set associated to the import.
-     * 
-     * @return See above.
-     */
-    public FilesetData getFileset() { return fileset; }
-
-    /**
-     * Sets the collection of files to import.
-     * 
-     * @param usedFiles The value to set.
-     */
-    public void setUsedFiles(String[] usedFiles)
-    {
-        if (usedFiles == null) return;
-        for (int i = 0; i < usedFiles.length; i++) {
-            sizeUpload += (new File(usedFiles[i])).length();
-        }
-        fileSize = FileUtils.byteCountToDisplaySize(sizeUpload);
-        String[] values = fileSize.split(" ");
-        if (values.length > 1) units = values[1];
-    }
-
-    /**
-     * Sets the callback. This method should only be invoked when the 
-     * file is imported from a folder.
-     * 
-     * @param cmd The object to handle.
-     */
-    public void setCallback(Object cmd)
-    {
-        if (cmd instanceof ImportException) exception = (ImportException) cmd;
-        else if (cmd instanceof CmdCallback || cmd instanceof Boolean)
-            callback = cmd;
-        firePropertyChange(UPLOAD_DONE_PROPERTY, null, this);
-    }
-
-    /**
-     * Sets the text of {@link #generalLabel}.
-     * 
-     * @param text The value to set.
-     */
-    public void setText(String text)
-    {
-        if (CommonsLangUtils.isEmpty(text)) {
-            String value = generalLabel.getText();
-            if (DEFAULT_TEXT.equals(value) || SCANNING_TEXT.equals(value))
-                generalLabel.setText(text);
-        } else generalLabel.setText(text);
-    }
-
-    /**
-     * Displays message when saving rois.
-     *
-     * @param text The text displayed
-     * @param completed Update progress bar.
-     */
-    public void updatePostProcessing(String text, boolean completed)
-    {
-        if (!completed) {
-            processingBar.setMaximum(processingBar.getMaximum()+1);
-            processingBar.setValue(processingBar.getValue()+1);
-        } else {
-            processingBar.setValue(processingBar.getMaximum());
-        }
-        processingBar.setString(text);
-    }
-
-    /** Marks the import has cancelled. */
-    public void markedAsCancel()
-    {
-        generalLabel.setText(CANCEL_TEXT);
-        this.markedAsCancel = true;
-    }
-
-    /**
-     * Returns <code>true</code> if the import is marked as cancel,
-     * <code>false</code> otherwise.
-     * 
-     * @return See above.
-     */
-    public boolean isMarkedAsCancel() { return markedAsCancel; }
-
-    /** Marks the import has duplicate. */
-    public void markedAsDuplicate()
-    {
-        this.markedAsDuplicate = true;
-        generalLabel.setText(DUPLICATE);
-    }
-
-    /**
-     * Returns <code>true</code> if the import is marked as duplicate,
-     * <code>false</code> otherwise.
-     * 
-     * @return See above.
-     */
-    public boolean isMarkedAsDuplicate() { return markedAsDuplicate; }
-
-    /**
-     * Returns the text if an error occurred.
-     * 
-     * @return See above.
-     */
-    public String getErrorText() { return ""; }
-
-    /**
-     * Returns the source files that have checksum values or <code>null</code>
-     * if no event stored.
-     * 
-     * @return See above.
-     */
-    public List<String> getChecksums()
-    {
-        if (!hasChecksum()) return null;
-        return checksumEvent.checksums;
-    }
-
-    /**
-     * Returns the checksum values or <code>null</code> if no event stored.
-     * 
-     * @return See above.
-     */
-    public Map<Integer, String> getFailingChecksums()
-    {
-        if (!hasChecksum()) return null;
-        return checksumEvent.failingChecksums;
-    }
-
-    /**
-     * Returns the source files that have checksum values or <code>null</code>
-     * if no event stored.
-     * 
-     * @return See above.
-     */
-    public String[] getChecksumFiles()
-    {
-        if (!hasChecksum()) return null;
-        return checksumEvent.srcFiles;
-    }
-
-    /** 
-     * Returns <code>true</code> if the checksums have been calculated,
-     * <code>false</code> otherwise.
-     * 
-     * @return See above.
-     */
-    public boolean hasChecksum() { return checksumEvent != null; }
-
-    /**
-     * Fires a property indicating to import the files.
-     * 
-     * @param files The file to handle.
-     */
-    public void setFiles(Map<File, StatusLabel> files)
-    {
-        if (isMarkedAsCancel()) return;
-        generalLabel.setText(NO_FILES_TEXT);
-        if (!CollectionUtils.isEmpty(files.entrySet())) {
-            StringBuffer buffer = new StringBuffer();
-            buffer.append("Importing ");
-            buffer.append(files.size());
-            buffer.append(" file");
-            if (files.size() > 1) buffer.append("s");
-            generalLabel.setText(buffer.toString());
-        }
-        firePropertyChange(FILES_SET_PROPERTY, null, files);
-    }
-
-    /**
-     * Indicates that the original container has been reset.
-     */
-    public void setNoContainer()
-    {
-        firePropertyChange(NO_CONTAINER_PROPERTY,
-                Boolean.valueOf(false), Boolean.valueOf(true));
-    }
-
-    /**
-     * Sets the container corresponding to the folder.
-     * 
-     * @param container The container to set.
-     */
-    public void setContainerFromFolder(DataObject container)
-    {
-        firePropertyChange(CONTAINER_FROM_FOLDER_PROPERTY, null, container);
-    }
-
-    /**
-     * Replaces the initial file by the specified one. This should only be
-     * invoked if the original file was an arbitrary one requiring to use the
-     * import candidate e.g. <code>.log</code>.
-     * 
-     * @param file The new file.
-     */
-    public void resetFile(File file)
-    {
-        firePropertyChange(FILE_RESET_PROPERTY, null, file);
-    }
-
-    /**
-     * Returns the number of series.
-     * 
-     * @return See above.
-     */
-    public int getSeriesCount() { return seriesCount; }
-
-    /**
-     * Returns <code>true</code> if the import can be cancelled,
-     * <code>false</code> otherwise.
-     * 
-     * @return See above.
-     */
-    public boolean isCancellable() { return cancellable; }
-
-    /**
-     * Returns the result of the import either a collection of
-     * <code>PixelsData</code> or an exception.
-     * 
-     * @return See above.
-     */
-    public Object getImportResult()
-    {
-        if (exception != null) return exception;
-        if (pixels != null) return pixels;
-        return callback;
-    }
-
-    /**
-     * Returns the number of pixels objects created or <code>0</code>.
-     * 
-     * @return See above.
-     */
-    public int getNumberOfImportedFiles()
-    {
-        if (pixels != null) return pixels.size();
-        return 0;
-    }
-
-    /**
-     * Returns the size of the upload.
-     * 
-     * @return See above.
-     */
-    public long getFileSize() { return sizeUpload; }
-
-    /**
-     * Returns the ID associated to the log file.
-     * 
-     * @return See above.
-     */
-    public long getLogFileID() { return logFileID; }
-
-    /**
-     * Returns <code>true</code> if the upload ever started, <code>false</code>
-     * otherwise.
-     * 
-     * @return See above.
-     */
-    public boolean didUploadStart() { return uploadStarted; }
-
-    /**
-     * Returns the container.
-     *
-     * @return See above.
-     */
-    public ImportContainer getImportContainer() { return ic; }
-
-    /**
-     * Sets the import container.
-     *
-     * @param ic The value to set.
-     */
-    public void setImportContainer(ImportContainer ic) { this.ic = ic; }
-
-    /**
-     * Displays the status of an on-going import.
-     * @see IObserver#update(IObservable, ImportEvent)
-     */
-    public void update(IObservable observable, ImportEvent event)
-    {
-        if (event == null) return;
-        cancellable = false;
-        if (event instanceof ImportEvent.IMPORT_DONE) {
-            step = 6;
-            processingBar.setValue(step);
-            processingBar.setString(STEPS.get(step));
-            pixels = PojoMapper.<PixelsData>convertToDataObjects(
-                    ((ImportEvent.IMPORT_DONE) event).pixels);
-            firePropertyChange(IMPORT_DONE_PROPERTY, null, this);
-        } else if (event instanceof ImportCandidates.SCANNING) {
-            if (!markedAsCancel) cancellable = true;
-            if (!markedAsCancel && exception == null)
-                generalLabel.setText(SCANNING_TEXT);
-            if (exception == null)
-                firePropertyChange(SCANNING_PROPERTY, null, this);
-        } else if (event instanceof ErrorHandler.MISSING_LIBRARY) {
-            exception = new ImportException(ImportException.MISSING_LIBRARY_TEXT,
-                    ((ErrorHandler.MISSING_LIBRARY) event).exception);
-            handleProcessingError(ImportException.MISSING_LIBRARY_TEXT, false);
-        } else if (event instanceof ErrorHandler.UNKNOWN_FORMAT) {
-            exception = new ImportException(ImportException.UNKNOWN_FORMAT_TEXT,
-                    ((ErrorHandler.UNKNOWN_FORMAT) event).exception);
-            if (sourceFile != null && !sourceFile.isDirectory())
-                handleProcessingError(ImportException.UNKNOWN_FORMAT_TEXT, true);
-        } else if (event instanceof ErrorHandler.FILE_EXCEPTION) {
-            ErrorHandler.FILE_EXCEPTION e = (ErrorHandler.FILE_EXCEPTION) event;
-            exception = new ImportException(e.exception);
-            String text = ImportException.FILE_NOT_VALID_TEXT;
-            if (sourceFile != null && sourceFile.isDirectory()) text = "";
-            handleProcessingError(text, false);
-        } else if (event instanceof ErrorHandler.INTERNAL_EXCEPTION) {
-            ErrorHandler.INTERNAL_EXCEPTION e =
-                    (ErrorHandler.INTERNAL_EXCEPTION) event;
-            exception = new ImportException(e.exception);
-            handleProcessingError("", true);
-        }  else if (event instanceof ImportEvent.FILE_UPLOAD_BYTES) {
-            ImportEvent.FILE_UPLOAD_BYTES e =
-                    (ImportEvent.FILE_UPLOAD_BYTES) event;
-            long v = totalUploadedSize+e.uploadedBytes;
-            if (sizeUpload != 0) {
-                uploadBar.setValue((int) (v*MAX/sizeUpload));
+    @Override
+    public void propertyChange(PropertyChangeEvent pe) {
+        if (pe.getPropertyName().equals(Status.IMPORT_EVENT)) {
+            ImportEvent event = (ImportEvent) pe.getNewValue();
+            if (event instanceof ImportCandidates.SCANNING) {
+                if (!status.isMarkedAsCancel() && exception == null)
+                    generalLabel.setText(SCANNING_TEXT);
+            } else if (event instanceof ErrorHandler.MISSING_LIBRARY) {
+                exception = new ImportException(
+                        ImportException.MISSING_LIBRARY_TEXT,
+                        ((ErrorHandler.MISSING_LIBRARY) event).exception);
+            } else if (event instanceof ErrorHandler.UNKNOWN_FORMAT) {
+                exception = new ImportException(
+                        ImportException.UNKNOWN_FORMAT_TEXT,
+                        ((ErrorHandler.UNKNOWN_FORMAT) event).exception);
+            } else if (event instanceof ErrorHandler.FILE_EXCEPTION) {
+                ErrorHandler.FILE_EXCEPTION e = (ErrorHandler.FILE_EXCEPTION) event;
+                exception = new ImportException(e.exception);
+            } else if (event instanceof ErrorHandler.INTERNAL_EXCEPTION) {
+                ErrorHandler.INTERNAL_EXCEPTION e = (ErrorHandler.INTERNAL_EXCEPTION) event;
+                exception = new ImportException(e.exception);
+            } else if (event instanceof ImportEvent.FILE_UPLOAD_BYTES) {
+                ImportEvent.FILE_UPLOAD_BYTES e = (ImportEvent.FILE_UPLOAD_BYTES) event;
+                long v = status.getTotalUploadedSize() + e.uploadedBytes;
+                if (status.getSizeUpload() != 0) {
+                    uploadBar.setValue((int) (v * MAX / status.getSizeUpload()));
+                }
+                StringBuffer buffer = new StringBuffer();
+                if (v != status.getSizeUpload())
+                    buffer.append(formatUpload(v));
+                else
+                    buffer.append(status.getFileSize());
+                buffer.append(" ");
+                if (e.timeLeft != 0) {
+                    String s = UIUtilities.calculateHMSFromMilliseconds(
+                            e.timeLeft, true);
+                    buffer.append(s);
+                    if (CommonsLangUtils.isNotBlank(s))
+                        buffer.append(" Left");
+                    else
+                        buffer.append("complete");
+                }
+                uploadBar.setString(buffer.toString());
+            } else if (event instanceof ImportEvent.FILESET_UPLOAD_START) {
+                Iterator<JLabel> i = labels.iterator();
+                while (i.hasNext()) {
+                    i.next().setVisible(true);
+                }
+                generalLabel.setText("");
+                uploadBar.setVisible(true);
+                processingBar.setVisible(true);
+            } else if (event instanceof ImportEvent.FILESET_UPLOAD_PREPARATION) {
+                generalLabel.setText("Preparing upload...");
+            } else if (event instanceof ImportEvent.IMPORT_STARTED) {
+                ImportEvent.IMPORT_STARTED e = (ImportEvent.IMPORT_STARTED) event;
             }
-            StringBuffer buffer = new StringBuffer();
-            if (v != sizeUpload) buffer.append(formatUpload(v));
-            else  buffer.append(fileSize);
-            buffer.append(" ");
-            if (e.timeLeft != 0) {
-                String s = UIUtilities.calculateHMSFromMilliseconds(e.timeLeft,
-                        true);
-                buffer.append(s);
-                if (CommonsLangUtils.isNotBlank(s)) buffer.append(" Left");
-                else buffer.append("complete");
-            }
-            uploadBar.setString(buffer.toString());
-        } else if (event instanceof ImportEvent.FILE_UPLOAD_COMPLETE) {
-            ImportEvent.FILE_UPLOAD_COMPLETE e =
-                    (ImportEvent.FILE_UPLOAD_COMPLETE) event;
-            totalUploadedSize += e.uploadedBytes;
-        } else if (event instanceof ImportEvent.FILESET_UPLOAD_END) {
-            checksumEvent = (ImportEvent.FILESET_UPLOAD_END) event;
-            if (exception == null) {
-                step = 1;
-                processingBar.setValue(step);
-                processingBar.setString(STEPS.get(step));
-            }
-        } else if (event instanceof ImportEvent.METADATA_IMPORTED) {
-            step = 2;
-            processingBar.setValue(step);
-            processingBar.setString(STEPS.get(step));
-        } else if (event instanceof ImportEvent.PIXELDATA_PROCESSED) {
-            step = 3;
-            processingBar.setValue(step);
-            processingBar.setString(STEPS.get(step));
-        } else if (event instanceof ImportEvent.THUMBNAILS_GENERATED) {
-            step = 4;
-            processingBar.setValue(step);
-            processingBar.setString(STEPS.get(step));
-        } else if (event instanceof ImportEvent.METADATA_PROCESSED) {
-            step = 5;
-            processingBar.setValue(step);
-            processingBar.setString(STEPS.get(step));
-        } else if (event instanceof ImportEvent.FILESET_UPLOAD_START) {
-            uploadStarted = true;
-            Iterator<JLabel> i = labels.iterator();
-            while (i.hasNext()) {
-                i.next().setVisible(true);
-            }
-            generalLabel.setText("");
-            uploadBar.setVisible(true);
-            processingBar.setVisible(true);
-            firePropertyChange(FILE_IMPORT_STARTED_PROPERTY, null, this);
-        } else if (event instanceof ImportEvent.FILESET_UPLOAD_PREPARATION) {
-            generalLabel.setText("Preparing upload...");
-        } else if (event instanceof ImportEvent.IMPORT_STARTED) {
-            ImportEvent.IMPORT_STARTED e =
-                    (ImportEvent.IMPORT_STARTED) event;
-            if (e.logFileId != null) {
-                logFileID = e.logFileId;
-            }
-        } else if (event instanceof ImportEvent.POST_UPLOAD_EVENT) {
-            ImportEvent.POST_UPLOAD_EVENT e =
-                    (ImportEvent.POST_UPLOAD_EVENT) event;
-            ic = e.container;
             
+            processingBar.setValue(status.getStep());
+            processingBar.setString(Status.STEPS.get(status.getStep()));
         }
+
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -58,53 +58,6 @@ import org.openmicroscopy.shoola.util.ui.UIUtilities;
  */
 public class StatusLabel extends JPanel implements PropertyChangeListener {
 
-    /** The text displayed when the file is already selected. */
-    public static final String DUPLICATE = "Already processed, skipping";
-
-    /** The text indicating the scanning steps. */
-    public static final String SCANNING_TEXT = "Scanning...";
-
-    /**
-     * Bound property indicating that the original container has been reset.
-     * */
-    public static final String NO_CONTAINER_PROPERTY = "noContainer";
-
-    /** Bound property indicating that children files have been set. */
-    public static final String FILES_SET_PROPERTY = "filesSet";
-
-    /**
-     * Bound property indicating that the file has to be reset This should be
-     * invoked if the log file for example has been selected.
-     */
-    public static final String FILE_RESET_PROPERTY = "fileReset";
-
-    /** Bound property indicating that the import of the file has started. */
-    public static final String FILE_IMPORT_STARTED_PROPERTY = "fileImportStarted";
-
-    /**
-     * Bound property indicating that the container corresponding to the folder
-     * has been created.
-     * */
-    public static final String CONTAINER_FROM_FOLDER_PROPERTY = "containerFromFolder";
-
-    /** Bound property indicating that the status has changed. */
-    public static final String CANCELLABLE_IMPORT_PROPERTY = "cancellableImport";
-
-    /** Bound property indicating that the debug text has been sent. */
-    public static final String DEBUG_TEXT_PROPERTY = "debugText";
-
-    /** Bound property indicating that the import is done. */
-    public static final String IMPORT_DONE_PROPERTY = "importDone";
-
-    /** Bound property indicating that the upload is done. */
-    public static final String UPLOAD_DONE_PROPERTY = "uploadDone";
-
-    /** Bound property indicating that the scanning has started. */
-    public static final String SCANNING_PROPERTY = "scanning";
-
-    /** Bound property indicating that the scanning has started. */
-    public static final String PROCESSING_ERROR_PROPERTY = "processingError";
-
     /** The default text of the component. */
     public static final String DEFAULT_TEXT = "Pending...";
 
@@ -129,6 +82,7 @@ public class StatusLabel extends JPanel implements PropertyChangeListener {
     /** The exception if an error occurred. */
     private ImportException exception;
 
+    /** The component tracking the status */
     private Status status;
     
     /**
@@ -211,7 +165,7 @@ public class StatusLabel extends JPanel implements PropertyChangeListener {
             ImportEvent event = (ImportEvent) pe.getNewValue();
             if (event instanceof ImportCandidates.SCANNING) {
                 if (!status.isMarkedAsCancel() && exception == null)
-                    generalLabel.setText(SCANNING_TEXT);
+                    generalLabel.setText(Status.SCANNING_TEXT);
             } else if (event instanceof ErrorHandler.MISSING_LIBRARY) {
                 exception = new ImportException(
                         ImportException.MISSING_LIBRARY_TEXT,

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/util/StatusLabel.java
@@ -149,8 +149,8 @@ public class StatusLabel extends JPanel implements PropertyChangeListener {
     /**
      * Creates a new instance.
      * 
-     * @param sourceFile
-     *            The file associated to that label.
+     * @param status
+     *            The status
      */
     public StatusLabel(Status status) {
         this.status = status;

--- a/components/insight/config/importer.xml
+++ b/components/insight/config/importer.xml
@@ -37,7 +37,7 @@ into a dataset -->
 <entry name="/options/FolderAsDataset" type="boolean">true</entry>
 <!-- if set to true, the debug tab will be displayed. -->
 <entry name="/options/Debug" type="boolean">false</entry>
-<!-- limit the number of files to import at once -->
-<entry name="/options/ImportFileLimit" type="integer">2000</entry>
+<!-- limit the number of files to show detailed import information for -->
+<entry name="/options/DetailedImportFileLimit" type="integer">100</entry>
 </options>
 </agent>


### PR DESCRIPTION
# What this PR does

If more than 100 images are selected for import the UI doesn't show a detailed UI component (with progress bars, buttons, etc.) for each file any longer, but just displays a simplified UI to track the overall import process.

![screen shot 2018-06-15 at 14 12 12](https://user-images.githubusercontent.com/6575139/41470312-28a0ba7e-70a8-11e8-87e0-0fcab06ded0f.png)

# Testing this PR

See also [Import workflow scenario](https://docs.openmicroscopy.org/internal/testing_scenarios/ImportUI.html)

Check that the general import workflow still works, with "import batches" less than 100 files.

Check the import workflow also works with the simplified UI, i. e. for "import batches" larger than 100 files. I tested it with 3000 files,  worked fine. There are still tons of objects created (non-UI at least), but the heap usage seems to stay under 500 MB and the import process didn't slow down (as it does with the "heavy UI" until it freezes completely). 

Include one or more broken files and check that these cases are handled correctly, i.e. show up as "failed", you can get the full error log and it doesn't "block" the importer (you don't have to "force quit" it).

Check the new "skip" options.

![screen shot 2018-07-03 at 16 09 06](https://user-images.githubusercontent.com/6575139/42228385-bf817fb4-7edb-11e8-86ac-97600fee9ee2.png)


# Related reading

https://docs.google.com/document/d/1e3jeIlYxzI9w5hEdD008gvIH6Q70xig7nplzmaaIpw8/edit#heading=h.bee3vpgcgqg2

