### PR TITLE
Insight: add null-check to ratings editor

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -2426,10 +2426,10 @@ class EditorModel
         if (!isMultiSelection()) {
             Map<DataObject, RatingAnnotationData> map = getAllUserRatingAnnotation();
             if (map != null) {
-            for (Entry<DataObject, RatingAnnotationData> e : map.entrySet()) {
-                if (e.getValue().getOwner().getId() == getLoggedInUserID())
-                    return e.getValue();
-            }
+                for (Entry<DataObject, RatingAnnotationData> e : map.entrySet()) {
+                    if (e.getValue().getOwner().getId() == getLoggedInUserID())
+                        return e.getValue();
+                }
             }
         }
         return null;

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/metadata/editor/EditorModel.java
@@ -2425,9 +2425,11 @@ class EditorModel
     RatingAnnotationData getUserRatingData() {
         if (!isMultiSelection()) {
             Map<DataObject, RatingAnnotationData> map = getAllUserRatingAnnotation();
+            if (map != null) {
             for (Entry<DataObject, RatingAnnotationData> e : map.entrySet()) {
                 if (e.getValue().getOwner().getId() == getLoggedInUserID())
                     return e.getValue();
+            }
             }
         }
         return null;


### PR DESCRIPTION
Adds a null check for getting user rating data. See [QA \#21545](https://www.openmicroscopy.org/qa2/qa/feedback/21545/).