### PR TITLE
Update Javadoc for resolution level getters/setters to clarify ordering

### DIFF
--- a/components/common/src/ome/api/RawPixelsStore.java
+++ b/components/common/src/ome/api/RawPixelsStore.java
@@ -130,13 +130,34 @@ public interface RawPixelsStore extends StatefulServiceInterface {
 
     public Object getResolutionDescriptions();
 
-    /* @see ome.io.nio.PixelBuffer#getResolutionLevels() */
+    /**
+     * Retrieves the number of resolution levels that the backing
+     * pixels pyramid contains.
+     * @return The number of resolution levels. This value does not
+     * necessarily indicate either the presence or absence of a
+     * pixels pyramid.
+     **/
     public int getResolutionLevels();
 
-    /* @see ome.io.nio.PixelBuffer#getResolutionLevel() */
+    /**
+     * Retrieves the active resolution level.
+     * @return The active resolution level.  The level will be non-negative and less
+     * than {@link #getResolutionLevels()}.  Resolution level 0 is the smallest
+     * resolution and resolution level <code>getResolutionLevels() - 1</code>
+     * is the largest resolution.  This is the inverse of how Bio-Formats indexes
+     * resolutions.
+     */
     public int getResolutionLevel();
 
-    /* @see ome.io.nio.PixelBuffer#setResolutionLevel(int) */
+    /**
+     * Sets the active resolution level.
+     * @param resolutionLevel The resolution level to be used.
+     * The level should be non-negative and less than
+     * {@link #getResolutionLevels()}.  * Resolution level 0 is the smallest
+     * resolution and resolution level <code>getResolutionLevels() - 1</code>
+     * is the largest resolution.  This is the inverse of how Bio-Formats indexes
+     * resolutions.
+     */
     public void setResolutionLevel(int resolutionLevel);
 
     public int[] getTileSize();

--- a/components/common/src/ome/api/RawPixelsStore.java
+++ b/components/common/src/ome/api/RawPixelsStore.java
@@ -130,10 +130,13 @@ public interface RawPixelsStore extends StatefulServiceInterface {
 
     public Object getResolutionDescriptions();
 
+    /* @see ome.io.nio.PixelBuffer#getResolutionLevels() */
     public int getResolutionLevels();
 
+    /* @see ome.io.nio.PixelBuffer#getResolutionLevel() */
     public int getResolutionLevel();
 
+    /* @see ome.io.nio.PixelBuffer#setResolutionLevel(int) */
     public void setResolutionLevel(int resolutionLevel);
 
     public int[] getTileSize();

--- a/components/common/src/omeis/providers/re/RenderingEngine.java
+++ b/components/common/src/omeis/providers/re/RenderingEngine.java
@@ -602,10 +602,13 @@ public interface RenderingEngine extends StatefulServiceInterface {
 
     public Object getResolutionDescriptions();
 
+    /* @see ome.io.nio.PixelBuffer#getResolutionLevels() */
     public int getResolutionLevels();
 
+    /* @see ome.io.nio.PixelBuffer#getResolutionLevel() */
     public int getResolutionLevel();
 
+    /* @see ome.io.nio.PixelBuffer#setResolutionLevel(int) */
     public void setResolutionLevel(int resolutionLevel);
 
     public int[] getTileSize();

--- a/components/rendering/src/omeis/providers/re/Renderer.java
+++ b/components/rendering/src/omeis/providers/re/Renderer.java
@@ -953,6 +953,7 @@ public class Renderer {
     /**
      * Sets the active resolution level.
      * @param resolutionLevel The resolution level to be used by the renderer.
+     * @see ome.io.nio.PixelBuffer#setResolutionLevel(int)
      **/
     public void setResolutionLevel(int resolutionLevel)
     {
@@ -962,6 +963,7 @@ public class Renderer {
     /**
      * Retrieves the active resolution level.
      * @return The active resolution level.
+     * @see ome.io.nio.PixelBuffer#getResolutionLevel()
      **/
     public int getResolutionLevel()
     {
@@ -974,6 +976,7 @@ public class Renderer {
      * @return The number of resolution levels. This value does not
      * necessarily indicate either the presence or absence of a
      * pixels pyramid.
+     * @see ome.io.nio.PixelBuffer#getResolutionLevels()
      **/
     public int getResolutionLevels()
     {

--- a/components/romio/src/ome/io/nio/PixelBuffer.java
+++ b/components/romio/src/ome/io/nio/PixelBuffer.java
@@ -678,14 +678,22 @@ public interface PixelBuffer extends Closeable
 
     /**
      * Retrieves the active resolution level.
-     * @return The active resolution level.
+     * @return The active resolution level.  The level will be non-negative and less
+     * than #getResolutionLevels().  Resolution level 0 is the smallest
+     * resolution and resolution level <code>getResolutionLevels() - 1</code>
+     * is the largest resolution.  This is the inverse of how Bio-Formats indexes
+     * resolutions.
      **/
     public int getResolutionLevel();
 
     /**
      * Sets the active resolution level.
      * @param resolutionLevel The resolution level to be used by
-     * the pixel buffer.
+     * the pixel buffer.  The level should be non-negative and less
+     * than #getResolutionLevels().  Resolution level 0 is the smallest
+     * resolution and resolution level <code>getResolutionLevels() - 1</code>
+     * is the largest resolution.  This is the inverse of how Bio-Formats indexes
+     * resolutions.
      **/
     public void setResolutionLevel(int resolutionLevel);
 

--- a/components/romio/src/ome/io/nio/PixelBuffer.java
+++ b/components/romio/src/ome/io/nio/PixelBuffer.java
@@ -679,7 +679,7 @@ public interface PixelBuffer extends Closeable
     /**
      * Retrieves the active resolution level.
      * @return The active resolution level.  The level will be non-negative and less
-     * than #getResolutionLevels().  Resolution level 0 is the smallest
+     * than {@link #getResolutionLevels()}.  Resolution level 0 is the smallest
      * resolution and resolution level <code>getResolutionLevels() - 1</code>
      * is the largest resolution.  This is the inverse of how Bio-Formats indexes
      * resolutions.
@@ -690,7 +690,7 @@ public interface PixelBuffer extends Closeable
      * Sets the active resolution level.
      * @param resolutionLevel The resolution level to be used by
      * the pixel buffer.  The level should be non-negative and less
-     * than #getResolutionLevels().  Resolution level 0 is the smallest
+     * than {@link #getResolutionLevels()}.  Resolution level 0 is the smallest
      * resolution and resolution level <code>getResolutionLevels() - 1</code>
      * is the largest resolution.  This is the inverse of how Bio-Formats indexes
      * resolutions.


### PR DESCRIPTION
# What this PR does

In particular, make it more obvious that OMERO resolution levels are
reversed compared to Bio-Formats resolution levels.  This is a Javadoc change only, and should have no impact on functionality.

# Testing this PR

Review added documentation for correctness and clarity.  The documentation is based upon the implementation of ```setResolutionLevel``` in ```BfPixelBuffer```: https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/romio/src/ome/io/bioformats/BfPixelBuffer.java#L594

# Related reading

This was prompted by a discussion at the OME users meeting with @manics and @petebankhead