### PR TITLE
datetime fix annotations

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -460,7 +460,8 @@ def _marshal_date(timestamp):
         def utcoffset(self, dt):
             # https://stackoverflow.com/questions/1111056/
             # /get-time-zone-information-of-the-system-in-python
-            offset = time.timezone if (time.localtime().tm_isdst == 0) else time.altzone
+            offset = time.timezone if (time.localtime().tm_isdst == 0) \
+                else time.altzone
             return timedelta(0, 0, 0, 0, 0, offset / 60 / 60 * -1)
 
         def tzname(self, dt):

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -457,7 +457,7 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
 def _marshal_date(time):
     try:
         d = datetime.fromtimestamp(time/1000)
-        return d.isoformat() + 'Z'
+        return d.isoformat()
     except ValueError:
         return ''
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -25,7 +25,7 @@ import omero
 from omero.rtypes import rlong, unwrap, wrap
 from django.conf import settings
 from django.http import Http404
-from datetime import datetime
+from datetime import datetime, tzinfo, timedelta
 from copy import deepcopy
 from omero.gateway import _letterGridLabel
 
@@ -454,9 +454,29 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
     return datasets
 
 
-def _marshal_date(time):
+def _marshal_date(timestamp):
+
+    class Local_tz(tzinfo):
+        def utcoffset(self, dt):
+            # https://stackoverflow.com/questions/1111056/
+            # /get-time-zone-information-of-the-system-in-python
+            offset = time.timezone if (time.localtime().tm_isdst == 0) else time.altzone
+            return timedelta(0, 0, 0, 0, 0, offset / 60 / 60 * -1)
+
+        def tzname(self, dt):
+            return "Local_tz"
+
+        def dst(self, dt):
+            """What we return here has no effect on usage below."""
+            if (time.localtime().tm_isdst == 0):
+                offset = 0
+            else:
+                offset = (time.altzone - time.timezone) / 60 / 60 * -1
+            offset = 0
+            return timedelta(0, 0, 0, 0, 0, offset)
+
     try:
-        d = datetime.fromtimestamp(time/1000)
+        d = datetime.fromtimestamp(timestamp/1000, Local_tz())
         return d.isoformat()
     except ValueError:
         return ''


### PR DESCRIPTION
# What this PR does

See https://trello.com/c/HEXZNdSC/227-omeroweb-default-timezone-is-different-from-omeroserver

This fixes the bug where Annotations show time-stamps 1 hour out in Summer time.
However, it doesn't yet try to determine the timezone as suggested in [comment](https://trello.com/c/HEXZNdSC/227-omeroweb-default-timezone-is-different-from-omeroserver#comment-5b28bc6bc6ba992ea159cfa7) as there seems to be no way to do that.

To test:
 - Add a Comment
 - Check that the time-stamp on the Comment shows the current time.
 - Repeat this for servers in a bunch of different time-zones ;)

NB: I think the bug was due to my misunderstanding e.g. https://stackoverflow.com/questions/19654578/python-utc-datetime-objects-iso-format-doesnt-include-z-zulu-or-zero-offset