### PR TITLE
import.py: generate scripts for use with parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,24 @@ RUN apt-get update \
  && pip install tables "zeroc-ice>3.5,<3.7"
 # TODO: unpin pip when possible
 RUN adduser omero
-COPY . /src
+
+# TODO: would be nice to not need to copy .git since it invalidates the build frequently and takes more time
+COPY .git /src/.git
+
+COPY build.py /src/
+COPY build.xml /src/
+COPY components /src/components
+COPY docs /src/docs
+COPY etc /src/etc
+COPY ivy.xml /src/
+COPY lib /src/lib
+COPY luts /src/luts
+COPY omero.class /src/
+COPY setup.cfg /src/
+COPY sql /src/sql
+COPY test.xml /src/
+COPY LICENSE.txt /src/
+COPY history.txt /src/
 RUN chown -R omero /src
 USER omero
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ ARG BUILD_IMAGE=openjdk
 # The produced /src directory will be copied the
 # RUN_IMAGE for end-use. This value can also be
 # set at build time with --build-arg RUN_IMAGE=...
-ARG RUN_IMAGE=openmicroscopy/omero-server:latest
+ARG COMPONENT=server
+ARG RUN_IMAGE=openmicroscopy/omero-${COMPONENT}:latest
+
 
 FROM ${BUILD_IMAGE} as build
 RUN apt-get update \
@@ -47,7 +49,7 @@ RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 
 RUN components/tools/travis-build
 
-FROM ${RUN_IMAGE}
+FROM ${RUN_IMAGE} as run
 COPY --from=build /src /src
 USER root
 RUN chown -R omero-server:omero-server /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 #
 #     https://trello.com/c/rPstbt4z/216-open-ssl-110
 #
-RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
+# RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
 
 RUN components/tools/travis-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # By default, building this dockerfile will use
 # the IMAGE argument below for the runtime image.
-ARG BUILD_IMAGE=openjdk
+ARG BUILD_IMAGE=openjdk:8
 
 # To build code with other runtimes
 # pass a build argument, e.g.:

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 #
 #     https://trello.com/c/rPstbt4z/216-open-ssl-110
 #
-# RUN sed -i 's/\("IceSSL.Ciphers".*ADH\)/\1:@SECLEVEL=0/' /src/componenthreadts/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
+RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
 
 RUN components/tools/travis-build
 

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -584,8 +584,10 @@ class ImportControl(BaseControl):
         command_args.dry_run = False
         if "dry_run" in bulk:
             dry_run = bulk.pop("dry_run")
-            if isinstance(dry_run, (unicode, str)) and dry_run.lower() != "false":
-                command_args.dry_run = dry_run
+            # Accept any non-false string since it might be a pattern
+            if isinstance(dry_run, (unicode, str)):
+                if dry_run.lower() != "false":
+                    command_args.dry_run = dry_run
 
         if "continue" in bulk:
             cont = True

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -583,12 +583,9 @@ class ImportControl(BaseControl):
 
         command_args.dry_run = False
         if "dry_run" in bulk:
-            dry_run = bulk.pop("dry_run")
+            dry_run = str(bulk.pop("dry_run"))
             # Accept any non-false string since it might be a pattern
-            if isinstance(dry_run, (unicode, str)):
-                if dry_run.lower() != "false":
-                    command_args.dry_run = dry_run
-            else:
+            if dry_run.lower() != "false":
                 command_args.dry_run = dry_run
 
         if "continue" in bulk:

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -588,6 +588,8 @@ class ImportControl(BaseControl):
             if isinstance(dry_run, (unicode, str)):
                 if dry_run.lower() != "false":
                     command_args.dry_run = dry_run
+            else:
+                command_args.dry_run = dry_run
 
         if "continue" in bulk:
             cont = True

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -584,7 +584,7 @@ class ImportControl(BaseControl):
         command_args.dry_run = False
         if "dry_run" in bulk:
             dry_run = bulk.pop("dry_run")
-            if dry_run.lower() != "false":
+            if isinstance(dry_run, (unicode, str)) and dry_run.lower() != "false":
                 command_args.dry_run = dry_run
 
         if "continue" in bulk:

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -1194,3 +1194,29 @@ class TestImport(CLITest):
 
         out, err = self.do_import(capfd)
         assert self.get_object(out, 'Image')
+
+    def testBulk(self, tmpdir, capfd):
+        """Test Bulk import"""
+
+        fakefile = tmpdir.join("test.fake")
+        fakefile.write('')
+
+        yml = tmpdir.join("test.yml")
+        yml.write("""---
+dry_run: "script%s.sh"
+path: test.tsv
+        """)
+
+        tsv = tmpdir.join("test.tsv")
+        tsv.write("test.fake")
+
+        script = tmpdir.join("script1.sh")
+
+        self.args += ["-f", "--bulk", str(yml)]
+        out, err = self.do_import(capfd)
+
+        # At this point, script1.sh has been created
+        assert script.exists()
+
+        # TBD
+        # assert self.get_object(out, 'Image')

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -3,6 +3,7 @@
 # with travis, but may be used by hand as well.
 
 set -e
+set -x
 
 if [ -z "$ICE_HOME" ]; then
   export ICE_HOME=/usr/share/Ice


### PR DESCRIPTION
Remove the need to process the output of a dry-run. E.g.

```
bin/omero import --bulk X.yml
```
by instead setting the value of dry-run to a pattern as such `/tmp/%s.sh`. These scripts can then be used as the input to parallel.

# Testing this PR

1. Setup the following files:

bulk.yml
```
continue: "true"
transfer: "ln_s"
exclude: "clientpath"
checksum_algorithm: "File-Size-64"
logprefix: "logs/"
output: "yaml"
dry_run: "script%s.sh"
path: bulk.tsv
```

bulk.tsv
```
bulk.dir
```
(could also use bulk.fake)

2. Run `bin/omero import --bulk bulk.yml  -f`

3. Execute `script1.sh` manually

(Note: the `dry_run` flag itself is not yet enough to prevent a login from being required. Adding the `-f` flag works around this issue)