### PR TITLE
new CLI subcommand: fs importtime

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -1195,8 +1195,8 @@ AND t.pixels.image.fileset.id = :id"""
                 fileset_param, ctx)[0][0].val
             if count > 0:
                 plural = "s" if count > 1 else ""
-                print(("   upload time of {:6.2f}s for "
-                       "{} file{} ({:.3f}s/file)")
+                print(("   upload time of {0:6.2f}s for "
+                       "{1} file{2} ({3:.3f}s/file)")
                       .format(time, count, plural, time/count))
 
         # Report the Bio-Formats setId time.
@@ -1204,14 +1204,14 @@ AND t.pixels.image.fileset.id = :id"""
         time = set_id_end - upload_end
         if time:
             time /= 1000.0
-            print("    setId time of {:6.2f}s".format(time))
+            print("    setId time of {0:6.2f}s".format(time))
 
         # Report the time to generate metadata.
 
         time = metadata_end - set_id_end
         if time:
             time /= 1000.0
-            print(" metadata time of {:6.2f}s".format(time))
+            print(" metadata time of {0:6.2f}s".format(time))
 
         # Report the time to generate pixel data.
         # Does not take account of background pyramid building.
@@ -1225,8 +1225,8 @@ AND t.pixels.image.fileset.id = :id"""
                 fileset_param, ctx)[0][0].val
             if count > 0:
                 plural = "s" if count > 1 else ""
-                print(("   pixels time of {:6.2f}s for "
-                       "{} plane{} ({:.3f}s/plane)")
+                print(("   pixels time of {0:6.2f}s for "
+                       "{1} plane{2} ({3:.3f}s/plane)")
                       .format(time, count, plural, time/count))
 
         # Report the time to generate overlays.
@@ -1239,7 +1239,7 @@ AND t.pixels.image.fileset.id = :id"""
             else:
                 time = thumbnails_end - pixeldata_end
             time /= 1000.0
-            print(" overlays time of {:6.2f}s".format(time))
+            print(" overlays time of {0:6.2f}s".format(time))
 
         # Report the time to generate rendering settings.
 
@@ -1256,8 +1256,8 @@ AND t.pixels.image.fileset.id = :id"""
                 fileset_param, ctx)[0][0].val
             if count > 0:
                 plural = "s" if count > 1 else ""
-                print(("    rdefs time of {:6.2f}s for "
-                       "{} rendering setting{} ({:.3f}s/rdef)")
+                print(("    rdefs time of {0:6.2f}s for "
+                       "{1} rendering setting{2} ({3:.3f}s/rdef)")
                       .format(time, count, plural, time/count))
 
         # Report the time to generate thumbnails.
@@ -1273,8 +1273,8 @@ AND t.pixels.image.fileset.id = :id"""
                 fileset_param, ctx)[0][0].val
             if count > 0:
                 plural = "s" if count > 1 else ""
-                print(("thumbnail time of {:6.2f}s for "
-                       "{} thumbnail{} ({:.3f}s/thumbnail)")
+                print(("thumbnail time of {0:6.2f}s for "
+                       "{1} thumbnail{2} ({3:.3f}s/thumbnail)")
                       .format(time, count, plural, time/count))
 
 try:

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -1082,7 +1082,7 @@ class ImportTime:
             self.ice_ctx)
 
         if not results:
-            self.cli_ctx.die(30, 'Could not query for import log')
+            self.cli_ctx.die(30, 'Could not query for import log.')
 
         upload_job_id = results[0][0].val
         upload_start = results[0][1].val

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -1353,7 +1353,7 @@ class ImportTime:
         """Report how long it took to import an existing fileset"""
         metrics_keys = set(self.metrics)
 
-        if {'UPLOAD', 'UPLOAD_C'} <= metrics_keys:
+        if set(['UPLOAD', 'UPLOAD_C']) <= metrics_keys:
             time = self.metrics['UPLOAD'] / 1000.0
             count = self.metrics['UPLOAD_C']
             plural = "s" if count > 1 else ""
@@ -1367,7 +1367,7 @@ class ImportTime:
         time = self.metrics['METADATA'] / 1000.0
         print(" metadata time of {0:6.2f}s".format(time))
 
-        if {'PIXELDATA', 'PIXELDATA_C'} <= metrics_keys:
+        if set(['PIXELDATA', 'PIXELDATA_C']) <= metrics_keys:
             time = self.metrics['PIXELDATA'] / 1000.0
             count = self.metrics['PIXELDATA_C']
             plural = "s" if count > 1 else ""
@@ -1379,7 +1379,7 @@ class ImportTime:
             time = self.metrics['OVERLAY'] / 1000.0
             print(" overlays time of {0:6.2f}s".format(time))
 
-        if {'RDEF', 'RDEF_C'} <= metrics_keys:
+        if set(['RDEF', 'RDEF_C']) <= metrics_keys:
             time = self.metrics['RDEF'] / 1000.0
             count = self.metrics['RDEF_C']
             plural = "s" if count > 1 else ""
@@ -1387,7 +1387,7 @@ class ImportTime:
                    "{1} rendering setting{2} ({3:.3f}s/rdef)")
                   .format(time, count, plural, time/count))
 
-        if {'THUMBNAIL', 'THUMBNAIL_C'} <= metrics_keys:
+        if set(['THUMBNAIL', 'THUMBNAIL_C']) <= metrics_keys:
             time = self.metrics['THUMBNAIL'] / 1000.0
             count = self.metrics['THUMBNAIL_C']
             plural = "s" if count > 1 else ""

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -1187,37 +1187,34 @@ AND t.pixels.image.fileset.id = :id"""
         # Report the upload time, including per file.
 
         time = upload_end - upload_start
-        if time:
-            time /= 1000.0
-            count = query.projection(
-                "SELECT COUNT(*) FROM FilesetEntry " +
-                "WHERE fileset.id = :id",
-                fileset_param, ctx)[0][0].val
-            if count > 0:
-                plural = "s" if count > 1 else ""
-                print(("   upload time of {0:6.2f}s for "
-                       "{1} file{2} ({3:.3f}s/file)")
-                      .format(time, count, plural, time/count))
+        time /= 1000.0
+        count = query.projection(
+            "SELECT COUNT(*) FROM FilesetEntry " +
+            "WHERE fileset.id = :id",
+            fileset_param, ctx)[0][0].val
+        if count > 0:
+            plural = "s" if count > 1 else ""
+            print(("   upload time of {0:6.2f}s for "
+                   "{1} file{2} ({3:.3f}s/file)")
+                  .format(time, count, plural, time/count))
 
         # Report the Bio-Formats setId time.
 
         time = set_id_end - upload_end
-        if time:
-            time /= 1000.0
-            print("    setId time of {0:6.2f}s".format(time))
+        time /= 1000.0
+        print("    setId time of {0:6.2f}s".format(time))
 
         # Report the time to generate metadata.
 
         time = metadata_end - set_id_end
-        if time:
-            time /= 1000.0
-            print(" metadata time of {0:6.2f}s".format(time))
+        time /= 1000.0
+        print(" metadata time of {0:6.2f}s".format(time))
 
         # Report the time to generate pixel data.
-        # Does not take account of background pyramid building.
+        # If there are no rendering settings then pyramids must be built first.
 
-        time = pixeldata_end - metadata_end
-        if time:
+        if settings_start:
+            time = pixeldata_end - metadata_end
             time /= 1000.0
             count = query.projection(
                 "SELECT SUM(sizeC * sizeT * sizeZ) FROM Pixels " +

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -1018,12 +1018,13 @@ Examples:
 
         # Get the upload job ID and its creation time, and the import log ID.
 
-        hql = """
-SELECT u.id, u.details.creationEvent.time, jol.child.id
-FROM FilesetJobLink fjl, UploadJob u, JobOriginalFileLink jol
-WHERE :id = fjl.parent.id AND fjl.child = u AND u = jol.parent
-AND jol.child.mimetype = :mimetype
-ORDER BY u.id"""
+        hql = (
+            "SELECT u.id, u.details.creationEvent.time, jol.child.id "
+            "FROM FilesetJobLink fjl, UploadJob u, JobOriginalFileLink jol "
+            "WHERE :id = fjl.parent.id AND fjl.child = u AND u = jol.parent "
+            "AND jol.child.mimetype = :mimetype "
+            "ORDER BY u.id"
+        )
 
         results = query.projection(
             hql, ParametersI()
@@ -1041,12 +1042,13 @@ ORDER BY u.id"""
 
         # From the event log to find when the upload job was first updated.
 
-        hql = """
-SELECT event.time
-FROM EventLog
-WHERE action = :action
-AND entityType = :type AND entityId = :id
-ORDER BY id"""
+        hql = (
+            "SELECT event.time "
+            "FROM EventLog "
+            "WHERE action = :action "
+            "AND entityType = :type AND entityId = :id "
+            "ORDER BY id"
+        )
 
         results = query.projection(
             hql, ParametersI()
@@ -1064,12 +1066,13 @@ ORDER BY id"""
         # Find when the import log was updated.
         # Its size is set after each step.
 
-        hql = """
-SELECT id, event.time
-FROM EventLog
-WHERE action = :action
-AND entityType = :type AND entityId = :id
-ORDER BY id"""
+        hql = (
+            "SELECT id, event.time "
+            "FROM EventLog "
+            "WHERE action = :action "
+            "AND entityType = :type AND entityId = :id "
+            "ORDER BY id"
+        )
 
         results = query.projection(
             hql, ParametersI()
@@ -1093,12 +1096,13 @@ ORDER BY id"""
         # Used as an estimate for when setId completed.
         # Ignores any inserts that follow the metadata phase.
 
-        hql = """
-SELECT el.event.time
-FROM Image i, EventLog el
-WHERE el.id < :last AND el.action = :action
-AND el.entityType = :type AND el.entityId = i.id
-AND i.fileset.id = :id"""
+        hql = (
+            "SELECT el.event.time "
+            "FROM Image i, EventLog el "
+            "WHERE el.id < :last AND el.action = :action "
+            "AND el.entityType = :type AND el.entityId = i.id "
+            "AND i.fileset.id = :id"
+        )
 
         results = query.projection(
             hql, ParametersI()
@@ -1117,12 +1121,13 @@ AND i.fileset.id = :id"""
         # Find when any ROIs were created during the thumbnails step.
         # These would be overlays as one finds with MIAS plates.
 
-        hql = """
-SELECT el.event.time
-FROM Roi r, EventLog el
-WHERE el.id > :first AND el.id < :last AND el.action = :action
-AND el.entityType = :type AND el.entityId = r.id
-AND r.image.fileset.id = :id"""
+        hql = (
+            "SELECT el.event.time "
+            "FROM Roi r, EventLog el "
+            "WHERE el.id > :first AND el.id < :last AND el.action = :action "
+            "AND el.entityType = :type AND el.entityId = r.id "
+            "AND r.image.fileset.id = :id"
+        )
 
         results = query.projection(
             hql, ParametersI()
@@ -1139,12 +1144,13 @@ AND r.image.fileset.id = :id"""
         # Find when any rendering settings were created during the thumbnails
         # step. These are created if the thumbnails can already be generated.
 
-        hql = """
-SELECT el.event.time
-FROM RenderingDef r, EventLog el
-WHERE el.id > :first AND el.id < :last AND el.action = :action
-AND el.entityType = :type AND el.entityId = r.id
-AND r.pixels.image.fileset.id = :id"""
+        hql = (
+            "SELECT el.event.time "
+            "FROM RenderingDef r, EventLog el "
+            "WHERE el.id > :first AND el.id < :last AND el.action = :action "
+            "AND el.entityType = :type AND el.entityId = r.id "
+            "AND r.pixels.image.fileset.id = :id"
+        )
 
         results = query.projection(
             hql, ParametersI()
@@ -1161,12 +1167,13 @@ AND r.pixels.image.fileset.id = :id"""
         # Find when any thumbnails were created during the thumbnails step.
         # These are created even if it is not yet possible to generate them.
 
-        hql = """
-SELECT el.event.time
-FROM Thumbnail t, EventLog el
-WHERE el.id > :first AND el.id < :last AND el.action = :action
-AND el.entityType = :type AND el.entityId = t.id
-AND t.pixels.image.fileset.id = :id"""
+        hql = (
+            "SELECT el.event.time "
+            "FROM Thumbnail t, EventLog el "
+            "WHERE el.id > :first AND el.id < :last AND el.action = :action "
+            "AND el.entityType = :type AND el.entityId = t.id "
+            "AND t.pixels.image.fileset.id = :id"
+        )
 
         results = query.projection(
             hql, ParametersI()

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -1045,7 +1045,7 @@ Examples:
             if count > 0:
                 plural = "s" if count > 1 else ""
                 print(("   upload time of {:6.2f}s for "
-                       "{} file{} ({:.2f}s/file)")
+                       "{} file{} ({:.3f}s/file)")
                       .format(time, count, plural, time/count))
 
         time = rsp.durations.get('SET_ID')
@@ -1068,7 +1068,7 @@ Examples:
             if count > 0:
                 plural = "s" if count > 1 else ""
                 print(("   pixels time of {:6.2f}s for "
-                       "{} plane{} ({:.2f}s/plane)")
+                       "{} plane{} ({:.3f}s/plane)")
                       .format(time, count, plural, time/count))
 
         time = rsp.durations.get('OVERLAYS')
@@ -1087,7 +1087,7 @@ Examples:
             if count > 0:
                 plural = "s" if count > 1 else ""
                 print(("    rdefs time of {:6.2f}s for "
-                       "{} rendering setting{} ({:.2f}s/rdef)")
+                       "{} rendering setting{} ({:.3f}s/rdef)")
                       .format(time, count, plural, time/count))
 
         time = rsp.durations.get('THUMBNAILS')
@@ -1101,7 +1101,7 @@ Examples:
             if count > 0:
                 plural = "s" if count > 1 else ""
                 print(("thumbnail time of {:6.2f}s for "
-                       "{} thumbnail{} ({:.2f}s/thumbnail)")
+                       "{} thumbnail{} ({:.3f}s/thumbnail)")
                       .format(time, count, plural, time/count))
 
         time = rsp.durations.get('PYRAMIDS')

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -1019,7 +1019,7 @@ Examples:
         import_time = ImportTime(self.ctx, client.sf.getQueryService())
         if args.fileset:
             if args.summary:
-                raise Exception("no summary if fileset provided")
+                self.ctx.die(28, "no summary if fileset provided")
             import_time.fileset_id = args.fileset.id
             import_time.get_cache()
             if not import_time.metrics:
@@ -1031,7 +1031,7 @@ Examples:
         elif args.summary:
             import_time.print_summary()
         else:
-            raise Exception("provide fileset or request summary")
+            self.ctx.die(29, "provide fileset or request summary")
 
 
 class ImportTime:
@@ -1082,7 +1082,7 @@ class ImportTime:
             self.ice_ctx)
 
         if not results:
-            raise Exception('Could not query for import log')
+            self.cli_ctx.die(30, 'Could not query for import log')
 
         upload_job_id = results[0][0].val
         upload_start = results[0][1].val
@@ -1107,7 +1107,7 @@ class ImportTime:
             self.ice_ctx)
 
         if not results:
-            raise Exception('Upload job is created but not yet updated.')
+            self.cli_ctx.die(31, 'Upload job is created but not yet updated.')
 
         upload_end = results[0][0].val
 
@@ -1131,7 +1131,7 @@ class ImportTime:
             self.ice_ctx)
 
         if not results or len(results) < 3:
-            raise Exception('Thumbnails step is not yet finished.')
+            self.cli_ctx.die(32, 'Thumbnails step is not yet finished.')
 
         metadata_before_id = results[0][0]
         pixeldata_before_id = results[1][0]
@@ -1162,7 +1162,7 @@ class ImportTime:
             self.ice_ctx)
 
         if not results:
-            raise Exception('Could not find images from metadata step.')
+            self.cli_ctx.die(33, 'Could not find images from metadata step.')
 
         set_id_end = results[0][0].val
 


### PR DESCRIPTION
# What this PR does

Adds a new "fs importtime" subcommand to OMERO.cli which attempts to estimate how long various import phases took.

# Testing this PR

Provide a fileset ID as an argument. Try for various kinds of import. Check the plausibility of the results. Small inaccuracies are fine. Pyramids are not reported on. There should be no exceptions from querying about vanilla fully imported filesets.

- `bin/omero fs importtime 123` pretty-prints stats for fileset 123
- `bin/omero fs importtime --cache 123` pretty-prints *and caches* stats for fileset 123
- `bin/omero fs importtime --summary` outputs CSV of cached raw stats

# Related reading

https://docs.google.com/document/d/1e3jeIlYxzI9w5hEdD008gvIH6Q70xig7nplzmaaIpw8/edit