### PR TITLE
 strToMapAnnotation.m components\tools\OmeroM\src\helper

### DIFF
--- a/components/tools/OmeroM/src/annotations/writeMapAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeMapAnnotation.m
@@ -46,16 +46,19 @@ function ma = writeMapAnnotation(session, keys, values, varargin)
 % Input check
 ip = inputParser;
 ip.addRequired('session');
-ip.addRequired('keys', @(x) ischar(x) || iscellstr(x));
-ip.addRequired('values', @(x) ischar(x) || iscellstr(x));
-ip.addParamValue('namespace', '', @ischar);
-ip.addParamValue('description', '', @ischar);
-ip.addParamValue('group', [], @(x) isscalar(x) && isnumeric(x));
+ip.addRequired('keys', @(x) ischar(x) || iscellstr(x) || isstring(x));
+ip.addRequired('values', @(x) ischar(x) || iscellstr(x) || isstring(x));
+ip.addParameter('namespace', '', @ischar);
+ip.addParameter('description', '', @ischar);
+ip.addParameter('group', [], @(x) isscalar(x) && isnumeric(x));
 ip.parse(session, keys, values, varargin{:});
 
 % Convert keys and values into cell arrays
 if ischar(keys), keys = {keys}; end
 if ischar(values), values = {values}; end
+if isstring(keys), keys = cellstr(keys); end
+if isstring(values),values = cellstr(values); end
+
 assert(numel(keys) == numel(values),...
     'Keys and values input should have the same number of elements');
 
@@ -69,11 +72,11 @@ end
 ma = omero.model.MapAnnotationI();
 ma.setMapValue(nv);
 
-if ~isempty(ip.Results.description),
+if ~isempty(ip.Results.description)
     ma.setDescription(rstring(ip.Results.description));
 end
 
-if ~isempty(ip.Results.namespace),
+if ~isempty(ip.Results.namespace)
     ma.setNs(rstring(ip.Results.namespace))
 end
 

--- a/components/tools/OmeroM/src/annotations/writeMapAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/writeMapAnnotation.m
@@ -46,8 +46,13 @@ function ma = writeMapAnnotation(session, keys, values, varargin)
 % Input check
 ip = inputParser;
 ip.addRequired('session');
-ip.addRequired('keys', @(x) ischar(x) || iscellstr(x) || isstring(x));
-ip.addRequired('values', @(x) ischar(x) || iscellstr(x) || isstring(x));
+if verLessThan('matlab','9.1.0')
+    ip.addRequired('keys', @(x) ischar(x) || iscellstr(x)); %#ok<ISCLSTR>
+    ip.addRequired('values', @(x) ischar(x) || iscellstr(x)); %#ok<ISCLSTR>
+else
+    ip.addRequired('keys', @(x) ischar(x) || iscellstr(x) || isstring(x));
+    ip.addRequired('values', @(x) ischar(x) || iscellstr(x) || isstring(x));
+end
 ip.addParameter('namespace', '', @ischar);
 ip.addParameter('description', '', @ischar);
 ip.addParameter('group', [], @(x) isscalar(x) && isnumeric(x));
@@ -56,8 +61,10 @@ ip.parse(session, keys, values, varargin{:});
 % Convert keys and values into cell arrays
 if ischar(keys), keys = {keys}; end
 if ischar(values), values = {values}; end
-if isstring(keys), keys = cellstr(keys); end
-if isstring(values),values = cellstr(values); end
+if ~verLessThan('matlab','9.1.0')
+    if isstring(keys), keys = cellstr(keys); end
+    if isstring(values),values = cellstr(values); end
+end
 
 assert(numel(keys) == numel(values),...
     'Keys and values input should have the same number of elements');

--- a/components/tools/OmeroM/src/helper/mapAnnotationToCellstr.m
+++ b/components/tools/OmeroM/src/helper/mapAnnotationToCellstr.m
@@ -1,0 +1,49 @@
+function str = mapAnnotationToCellstr(ma)
+% mapAnnotationToStr returns MapAnnotation object of OMERO from
+% cell array of strings
+%
+% SYNTAX
+% str = mapAnnotationToStr(ma)
+%
+% REQUIREMENTS
+%
+%   OMERO.matlab toolbox
+%   https://docs.openmicroscopy.org/latest/omero/developers/Matlab.html
+%
+%   Before using this function, you need to run an equivalent of the
+%   following command.
+%
+%     client = loadOmero('demo.openmicroscopy.org', 4064)
+%
+% INPUT ARGUMENTS
+% ma          MapAnnotationI object
+%
+% OUTPUT ARGUMENTS
+% str         cell array of strings
+%             The number of columns is 2.
+%
+% Written by Kouichi C. Nakamura Ph.D.
+% MRC Brain Network Dynamics Unit
+% University of Oxford
+% kouichi.c.nakamura@gmail.com
+% 26-Jun-2018 17:22:17
+%
+% See also
+% linkAnnotation, strToMapAnnotation
+
+p = inputParser;
+p.addRequired('ma',@(x) isa(x,'omero.model.MapAnnotationI'));
+p.parse(ma);
+
+
+mv = ma.getMapValue;
+
+str = cell(size(mv),2);
+
+for i = 1:size(mv)
+    
+   str{i,1} = char(mv.get(i-1).name);
+   str{i,2} = char(mv.get(i-1).value);
+    
+end
+

--- a/components/tools/OmeroM/src/helper/strToMapAnnotation.m
+++ b/components/tools/OmeroM/src/helper/strToMapAnnotation.m
@@ -22,11 +22,11 @@ function ma = strToMapAnnotation(session, str, varargin)
 % str         string array | cell array of strings
 %             Number of columns must be 2.
 %
-% iseditable  false (default) | true | 0 | 1 
+% iseditable  false (default) | true | 0 | 1
 %             (Optional) If true or 1, MapAnnotation (Key-Value Pairs) will
 %             be editable via GUI (OMERO.web or OMERO.insight)
 %
-% OPTIONAL PARA<ETER/VALUE PAIRS
+% OPTIONAL PARAMETER/VALUE PAIRS
 % 'description'
 %             char
 %             Description for the MapAnnotation
@@ -36,7 +36,7 @@ function ma = strToMapAnnotation(session, str, varargin)
 % ma          MapAnnotationI object
 %             To link ma to an image in OMERO, identify image ID from OMERO
 %             GUI and execute the following command
-%     
+%
 %               client = loadOmero('demo.openmicroscopy.org', 4064)
 %               session = client.createSession(username, password)
 %
@@ -75,10 +75,10 @@ description = p.Results.description;
 
 %% Job
 
-if ~verLessThan('matlab','9.1.0') && isstring(str) 
-    
+if ~verLessThan('matlab','9.1.0') && isstring(str)
+
    str = cellstr(str);
-    
+
 end
 
 
@@ -97,4 +97,3 @@ ma = writeMapAnnotation(session,...
 
 
 end
-

--- a/components/tools/OmeroM/src/helper/strToMapAnnotation.m
+++ b/components/tools/OmeroM/src/helper/strToMapAnnotation.m
@@ -56,22 +56,28 @@ function ma = strToMapAnnotation(session, str, varargin)
 
 p = inputParser;
 p.addRequired('session',@(x) isscalar(x));
-p.addRequired('str',@(x) (size(str,2) ==2 || size(str,2) == 3) ...
-    && iscellstr(x) || isstring(x) );
+
+if verLessThan('matlab','9.1.0')
+    p.addRequired('str',@(x) (size(str,2) ==2 || size(str,2) == 3) ...
+        && iscellstr(x));  %#ok<ISCLSTR>
+else
+    p.addRequired('str',@(x) (size(str,2) ==2 || size(str,2) == 3) ...
+        && iscellstr(x) || isstring(x) );
+end
 p.addOptional('iseditable',false,@(x) isscalar(x) && x == 1 || x == 0);
 p.addParameter('description', '', @ischar);
 
 p.parse(session,str,varargin{:});
 
-iseditable = p.Results.iseditable;
+iseditable  = p.Results.iseditable;
 description = p.Results.description;
 
 
 %% Job
 
-if iscellstr(str) %#ok<ISCLSTR>
+if ~verLessThan('matlab','9.1.0') && isstring(str) 
     
-   str = string(str);
+   str = cellstr(str);
     
 end
 

--- a/components/tools/OmeroM/src/helper/strToMapAnnotation.m
+++ b/components/tools/OmeroM/src/helper/strToMapAnnotation.m
@@ -1,0 +1,95 @@
+function ma = strToMapAnnotation(str, varargin)
+% strToMapAnnotation returns MapAnnotation object of OMERO from
+% string array or cell array of strings
+%
+% SYNTAX
+% ma = strToMapAnnotation(str)
+% ma = strToMapAnnotation(str,iseditable)
+%
+% REQUIREMENTS
+%
+%   OMERO.matlab toolbox
+%   https://docs.openmicroscopy.org/latest/omero/developers/Matlab.html
+%
+%   Before using this function, you need to run an equivalent of the
+%   following command.
+%
+%     client = loadOmero('demo.openmicroscopy.org', 4064)
+%
+% INPUT ARGUMENTS
+% str         string array | cell array of strings
+%             Number of columns must be 2.
+%
+% iseditable  false (default) | true | 0 | 1 
+%             (Optional) If true or 1, MapAnnotation (Key-Value Pairs) will
+%             be editable via GUI (OMERO.web or OMERO.insight)
+%
+%
+%
+% OUTPUT ARGUMENTS
+% ma          MapAnnotationI object
+%             To link ma to an image in OMERO, identify image ID from OMERO
+%             GUI and execute the following command
+%     
+%               client = loadOmero('demo.openmicroscopy.org', 4064)
+%               session = client.createSession(username, password)
+%
+%               link1 = linkAnnotation(session, ma, 'image', imageID);
+%
+%               clear
+%               unloadOmero
+%
+% Written by Kouichi C. Nakamura Ph.D.
+% MRC Brain Network Dynamics Unit
+% University of Oxford
+% kouichi.c.nakamura@gmail.com
+% 09-Jun-2018 15:20:17
+%
+% See also
+% linkAnnotation
+
+p = inputParser;
+p.addRequired('str',@(x) size(str,2) ==2 && iscellstr(x) || isstring(x) );
+p.addOptional('iseditable',false,@(x) isscalar(x) && x == 1 || x == 0);
+
+p.parse(str,varargin{:});
+
+iseditable = p.Results.iseditable;
+
+
+%% Job
+
+if iscellstr(str) %#ok<ISCLSTR>
+    
+   str = string(str);
+    
+end
+
+
+import java.util.ArrayList
+eval('import omero.model.NamedValue')
+
+li = ArrayList;
+
+for r = 1:size(str,1)
+    
+    li.add(NamedValue(str{r,1},str{r,2}));
+
+end
+
+eval('import omero.model.MapAnnotationI')
+
+ma = MapAnnotationI(int64(1),true); % 'false' results in Java exception occurred: omero.UnloadedEntityException:
+ma.setMapValue(li);
+
+if iseditable
+    %NOTE this is required to make it editable from GUI
+    eval('import omero.constants.metadata.NSCLIENTMAPANNOTATION')
+    ma.setNs(rstring(NSCLIENTMAPANNOTATION.value));
+end
+
+
+
+
+end
+


### PR DESCRIPTION
 mapAnnotationToCellstr.m components\tools\OmeroM\src\helper

# What this PR does

The two MATLAB functions were added to assist manipulation of MapAnnoation objects in MATLAB.
 
strToMapAnnotation.m components\tools\OmeroM\src\helper
 mapAnnotationToCellstr.m components\tools\OmeroM\src\helper

# Testing this PR

1. required setup
None particularly.

2. actions to perform

```matlab
client = loadOmero('demo.openmicroscopy.org', 4064)

str = ["hoge","bar"; "boo","hoo"; "poo",""];
ma = strToMapAnnotation(str)
str2 = mapAnnotationToCellstr(ma)
```

3. expected observations

ma is `omero.model.MapAnnotationI` object.
str2 is a cell array of chars.


# Related reading

Link to cards, tickets, other PRs:

1. background for understanding this PR

Handling of MapAnnotation in MATLAB was cumbersome.

2. what this PR assists, fixes, or otherwise affects

Addition of these functions will simplify the task of editing MapAnnotation objects.