### PR TITLE
adjust help.o.org links to https

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,7 @@
 
 Full documentation is hosted at https://docs.openmicroscopy.org/latest/omero/
 
-User help guides are available at http://help.openmicroscopy.org
+User help guides are available at https://help.openmicroscopy.org/
 
 If you need to contact us for further assistance, please see the
 [support page](https://www.openmicroscopy.org/support/) - our preferred

--- a/components/insight/config/container.xml
+++ b/components/insight/config/container.xml
@@ -307,8 +307,8 @@
     <entry name="Version">@OMERO_DISPLAY_VERSION@</entry>
     <entry name="SoftwareName">OMERO.insight</entry>
     <entry name="AboutFile">about.xml</entry>
-    <entry name="HelpOnLine">http://help.openmicroscopy.org/</entry>
-    <entry name="HelpOnLineSearch">http://help.openmicroscopy.org/search.html</entry>
+    <entry name="HelpOnLine">https://help.openmicroscopy.org/</entry>
+    <entry name="HelpOnLineSearch">https://help.openmicroscopy.org/search.html</entry>
     <entry name="Forum">https://www.openmicroscopy.org/community/</entry>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/insight/config/containerImporter.xml
+++ b/components/insight/config/containerImporter.xml
@@ -298,7 +298,7 @@
   <entry name="Version">@OMERO_DISPLAY_VERSION@</entry>
   <entry name="SoftwareName">OMERO.importer</entry>
   <entry name="AboutFile">about.xml</entry>
-  <entry name="HelpOnLine">http://help.openmicroscopy.org/</entry>
+  <entry name="HelpOnLine">https://help.openmicroscopy.org/</entry>
   <entry name="Forum">https://www.openmicroscopy.org/community/</entry>
 
   <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -207,7 +207,7 @@ class ConfigXml(object):
                                  "Browse Data via Projects, Tags etc"}],
                             ["History", "history",
                                 {"title": "History"}],
-                            ["Help", "http://help.openmicroscopy.org/",
+                            ["Help", "https://help.openmicroscopy.org/",
                                 {"target": "new", "title":
                                     "Open OMERO user guide in a new tab"}]]
                         toplinks = defaultlinks + toplinks

--- a/components/tools/OmeroPy/test/unit/test_config.py
+++ b/components/tools/OmeroPy/test/unit/test_config.py
@@ -259,7 +259,7 @@ class TestConfig(object):
             '{"title": "Browse Data via Projects, Tags etc"}], ' \
             '["History", "history", ' \
             '{"title": "History"}], ' \
-            '["Help", "http://help.openmicroscopy.org/", ' \
+            '["Help", "https://help.openmicroscopy.org/", ' \
             '{"target": "new", "title": ' \
             '"Open OMERO user guide in a new tab"}], ' \
             '["Figure", "figure_index"]]'

--- a/components/tools/OmeroWeb/omeroweb/feedback/templates/comment.html
+++ b/components/tools/OmeroWeb/omeroweb/feedback/templates/comment.html
@@ -35,7 +35,7 @@
         
         <ul style="list-style: disc inside none">
             <li>
-                <a href="http://help.openmicroscopy.org/">User Assistance</a>:
+                <a href="https://help.openmicroscopy.org/">User Assistance</a>:
                 More information about the OMERO clients.
             </li>
             <li>

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -682,7 +682,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
           '["Data", "webindex", {"title": "Browse Data via Projects, Tags'
           ' etc"}],'
           '["History", "history", {"title": "History"}],'
-          '["Help", "http://help.openmicroscopy.org/",'
+          '["Help", "https://help.openmicroscopy.org/",'
           '{"title":"Open OMERO user guide in a new tab", "target":"new"}]'
           ']'),
          json.loads,

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -254,7 +254,7 @@
                 <br>
                 <div>
                     For more info, see the
-                    <a title="Open link in new Tab" target="new" href="http://help.openmicroscopy.org/search.html">
+                    <a title="Open link in new Tab" target="new" href="https://help.openmicroscopy.org/search.html">
                         User Help</a>
                     pages.
                 </div>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
@@ -843,7 +843,7 @@ class AutoLockFile (file):
     """
 
     def __init__(self, fn, mode):
-        """ creates a '.lock' file with the spicified file name and mode """
+        """ creates a '.lock' file with the specified file name and mode """
         super(AutoLockFile, self).__init__(fn, mode)
         self._lock = os.path.join(os.path.dirname(fn), '.lock')
         file(self._lock, 'a').close()

--- a/components/tools/OmeroWeb/test/unit/test_render_response.py
+++ b/components/tools/OmeroWeb/test/unit/test_render_response.py
@@ -59,7 +59,7 @@ class TestRenderResponse(object):
                 'attrs': {u'title': u'History'},
                 'label': u'History'
             }, {
-                'link': u'http://help.openmicroscopy.org/',
+                'link': u'https://help.openmicroscopy.org/',
                 'attrs': {
                     u'target': u'new',
                     u'title': u'Open OMERO user guide in a new tab'


### PR DESCRIPTION
Switches links to help.openmicroscopy.org to use TLS. See https://trello.com/c/mTAsiIpK/4014-help-website-has-bad-certificate.