### PR TITLE
disable pyramid building on read-only servers

### DIFF
--- a/components/server/resources/ome/services/pixeldata.xml
+++ b/components/server/resources/ome/services/pixeldata.xml
@@ -41,6 +41,13 @@
     <property name="cronExpression" value="${omero.pixeldata.cron}" />
   </bean>
 
+  <bean id="pixelDataTriggerGuard" class="ome.services.util.BeanInstantiationGuard" depends-on="executor">
+    <constructor-arg ref="readOnlyStatus"/>
+    <constructor-arg value="pixelDataTrigger"/>
+    <property name="isWriteDb" value="true"/>
+    <property name="isWriteRepo" value="true"/>
+  </bean>
+
   <!-- used by session factory -->
   <bean id="org.hibernate.EmptyInterceptor.INSTANCE"
     class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean"/>

--- a/components/server/resources/ome/services/service-ome.io.nio.PixelData.xml
+++ b/components/server/resources/ome/services/service-ome.io.nio.PixelData.xml
@@ -27,6 +27,7 @@
     <constructor-arg index="3" ref="uuid"/>
     <constructor-arg index="4" value="${omero.pixeldata.threads}"/>
     <constructor-arg index="5" ref="metrics"/>
+    <constructor-arg index="6" ref="readOnlyStatus"/>
   </bean>
 
   <bean id="pixelDataHandler" class="ome.services.pixeldata.PixelDataHandler">


### PR DESCRIPTION
# What this PR does

For read-only servers disables the periodic triggering of pixel thread runs and ignores missing pyramid messages.

# Testing this PR

Check for functionality regressions in the pixels service or new complaints in logs, especially with importing images like `8kx8k.jpg`. Include a multi-server setup in which read-write and read-only coexist.

# Related reading

https://trello.com/c/xXQSXhzw/14-read-only-pixeldata-thread