### PR TITLE
Link annotation

### DIFF
--- a/components/tools/OmeroM/src/annotations/linkAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/linkAnnotation.m
@@ -5,11 +5,31 @@ function link = linkAnnotation(session, annotation, parentType, parentId)
 %    a link between the input annotation to the object of the input type
 %    specified by the input identifier and owned by the session user.
 %
-%    Examples:
 %
-%        link = linkAnnotation(session, annotation, parentType, parentId)
+% SYNTAX
+% link = linkAnnotation(session, annotation, parentType, parentId)
 %
-% See also:
+% INPUT ARGUMENTS
+% session     omero.api.ServiceFactoryPrxHelper object
+%
+%               client = loadOmero('demo.openmicroscopy.org', 4064)
+%               session = client.createSession(username, password)
+%
+%
+% annotation  an omero.model.Annotation object 
+%             
+% parentType  'project' | 'dataset' | 'image' | 'screem' | 'plate' |
+%             'plateacquisition' | 'roi'
+%             Depends on output of getObjectTypes()
+%
+% parentId    a scalar or vector positive integers
+%             Id numbers of parent objects.
+%
+%
+% OUTPUT ARGUMENTS
+% link       omero.model.ImageAnnotationLinkI object 
+%
+% See also
 
 % Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
 % All rights reserved.

--- a/components/tools/OmeroM/src/annotations/linkAnnotation.m
+++ b/components/tools/OmeroM/src/annotations/linkAnnotation.m
@@ -51,12 +51,15 @@ else
     parent = parentId;
 end
 
-% Create object annotation link
-context = java.util.HashMap;
-group = parent.getDetails().getGroup().getId().getValue();
-context.put('omero.group', java.lang.String(num2str(group)));
+for i = 1:numel(parent)
+    % Create object annotation link
+    context = java.util.HashMap;
+    group = parent(i).getDetails().getGroup().getId().getValue();
+    context.put('omero.group', java.lang.String(num2str(group)));
+    
+    link = objectType.annotationLink();
+    link.setParent(parent(i))
+    link.setChild(annotation);
+    link = session.getUpdateService().saveAndReturnObject(link, context);
 
-link = objectType.annotationLink();
-link.setParent(parent)
-link.setChild(annotation);
-link = session.getUpdateService().saveAndReturnObject(link, context);
+end


### PR DESCRIPTION
# What this PR does

linkAnnotation supports parentID as a vector.

The input validation for parent ID accepts vector but running the function with parentID as a vector issued an error.
  
https://github.com/openmicroscopy/openmicroscopy/blob/c60092a554f8295c2992c407a94a2623011306b5/components/tools/OmeroM/src/annotations/linkAnnotation.m#L38

To avoid this issue, I added a `for` loop.

# Testing this PR

1. required setup

You need at least two images as parents of a tag annotation.

2. actions to perform

```matlab
eval('import omero.model.TagAnnotationI')

tag1 = TagAnnotationI;
tag1.setTextValue(rstring('Super cool'));

img_ids = [1 2]; % two images

linkAnnotation(session, tag1, 'image', img_ids );

```


3. expected observations

The modified version of linkAnnotation should link the tag to three images.


# Related reading

Link to cards, tickets, other PRs:

1. background for understanding this PR

Although `InputParser` of `linkAnnotation` accepts `parentID` as vector, it was not supported.

2. what this PR assists, fixes, or otherwise affects

Part of the problem was the poor documentation, so I added a lot more specifications to the comments.
