### PR TITLE
temporarily disable bin/omero fs rename

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -497,6 +497,9 @@ template. By default the original files and import log are also
 moved.
 """
 
+        # See https://trello.com/c/J3LNquSH/ for more information.
+        raise Exception('disabled since OMERO 5.4.7 due to Pixels.path bug')
+
         fid = args.fileset.id.val
         client = self.ctx.conn(args)
         uid = self.ctx.get_event_context().userId

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -499,6 +499,7 @@ moved.
 """
 
         # See https://trello.com/c/J3LNquSH/ for more information.
+        # When reenabling, also reenable testRenameAdminOnly.
         self.ctx.die(30, 'disabled since OMERO 5.4.7 due to Pixels.path bug')
         # Keep privilege imports used until @admin_only decorator restored.
         [AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -486,8 +486,9 @@ omero.fs.repo.path are all set to be owned by the root user.
         mrepo.makeDir(args.new_dir, args.parents)
 
     @windows_warning
-    @admin_only(AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
-                AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo)
+    # Remove decorator from disabled rename to more promptly raise Exception.
+    # @admin_only(AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
+    #             AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo)
     def rename(self, args):
         """Moves an existing fileset to a new location (admin-only)
 
@@ -499,6 +500,9 @@ moved.
 
         # See https://trello.com/c/J3LNquSH/ for more information.
         raise Exception('disabled since OMERO 5.4.7 due to Pixels.path bug')
+        # Keep privilege imports used until @admin_only decorator restored.
+        [AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
+         AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo]
 
         fid = args.fileset.id.val
         client = self.ctx.conn(args)

--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -499,7 +499,7 @@ moved.
 """
 
         # See https://trello.com/c/J3LNquSH/ for more information.
-        raise Exception('disabled since OMERO 5.4.7 due to Pixels.path bug')
+        self.ctx.die(30, 'disabled since OMERO 5.4.7 due to Pixels.path bug')
         # Keep privilege imports used until @admin_only decorator restored.
         [AdminPrivilegeWriteOwned, AdminPrivilegeWriteManagedRepo,
          AdminPrivilegeDeleteOwned, AdminPrivilegeDeleteManagedRepo]

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -107,6 +107,7 @@ class TestFS(CLITest):
         out, err = capsys.readouterr()
         assert err.endswith("SecurityViolation: Admins only!\n")
 
+    @pytest.mark.broken(reason="fs rename is temporarily disabled")
     def testRenameAdminOnly(self, capsys):
         """Test fs rename is admin-only"""
 


### PR DESCRIPTION
# What this PR does

Disables `fs rename` in CLI because it makes images' pixel data unreadable.

Takes a simple, expedient approach. We should fix this promptly and I suspect nobody uses it anyway.

# Testing this PR

Check that `fs rename` now raises an exception with a related message.

# Related reading

https://trello.com/c/J3LNquSH/1-bug-omero-fs-rename