### PR TITLE
in webadmin gray out user role when editing root user

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/forms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2008-2014 University of Dundee.
+# Copyright (c) 2008-2018 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -151,7 +151,8 @@ class ExperimenterForm(NonASCIIForm):
             initial='user')
         # If current user is restricted Admin, can't create full Admin
         restricted_admin = "ReadSession" not in self.user_privileges
-        self.fields['role'].widget.renderer.disable_admin = restricted_admin
+        self.fields['role'].widget.renderer.disable_admin = \
+            restricted_admin or experimenter_root
 
         if ('with_password' in kwargs['initial'] and
                 kwargs['initial']['with_password']):

--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -3,7 +3,7 @@
 #
 #
 #
-# Copyright (c) 2008-2014 University of Dundee.
+# Copyright (c) 2008-2018 University of Dundee.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -506,7 +506,7 @@ def manage_experimenter(request, action, eid=None, conn=None, **kwargs):
                 role = 'restricted_administrator'
         initial['role'] = role
 
-        root_id = [conn.getAdminService().getSecurityRoles().rootId]
+        root_id = conn.getAdminService().getSecurityRoles().rootId
         user_id = conn.getUserId()
         experimenter_root = long(eid) == root_id
         experimenter_me = long(eid) == user_id


### PR DESCRIPTION
In webadmin adjusts user editing form so that one may not choose to downgrade root user from full admin. See https://trello.com/c/oJPTE5vq/2-bug-edit-root-user.