### PR TITLE
If no tty check for missing and incorrect passwords

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/sessions.py
+++ b/components/tools/OmeroPy/src/omero/plugins/sessions.py
@@ -511,15 +511,13 @@ class SessionsControl(UserGroupControl):
             if not pasw:
                 pasw = os.getenv("OMERO_PASSWORD")
 
-            if not pasw:
-                # Note: duplicating the `not pasw` check here
-                # for an overall nicer error message.
-                self._require_tty("cannot request password")
-
             tries = 3
             while True:
                 try:
                     if not pasw:
+                        # Handle absent and incorrect passwords in
+                        # non-interactive mode
+                        self._require_tty("cannot request password")
                         if args.sudo:
                             prompt = "Password for %s:" % args.sudo
                         else:


### PR DESCRIPTION
# What this PR does

Follow-up to #5359. Previously you'd be prompted in non-interactive mode if an *incorrect* password was given on the command line or as an env-var. Now this case should be handled in addition to the cases handled in #5359.

# Testing this PR

All these should return an error message instead of displaying a password prompt:
```
    echo | bin/omero login
    echo | bin/omero login localhost
    echo | bin/omero login root@localhost
    echo | bin/omero login root@localhost -w incorrectpassword
```
# Related reading

Link to cards, tickets, other PRs:

- #5359
- https://trello.com/c/mUAfr6kf/60-bin-omero-should-fail-if-not-logged-in-and-no-stdin