### PR TITLE
Preview pane large channel count features

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -541,10 +541,21 @@
         //border-left: solid 1px hsl(210,10%,85%);
         min-width:240px;
     }
-    
-   
-   
-   
+
+    #preview_tab .right_tab_inner {
+        display: flex;
+        flex-direction: column;
+    }
+
+    #preview_tab .right_tab_inner > * {
+        flex-shrink: 0;
+    }
+
+    #preview_tab .right_tab_inner #rdef-container {
+        flex-shrink: 1;
+        overflow-y: auto;
+    }
+
     /* Seperator */
     
     hr {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -448,10 +448,14 @@
     <div id="rdef-container">
       <div id="rdef-postit">
         <div id="rdef-active-area">
-          <input id="rd-wblitz-rmodel" type="checkbox" />
-          <label for="rd-wblitz-rmodel">Grayscale</label>
-          <input id="showactive" title="Show only active channels" type="checkbox" />
-          <label for="showactive">Active</label>
+          <label title="Enable grayscale rendering mode">
+            <input id="rd-wblitz-rmodel" type="checkbox" />
+            Grayscale
+          </label>
+          <label title="Show only active channels">
+            <input id="showactive" type="checkbox" />
+            Active
+          </label>
           <div style="float:right {% if tiledImage %}; color:#bbb{%endif%}"
             {% if tiledImage or share %}
               title="Histogram not supported for tiled images or in share"

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -185,6 +185,12 @@
               setModel(OME.preview_viewport, $(this).get(0).checked?'g':'c');
             });
 
+            // handle 'Active' checkbox
+            $('#showactive').click(function(e){
+              $("#preview_tab #rdef-active-area table tr.rdef-window:not(:has(button.pressed))")
+                  .css({'display': this.checked? 'none' : ''});
+            });
+
             // Save settings
             $("#rdef-setdef-btn").click(function(){
               setImageDefaults(OME.preview_viewport, this, function() {
@@ -444,6 +450,8 @@
         <div id="rdef-active-area">
           <input id="rd-wblitz-rmodel" type="checkbox" />
           <label for="rd-wblitz-rmodel">Grayscale</label>
+          <input id="showactive" title="Show only active channels" type="checkbox" />
+          <label for="showactive">Active</label>
           <div style="float:right {% if tiledImage %}; color:#bbb{%endif%}"
             {% if tiledImage or share %}
               title="Histogram not supported for tiled images or in share"

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -371,6 +371,7 @@
 	
 <!-- open-image link -->
 
+    <div>
 			<a id="preview_open_viewer"
         href="{% if share and not share.share.isOwned %}{% url 'web_image_viewer' share.share.id manager.image.id %}{% else %}{% url 'web_image_viewer' manager.image.id %}{% endif %}"
         class="btn silver btn_text" alt="View"
@@ -379,6 +380,7 @@
                 {% trans "Full viewer" %} 
 				</span>
 			</a>
+    </div>
 
     <div style="clear:both; margin-bottom: 3px"></div>
 
@@ -437,59 +439,61 @@
       </button></li>
     </ul>
 
-    <div id="rdef-postit">
-      <div id="rdef-active-area">
-        <input id="rd-wblitz-rmodel" type="checkbox" />
-        <label for="rd-wblitz-rmodel">Grayscale</label>
-        <div style="float:right {% if tiledImage %}; color:#bbb{%endif%}"
-          {% if tiledImage or share %}
-            title="Histogram not supported for tiled images or in share"
-          {%else%}
-            title="Show histogram of pixel intensities for selected channel"
-          {% endif %} >
-          <!-- histogram (not supported for Big images) -->
-          <input id="showhistogram" type="checkbox" {% if tiledImage or share %}disabled{% endif %}/>
-          <label for="showhistogram">Show Histogram</label>
+    <div id="rdef-container">
+      <div id="rdef-postit">
+        <div id="rdef-active-area">
+          <input id="rd-wblitz-rmodel" type="checkbox" />
+          <label for="rd-wblitz-rmodel">Grayscale</label>
+          <div style="float:right {% if tiledImage %}; color:#bbb{%endif%}"
+            {% if tiledImage or share %}
+              title="Histogram not supported for tiled images or in share"
+            {%else%}
+              title="Show histogram of pixel intensities for selected channel"
+            {% endif %} >
+            <!-- histogram (not supported for Big images) -->
+            <input id="showhistogram" type="checkbox" {% if tiledImage or share %}disabled{% endif %}/>
+            <label for="showhistogram">Show Histogram</label>
+          </div>
+          <div id="histogram" style="display:none; width: 100%; height: 125px; background:white; border: solid #ccc 1px; margin-bottom: 6px"></div>
+          <table cellspacing="0" style="font-size:0.9em">
+            <tr>
+            </tr>
+          </table>
         </div>
-        <div id="histogram" style="display:none; width: 100%; height: 125px; background:white; border: solid #ccc 1px; margin-bottom: 6px"></div>
-        <table cellspacing="0" style="font-size:0.9em">
-          <tr>
-          </tr>
-        </table>
       </div>
-    </div>
 
-    <ul>
-      <li>
-        <button id="rdef-minmax-btn" title="Each slider will be set to cover the min/max pixel intensities for that channel">
-          Min/Max
-        </button>
-        <button id="rdef-fullrange-btn" title="Each slider will be set to cover the full range of pixel intensities for the image">
-          Full Range
-        </button>
-        <button id="rdef-reset-btn" title="Applies the original imported settings for this image">
-          Imported
-        </button>
-      </li>
-
-      <hr class="thin-margin"/>
-
-      <h3 style="margin-bottom:2px; margin-top:4px">User Settings:</h3>
-
-      <li id='rdef-buttons'>
-        {% for rdef in rdefs %}
-          <button class='rdef {% if rdef.current %}clicked{% endif %}'
-            data-ownerid="{{ rdef.owner.id }}" data-rdid="{{ rdef.id }}">
-            <img class='rdef' src="
-{% if share.share.id and not share.share.isOwned %}{% url 'render_thumbnail'  manager.image.id share.share.id%}
-{% else %}{% url 'render_thumbnail' manager.image.id %}{% endif %}?rdefId={{ rdef.id }}"/><br>
-            <span {% ifequal manager.image.getDetails.owner.id.val rdef.owner.id %}class="owner"{% endifequal %}>
-              {{ rdef.owner.firstName }} {{ rdef.owner.lastName }}
-            </span>
+      <ul>
+        <li>
+          <button id="rdef-minmax-btn" title="Each slider will be set to cover the min/max pixel intensities for that channel">
+            Min/Max
           </button>
-        {% endfor %}
-      </li>
-    </ul>
+          <button id="rdef-fullrange-btn" title="Each slider will be set to cover the full range of pixel intensities for the image">
+            Full Range
+          </button>
+          <button id="rdef-reset-btn" title="Applies the original imported settings for this image">
+            Imported
+          </button>
+        </li>
+
+        <hr class="thin-margin"/>
+
+        <h3 style="margin-bottom:2px; margin-top:4px">User Settings:</h3>
+
+        <li id='rdef-buttons'>
+          {% for rdef in rdefs %}
+            <button class='rdef {% if rdef.current %}clicked{% endif %}'
+              data-ownerid="{{ rdef.owner.id }}" data-rdid="{{ rdef.id }}">
+              <img class='rdef' src="
+  {% if share.share.id and not share.share.isOwned %}{% url 'render_thumbnail'  manager.image.id share.share.id%}
+  {% else %}{% url 'render_thumbnail' manager.image.id %}{% endif %}?rdefId={{ rdef.id }}"/><br>
+              <span {% ifequal manager.image.getDetails.owner.id.val rdef.owner.id %}class="owner"{% endifequal %}>
+                {{ rdef.owner.firstName }} {{ rdef.owner.lastName }}
+              </span>
+            </button>
+          {% endfor %}
+        </li>
+      </ul>
+    </div>
 
 
 </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.preview.js.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/includes/right_plugin.preview.js.html
@@ -25,9 +25,13 @@ $(document).ready(function() {
     $("#right_panel").bind('resize', function(event) {
 
         // This behaviour is also in the metatdata_preview.html itself
-        var vpWidth = $(this).width() - 50,
-            vpHeight = Math.min(vpWidth, $("#preview_tab").height() - 100);
-        vpHeight = Math.max(300, vpHeight);
+        var vpWidth = $(this).width() - 50;
+        // Use a 1:1 aspect ratio with the width.  Keep the viewport from
+        // taking up more than 75% of the available height.
+        var vpHeight = Math.max(
+            300,
+            Math.min(vpWidth, ($("#preview_tab").height() - 100) * 0.75)
+        );
 
         if (OME.preview_viewport) {
             // Need to set a few sizes, then call viewport.refresh()


### PR DESCRIPTION
# What this PR does

A couple of useful OMERO.web features for the preview pane when working with large (10+) channel counts:

* Scroll the channel rendering settings rather than the entire preview tab
* Option to toggle on or off display of only the active channels rendering settings

# Testing this PR

1. required setup

Regular image and an image with a large number of channels. For our own testing we used two fake files:

 * `lotsachannels&sizeC=30.fake`
 * `threechannels&sizeC=3.fake`

2. actions to perform

The preview pane in the right hand panel should only have the list of channels scroll rather than the entire pane:

![image](https://user-images.githubusercontent.com/487082/42682773-63a18360-8683-11e8-89fb-5496d292865a.png)

And the "Active" checkbox should toggle the display back and forth based on which channels are currently active:

![image](https://user-images.githubusercontent.com/487082/42683019-13b91d4e-8684-11e8-8b5c-9f960f3962fe.png)

3. expected observations

See above. No changes to the behaviour of other preview pane controls should be noticed and resizing of the right hand panel should behave as previously.

# Related reading

N/A