### PR TITLE
deprecate bin/omero admin sessionlist

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -350,7 +350,8 @@ dt_socket,address=8787,suspend=y" \\
             help="Re-enables the background indexer after for indexing")
 
         sessionlist = Action(
-            "sessionlist", "List currently running sessions").parser
+            "sessionlist", "List currently running sessions (deprecated)") \
+            .parser
         sessionlist.add_login_arguments()
 
         cleanse = Action("cleanse", """Remove binary data files from OMERO  (admins only)

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1783,7 +1783,7 @@ present, the user will enter a console""")
         client.submit(req).loop(100, 100)
 
     def sessionlist(self, args):
-        self.ctx.err('warning: "admin sessionlist" is deprecated, '
+        self.ctx.err('WARNING: "admin sessionlist" is deprecated, '
                      'use "sessions who" instead')
         client = self.ctx.conn(args)
         service = client.sf.getQueryService()

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1783,6 +1783,8 @@ present, the user will enter a console""")
         client.submit(req).loop(100, 100)
 
     def sessionlist(self, args):
+        self.ctx.err('warning: "admin sessionlist" is deprecated, '
+                     'use "sessions who" instead')
         client = self.ctx.conn(args)
         service = client.sf.getQueryService()
         params = omero.sys.ParametersI()


### PR DESCRIPTION
# What this PR does

Deprecates OMERO.cli `admin sessionlist`.

# Testing this PR

Try using `admin sessionlist` and see a warning message, though it should still work.

# Related reading

https://trello.com/c/vcM2a41a/298-bug-bin-omero-admin-sessionlist