### PR TITLE
deprecate bin/omero config list

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -280,7 +280,7 @@ class PrefsControl(WriteableConfigControl):
 
     @with_config
     def list(self, args, config):
-        self.ctx.err('warning: "config list" is deprecated, '
+        self.ctx.err('WARNING: "config list" is deprecated, '
                      'use "config get" instead')
         args.KEY = []
         self.get(args, config)

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -280,6 +280,8 @@ class PrefsControl(WriteableConfigControl):
 
     @with_config
     def list(self, args, config):
+        self.ctx.err('warning: "config list" is deprecated, '
+                     'use "config get" instead')
         args.KEY = []
         self.get(args, config)
 

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -140,7 +140,7 @@ class PrefsControl(WriteableConfigControl):
 
         list = parser.add(
             sub, self.list,
-            "List all key-value pairs from the current profile")
+            "List all key-value pairs from the current profile (deprecated)")
         list.set_defaults(func=self.list)
 
         get = parser.add(

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -44,7 +44,7 @@ class TestPrefs(object):
     def assertStdoutStderr(self, capsys, out='', err='', strip_warning=False):
         o, e = capsys.readouterr()
         if strip_warning:
-            assert(e.startswith('warning: '))
+            assert(e.startswith('WARNING: '))
             e = '\n'.join(e.split('\n')[1:])
         assert (o.strip() == out and
                 e.strip() == err)

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -41,8 +41,11 @@ class TestPrefs(object):
     def config(self):
         return ConfigXml(filename=str(self.p))
 
-    def assertStdoutStderr(self, capsys, out='', err=''):
+    def assertStdoutStderr(self, capsys, out='', err='', strip_warning=False):
         o, e = capsys.readouterr()
+        if strip_warning:
+            assert(e.startswith('warning: '))
+            e = '\n'.join(e.split('\n')[1:])
         assert (o.strip() == out and
                 e.strip() == err)
 
@@ -136,9 +139,11 @@ class TestPrefs(object):
         self.invoke("get --show-password")
         self.assertStdoutStderr(capsys, out=output_with_password)
         self.invoke("list")
-        self.assertStdoutStderr(capsys, out=output_hidden_password)
+        self.assertStdoutStderr(capsys, out=output_hidden_password,
+                                strip_warning=True)
         self.invoke("list --show-password")
-        self.assertStdoutStderr(capsys, out=output_with_password)
+        self.assertStdoutStderr(capsys, out=output_with_password,
+                                strip_warning=True)
 
     @pytest.mark.parametrize('argument', ['A=B', 'A= B'])
     def testSetFails(self, capsys, argument):
@@ -372,7 +377,7 @@ class TestPrefs(object):
         for k, v in data[0].items():
             self.invoke("set %s %s" % (k, v))
         self.invoke("list")
-        self.assertStdoutStderr(capsys, out=data[1])
+        self.assertStdoutStderr(capsys, out=data[1], strip_warning=True)
 
     @pytest.mark.parametrize("data", (
         ("omero.a=b\nomero.c=d\n##ignore=me\n",


### PR DESCRIPTION
# What this PR does

Deprecates OMERO.cli `config list`.

# Testing this PR

Try using `config list` and see a warning message, though it should still work.

# Related reading

https://trello.com/c/7KNfAJAD/373-cli-config-list-deprecation