### PR TITLE
Have Insight import dialog report empty files as such.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/FileElement.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/FileElement.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2010 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -142,9 +142,14 @@ class FileElement
 	 */
 	String getFileLengthAsString()
 	{
-		long l = getFileLength();
-		if (l <= 0) return "--";
-		return UIUtilities.formatFileSize(l);
+        final long l = getFileLength();
+        if (l > 0) {
+            return UIUtilities.formatFileSize(l);
+        } else if (l == 0) {
+            return "empty";
+        } else {
+            return "--";
+        }
 	}
 	
 	/**


### PR DESCRIPTION
This PR adjusts Insight's import dialog so that when one adds empty files (e.g. fakes) for import then their size is listed as "empty" rather than "--" which I found confusingly indeterminate. Non-empty file sizes should be reported as before.