### PR TITLE
test_cmdcallback: fix race condition on t_lock

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_cmdcallback.py
+++ b/components/tools/OmeroPy/test/integration/test_cmdcallback.py
@@ -34,11 +34,11 @@ from omero.util.concurrency import get_event
 class CmdCallback(omero.callbacks.CmdCallbackI):
 
     def __init__(self, client, handle):
-        super(CmdCallback, self).__init__(client, handle)
         self.t_lock = threading.RLock()
         self.t_steps = 0
         self.t_finished = 0
         self.t_event = get_event("CmdCallback")
+        super(CmdCallback, self).__init__(client, handle)
 
     def step(self, complete, total, current=None):
         self.t_lock.acquire()


### PR DESCRIPTION
Apparently onFinished was being called during construction
and therefore the subclass instance variables hadn't been
set:

```
   Traceback (most recent call last):
     File "target/omero/callbacks.py", line 300, in finished
       self.onFinished(rsp, status, current)
     File "test/integration/test_cmdcallback.py", line 51, in onFinished
       self.t_lock.acquire()
   AttributeError: 'CmdCallback' object has no attribute 't_lock'
```

see:
https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-python/935/testReport/junit/OmeroPy.test.integration.test_cmdcallback/TestCmdCallback/testDoNothingFinishesOnLoop/
