### PR TITLE
Bring custom HTTP response in line with cleanup semantics

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -84,9 +84,7 @@ class ConnCleaningHttpResponse(StreamingHttpResponse):
         try:
             logger.debug('Closing OMERO connection in %r' % self)
             if self.conn is not None and self.conn.c is not None:
-                for v in self.conn._proxies.values():
-                    v.close()
-                self.conn.c.closeSession()
+                self.conn.close(hard=False)
         except:
             logger.error('Failed to clean up connection.', exc_info=True)
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2902,10 +2902,10 @@ def get_original_file(request, fileId, download=False, conn=None, **kwargs):
 @login_required(doConnectionCleanup=False)
 def download_annotation(request, annId, conn=None, **kwargs):
     """ Returns the file annotation as an http response for download """
-    ann = conn.getObject("Annotation", annId)
+    ann = conn.getObject("FileAnnotation", annId)
     if ann is None:
         rsp = ConnCleaningHttpResponse(StringIO(
-            "Annotation does not exist (id:%s)." % (annId)), status=404)
+            "FileAnnotation does not exist (id:%s)." % (annId)), status=404)
         rsp.conn = conn
         return rsp
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -34,6 +34,7 @@ import re
 import sys
 import warnings
 
+from StringIO import StringIO
 from time import time
 
 from omero_version import build_year
@@ -2877,8 +2878,10 @@ def get_original_file(request, fileId, download=False, conn=None, **kwargs):
 
     orig_file = conn.getObject("OriginalFile", fileId)
     if orig_file is None:
-        return handlerInternalError(
-            request, "Original File does not exists (id:%s)." % (fileId))
+        rsp = ConnCleaningHttpResponse(StringIO(
+            "Original File does not exist (id:%s)." % (fileId)), status=404)
+        rsp.conn = conn
+        return rsp
 
     rsp = ConnCleaningHttpResponse(
         orig_file.getFileInChunks(buf=settings.CHUNK_SIZE))
@@ -2901,8 +2904,10 @@ def download_annotation(request, annId, conn=None, **kwargs):
     """ Returns the file annotation as an http response for download """
     ann = conn.getObject("Annotation", annId)
     if ann is None:
-        return handlerInternalError(
-            request, "Annotation does not exist (id:%s)." % (annId))
+        rsp = ConnCleaningHttpResponse(StringIO(
+            "Annotation does not exist (id:%s)." % (annId)), status=404)
+        rsp.conn = conn
+        return rsp
 
     rsp = ConnCleaningHttpResponse(
         ann.getFileInChunks(buf=settings.CHUNK_SIZE))


### PR DESCRIPTION
Use the same cleanup semantics, which were introduced in order to avoid
filehandle and socket leakage (in #5699), as the rest of the codebase.

# What this PR does

More explicit gateway connection closure.

# Testing this PR

1. required setup

Valid session and the following available:

 * Loose, or attached via FileAnnotation, OriginalFile ID
 * FileAnnotation ID with associated OriginalFile
 * Image ID and Well ID in both single and multiples with archived files available

2. actions to perform

`ab -C 'sessionid=<session_id>' -n 1000 'http://host:port/<endpoint>'`

Endpoints, should be tested with both valid and **missing** identifiers:

 * `webclient/annotation/<file_annotation_id>/`
 * `webclient/get_original_file/<original_file_id>/`
 * `webgateway/archived_files/download/<image_id>/`
 * `webgateway/archived_files/download/`
 * `webgateway/archived_files/download/?image=<image_id>`
 * `webgateway/archived_files/download/?well=<well_id>`

When objects are missing HTTP 404s should be returned. When parameters are missing or incorrect HTTP 400s should be returned.

3. expected observations

No socket, pipe, or filehandle leakage.

# Related reading

 * https://trello.com/c/UYsZa42J/478-bug-omeroweb-open-files-leak-not-being-cleaned-up
 * #5699