### PR TITLE
download_fileannotation_only

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2899,10 +2899,10 @@ def get_original_file(request, fileId, download=False, conn=None, **kwargs):
 @login_required(doConnectionCleanup=False)
 def download_annotation(request, annId, conn=None, **kwargs):
     """ Returns the file annotation as an http response for download """
-    ann = conn.getObject("Annotation", annId)
+    ann = conn.getObject("FileAnnotation", annId)
     if ann is None:
         return handlerInternalError(
-            request, "Annotation does not exist (id:%s)." % (annId))
+            request, "File Annotation does not exist (id:%s)." % (annId))
 
     rsp = ConnCleaningHttpResponse(
         ann.getFileInChunks(buf=settings.CHUNK_SIZE))


### PR DESCRIPTION
# What this PR does

Handles error from /webclient/annotation/id where this ID is not a File annotation (e.g. Map annotation)
(e-mail errors from demo server on 30th July).

```
Internal Server Error: /webclient/annotation/21/
Traceback (most recent call last):
 File "/opt/omero/web/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
   response = wrapped_callback(request, *callback_args, **callback_kwargs)
 File "/opt/omero/web/OMERO.web/lib/python/omeroweb/decorators.py", line 488, in wrapped
   retval = f(request, *args, **kwargs)
 File "/opt/omero/web/OMERO.web/lib/python/omeroweb/webclient/views.py", line 2908, in download_annotation
   ann.getFileInChunks(buf=settings.CHUNK_SIZE))
 File "/opt/omero/web/OMERO.web/lib/python/omero/gateway/__init__.py", line 1317, in __getattr__
   % (self._obj.__class__.__name__, attr))
AttributeError: 'MapAnnotationI' object has no attribute 'getFileInChunks'
```

Don't know how user tried to access this link since webclient shouldn't allow it.

# Testing this PR

1. Find or add a Map annotation. Hover over it in webclient to show ID in tooltip.
1. Go to /webclient/annotation/ID/
1. Should see 'Not Found' message instead of Exception.

see https://trello.com/c/f1zr0D5W/22-bug-attributeerror-mapannotationi-object-has-no-attribute-getfileinchunks