### PR TITLE
ChannelProcessor: do not change color to white if Bio-Formats set a color

### DIFF
--- a/components/blitz/src/ome/formats/model/ChannelProcessor.java
+++ b/components/blitz/src/ome/formats/model/ChannelProcessor.java
@@ -106,13 +106,9 @@ public class ChannelProcessor implements ModelProcessor {
   private void setSingleChannel(ChannelData channelData) {
     int channelIndex = channelData.getChannelIndex();
     Channel channel = channelData.getChannel();
-    Integer red = getValue(channel.getRed());
-    Integer green = getValue(channel.getGreen());
-    Integer blue = getValue(channel.getBlue());
-    Integer alpha = getValue(channel.getAlpha());
     RString name;
-    //color already set by Bio-formats
-    if (red != null && green != null && blue != null && alpha != null) {
+    if (hasColor(channel)) {
+      //color already set by Bio-formats
       return;
     }
     int[] defaultColor = ColorsFactory.newGreyColor();
@@ -163,13 +159,9 @@ public class ChannelProcessor implements ModelProcessor {
       return;
     }
 
-    Integer red = getValue(channel.getRed());
-    Integer green = getValue(channel.getGreen());
-    Integer blue = getValue(channel.getBlue());
-    Integer alpha = getValue(channel.getAlpha());
     RString name;
-    //color already set by Bio-formats
-    if (red != null && green != null && blue != null && alpha != null) {
+    if (hasColor(channel)) {
+      //color already set by Bio-formats
       //Try to set the name.
       log.debug("Already set in BF.");
       if (lc.getName() == null) {
@@ -274,6 +266,22 @@ public class ChannelProcessor implements ModelProcessor {
 
     //not been able to set the color
     setDefaultChannelColor(channel, channelIndex);
+  }
+
+  /**
+   * Checks if a valid color is already set on the Channel.
+   * All four color components (red, green, blue, alpha)
+   * must be non-null.
+   *
+   * @param channel the Channel to check for a color
+   * @return true if a valid color was found; false otherwise
+   */
+  private boolean hasColor(Channel channel) {
+    Integer red = getValue(channel.getRed());
+    Integer green = getValue(channel.getGreen());
+    Integer blue = getValue(channel.getBlue());
+    Integer alpha = getValue(channel.getAlpha());
+    return red != null && green != null && blue != null && alpha != null;
   }
 
   /**
@@ -473,13 +481,16 @@ public class ChannelProcessor implements ModelProcessor {
       } else {
         for (int c = 0; c < sizeC; c++) {
           channelData = ChannelData.fromObjectContainerStore(store, i, c);
+          boolean hasBFColor = hasColor(channelData.getChannel());
           //Color section
           populateDefault(channelData, isGraphicsDomain);
 
           //only retrieve if not graphics
           if (!isGraphicsDomain) {
             //Determine if the channel same emission wavelength.
-            v = ColorsFactory.hasEmissionData(channelData);
+            // don't allow the color to be reset to white if a color
+            // was set by Bio-Formats
+            v = ColorsFactory.hasEmissionData(channelData) || hasBFColor;
             if (!v) {
               count++;
             }


### PR DESCRIPTION
# What this PR does

Channels with no emission wavelength data are typically candidates for
having their colors reset to white.  This prevents the color from being
reset if the Bio-Formats reader supplied a color via ```MetadataStore```.

# Testing this PR

Using 5.4.7 or a develop build without this change, start the server and import ```data_repo/curated/nd2/jose/08_SO4_Fasc100_at_surface_w_average.nd2```.  Querying the database or opening the imported image in web should show that the channel colors are green (16711935), white (-1) and white (-1), in that order.  This differs from the channel colors reported by Bio-Formats, which are green (16711935), red (-16776961), and white (-1) as can be seen with ```showinf -nopix -omexml``` or by opening in ImageJ with color mode set to ```Composite``` or ```Colorized```.

Using an OMERO build that includes this PR, import the file again and confirm that the colors are now green, red, and white.

To verify that the channel color is still set to white when neither emission wavelength nor channel color is set by Bio-Formats, import ```data_repo/curated/fv1000/aryeh/1h.oib``` with and without this PR.  This file has 3 channels, none of which have a color and the last of which does not have an emission wavelength.  There should be no difference in channel colors with this PR; in particular, the last channel should be white.

# Related reading

The logic to reset a channel color to white was introduced in openmicroscopy/openmicroscopy@6a324bf.  That commit is approximately 9 years old (pre-4.4.x), and dates from a time when trusting the colors supplied by Bio-Formats was not realistic and colors were rarely supplied in any case.  We now have a little more confidence in Bio-Formats (at least I hope so!), so defaulting to whatever color is set by the reader makes more sense now.