### PR TITLE
Bump Bio-Formats to version 5.9.1

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -936,7 +936,7 @@ product.name=OMERO.server
 #############################################
 
 org.bioformats=ome
-versions.bioformats=5.9.0
+versions.bioformats=5.9.1
 
 ##
 versions.JHotDraw=7.0.9


### PR DESCRIPTION
See https://www.openmicroscopy.org/2018/08/14/bio-formats-5-9-1.html for the full announcement

## Testing this PR

1. Feature testing: https://github.com/openmicroscopy/bioformats/pull/3181 should be a good example of feature. The associated sample file (QA21574) should fail to import at the candidate detection time in OMERO 5.4.7. With this PR included, the file should correctly import as a 12-channel image.

2. Serialization testing: the library bump should not affect memo files. Testing this is still manual and requires access to the server:
  - either find a  fileset imported with Bio-Formats 5.9.0 or downgrade the testing server to OMERO 5.4.7, import an image and re-upgrade the server with this PR included
  - optionally, check the timestamp of the cache file locate under `<path_to_omero_data_dir>/BioFormatsCache/<path_to_file>/<filename>.bfmemo`
  - load a plane of the image e.g. by launching the Web client or iviewer.
  - check memo files in the `Blitz.log`, `grep <filename>.memo Blitz.log` should show no occurrence of `deleting invalid memo file:  <path_to_omero_data_dir>/BioFormatsCache/<path_to_file>/<filename>.bfmemo` and/or check the cache file timestamp was not altered from the step above
