### PR TITLE
fix lexical issue in Slice file's Timeline docs

### DIFF
--- a/components/blitz/resources/omero/api/ITimeline.ice
+++ b/components/blitz/resources/omero/api/ITimeline.ice
@@ -53,8 +53,8 @@ module omero {
          * The methods which take a StringSet and a Parameters object, also
          * have a <i>bool merge</i> argument. This argument defines whether or
          * not the LIMIT applies to each object independently
-         * (<code>["a","b"] @ 100 == 200</code>) or merges the lists together
-         * chronologically (<code>["a","b"] @ 100 merged == 100</code>).
+         * (<code>\["a","b"] @ 100 == 200</code>) or merges the lists together
+         * chronologically (<code>\["a","b"] @ 100 merged == 100</code>).
          *
          * <h4>Time used</h4>
          *

--- a/components/blitz/resources/omero/api/ITimeline.ice
+++ b/components/blitz/resources/omero/api/ITimeline.ice
@@ -1,9 +1,6 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
- *
  */
 
 #ifndef OMERO_API_ITIMELINE_ICE


### PR DESCRIPTION
# What this PR does

Quotes the `[` in Slice documentation so Ice does not take it as being a link.

# Testing this PR

Note the effect of this PR on `docs/api/slice2html/omero/api/ITimeline.html`.