### PR TITLE
adjust ordering of Java "static" "final" modifier keywords

### DIFF
--- a/components/blitz/resources/omero/api/IContainer.ice
+++ b/components/blitz/resources/omero/api/IContainer.ice
@@ -328,7 +328,7 @@ module omero {
                  *
                  * @param obj Can be <i>unloaded</i>.
                  * @param collectionName
-                 *            <code>public final static String</code> from the
+                 *            <code>public static final String</code> from the
                  *            IObject.class
                  * @param options
                  *            Parameters. Unused.

--- a/components/blitz/resources/omero/api/IQuery.ice
+++ b/components/blitz/resources/omero/api/IQuery.ice
@@ -105,7 +105,7 @@ module omero {
                  *
                  * @param klass type of entity to be searched
                  * @param field the name of the field, either as simple string
-                 *              or as public final static from the entity
+                 *              or as public static final from the entity
                  *              class, e.g. {@link omero.model.Project#NAME}
                  * @param value String used for search.
                  * @return found entity or possibly null.
@@ -122,7 +122,7 @@ module omero {
                  *
                  * @param klass type of entity to be searched. Not null.
                  * @param field the name of the field, either as simple string
-                 *              or as public final static from the entity
+                 *              or as public static final from the entity
                  *              class, e.g. {@link omero.model.Project#NAME}.
                  *              Not null.
                  * @param value String used for search. Not null.

--- a/components/blitz/resources/templates/combined.vm
+++ b/components/blitz/resources/templates/combined.vm
@@ -258,7 +258,7 @@ STATIC FIELDS:
 
 [$hdr]    public:
 #foreach( $property in $type.propertyClosure )
-[$jav]       public final static String ${property.nameUpper} = "${type.id}_${property.name}";
+[$jav]       public static final String ${property.nameUpper} = "${type.id}_${property.name}";
 [$pyc]       ${property.nameUpper} =  "${type.id}_${property.name}"
 [$hdr]       static const std::string ${property.nameUpper};
 [$cpp]       const std::string ${PojoI}::${property.nameUpper} =  "${type.id}_${property.name}";

--- a/components/blitz/resources/templates/java_ice_map.vm
+++ b/components/blitz/resources/templates/java_ice_map.vm
@@ -21,18 +21,18 @@ import java.util.Map;
  */
 public class IceMap {
 
-        private final static Map<Class, Class> _ome2omero = new HashMap<Class, Class>();
-        private final static Map<Class, Class> _omero2ome = new HashMap<Class, Class>();
+        private static final Map<Class, Class> _ome2omero = new HashMap<Class, Class>();
+        private static final Map<Class, Class> _omero2ome = new HashMap<Class, Class>();
 
         /**
          * Unmodifiable map of ome.model.* classes to omero.model.* classes.
          */
-        public final static Map<Class, Class> OMEtoOMERO;
+        public static final Map<Class, Class> OMEtoOMERO;
 
         /**
          * Unmodifiable map of omero.model.* classes to ome.model.* classes.
          */
-        public final static Map<Class, Class> OMEROtoOME;
+        public static final Map<Class, Class> OMEROtoOME;
 
         static {
 #macro(put $longtype $shorttype)

--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -330,7 +330,7 @@ implements java.io.Serializable, IObject
 #foreach($prop in $type.properties)
 #if($prop.class.name == "ome.dsl.EntryField")
 #set($enumSymbol = ${prop.name.replaceAll("-","_").replaceAll("([a-z])([A-Z])", "$1_$2").toUpperCase().replaceAll("[^A-Z0-9_]","")})
-    public final static String VALUE_${enumSymbol} = "${prop.name}";
+    public static final String VALUE_${enumSymbol} = "${prop.name}";
 #end
 #end
 
@@ -340,10 +340,10 @@ implements java.io.Serializable, IObject
     * Constants naming filters used by the OMERO
     * security system.
     */
-    public final static String OWNER_FILTER = "${ofilter}";
-    public final static String GROUP_FILTER = "${gfilter}";
-    public final static String EVENT_FILTER = "${efilter}";
-    public final static String PERMS_FILTER = "${pfilter}";
+    public static final String OWNER_FILTER = "${ofilter}";
+    public static final String GROUP_FILTER = "${gfilter}";
+    public static final String EVENT_FILTER = "${efilter}";
+    public static final String PERMS_FILTER = "${pfilter}";
 
 #end
     public ${type.shortname} () {
@@ -397,7 +397,7 @@ implements java.io.Serializable, IObject
 #end## END ctorWithRequiredNeeded
 
 #if(!${type.superclass})
-    public final static String ID = "${type.id}_id";
+    public static final String ID = "${type.id}_id";
     
     protected Long id;
 
@@ -435,7 +435,7 @@ implements java.io.Serializable, IObject
     */
 
 #if(!${type.immutable} && !${type.superclass})
-    public final static String VERSION = "${type.id}_version";
+    public static final String VERSION = "${type.id}_version";
 
     protected Integer version = 0;
 
@@ -584,10 +584,10 @@ implements java.io.Serializable, IObject
     * Filter names which are used by the security system to turn on filters
     * for this particular collection.
     */
-    public final static String OWNER_FILTER_${prop.nameUpper} = "${ofilter}_${prop.nameUpper}";
-    public final static String GROUP_FILTER_${prop.nameUpper} = "${gfilter}_${prop.nameUpper}";
-    public final static String EVENT_FILTER_${prop.nameUpper} = "${efilter}_${prop.nameUpper}";
-    public final static String PERMS_FILTER_${prop.nameUpper} = "${pfilter}_${prop.nameUpper}";
+    public static final String OWNER_FILTER_${prop.nameUpper} = "${ofilter}_${prop.nameUpper}";
+    public static final String GROUP_FILTER_${prop.nameUpper} = "${gfilter}_${prop.nameUpper}";
+    public static final String EVENT_FILTER_${prop.nameUpper} = "${efilter}_${prop.nameUpper}";
+    public static final String PERMS_FILTER_${prop.nameUpper} = "${pfilter}_${prop.nameUpper}";
 #end
 
    /**
@@ -1469,12 +1469,12 @@ implements java.io.Serializable, IObject
 
 #foreach($prop in $type.classProperties)
 #if($prop.one2Many && $prop.isLink && !$prop.actualTarget.global)
-    public final static String ${prop.name.toUpperCase()}COUNTPEROWNER = "${type.id}_${prop.name}CountPerOwner";
+    public static final String ${prop.name.toUpperCase()}COUNTPEROWNER = "${type.id}_${prop.name}CountPerOwner";
 #end
-    public final static String ${prop.nameUpper} = "${type.id}_${prop.name}";
+    public static final String ${prop.nameUpper} = "${type.id}_${prop.name}";
 #end
 
-    public final static java.util.Set<String> FIELDS;
+    public static final java.util.Set<String> FIELDS;
     static {
        java.util.Set<String> raw = new java.util.HashSet<String>();
 #if(!$type.superclass)
@@ -1693,7 +1693,7 @@ implements java.io.Serializable, IObject
 #if(!$type.superclass)
     public static class Details extends ome.model.internal.Details {
 
-        private final static long serialVersionUID = 0000000030000020301L;
+        private static final long serialVersionUID = 0000000030000020301L;
 
         public Details() {
             super();

--- a/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTestAll.java
@@ -104,7 +104,7 @@ public class PermissionsTestAll extends AbstractServerTest {
             );
 
     /** The password used for user. **/
-    private final static String PASSWORD = "ome";
+    private static final String PASSWORD = "ome";
 
     @Override
     @BeforeClass

--- a/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AnnotationDeleteTest.java
@@ -68,7 +68,7 @@ import com.google.common.primitives.Ints;
 public class AnnotationDeleteTest extends AbstractServerTest {
 
     /** Reference to the <code>Rating</code> name space. */
-    public final static RString RATING = omero.rtypes.rstring(omero.constants.metadata.NSINSIGHTRATING.value);
+    public static final RString RATING = omero.rtypes.rstring(omero.constants.metadata.NSINSIGHTRATING.value);
 
     /**
      * Tests that the object, an annotation, and the link are all deleted.

--- a/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/HierarchyDeleteTest.java
@@ -87,7 +87,7 @@ import com.google.common.collect.Multimap;
 @Test(groups = "ticket:2615")
 public class HierarchyDeleteTest extends AbstractServerTest {
 
-    private final static omero.RString t3031 = omero.rtypes.rstring("#3031");
+    private static final omero.RString t3031 = omero.rtypes.rstring("#3031");
 
     /**
      * Test to delete a dataset containing an image also contained in another

--- a/examples/ScriptingService/Notifications.java
+++ b/examples/ScriptingService/Notifications.java
@@ -4,7 +4,7 @@ import omero.grid.*;
 
 public class Notifications {
 
-    public final static String SCRIPT = "" +
+    public static final String SCRIPT = "" +
     "import omero\n" +
     "import omero.scripts as s\n" +
     "s.client(\"name\")\n";


### PR DESCRIPTION
# What this PR does

Switches `final static` to `static final` in some code so it doesn't look distractingly odd.

Targets just some rather visible code and codegen; more can be done in other PRs.

# Testing this PR

Should not change behavior at all. No regressions in CI.

# Related reading

https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.1.1