### PR TITLE
perf4j: log import timings in import log

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -35,11 +35,13 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 import Ice.Current;
+
 import ome.services.blitz.impl.AbstractCloseableAmdServant;
 import ome.services.blitz.impl.ServiceFactoryI;
 import ome.services.blitz.repo.PublicRepositoryI.AMD_submit;
 import ome.services.blitz.repo.path.FsFile;
 import ome.services.blitz.util.ServiceFactoryAware;
+
 import omero.ServerError;
 import omero.api.RawFileStorePrx;
 import omero.cmd.CallContext;
@@ -260,7 +262,6 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                         throw re;
                     } finally {
                         sw2.stop("omero.import.process.opener");
-                        MDC.clear();
                     }
                     return new UploadState(prx);
                 }
@@ -378,7 +379,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
             this.handle = submit.ret;
             // TODO: in 5.1 this should be added to the request object
             ((ManagedImportRequestI) req).handle = submit.ret;
-            sw2.stop("omero.import.process.verify");
+            sw2.stop("omero.import.process.submit");
             return submit.ret;
         } finally {
             MDC.clear();

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -471,9 +471,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             cleanupReader();
             cleanupStore();
 
-            log.info(ClassicConstants.FINALIZE_SESSION_MARKER, "Finalizing log file.");
-            /* hereafter back to normal log destination, not import log file*/
-            MDC.clear();
+            log.info(ClassicConstants.FINALIZE_SESSION_MARKER, "Cleaning up import.");
             try {
                 /* requires usable session */
                 setLogFileSize();
@@ -483,9 +481,14 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
 
             cleanupSession();
         } finally {
-            autoClose(); // Doesn't throw
-            if (resources != null) {
-                resources.remove(resourcesEntry);
+            try {
+                autoClose(); // Doesn't throw
+                if (resources != null) {
+                    resources.remove(resourcesEntry);
+                }
+            } finally {
+                /* hereafter back to normal log destination, not import log file*/
+                MDC.clear();
             }
         }
     }

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportRequestI.java
@@ -76,6 +76,8 @@ import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.perf4j.StopWatch;
+import org.perf4j.slf4j.Slf4JStopWatch;
 
 import ch.qos.logback.classic.ClassicConstants;
 
@@ -205,6 +207,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
     }
 
     public void init(Helper helper) {
+        StopWatch sw = new Slf4JStopWatch();
         this.helper = helper;
         helper.setSteps(5);
 
@@ -283,6 +286,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
         } catch (Throwable t) {
             throw helper.cancel(new ERR(), t, "error-on-init");
         } finally {
+            sw.stop("omero.import.request.init");
             MDC.clear();
         }
     }
@@ -498,6 +502,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
     }
 
     public Object step(int step) {
+        StopWatch sw = new Slf4JStopWatch();
         helper.assertStep(step);
         try {
             MDC.put("fileset", logFilename);
@@ -565,6 +570,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             } catch (Throwable t) {
                 throw helper.cancel(new ERR(), t, "update-log-file-size");
             }
+            sw.stop("omero.import.request.step");
             MDC.clear();
         }
     }
@@ -619,6 +625,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Map<String, List<IObject>> importMetadata(MetadataImportJob mij) throws Throwable {
+        StopWatch sw = new Slf4JStopWatch();
         notifyObservers(new ImportEvent.LOADING_IMAGE(
                 shortName, 0, 0, 0));
 
@@ -646,11 +653,13 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
         notifyObservers(new ImportEvent.END_SAVE_TO_DB(
                 0, null, userSpecifiedTarget, null, 0, null));
 
+        sw.stop("omero.import.request.metadata");
         return objects;
 
     }
 
     public Object pixelData(PixelDataJob pdj) throws Throwable {
+        StopWatch sw = new Slf4JStopWatch();
 
         if (!reader.isMinMaxSet() && !noStatsInfo)
         {
@@ -691,11 +700,13 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
         }
 
 
+        sw.stop("omero.import.request.pixels");
         return null;
     }
 
 
     public Object generateThumbnails(ThumbnailGenerationJob tgj) throws Throwable {
+        StopWatch sw = new Slf4JStopWatch();
 
         List<Long> plateIds = new ArrayList<Long>();
         Image image = pixList.get(0).getImage();
@@ -721,6 +732,7 @@ public class ManagedImportRequestI extends ImportRequest implements IRequest {
             log.warn("Not creating thumbnails at user request!");
         }
 
+        sw.stop("omero.import.request.thumbs");
         return null;
     }
 

--- a/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -86,8 +86,11 @@ import omero.util.IceMapper;
 
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.Session;
+import org.perf4j.StopWatch;
+import org.perf4j.slf4j.Slf4JStopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import Ice.Current;
 
@@ -440,6 +443,8 @@ public class ManagedRepositoryI extends PublicRepositoryI
             ImportLocation location, ImportSettings settings, Current __current)
                 throws ServerError {
 
+        StopWatch sw = new Slf4JStopWatch();
+
         // Initialization version info
         final ImportConfig config = new ImportConfig();
         final List<NamedValue> serverVersionInfo = new ArrayList<NamedValue>();
@@ -477,9 +482,16 @@ public class ManagedRepositoryI extends PublicRepositoryI
         fs.linkJob(new IndexingJobI());
 
         if (location instanceof ManagedImportLocationI) {
-            OriginalFile of = ((ManagedImportLocationI) location).getLogFile().asOriginalFile(IMPORT_LOG_MIMETYPE);
+            CheckedPath logFile  = ((ManagedImportLocationI) location).getLogFile();
+            OriginalFile of = logFile.asOriginalFile(IMPORT_LOG_MIMETYPE);
             of = persistLogFile(of, __current);
             job.linkOriginalFile((omero.model.OriginalFile) new IceMapper().map(of));
+            try {
+                MDC.put("fileset", logFile.getFullFsPath());
+                sw.stop("omero.import.process.init");
+            } finally {
+                MDC.clear();
+            }
         }
 
         return createUploadProcess(fs, location, settings, __current, false);
@@ -495,22 +507,29 @@ public class ManagedRepositoryI extends PublicRepositoryI
             ImportLocation location, ImportSettings settings,
             Current __current, boolean uploadOnly) throws ServerError {
 
-        // Create CheckedPath objects for use by saveFileset
-        final int size = fs.sizeOfUsedFiles();
-        final List<CheckedPath> checked = new ArrayList<CheckedPath>();
-        for (int i = 0; i < size; i++) {
-            final String path = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
-            checked.add(checkPath(path, settings.checksumAlgorithm, __current));
+        StopWatch sw = new Slf4JStopWatch();
+        MDC.put("fileset", ((ManagedImportLocationI) location).getLogFile().getFullFsPath());
+        try {
+            // Create CheckedPath objects for use by saveFileset
+            final int size = fs.sizeOfUsedFiles();
+            final List<CheckedPath> checked = new ArrayList<CheckedPath>();
+            for (int i = 0; i < size; i++) {
+                final String path = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
+                checked.add(checkPath(path, settings.checksumAlgorithm, __current));
+            }
+
+            final Fileset managedFs = repositoryDao.saveFileset(getRepoUuid(), fs, settings.checksumAlgorithm, checked, __current);
+            // Since the fileset saved validly, we create a session for the user
+            // and return the process.
+
+            final ManagedImportProcessI proc = new ManagedImportProcessI(this,
+                    managedFs, location, settings, __current);
+            processes.addProcess(proc);
+            return proc.getProxy();
+        } finally {
+            sw.stop("omero.import.process.create");
+            MDC.clear();
         }
-
-        final Fileset managedFs = repositoryDao.saveFileset(getRepoUuid(), fs, settings.checksumAlgorithm, checked, __current);
-        // Since the fileset saved validly, we create a session for the user
-        // and return the process.
-
-        final ManagedImportProcessI proc = new ManagedImportProcessI(this,
-                managedFs, location, settings, __current);
-        processes.addProcess(proc);
-        return proc.getProxy();
     }
 
     /**

--- a/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -523,7 +523,7 @@ public class ManagedRepositoryI extends PublicRepositoryI
             // and return the process.
 
             final ManagedImportProcessI proc = new ManagedImportProcessI(this,
-                    managedFs, location, settings, __current);
+                    managedFs, location, settings, __current, rootSessionUuid);
             processes.addProcess(proc);
             return proc.getProxy();
         } finally {

--- a/components/blitz/src/ome/services/blitz/util/RegisterServantMessage.java
+++ b/components/blitz/src/ome/services/blitz/util/RegisterServantMessage.java
@@ -65,7 +65,7 @@ public class RegisterServantMessage extends FindServiceFactoryMessage {
             final String name = UUID.randomUUID().toString() + "-" + readableName;
             final Ice.Identity newId = new Ice.Identity(name, id.name);
             sf.configureServant(servant); // Sets holder
-            setProxy(sf.registerServant(newId, servant));
+            setProxy(sf.registerServant(newId, servant, getCurrent()));
         }
     }
 

--- a/components/blitz/src/omero/cmd/CallContext.java
+++ b/components/blitz/src/omero/cmd/CallContext.java
@@ -27,20 +27,32 @@ import omero.SecurityViolation;
  */
 public class CallContext implements MethodInterceptor {
 
+    public static final String FILENAME_KEY = "omero.logfilename";
+
+    public static final String TOKEN_KEY = "omero.logfilename.token";
+
     private static Logger log = LoggerFactory.getLogger(CallContext.class);
 
     private final CurrentDetails cd;
 
     private final String token;
 
-    public CallContext(OmeroContext ctx, String token) {
+    private final Ice.Current current;
+
+    public CallContext(OmeroContext ctx, String token, Ice.Current current) {
         this.cd = ctx.getBean(CurrentDetails.class);
         this.token = token;
+        this.current = current;
+    }
+
+    public CallContext(OmeroContext ctx, String token) {
+        this(ctx, token, null);
     }
 
     public CallContext(CurrentDetails cd, String token) {
         this.cd = cd;
         this.token = token;
+        this.current = null;
     }
 
     /**
@@ -57,16 +69,11 @@ public class CallContext implements MethodInterceptor {
                     final Map<String, String> ctx = current.ctx;
                     if (ctx != null && ctx.size() > 0) {
                         cd.setContext(ctx);
-                        if (ctx.containsKey("omero.logfilename")) {
-                            if (ctx.containsKey("omero.logfilename.token")
-                                    && token.equals(ctx
-                                            .get("omero.logfilename.token"))) {
-                                MDC.put("fileset", ctx.get("omero.logfilename"));
-                            } else {
-                                throw new SecurityViolation(null, null,
-                                        "Setting the omero.logfilename value is"
-                                        + " not permitted without a secure"
-                                        + " server token!");
+                        // Don't trust user-passed values
+                        if (!checkLogFile(ctx, true)) {
+                            if (this.current != null) {
+                                // fall back to the service wide-values
+                                checkLogFile(this.current.ctx, true);
                             }
                         }
                     }
@@ -80,5 +87,38 @@ public class CallContext implements MethodInterceptor {
             cd.setContext(null);
             MDC.clear();
         }
+    }
+
+    /**
+     * If "omero.logfilename" is in the passed {@link Map}, then set it in the
+     * {@link MDC} IFF requireToken is false or the token is present and matches
+     * the original token set on this instance.
+     */
+    private boolean checkLogFile(Map<String, String> ctx, boolean requireToken)
+        throws SecurityViolation {
+
+        if (ctx == null) {
+            return false;
+        }
+
+        String filename = ctx.getOrDefault(FILENAME_KEY, null);
+        if (filename == null) {
+            return false;
+        }
+
+        if (requireToken) {
+            String token = ctx.getOrDefault(TOKEN_KEY, null);
+            if (!this.token.equals(token)) {
+                log.error("Found bad token: user={} != server={}",
+                        token, this.token);
+                throw new SecurityViolation(null, null,
+                        String.format("Setting the %s value is"
+                        + " not permitted without a secure"
+                        + " server token!", FILENAME_KEY));
+            }
+        }
+
+        MDC.put("fileset", filename);
+        return true;
     }
 }

--- a/components/blitz/src/omero/cmd/CallContext.java
+++ b/components/blitz/src/omero/cmd/CallContext.java
@@ -72,7 +72,7 @@ public class CallContext implements MethodInterceptor {
                         // Don't trust user-passed values
                         if (!checkLogFile(ctx, true)) {
                             if (this.current != null) {
-                                // fall back to the service wide-values
+                                // fall back to the service-wide values
                                 checkLogFile(this.current.ctx, true);
                             }
                         }

--- a/components/blitz/src/omero/cmd/CallContext.java
+++ b/components/blitz/src/omero/cmd/CallContext.java
@@ -101,13 +101,13 @@ public class CallContext implements MethodInterceptor {
             return false;
         }
 
-        String filename = ctx.getOrDefault(FILENAME_KEY, null);
+        String filename = ctx.get(FILENAME_KEY);
         if (filename == null) {
             return false;
         }
 
         if (requireToken) {
-            String token = ctx.getOrDefault(TOKEN_KEY, null);
+            String token = ctx.get(TOKEN_KEY);
             if (!this.token.equals(token)) {
                 log.error("Found bad token: user={} != server={}",
                         token, this.token);

--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -150,6 +150,11 @@
     <appender-ref ref="SIFT"/>
   </logger>
 
+  <logger name="org.perf4j">
+    <level value="DEBUG"/>
+    <appender-ref ref="SIFT"/>
+  </logger>
+
   <logger name="ome.annotations">
     <level value="INFO"/>
     <appender-ref ref="SIFT"/>


### PR DESCRIPTION
By adding use of Slf4J's MDC to ManagedImportProcessI and
ManagedRepositoryI, we are able to get stop watch info as
to various internal stages of the import process.

Note: this also required adding perf4j to the SIFT logger in etc/logback.xml

# Testing this PR

1. with a new server, perform an import (I've used here the 300 fakes from the linked trello card)
2. examine the perf4j lines in the import log

```
bin/omero fs logfile 351 | grep perf4j | grep omero.import | java -jar lib/server/perf4j.jar -r -t 120000
Performance Statistics   2018-08-15 08:40:00 - 2018-08-15 08:42:00
Tag                                                  Avg(ms)         Min         Max     Std Dev       Count
omero                                                   47.0           0        1965        91.9         605
omero.import                                            47.0           0        1965        91.9         605
omero.import.process                                    47.0           0        1965        91.9         605
omero.import.process.checksum                            0.0           0           0         0.0         301
omero.import.process.create                           1965.0        1965        1965         0.0           1
omero.import.process.init                              255.0         255         255         0.0           1
omero.import.process.opener                             86.6          48         226        28.1         301
omero.import.process.verify                            161.0         161         161         0.0           1
```

# Related reading

1. https://trello.com/c/BPrkScBc/36-file-upload-should-be-faster
