### PR TITLE
make data provider builder available to integration tests

### DIFF
--- a/components/common/test/ome/testing/DataProviderBuilder.java
+++ b/components/common/test/ome/testing/DataProviderBuilder.java
@@ -17,7 +17,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package ome.services.graphs;
+package ome.testing;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,7 +34,7 @@ import org.testng.annotations.DataProvider;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.4.1
  */
-class DataProviderBuilder {
+public class DataProviderBuilder {
 
     private List<List<Object>> args = Collections.singletonList(Collections.emptyList());
 
@@ -43,7 +43,7 @@ class DataProviderBuilder {
      * @param enumClass the enumeration class whose values are to be iterated through
      * @return this builder with the additional argument noted
      */
-    DataProviderBuilder add(Class<? extends Enum<?>> enumClass) {
+    public DataProviderBuilder add(Class<? extends Enum<?>> enumClass) {
         final Enum<?>[] enums = enumClass.getEnumConstants();
         final List<List<Object>> newArgs = new ArrayList<>(args.size() * enums.length);
         for (final List<Object> arg : args) {
@@ -65,7 +65,7 @@ class DataProviderBuilder {
      * @return this builder with the additional argument noted
      * @throws ReflectiveOperationException if the model object could not be instantiated
      */
-    DataProviderBuilder add(Collection<Class<? extends IObject>> objectClasses)
+    public DataProviderBuilder add(Collection<Class<? extends IObject>> objectClasses)
             throws ReflectiveOperationException {
         final List<IObject> objects = new ArrayList<>(objectClasses.size());
         for (final Class<? extends IObject> objectClass : objectClasses) {
@@ -89,7 +89,7 @@ class DataProviderBuilder {
      * @param isNullable if {@code null} should be included along with {@code true} and {@code false}
      * @return this builder with the additional argument noted
      */
-    DataProviderBuilder addBoolean(boolean isNullable) {
+    public DataProviderBuilder addBoolean(boolean isNullable) {
         final List<List<Object>> newArgs = new ArrayList<>(args.size() * (isNullable ? 3 : 2));
         for (final List<Object> arg : args) {
             List<Object> newArg;
@@ -115,7 +115,7 @@ class DataProviderBuilder {
     /**
      * @return the return value of a {@link DataProvider} that provides the arguments noted by this builder
      */
-    Object[][] build() {
+    public Object[][] build() {
         final Object[][] argsArray = new Object[args.size()][];
         int index = 0;
         for (final List<Object> arg : args) {

--- a/components/server/test/ome/services/graphs/GraphPolicyRuleTest.java
+++ b/components/server/test/ome/services/graphs/GraphPolicyRuleTest.java
@@ -207,6 +207,7 @@ import ome.services.graphs.GraphPolicy.Action;
 import ome.services.graphs.GraphPolicy.Details;
 import ome.services.graphs.GraphPolicy.Orphan;
 import ome.services.graphs.GraphPolicyRule;
+import ome.testing.DataProviderBuilder;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2348,6 +2348,7 @@ public class AbstractServerTest extends AbstractTest {
      * Convenient helper function for providing Boolean arguments to TestNG tests.
      * @param argCount how many arguments the test takes
      * @return every combination of argument values
+     * @see ome.testing.DataProviderBuilder#addBoolean(boolean)
      */
     private static Boolean[][] provideEveryBooleanCombination(int argCount) {
         // TODO: Once we use Guava 19 we can use Collections.nCopies and Lists.cartesianProduct instead of this manual approach.


### PR DESCRIPTION
# What this PR does

Exposes #5537's `DataProviderBuilder` and moves it to `components/common/test/` so that it can be used from `components/tools/OmeroJava/test/integration/`.

# Testing this PR

Travis should pass (i.e. `GraphPolicyRuleTest` unit test). I can also point to other code that uses this class.

# Related reading

https://trello.com/c/B9feHhY6/465-expose-dataproviderbuilder