### PR TITLE
getFileName_return_string

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5207,7 +5207,7 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
         fpath = f.getPath()
         if fpath is not None and len(fpath) > 0:
             return fpath
-        return f.id
+        return str(f.id)
 
     def getFileInChunks(self, buf=2621440):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5201,13 +5201,7 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
         f = self.getFile()
         if f is None or f._obj is None:
             return None
-        fname = f.getName()
-        if fname is not None and len(fname) > 0:
-            return fname
-        fpath = f.getPath()
-        if fpath is not None and len(fpath) > 0:
-            return fpath
-        return "No name (id:%s)" % f.id
+        return f.getName()
 
     def getFileInChunks(self, buf=2621440):
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5207,7 +5207,7 @@ class FileAnnotationWrapper (AnnotationWrapper, OmeroRestrictionWrapper):
         fpath = f.getPath()
         if fpath is not None and len(fpath) > 0:
             return fpath
-        return str(f.id)
+        return "No name (id:%s)" % f.id
 
     def getFileInChunks(self, buf=2621440):
         """

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -340,7 +340,7 @@ def testFileAnnotationNoName(author_testimg_generated, gatewaywrapper):
                                                         conn.SERVICE_OPTS)
     # reload file_ann to update
     file_ann = conn.getObject("FileAnnotation", ann_id)
-    assert file_ann.getFileName() == "No name (id:%s)" % file_id
+    assert file_ann.getFileName() == ""
 
 
 def testFileAnnotationSpeed(author_testimg_generated, gatewaywrapper):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -331,7 +331,6 @@ def testFileAnnotationNoName(author_testimg_generated, gatewaywrapper):
     ann_id = fa.id.val
     file_ann = FileAnnotationWrapper(conn, fa)
 
-    file_id = orig_file.getId()
     assert file_ann.getFileName() == file_name
 
     # Set Name to None - getFileName() should return file ID as string

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -340,7 +340,7 @@ def testFileAnnotationNoName(author_testimg_generated, gatewaywrapper):
                                                         conn.SERVICE_OPTS)
     # reload file_ann to update
     file_ann = conn.getObject("FileAnnotation", ann_id)
-    assert file_ann.getFileName() == str(file_id)
+    assert file_ann.getFileName() == "No name (id:%s)" % file_id
 
 
 def testFileAnnotationSpeed(author_testimg_generated, gatewaywrapper):

--- a/components/tools/OmeroWeb/omeroweb/webclient/custom_forms.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/custom_forms.py
@@ -138,9 +138,12 @@ class AnnotationQuerySetIterator(object):
         for obj in self.queryset:
             textValue = None
             if isinstance(obj._obj, FileAnnotationI):
-                textValue = (
-                    (len(obj.getFileName()) < 45) and (obj.getFileName()) or
-                    (obj.getFileName()[:42]+"..."))
+                file_name = obj.getFileName()
+                if not file_name:
+                    textValue = "No name. ID %s" % obj.id
+                else:
+                    textValue = (len(file_name) < 45 and file_name or
+                                 (file_name[:42]+"..."))
             elif isinstance(obj._obj, TagAnnotationI):
                 if obj.textValue is not None:
                     if obj.ns is not None and obj.ns != "":


### PR DESCRIPTION
# What this PR does

This fixes Blitz FileAnnotation.getFileName() for when there is no name or empty string.
See https://trello.com/c/18d8k6F1/7-fileanngetfilename

# Testing this PR

1. Test should be green
1. Web adding file annotation dialog: files with empty string Name should show "No name. ID 123"
![screen shot 2018-09-03 at 12 42 31](https://user-images.githubusercontent.com/900055/44985152-2b772e00-af77-11e8-9119-b75a62979818.png)

