### PR TITLE
calculate StatsInfo when missing even for not-big images

### DIFF
--- a/components/romio/src/ome/io/nio/PixelsService.java
+++ b/components/romio/src/ome/io/nio/PixelsService.java
@@ -585,7 +585,7 @@ public class PixelsService extends AbstractFileSystemService
         }
         // Note: since the OMERO.fs work, a pixels pyramid is only required
         // when the pixels set meets big image criteria.
-        if (!pixelsFileExists && requirePyramid && originalFilePath != null)
+        if (!pixelsFileExists && originalFilePath != null)
         {
             handleMissingStatsInfo(pixels);
         }


### PR DESCRIPTION
# What this PR does

If [`StatsInfo`](https://docs.openmicroscopy.org/latest/omero5.4/developers/Model/EveryObject.html#statsinfo) is not available for an image then create it before attempting to render the image. This means that global min-max is used for default rendering settings instead of a hopeful guess at intensity range.

# Testing this PR

Any OMERO 5.4 clients should suffice for imports: this PR changes the server only.

Unzip [test-image.ome.xml.gz](https://github.com/openmicroscopy/openmicroscopy/files/2293788/test-image.ome.xml.gz) and import it into both eel latest and eel merge. Notice how it has five planes with the darkest being the middle one. This is a correct rendering of the image.

Now import it into both again but using,
```
bin/omero import -- --no-stats-info --no-thumbnails test-image.ome.xml
```
* On eel latest, without this PR, you will see that the planes all look the same because misleading rendering settings were chosen.
* On eel merge, with this PR, you will see a clock thumbnail. Refresh and it will become the image. When you view it then it should be rendered correctly.

Omitting `--no-thumbnails` gets the clock-fixing process moving on import rather than first waiting for viewing.

Is the correctness worth the delay?