### PR TITLE
have import calculate the uploaded file checksum only once, not twice

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -344,10 +344,15 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                 StopWatch sw1 = new Slf4JStopWatch();
                 String usedFile = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
                 final Parameters params = new ParametersI().addId(fs.getId()).add("usedfile", omero.rtypes.rstring(usedFile));
-                final RString result = (RString) iQuery.projection(hql, params, allGroupsContext).get(0).get(0);
                 final String clientHash = hashes.get(i);
-                final String serverHash = result.getValue();
-                if (!clientHash.equals(serverHash)) {
+                String serverHash = "";
+                try {
+                    final RString result = (RString) iQuery.projection(hql, params, allGroupsContext).get(0).get(0);
+                    serverHash = result.getValue();
+                } catch (IndexOutOfBoundsException | NullPointerException e) {
+                    log.error("no server checksum on imported file {}", usedFile, e);
+                }
+                if (serverHash.isEmpty() || !clientHash.equals(serverHash)) {
                     failingChecksums.put(i, serverHash);
                 }
                 sw1.stop("omero.import.process.checksum");

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -33,6 +33,7 @@ import org.springframework.aop.framework.Advised;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableMap;
 
 import Ice.Current;
 
@@ -41,6 +42,7 @@ import ome.services.blitz.impl.ServiceFactoryI;
 import ome.services.blitz.repo.PublicRepositoryI.AMD_submit;
 import ome.services.blitz.repo.path.FsFile;
 import ome.services.blitz.util.ServiceFactoryAware;
+import ome.system.Login;
 
 import omero.RString;
 import omero.ServerError;
@@ -334,6 +336,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
             }
 
             Map<Integer, String> failingChecksums = new HashMap<Integer, String>();
+            final Map<String, String> allGroupsContext = ImmutableMap.of(Login.OMERO_GROUP, "-1");
             final IQueryPrx iQuery = sf.getQueryService(__current);
             final String hql = "SELECT originalFile.hash FROM FilesetEntry "
                     + "WHERE fileset.id = :id AND originalFile.path || originalFile.name = :usedfile";
@@ -341,7 +344,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                 StopWatch sw1 = new Slf4JStopWatch();
                 String usedFile = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
                 final Parameters params = new ParametersI().addId(fs.getId()).add("usedfile", omero.rtypes.rstring(usedFile));
-                final RString result = (RString) iQuery.projection(hql, params).get(0).get(0);
+                final RString result = (RString) iQuery.projection(hql, params, allGroupsContext).get(0).get(0);
                 final String clientHash = hashes.get(i);
                 final String serverHash = result.getValue();
                 if (!clientHash.equals(serverHash)) {

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -350,7 +350,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                     final RString result = (RString) iQuery.projection(hql, params, allGroupsContext).get(0).get(0);
                     serverHash = result.getValue();
                 } catch (IndexOutOfBoundsException | NullPointerException e) {
-                    log.error("no server checksum on imported file {}", usedFile, e);
+                    log.error("no server checksum on uploaded file {}", usedFile, e);
                 }
                 if (serverHash.isEmpty() || !clientHash.equals(serverHash)) {
                     failingChecksums.put(i, serverHash);

--- a/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -39,7 +39,6 @@ import ome.services.blitz.repo.PublicRepositoryI.AMD_submit;
 import ome.services.blitz.repo.path.FsFile;
 import ome.services.blitz.util.ServiceFactoryAware;
 
-import omero.RLong;
 import omero.RString;
 import omero.ServerError;
 import omero.api.IQueryPrx;
@@ -299,10 +298,11 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
 
         Map<Integer, String> failingChecksums = new HashMap<Integer, String>();
         final IQueryPrx iQuery = sf.getQueryService(__current);
-        final String hql = "SELECT hash FROM OriginalFile WHERE id = :id";
+        final String hql = "SELECT originalFile.hash FROM FilesetEntry "
+                + "WHERE fileset.id = :id AND originalFile.path || originalFile.name = :usedfile";
         for (int i = 0; i < size; i++) {
-            final RLong fileId = fs.getFilesetEntry(i).getOriginalFile().getId();
-            final Parameters params = new ParametersI().addId(fileId);
+            String usedFile = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
+            final Parameters params = new ParametersI().addId(fs.getId()).add("usedfile", omero.rtypes.rstring(usedFile));
             final RString result = (RString) iQuery.projection(hql, params).get(0).get(0);
             final String clientHash = hashes.get(i);
             final String serverHash = result.getValue();


### PR DESCRIPTION
# What this PR does

@joshmoore discovered that import calculates each file checksum twice over. This PR reduces that to being only once.

# Testing this PR

Import should still work fine with no regressions. To try to break it: In the CLI you can try the `--checksum-algorithm` option and with the server configuration you can adjust `omero.checksum.supported` to force selection of different algorithms.

# Related reading

https://trello.com/c/BPrkScBc/36-file-upload-should-be-faster