### PR TITLE
Updates to ThumbnailLoader and ThumbnailService

### DIFF
--- a/components/blitz/resources/omero/api/ThumbnailStore.ice
+++ b/components/blitz/resources/omero/api/ThumbnailStore.ice
@@ -90,7 +90,8 @@ module omero {
                  * in the on-disk cache it will be returned directly,
                  * otherwise it will be created as in
                  * {@link #getThumbnailDirect}, placed in the on-disk
-                 * cache and returned.
+                 * cache and returned. If the thumbnail is missing, a clock will
+                 * be returned to signify that the thumbnail is yet to be generated.
                  *
                  * @param sizeX the X-axis width of the thumbnail.
                  *              <code>null</code> specifies the default size
@@ -111,6 +112,35 @@ module omero {
                  * @see #getThumbnailDirect
                  */
                 idempotent Ice::ByteSeq getThumbnail(omero::RInt sizeX, omero::RInt sizeY) throws ServerError;
+
+                /**
+                 * Retrieves a thumbnail for a pixels set using a given set of
+                 * rendering settings (RenderingDef). If the thumbnail exists
+                 * in the on-disk cache it will be returned directly,
+                 * otherwise it will be created as in
+                 * {@link #getThumbnailDirect}, placed in the on-disk
+                 * cache and returned. If the thumbnail is still to be generated, an empty array will
+                 * be returned.
+                 *
+                 * @param sizeX the X-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @param sizeY the Y-axis width of the thumbnail.
+                 *              <code>null</code> specifies the default size
+                 *              of 48.
+                 * @throws ApiUsageException
+                 *             if:
+                 *             <ul>
+                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is negative</li>
+                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is negative</li>
+                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             </ul>
+                 * @return a JPEG thumbnail byte buffer
+                 * @see #getThumbnailDirect
+                 */
+                idempotent Ice::ByteSeq getThumbnailWithoutDefault(omero::RInt sizeX, omero::RInt sizeY) throws ServerError;
 
                 /**
                  * Retrieves a number of thumbnails for pixels sets using

--- a/components/blitz/src/ome/services/blitz/impl/ThumbnailStoreI.java
+++ b/components/blitz/src/ome/services/blitz/impl/ThumbnailStoreI.java
@@ -16,6 +16,7 @@ import omero.api.AMD_ThumbnailStore_createThumbnails;
 import omero.api.AMD_ThumbnailStore_createThumbnailsByLongestSideSet;
 import omero.api.AMD_ThumbnailStore_getRenderingDefId;
 import omero.api.AMD_ThumbnailStore_getThumbnail;
+import omero.api.AMD_ThumbnailStore_getThumbnailWithoutDefault;
 import omero.api.AMD_ThumbnailStore_getThumbnailByLongestSide;
 import omero.api.AMD_ThumbnailStore_getThumbnailByLongestSideDirect;
 import omero.api.AMD_ThumbnailStore_getThumbnailByLongestSideSet;
@@ -121,6 +122,12 @@ public class ThumbnailStoreI extends AbstractCloseableAmdServant implements
     }
 
     public void getThumbnail_async(AMD_ThumbnailStore_getThumbnail __cb,
+            RInt sizeX, RInt sizeY, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, sizeX, sizeY);
+
+    }
+
+    public void getThumbnailWithoutDefault_async(AMD_ThumbnailStore_getThumbnailWithoutDefault __cb,
             RInt sizeX, RInt sizeY, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, sizeX, sizeY);
 

--- a/components/blitz/test/ome/services/blitz/test/utests/IceMethodInvokerUnitTest.java
+++ b/components/blitz/test/ome/services/blitz/test/utests/IceMethodInvokerUnitTest.java
@@ -233,6 +233,11 @@ public class IceMethodInvokerUnitTest extends MockObjectTestCase {
             return -1;
         }
 
+        @Override
+        public byte[] getThumbnailWithoutDefault(Integer arg0, Integer arg1) {
+            return null;
+        }
+
     }
 
     // 

--- a/components/common/src/ome/api/ThumbnailStore.java
+++ b/components/common/src/ome/api/ThumbnailStore.java
@@ -105,6 +105,35 @@ public interface ThumbnailStore extends StatefulServiceInterface {
      * @see #getThumbnailDirect(Integer, Integer)
      */
     public byte[] getThumbnail(Integer sizeX, Integer sizeY);
+
+    /**
+    * Retrieves a thumbnail for a pixels set using a given set of
+    * rendering settings (RenderingDef). If the thumbnail exists
+    * in the on-disk cache it will be returned directly,
+    * otherwise it will be created as in
+    * {@link #getThumbnailDirect}, placed in the on-disk
+    * cache and returned. If the thumbnail is still to be generated, an empty array will
+    * be returned.
+    *
+    * @param sizeX the X-axis width of the thumbnail.
+    *              <code>null</code> specifies the default size
+    *              of 48.
+    * @param sizeY the Y-axis width of the thumbnail.
+    *              <code>null</code> specifies the default size
+    *              of 48.
+    * @throws ApiUsageException
+    *             if:
+    *             <ul>
+    *             <li><code>sizeX</code> > pixels.sizeX</li>
+    *             <li><code>sizeX</code> is negative</li>
+    *             <li><code>sizeY</code> > pixels.sizeY</li>
+    *             <li><code>sizeY</code> is negative</li>
+    *             <li>{@link #setPixelsId} has not yet been called</li>
+    *             </ul>
+    * @return a JPEG thumbnail byte buffer
+    * @see #getThumbnailDirect
+    */
+    public byte[] getThumbnailWithoutDefault(Integer sizeX, Integer sizeY);
     
     /**
      * Retrieves a number of thumbnails for pixels sets using given sets of 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserModel.java
@@ -1022,24 +1022,7 @@ abstract class DataBrowserModel
 	{
 		if (images == null) return null;
 		List<DataBrowserLoader> loaders = new ArrayList<DataBrowserLoader>();
-		int n = images.size();
-		int diff = n/MAX_LOADER;
-		List<DataObject> l;
-		int j;
-		int step = 0;
-		if (n < MAX_LOADER) diff = 1;
-		for (int k = 0; k < MAX_LOADER; k++) {
-			l = new ArrayList<DataObject>();
-			j = step+diff;
-			if (k == (MAX_LOADER-1)) j += (n-j);
-			if (j <= n) {
-				l = images.subList(step, j);
-				step += l.size();
-			}
-			if (l.size() > 0) {
-				loaders.add(new ThumbnailLoader(component, ctx, l, n));
-			}
-		}
+		loaders.add(new ThumbnailLoader(component, ctx, images, images.size()));
 		return loaders;
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/dataBrowser/view/DataBrowserModel.java
@@ -1022,7 +1022,24 @@ abstract class DataBrowserModel
 	{
 		if (images == null) return null;
 		List<DataBrowserLoader> loaders = new ArrayList<DataBrowserLoader>();
-		loaders.add(new ThumbnailLoader(component, ctx, images, images.size()));
+		int n = images.size();
+		int diff = n/MAX_LOADER;
+		List<DataObject> l;
+		int j;
+		int step = 0;
+		if (n < MAX_LOADER) diff = 1;
+		for (int k = 0; k < MAX_LOADER; k++) {
+			l = new ArrayList<DataObject>();
+			j = step+diff;
+			if (k == (MAX_LOADER-1)) j += (n-j);
+			if (j <= n) {
+				l = images.subList(step, j);
+				step += l.size();
+			}
+			if (l.size() > 0) {
+				loaders.add(new ThumbnailLoader(component, ctx, l, n));
+			}
+		}
 		return loaders;
 	}
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ThumbnailData.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/model/ThumbnailData.java
@@ -11,7 +11,7 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -22,12 +22,14 @@
 package org.openmicroscopy.shoola.env.data.model;
 
 import java.awt.Graphics2D;
+import java.awt.Image;
 import java.awt.image.BufferedImage;
 
 
 import omero.gateway.model.ImageData;
+import org.openmicroscopy.shoola.util.image.geom.Factory;
 
-/** 
+/**
  * Holds a {@link BufferedImage} serving as a thumbnail for a given <i>OME</i>
  * image.
  *
@@ -45,79 +47,79 @@ public class ThumbnailData
 
 	/** The id of the image to which the thumbnail belong. */
     private long            userID;
-    
+
     /** The id of the image to which the thumbnail belong. */
     private long            imageID;
-    
+
     /** The thumbnail pixels. */
     private BufferedImage   thumbnail;
 
     /** Flag indicating if the image is a default image or not. */
     private boolean			validImage;
-    
+
     /** Used to store the image. */
     private ImageData		image;
-    
+
     /** Flag indicating that the image required a pyramid to be build.*/
     private Boolean			requirePyramid;
-    
+
     /** The object of reference. */
     private omero.gateway.model.DataObject refObject;
-    
-    /** 
+
+    /**
      * Exception if not possible to create the object. This should
      * be used when imported.
      */
     private Exception		error;
-    
+
     /**
      * Creates a new instance.
-     * 
+     *
      * @param imageID    The id of the image to which the thumbnail belong.
      *                   Must be positive.
      * @param thumbnail  The thumbnail pixels.  Mustn't be <code>null</code>.
      * @param userID   	 The id of the user the thumbnail is for.
      *                   Must be positive.
-     * @param validImage Pass <code>true</code> if the image is a real image, 
+     * @param validImage Pass <code>true</code> if the image is a real image,
      * 					 <code>false</code> otherwise.
      */
-    public ThumbnailData(long imageID, BufferedImage thumbnail, long userID, 
-    		boolean validImage)
+    public ThumbnailData(long imageID, Image thumbnail, long userID,
+                         boolean validImage)
     {
-        if (imageID <= 0) 
+        if (imageID <= 0)
             throw new IllegalArgumentException("Non-positive image id: "+
                                                imageID+".");
         this.imageID = imageID;
-        this.thumbnail = thumbnail;
+        this.thumbnail = toBufferedImage(thumbnail);
         this.userID = userID;
         this.validImage = validImage;
         requirePyramid = null;
     }
-    
+
     /**
      * Creates a new instance.
-     * 
+     *
      * @param imageID    The id of the image to which the thumbnail belong.
      *                   Must be positive.
      * @param thumbnail  The thumbnail pixels. Mustn't be <code>null</code>.
-     * @param validImage Pass <code>true</code> if the image is a real image, 
+     * @param validImage Pass <code>true</code> if the image is a real image,
      * 					 <code>false</code> otherwise.
      */
-    public ThumbnailData(long imageID, BufferedImage thumbnail, 
+    public ThumbnailData(long imageID, Image thumbnail,
     		boolean validImage)
     {
         this(imageID, thumbnail, -1, validImage);
     }
-    
+
     /**
      * Creates a new instance.
-     * 
+     *
      * @param refOjbect The object of reference. Mustn't be <code>null</code>.
      * @param thumbnail The thumbnail pixels. Mustn't be <code>null</code>.
-     * @param validImage Passed <code>true</code> if it is a valid image, 
+     * @param validImage Passed <code>true</code> if it is a valid image,
      * <code>false</code> otherwise.
      */
-    public ThumbnailData(omero.gateway.model.DataObject refOjbect, BufferedImage thumbnail,
+    public ThumbnailData(omero.gateway.model.DataObject refOjbect, Image thumbnail,
     		boolean validImage)
     {
     	  if (refOjbect == null)
@@ -126,13 +128,13 @@ public class ThumbnailData
     		  throw new IllegalArgumentException("Type not valid.");
     	  this.refObject = refOjbect;
     	  this.validImage = validImage;
-    	  this.thumbnail = thumbnail;
+    	  this.thumbnail = toBufferedImage(thumbnail);
     	  requirePyramid = null;
     }
-    
+
     /**
      * Creates a new instance.
-     * 
+     *
      * @param refOjbect The object of reference. Mustn't be <code>null</code>.
      * @param requirePyramid Pass <code>true</code> if a pyramid is required,
      * 						<code>false</code> otherwise.
@@ -142,10 +144,10 @@ public class ThumbnailData
         this(refOjbect, null, false);
         this.requirePyramid = requirePyramid;
     }
-    
+
     /**
      * Creates a new instance.
-     * 
+     *
      * @param refOjbect The object of reference. Mustn't be <code>null</code>.
      * @param thumbnail The thumbnail pixels. Mustn't be <code>null</code>.
      */
@@ -153,43 +155,43 @@ public class ThumbnailData
     {
     	  this(refOjbect, thumbnail, true);
     }
-    
+
     /**
      * Sets the time the flag indicating if the image requires a pyramid to be
      * built.
-     * 
+     *
      * @param requirePyramid The value to set.
      */
     public void setBackOffForPyramid(Boolean requirePyramid)
     {
     	this.requirePyramid = requirePyramid;
     }
-    
+
     /**
      * Sets the exception thrown when trying to create a thumbnail.
-     * 
+     *
      * @param error The exception to set.
      */
     public void setError(Exception error) { this.error = error; }
-    
+
     /**
      * Returns the exception.
-     * 
+     *
      * @return See above.
      */
     public Exception getError() { return error; }
-    
-    /** 
+
+    /**
      * Sets the image.
-     * 
+     *
      * @param image The image to set.
      */
     public void setImage(ImageData image) { this.image = image; }
-    
+
     /**
      * Clones this object.
      * This is a deep-copy, the thumbnail pixels are cloned too.
-     * 
+     *
      * @see org.openmicroscopy.shoola.env.data.model.DataObject#makeNew()
      */
     public DataObject makeNew()
@@ -197,7 +199,7 @@ public class ThumbnailData
         BufferedImage pixClone = null;
         if (thumbnail != null) {
         	pixClone = new BufferedImage( thumbnail.getWidth(),
-                    thumbnail.getHeight(), 
+                    thumbnail.getHeight(),
                     thumbnail.getType());
         	 Graphics2D g2D = pixClone.createGraphics();
              g2D.drawImage(thumbnail, null, 0, 0);
@@ -216,58 +218,71 @@ public class ThumbnailData
     }
 
     /**
-     * Returns <code>true</code> if the image is a real image, 
+     * Returns <code>true</code> if the image is a real image,
      * <code>false</code> otherwise.
-     * 
+     *
      * @return See above.
      */
     public boolean isValidImage() { return validImage; }
-    
+
     /**
      * Returns the id of the user.
-     * 
+     *
      * @return See above.
      */
     public long getUserID() { return userID; }
-    
+
     /**
      * Returns the id of the image to which the thumbnail belong.
-     * 
+     *
      * @return See above.
      */
     public long getImageID() { return imageID; }
-    
+
     /**
      * Returns the thumbnail pixels.
-     * 
+     *
      * @return See above.
      */
     public BufferedImage getThumbnail() { return thumbnail; }
-    
+
     /**
      * Returns the image.
-     * 
+     *
      * @return See above.
      */
     public ImageData getImage() { return image; }
-    
+
     /**
      * Returns the object of reference.
-     * 
+     *
      * @return See above.
      */
     public omero.gateway.model.DataObject getRefObject() { return refObject; }
-    
+
     /**
      * Returns <code>true</code> if a pyramid is required, <code>false</code>
      * otherwise.
-     * 
+     *
      * @return See above.
      */
     public Boolean requirePyramid()
-    { 
+    {
     	if (requirePyramid != null) return requirePyramid.booleanValue();
     	return null;
+    }
+
+    /**
+     * Converts a given Image into a BufferedImage
+     *
+     * @param img The Image to be converted
+     * @return The converted BufferedImage
+     */
+    public static BufferedImage toBufferedImage(Image img) {
+        if (img instanceof BufferedImage) {
+            return (BufferedImage) img;
+        }
+        return Factory.createImage(img);
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/DataManagerViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/DataManagerViewImpl.java
@@ -141,8 +141,7 @@ class DataManagerViewImpl
 	public CallHandle loadThumbnail(SecurityContext ctx, ImageData image,
 		int maxWidth, int maxHeight, long userID, AgentEventListener observer)
 	{
-		BatchCallTree cmd = new ThumbnailLoader(ctx, image, maxWidth, maxHeight,
-				userID);
+		BatchCallTree cmd = new ThumbnailLoader(ctx, image, maxWidth, maxHeight, userID);
 		return cmd.exec(observer);
 	}
 	

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/HierarchyBrowsingViewImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/HierarchyBrowsingViewImpl.java
@@ -65,18 +65,18 @@ class HierarchyBrowsingViewImpl
     
     /**
      * Implemented as specified by the view interface.
-     * @see HierarchyBrowsingView#loadThumbnails(Collection, int, int, long,
-     *                                           AgentEventListener)
+     * @see HierarchyBrowsingView#loadThumbnails(SecurityContext, Collection, int, int, long, int, AgentEventListener)
      */
     public CallHandle loadThumbnails(SecurityContext ctx,
     	Collection<DataObject> images, int maxWidth, int maxHeight, long userID,
         int type, AgentEventListener observer)
     {
     	BatchCallTree cmd;
-    	if (type == EXPERIMENTER)
-    		cmd = new ThumbnailSetLoader(ctx, images, maxHeight, type);
-    	else cmd = new ThumbnailLoader(ctx, images, maxWidth,
-    			maxHeight, userID);
+    	if (type == EXPERIMENTER) {
+            cmd = new ThumbnailSetLoader(ctx, images, maxHeight, type);
+        } else {
+            cmd = new ThumbnailLoader(ctx, images, maxWidth, maxHeight, userID);
+        }
         return cmd.exec(observer);
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -216,7 +216,7 @@ public class ThumbnailLoader
                     @Override
                     public void doCall() throws Exception {
                         // System.out.println(image.getId());
-                        ThumbnailStorePrx store = service.createThumbnailStore(ctx);
+                        ThumbnailStorePrx store = getThumbnailStore(pxd);
                         try {
                             handleBatchCall(store, pxd, userId);
                         } finally {
@@ -289,6 +289,17 @@ public class ThumbnailLoader
         return Factory.createDefaultThumbnail("Error");
     }
 
+    private ThumbnailStorePrx getThumbnailStore(PixelsData pxd) throws DSAccessException,
+            DSOutOfServiceException, ServerError {
+        // System.out.println(image.getId());
+        ThumbnailStorePrx store = service.createThumbnailStore(ctx);
+        if (!store.setPixelsId(pxd.getId())) {
+            store.resetDefaults();
+            store.setPixelsId(pxd.getId());
+        }
+        return store;
+    }
+
     /**
      * Loads the thumbnail for {@link #images}<code>[index]</code>.
      *
@@ -307,11 +318,6 @@ public class ThumbnailLoader
                     pxd.getSizeX(), pxd.getSizeY());
             sizeX = d.width;
             sizeY = d.height;
-        }
-
-        if (!store.setPixelsId(pxd.getId())) {
-            store.resetDefaults();
-            store.setPixelsId(pxd.getId());
         }
 
         if (userId >= 0) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -11,7 +11,7 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License along
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -21,38 +21,34 @@
 
 package org.openmicroscopy.shoola.env.data.views.calls;
 
-import java.awt.Dimension;
-import java.awt.image.BufferedImage;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-
+import ome.conditions.ResourceError;
 import omero.ServerError;
-
+import omero.api.IConfigPrx;
+import omero.api.RawPixelsStorePrx;
 import omero.api.ThumbnailStorePrx;
-
-import org.openmicroscopy.shoola.env.data.OmeroImageService;
-import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
-
 import omero.gateway.SecurityContext;
-import omero.gateway.exception.RenderingServiceException;
-
-import org.openmicroscopy.shoola.env.data.views.BatchCall;
-import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
-
-import omero.log.LogMessage;
-
-import org.openmicroscopy.shoola.util.image.geom.Factory;
-import org.openmicroscopy.shoola.util.image.io.WriterImage;
-
+import omero.gateway.exception.DSAccessException;
+import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
+import omero.log.LogMessage;
+import org.openmicroscopy.shoola.env.data.OmeroImageService;
+import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
+import org.openmicroscopy.shoola.env.data.views.BatchCall;
+import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
+import org.openmicroscopy.shoola.util.image.geom.Factory;
+import org.openmicroscopy.shoola.util.image.io.WriterImage;
 
-/** 
+import java.awt.Dimension;
+import java.awt.Image;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+/**
  * Command to load a given set of thumbnails.
- * <p>As thumbnails are retrieved from <i>OMERO</i>, they're posted back to the 
+ * <p>As thumbnails are retrieved from <i>OMERO</i>, they're posted back to the
  * caller through <code>DSCallFeedbackEvent</code>s. Each thumbnail will be
  * posted in a single event; the caller can then invoke the <code>
  * getPartialResult</code> method to retrieve a <code>ThumbnailData</code>
@@ -62,195 +58,206 @@ import omero.gateway.model.PixelsData;
  * original image and so that their area doesn't exceed <code>maxWidth*
  * maxHeight</code>, which is specified to the constructor.</p>
  *
- * @author  Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
- * 				<a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
- * @author  <br>Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
- * 				<a href="mailto:a.falconi@dundee.ac.uk">
- * 					a.falconi@dundee.ac.uk</a>
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @author <br>Andrea Falconi &nbsp;&nbsp;&nbsp;&nbsp;
+ * <a href="mailto:a.falconi@dundee.ac.uk">
+ * a.falconi@dundee.ac.uk</a>
  * @version 2.2
  * @since OME2.2
  */
 public class ThumbnailLoader
-    extends BatchCallTree
-{
+        extends BatchCallTree {
 
-    /** The images for which we need thumbnails. */
+    /**
+     * The images for which we need thumbnails.
+     */
     private Collection<DataObject> images;
 
-    /** The maximum acceptable width of the thumbnails. */
+    /**
+     * The maximum acceptable width of the thumbnails.
+     */
     private int maxWidth;
 
-    /** The maximum acceptable height of the thumbnails. */
+    /**
+     * The maximum acceptable height of the thumbnails.
+     */
     private int maxHeight;
 
-    /** The lastly retrieved thumbnail. */
+    /**
+     * The lastly retrieved thumbnail.
+     */
     private Object currentThumbnail;
 
-    /** Flag to indicate if the class was invoked for a pixels ID. */
-    private boolean pixelsCall;
+    /**
+     * Collection of user IDs.
+     */
+    private Collection<Long> userIDs;
 
-    /** The id of the pixels set this loader is for. */
-    private long pixelsID;
-
-    /** Collection of user IDs. */
-    private Set<Long> userIDs;
-
-    /** Helper reference to the image service. */
+    /**
+     * Helper reference to the image service.
+     */
     private OmeroImageService service;
 
-    /** Load the thumbnail as an full size image. */
-    private boolean asImage;
-
-    /** The security context.*/
+    /**
+     * The security context.
+     */
     private SecurityContext ctx;
 
     /**
-     * Loads the thumbnail for {@link #images}<code>[index]</code>.
-     * 
-     * @param pxd The image the thumbnail for.
-     * @param userID The id of the user the thumbnail is for.
-     * @param store The thumbnail store to use.
-     * @param imageID The id of the image associated to the pixels set.
+     * Use getConfigService() instead of this directly
      */
-    private void loadThumbail(PixelsData pxd, long userID,
-            ThumbnailStorePrx store, boolean last, long imageID)
-    {
-        BufferedImage thumbPix = null;
-        boolean valid = true;
-        int sizeX = maxWidth, sizeY = maxHeight;
-        try {
-            if (asImage) {
-                sizeX = pxd.getSizeX();
-                sizeY = pxd.getSizeY();
-            } else {
-                Dimension d = Factory.computeThumbnailSize(sizeX, sizeY,
-                        pxd.getSizeX(), pxd.getSizeY());
-                sizeX = d.width;
-                sizeY = d.height;
-            }
+    private IConfigPrx configService;
 
-            if (!store.setPixelsId(pxd.getId())) {
-                store.resetDefaults();
-                store.setPixelsId(pxd.getId());
-            }
-            if (userID >= 0) {
-                long rndDefId = service.getRenderingDef(ctx,
-                        pxd.getId(), userID);
-                // the user might not have own rendering settings
-                // for this image
-                if (rndDefId >= 0)
-                    store.setRenderingDefId(rndDefId);
-            }
-            thumbPix = WriterImage.bytesToImage(
-                    store.getThumbnail(omero.rtypes.rint(sizeX),
-                            omero.rtypes.rint(sizeY)));
-        } catch (Throwable e) {
-            thumbPix = null;
-            LogMessage msg = new LogMessage();
-            msg.print("Cannot retrieve thumbnail");
-            msg.print(e);
-            context.getLogger().error(this, msg);
-        } finally {
-            if (last) {
-                context.getDataService().closeService(ctx, store);
-            }
+    /**
+     * Load the thumbnail as an full size image.
+     */
+    private boolean asImage = false;
+
+
+    private IConfigPrx getConfigService() throws DSOutOfServiceException {
+        if (configService == null) {
+            configService = context.getGateway()
+                    .getConfigService(ctx);
         }
-        if (thumbPix == null) {
-            valid = false;
-            thumbPix = Factory.createDefaultImageThumbnail(sizeX, sizeY);
+        return configService;
+    }
+
+    private void handleBatchCall(ThumbnailStorePrx store, PixelsData pxd, long userId) {
+        // If image has pyramids, check to see if image is ready for loading as a thumbnail.
+        try {
+            Image thumbnail;
+            byte[] thumbnailData = loadThumbnail(store, pxd, userId);
+            if (thumbnailData == null || thumbnailData.length == 0) {
+                // Find out why the thumbnail is not ready on the server
+                if (requiresPixelsPyramid(pxd)) {
+                    thumbnail = determineThumbnailState(pxd);
+                } else {
+                    thumbnail = Factory.createDefaultThumbnail("Loading");
+                }
+            } else {
+                thumbnail = WriterImage.bytesToImage(thumbnailData);
+            }
+            // Convert thumbnail to whatever
+            currentThumbnail = new ThumbnailData(pxd.getImage().getId(),
+                    thumbnail, userId, true);
+        } catch (Exception e) {
+            context.getLogger().error(this, e.getMessage());
         }
-        currentThumbnail = new ThumbnailData(imageID, thumbPix, userID, valid);
+    }
+
+    private PixelsData dataObjectToPixelsData(DataObject image) {
+        return image instanceof ImageData ?
+                ((ImageData) image).getDefaultPixels() :
+                (PixelsData) image;
+    }
+
+    private Image determineThumbnailState(PixelsData pxd)
+            throws DSOutOfServiceException, ServerError {
+        RawPixelsStorePrx rawPixelStore = context.getGateway()
+                .getPixelsStore(ctx);
+        try {
+            // This method will throw if there is an issue with the pyramid
+            // generation (i.e. it's not finished, corrupt)
+            rawPixelStore.setPixelsId(pxd.getId(), false);
+        } catch (omero.MissingPyramidException e) {
+            // Thrown if pyramid file is missing
+            // create and show a loading .symbol
+            return Factory.createDefaultThumbnail("Loading");
+        } catch (ResourceError e) {
+            context.getLogger().error(this, new LogMessage("Error getting pyramid from server," +
+                    " it might be corrupt", e));
+        }
+        return Factory.createDefaultThumbnail("Error");
     }
 
     /**
-     * Creates a {@link BatchCall} to retrieve rendering control.
-     * 
-     * @return The {@link BatchCall}.
+     * Loads the thumbnail for {@link #images}<code>[index]</code>.
+     *
+     * @param pxd    The image the thumbnail for.
+     * @param userId The id of the user the thumbnail is for.
+     * @param store  The thumbnail store to use.
      */
-    private BatchCall makeBatchCall()
-    {
-        return new BatchCall("Loading thumbnail for: "+pixelsID) {
-            public void doCall() throws Exception
-            {
-                BufferedImage thumbPix = null;
-                try {
-                    thumbPix = service.getThumbnail(ctx, pixelsID, maxWidth,
-                            maxHeight, -1);
+    private byte[] loadThumbnail(ThumbnailStorePrx store, PixelsData pxd, long userId)
+            throws ServerError, DSAccessException, DSOutOfServiceException {
+        int sizeX = maxWidth, sizeY = maxHeight;
+        if (asImage) {
+            sizeX = pxd.getSizeX();
+            sizeY = pxd.getSizeY();
+        } else {
+            Dimension d = Factory.computeThumbnailSize(sizeX, sizeY,
+                    pxd.getSizeX(), pxd.getSizeY());
+            sizeX = d.width;
+            sizeY = d.height;
+        }
 
-                } catch (RenderingServiceException e) {
-                    context.getLogger().error(this, 
-                            "Cannot retrieve thumbnail from ID: "+
-                                    e.getExtendedMessage());
-                }
-                if (thumbPix == null) 
-                    thumbPix = Factory.createDefaultImageThumbnail(-1);
-                currentThumbnail = thumbPix;
-            }
-        };
-    } 
+        if (!store.setPixelsId(pxd.getId())) {
+            store.resetDefaults();
+            store.setPixelsId(pxd.getId());
+        }
+
+        if (userId >= 0) {
+            long rndDefId = service.getRenderingDef(ctx,
+                    pxd.getId(), userId);
+            // the user might not have own rendering settings
+            // for this image
+            if (rndDefId >= 0)
+                store.setRenderingDefId(rndDefId);
+        }
+
+        return store.getThumbnailWithoutDefault(omero.rtypes.rint(sizeX),
+                omero.rtypes.rint(sizeY));
+    }
+
+    /**
+     * Returns whether a pyramid should be used for the given {@link PixelsData}.
+     * This usually implies that this is a "Big image" and therefore will
+     * need tiling.
+     *
+     * @param pxd
+     * @return
+     */
+    private boolean requiresPixelsPyramid(PixelsData pxd) throws DSOutOfServiceException, ServerError {
+        int maxWidth = Integer.parseInt(getConfigService()
+                .getConfigValue("omero.pixeldata.max_plane_width"));
+        int maxHeight = Integer.parseInt(getConfigService()
+                .getConfigValue("omero.pixeldata.max_plane_height"));
+        return pxd.getSizeX() * pxd.getSizeY() > maxWidth * maxHeight;
+    }
 
     /**
      * Adds a {@link BatchCall} to the tree for each thumbnail to retrieve.
+     *
      * @see BatchCallTree#buildTree()
      */
-    protected void buildTree()
-    {
-        if (pixelsCall) {
-            add(makeBatchCall());
-            return;
-        }
-        String description;
-        Iterator<Long> j = userIDs.iterator();
-        Long id;
-        Iterator<DataObject> i;
-        DataObject image;
-        PixelsData pxd;
-        while (j.hasNext()) {
-            id = j.next();
-            final long userID = id;
-            i = images.iterator();
-            ThumbnailStorePrx store = null;
-            try {
-                store = service.createThumbnailStore(ctx);
-            } catch (Exception e) {
-                context.getLogger().debug(this,
-                        "Cannot start thumbnail store.");
-            }
-            try {
-                final ThumbnailStorePrx value = store;
-                int size = images.size()-1;
-                int k = 0;
-                long imageID = -1;
-                while (i.hasNext()) {
-                    image = (DataObject) i.next();
-                    if (image instanceof ImageData) {
-                        pxd = ((ImageData) image).getDefaultPixels();
-                        imageID = image.getId();
-                    } else {
-                        pxd = (PixelsData) image;
-                        if (pxd != null) imageID = pxd.getImage().getId();
-                    }
-                    description = "Loading thumbnail";
-                    final PixelsData index = pxd;
-                    final boolean last = size == k;
-                    k++;
-                    final long iid = imageID;
-                    add(new BatchCall(description) {
-                        public void doCall() {
-                            loadThumbail(index, userID, value, last, iid);
+    @Override
+    protected void buildTree() {
+        final int lastIndex = images.size() - 1;
+        for (final long userId : userIDs) {
+            int k = 0;
+            for (DataObject image : images) {
+                // Cast our image to pixels object
+                final PixelsData pxd = dataObjectToPixelsData(image);
+
+                // Flag to check if we've iterated to the last image
+                final boolean last = lastIndex == k++;
+
+                // Add a new load thumbnail task to tree
+                add(new BatchCall("Loading thumbnails") {
+                    @Override
+                    public void doCall() throws Exception {
+                        super.doCall();
+                        ThumbnailStorePrx store = service.createThumbnailStore(ctx);
+                        try {
+                            handleBatchCall(store, pxd, userId);
+                        } finally {
+                            if (last) {
+                                context.getDataService()
+                                        .closeService(ctx, store);
+                            }
                         }
-                    });
-                }
-            } catch (RuntimeException r) {
-                // If we fail to pass control to loadThumbnail
-                // then we need to clean up the service.
-                if (store != null) {
-                    try {
-                        store.close();
-                    } catch (ServerError e) {
-                        context.getLogger().warn(this, "Failed to close " + store);
                     }
-                }
+                });
             }
         }
     }
@@ -259,198 +266,78 @@ public class ThumbnailLoader
      * Returns the lastly retrieved thumbnail.
      * This will be packed by the framework into a feedback event and
      * sent to the provided call observer, if any.
-     * 
+     *
      * @return A {@link ThumbnailData} containing the thumbnail pixels.
      */
-    protected Object getPartialResult() { return currentThumbnail; }
+    protected Object getPartialResult() {
+        return currentThumbnail;
+    }
 
     /**
      * Returns the last loaded thumbnail (important for the BirdsEyeLoader to
-     * work correctly). But in fact, thumbnails are progressively delivered with 
-     * feedback events. 
+     * work correctly). But in fact, thumbnails are progressively delivered with
+     * feedback events.
+     *
      * @see BatchCallTree#getResult()
      */
-    protected Object getResult() { return currentThumbnail; }
-
-    /**
-     * Creates a new instance.
-     * If bad arguments are passed, we throw a runtime exception so to fail
-     * early and in the caller's thread.
-     * 
-     * @param ctx The security context.
-     * @param imgs Contains {@link DataObject}s, one 
-     *             for each thumbnail to retrieve.
-     * @param maxWidth The maximum acceptable width of the thumbnails.
-     * @param maxHeight The maximum acceptable height of the thumbnails.
-     * @param userIDs The users the thumbnail are for.
-     */
-    public ThumbnailLoader(SecurityContext ctx, Set<DataObject> imgs,
-            int maxWidth, int maxHeight, Set<Long> userIDs)
-    {
-        if (imgs == null) throw new NullPointerException("No images.");
-        if (maxWidth <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive width: "+maxWidth+".");
-        if (maxHeight <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive height: "+maxHeight+".");
-        this.ctx = ctx;
-        this.maxWidth = maxWidth;
-        this.maxHeight = maxHeight;
-        images = imgs;
-        this.userIDs = userIDs;
-        asImage = false;
-        service = context.getImageService();
+    @Override
+    protected Object getResult() {
+        return currentThumbnail;
     }
 
     /**
      * Creates a new instance.
      * If bad arguments are passed, we throw a runtime exception so to fail
      * early and in the caller's thread.
-     * 
-     * @param ctx The security context.
-     * @param imgs Contains {@link DataObject}s, one for each thumbnail to 
-     *             retrieve.
-     * @param userID The user the thumbnail are for.
+     *
+     * @param ctx       The security context.
+     * @param imgs      Contains {@link DataObject}s, one
+     *                  for each thumbnail to retrieve.
+     * @param maxWidth  The maximum acceptable width of the thumbnails.
+     * @param maxHeight The maximum acceptable height of the thumbnails.
+     * @param userIDs   The users the thumbnail are for.
      */
     public ThumbnailLoader(SecurityContext ctx, Collection<DataObject> imgs,
-            long userID)
-    {
-        if (imgs == null) throw new NullPointerException("No images.");
-        this.ctx = ctx;
-        asImage = true;
-        images = imgs;
-        userIDs = new HashSet<Long>(1);
-        userIDs.add(userID);
-        service = context.getImageService();
-    }
+                           int maxWidth, int maxHeight, Collection<Long> userIDs) {
+        if (images == null) {
+            throw new NullPointerException("No images.");
+        }
 
-    /**
-     * Creates a new instance.
-     * If bad arguments are passed, we throw a runtime exception so to fail
-     * early and in the caller's thread.
-     * 
-     * @param ctx The security context.
-     * @param imgs Contains {@link DataObject}s, one for each thumbnail to
-     *             retrieve.
-     * @param maxWidth The maximum acceptable width of the thumbnails.
-     * @param maxHeight The maximum acceptable height of the thumbnails.
-     * @param userID The user the thumbnail are for.
-     */
-    public ThumbnailLoader(SecurityContext ctx, Collection<DataObject> imgs,
-            int maxWidth, int maxHeight, long userID)
-    {
-        if (imgs == null) throw new NullPointerException("No images.");
-        if (maxWidth <= 0)
+        if (maxWidth <= 0) {
             throw new IllegalArgumentException(
-                    "Non-positive width: "+maxWidth+".");
-        if (maxHeight <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive height: "+maxHeight+".");
-        this.ctx = ctx;
-        this.maxWidth = maxWidth;
-        this.maxHeight = maxHeight;
-        images = imgs;
-        userIDs = new HashSet<Long>(1);
-        userIDs.add(userID);
-        asImage = false;
-        service = context.getImageService();
-    }
+                    "Non-positive width: " + maxWidth + ".");
+        }
 
-    /**
-     * Creates a new instance.
-     * If bad arguments are passed, we throw a runtime exception so to fail
-     * early and in the caller's thread.
-     * 
-     * @param ctx The security context.
-     * @param image The {@link ImageData}, the thumbnail
-     * @param maxWidth The maximum acceptable width of the thumbnails.
-     * @param maxHeight The maximum acceptable height of the thumbnails.
-     * @param userID The user the thumbnails are for.
-     */
-    public ThumbnailLoader(SecurityContext ctx, ImageData image, int maxWidth,
-            int maxHeight, long userID)
-    {
-        if (image == null) throw new IllegalArgumentException("No image.");
-        if (maxWidth <= 0)
+        if (maxHeight <= 0) {
             throw new IllegalArgumentException(
-                    "Non-positive width: "+maxWidth+".");
-        if (maxHeight <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive height: "+maxHeight+".");
-        this.ctx = ctx;
-        userIDs = new HashSet<Long>(1);
-        userIDs.add(userID);
-        images = new HashSet<DataObject>(1);
-        images.add(image);
-        this.maxWidth = maxWidth;
-        this.maxHeight = maxHeight;
-        asImage = false;
-        service = context.getImageService();
-    }
+                    "Non-positive height: " + maxHeight + ".");
+        }
 
-    /**
-     * Creates a new instance.
-     * If bad arguments are passed, we throw a runtime exception so to fail
-     * early and in the caller's thread.
-     * 
-     * @param ctx The security context.
-     * @param pixelsID The id of the pixel set.
-     * @param maxWidth The m aximum acceptable width of the thumbnails.
-     * @param maxHeight The maximum acceptable height of the thumbnails.
-     * @param userID The user the thumbnail are for.
-     */
-    public ThumbnailLoader(SecurityContext ctx, long pixelsID, int maxWidth,
-            int maxHeight, long userID)
-    {
-        if (maxWidth <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive id: "+pixelsID+".");
-        if (maxWidth <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive width: "+maxWidth+".");
-        if (maxHeight <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive height: "+maxHeight+".");
-        this.ctx = ctx;
-        pixelsCall = true;
-        this.maxWidth = maxWidth;
-        this.maxHeight = maxHeight;
-        this.pixelsID = pixelsID;
-        userIDs = new HashSet<Long>(1);
-        userIDs.add(userID);
-        service = context.getImageService();
-    }
-
-    /**
-     * Creates a new instance.
-     * If bad arguments are passed, we throw a runtime exception so to fail
-     * early and in the caller's thread.
-     * 
-     * @param ctx The security context.
-     * @param image The {@link ImageData}, the thumbnail
-     * @param maxWidth The maximum acceptable width of the thumbnails.
-     * @param maxHeight The maximum acceptable height of the thumbnails.
-     * @param userIDs The users the thumbnail are for.
-     */
-    public ThumbnailLoader(SecurityContext ctx, ImageData image, int maxWidth,
-            int maxHeight, Set<Long> userIDs)
-    {
-        if (image == null) throw new IllegalArgumentException("No image.");
-        if (maxWidth <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive width: "+maxWidth+".");
-        if (maxHeight <= 0)
-            throw new IllegalArgumentException(
-                    "Non-positive height: "+maxHeight+".");
-        this.ctx = ctx;
-        images = new HashSet<DataObject>(1);
-        images.add(image);
+        this.images = imgs;
         this.maxWidth = maxWidth;
         this.maxHeight = maxHeight;
         this.userIDs = userIDs;
-        asImage = false;
-        service = context.getImageService();
+        this.ctx = ctx;
+        this.service = context.getImageService();
+    }
+
+    public ThumbnailLoader(SecurityContext ctx, Collection<DataObject> imgs, long userID) {
+        this(ctx, imgs, 0, 0, Collections.singleton(userID));
+        this.asImage = true;
+    }
+
+    public ThumbnailLoader(SecurityContext ctx, Collection<DataObject> imgs, int maxWidth, int maxHeight, long userID) {
+        this(ctx, imgs, maxWidth, maxHeight, Collections.singleton(userID));
+    }
+
+    public ThumbnailLoader(SecurityContext ctx, ImageData image, int maxWidth, int maxHeight, long userID) {
+        this(ctx, new HashSet<DataObject>(), maxWidth, maxHeight, Collections.singleton(userID));
+        images.add(image);
+    }
+
+    public ThumbnailLoader(SecurityContext ctx, ImageData image, int maxWidth, int maxHeight, Collection<Long> userIDs) {
+        this(ctx, new HashSet<DataObject>(), maxWidth, maxHeight, userIDs);
+        images.add(image);
     }
 
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -299,7 +299,7 @@ public class ThumbnailLoader
      */
     public ThumbnailLoader(SecurityContext ctx, Collection<DataObject> imgs,
                            int maxWidth, int maxHeight, Collection<Long> userIDs) {
-        if (images == null) {
+        if (imgs == null) {
             throw new NullPointerException("No images.");
         }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -215,7 +215,6 @@ public class ThumbnailLoader
                 BatchCall call = new BatchCall("Loading thumbnails") {
                     @Override
                     public void doCall() throws Exception {
-                        // System.out.println(image.getId());
                         ThumbnailStorePrx store = getThumbnailStore(pxd);
                         try {
                             handleBatchCall(store, pxd, userId);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -126,15 +126,16 @@ public class ThumbnailLoader
     private void handleBatchCall(ThumbnailStorePrx store, PixelsData pxd, long userId) {
         // If image has pyramids, check to see if image is ready for loading as a thumbnail.
         try {
-            Image thumbnail;
+            Image   thumbnail;
             byte[] thumbnailData = loadThumbnail(store, pxd, userId);
             if (thumbnailData == null || thumbnailData.length == 0) {
                 // Find out why the thumbnail is not ready on the server
-                if (requiresPixelsPyramid(pxd)) {
-                    thumbnail = determineThumbnailState(pxd);
-                } else {
-                    thumbnail = Factory.createDefaultThumbnail("Loading");
-                }
+                thumbnail = Factory.createDefaultThumbnail("Loading");
+//                if (requiresPixelsPyramid(pxd)) {
+//                    thumbnail = determineThumbnailState(pxd);
+//                } else {
+//                    thumbnail = Factory.createDefaultThumbnail("Loading");
+//                }
             } else {
                 thumbnail = WriterImage.bytesToImage(thumbnailData);
             }
@@ -243,10 +244,9 @@ public class ThumbnailLoader
                 final boolean last = lastIndex == k++;
 
                 // Add a new load thumbnail task to tree
-                add(new BatchCall("Loading thumbnails") {
+                BatchCall call = new BatchCall("Loading thumbnails") {
                     @Override
                     public void doCall() throws Exception {
-                        super.doCall();
                         ThumbnailStorePrx store = service.createThumbnailStore(ctx);
                         try {
                             handleBatchCall(store, pxd, userId);
@@ -257,7 +257,9 @@ public class ThumbnailLoader
                             }
                         }
                     }
-                });
+                };
+
+                add(call);
             }
         }
     }

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/VersionCompare.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/VersionCompare.java
@@ -1,0 +1,36 @@
+package org.openmicroscopy.shoola.util;
+
+public class VersionCompare {
+
+    /**
+     * Compares two version strings. https://stackoverflow.com/a/6702029/272446
+     * <p>
+     * Use this instead of String.compareTo() for a non-lexicographical
+     * comparison that works for version strings. e.g. "1.10".compareTo("1.6").
+     *
+     * @param str1 a string of ordinal numbers separated by decimal points.
+     * @param str2 a string of ordinal numbers separated by decimal points.
+     * @return The result is a negative integer if str1 is _numerically_ less than str2.
+     * The result is a positive integer if str1 is _numerically_ greater than str2.
+     * The result is zero if the strings are _numerically_ equal.
+     * @note It does not work if "1.10" is supposed to be equal to "1.10.0".
+     */
+    public static int compare(String str1, String str2) {
+        String[] vals1 = str1.split("\\.");
+        String[] vals2 = str2.split("\\.");
+        int i = 0;
+        // set index to first non-equal ordinal or length of shortest version string
+        while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
+            i++;
+        }
+        // compare first non-equal ordinal number
+        if (i < vals1.length && i < vals2.length) {
+            int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
+            return Integer.signum(diff);
+        }
+        // the strings are equal or one string is a substring of the other
+        // e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+        return Integer.signum(vals1.length - vals2.length);
+    }
+
+}

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/VersionCompare.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/VersionCompare.java
@@ -3,17 +3,18 @@ package org.openmicroscopy.shoola.util;
 public class VersionCompare {
 
     /**
-     * Compares two version strings. https://stackoverflow.com/a/6702029/272446
+     * Compares two version strings. <a href="https://stackoverflow.com/a/6702029/272446">Source</a>
      * <p>
      * Use this instead of String.compareTo() for a non-lexicographical
      * comparison that works for version strings. e.g. "1.10".compareTo("1.6").
+     * <p>
+     * <b>Note:</b> It does not work if "1.10" is supposed to be equal to "1.10.0".
      *
      * @param str1 a string of ordinal numbers separated by decimal points.
      * @param str2 a string of ordinal numbers separated by decimal points.
      * @return The result is a negative integer if str1 is _numerically_ less than str2.
      * The result is a positive integer if str1 is _numerically_ greater than str2.
      * The result is zero if the strings are _numerically_ equal.
-     * @note It does not work if "1.10" is supposed to be equal to "1.10.0".
      */
     public static int compare(String str1, String str2) {
         String[] vals1 = str1.split("\\.");

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1249,7 +1249,7 @@ public class ThumbnailBean extends AbstractLevel2Service
         }
     }
 
-    /**
+    /*
      * (non-Javadoc)
      *
      * @see ome.api.ThumbnailStore#getThumbnailByLongestSide(ome.model.core.Pixels,

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -821,7 +821,12 @@ public class ThumbnailBean extends AbstractLevel2Service
         }
     }
 
-    /** Helper function for using local thumbnailMetadata */
+    /**
+     * Calls {@code _createThumbnail(Thumbnail thumbMetaData)} with the local
+     * variable {@code thumbnailMetadata} as the input parameter.
+     *
+     * @return thumbnail object
+     */
     private Thumbnail _createThumbnail() {
         // For old times sake
         return _createThumbnail(thumbnailMetadata);

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1102,33 +1102,10 @@ public class ThumbnailBean extends AbstractLevel2Service
             thumbnailMetadata = ctx.createThumbnailMetadata(pixels, dimensions);
         }
 
+        byte[] value = retrieveThumbnail(thumbnailMetadata);
         // I don't really know why this is here, no iquery calls being that I can see...
         iQuery.clear();//see #11072
-
-        return retrieveThumbnail(thumbnailMetadata);
-
-//        return retrieveThumbnailDirect((int) dimensions.getWidth(),
-//                (int) dimensions.getHeight(), null, null, true);
-
-        /*byte[] value = retrieveThumbnail(thumbMetaData);
-        if (value.length == 0) {
-            try {
-                pixelDataService.getPixelBuffer(ctx.getPixels(pixelsId), false);
-            } catch (ConcurrencyException e) {
-                log.debug("ConcurrencyException on retrieveThumbnailSet.ctx.hasSettings: pyramid in progress");
-                return value;
-            }
-
-            // Trigger a thumbnail creation
-            // ToDo: make this async
-            // _createThumbnail(thumbMetaData);
-
-            // Now try to load thumbnail
-            // value = retrieveThumbnail(thumbMetaData);
-        }*/
-
-
-        // return value;
+        return value;
     }
 
     /**
@@ -1231,6 +1208,15 @@ public class ThumbnailBean extends AbstractLevel2Service
         } catch (IOException e) {
             if (log.isDebugEnabled()) {
                 log.debug("Cache miss, thumbnail missing or out of date.");
+            }
+
+            final long pixelsId = thumbMetaData.getPixels().getId();
+            if (!ctx.hasSettings(pixelsId)) {
+                try {
+                    pixelDataService.getPixelBuffer(ctx.getPixels(pixelsId), false);
+                } catch (ConcurrencyException ce) {
+                    return new byte[0];
+                }
             }
 
             // If we get here, then we can assume the thumbnail just needs created

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -495,6 +495,25 @@ public class ThumbnailCtx
     }
 
     /**
+     * Retrieves the Thumbnail object for a given Pixels ID.
+     *
+     * @param pixelsId Pixels ID to retrieve the Thumbnail object for.
+     * @return returns null if the thumbnail metadata can't be found
+     */
+    public Thumbnail getMetadataSimple(long pixelsId) throws ResourceError {
+        Thumbnail thumbnail = pixelsIdMetadataMap.get(pixelsId);
+        if (thumbnail == null && securitySystem.isGraphCritical(null)) {
+            Pixels pixels = pixelsIdPixelsMap.get(pixelsId);
+            long ownerId = pixels.getDetails().getOwner().getId();
+            throw new ResourceError(String.format(
+                    "The user id:%s may not be the owner id:%d. The owner " +
+                            "has not viewed the Pixels set id:%d and thumbnail " +
+                            "metadata is missing.", userId, ownerId, pixelsId));
+        }
+        return thumbnail;
+    }
+
+    /**
      * Whether or not the thumbnail metadata for a given Pixels ID is dirty
      * (the RenderingDef has been updated since the Thumbnail was).
      * @param pixelsId Pixels ID to check for dirty metadata.


### PR DESCRIPTION
# What this PR does

Updates thumbnail loading of the Insight client to try convey the state of an images import status to a user.

Code has been added to Insight to check if an image to be displayed has pyramids. If it does, a check is performed to determine if an image has completed it's import process. _Please note, this PR assumes that the final, and slowest, part of an image import is the pyramid generation._

Server code has been updated to only return a thumbnail if a thumbnail is available. Otherwise, nothing is returned and it becomes the clients responsibility to display a loading symbol. 

# Testing this PR

Setup a local OMERO.server, and import some images greater than 2K width/height (squig/ome/data_repo/test_images_good/png)

To do: add testing steps

# Related reading

[Trello card](https://trello.com/c/EaAuRPvm/23-importer-improvements-part-1) 

## Changes
Adds an extra public method to the ThumbnailStore / ThumbnailBean API
Changes logic of ThumbnailLoader in Insight.

