### PR TITLE
for CLI import add --parallel-{upload,fileset} options

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -282,7 +282,7 @@ public class ImportConfig {
         numOfDirectories = new IntValue("numOfDirectories", this, 0);
         savedDirectory = new FileValue("savedDirectory", this);
 
-        encryptedConnection = new BoolValue("ecryptedConnection", this, true);
+        encryptedConnection = new BoolValue("encryptedConnection", this, true);
         autoClose = new BoolValue("autoClose", this, false);
 
         annotations = new AnnotationListValue(

--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -129,6 +129,7 @@ public class ImportConfig {
     public final BoolValue sendReport;
     public final BoolValue sendFiles;
     public final BoolValue sendLogFile;
+    public final IntValue parallelUpload;
     public final StrValue qaBaseURL;
     public final BoolValue checkUpgrade;
 
@@ -274,6 +275,7 @@ public class ImportConfig {
         sendReport   = new BoolValue("sendReport", this, false);
         sendFiles    = new BoolValue("sendFiles", this, true);
         sendLogFile  = new BoolValue("sendLogFile", this, true);
+        parallelUpload = new IntValue("parallelUpload", this, 1);
 
         useFullPath  = new BoolValue("useFullPath", this, true);
         useCustomImageNaming = new BoolValue("overrideImageName", this, true);

--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -130,6 +130,7 @@ public class ImportConfig {
     public final BoolValue sendFiles;
     public final BoolValue sendLogFile;
     public final IntValue parallelUpload;
+    public final IntValue parallelFileset;
     public final StrValue qaBaseURL;
     public final BoolValue checkUpgrade;
 
@@ -275,7 +276,8 @@ public class ImportConfig {
         sendReport   = new BoolValue("sendReport", this, false);
         sendFiles    = new BoolValue("sendFiles", this, true);
         sendLogFile  = new BoolValue("sendLogFile", this, true);
-        parallelUpload = new IntValue("parallelUpload", this, 1);
+        parallelUpload  = new IntValue("parallelUpload", this, 1);
+        parallelFileset = new IntValue("parallelFileset", this, 1);
 
         useFullPath  = new BoolValue("useFullPath", this, true);
         useCustomImageNaming = new BoolValue("overrideImageName", this, true);

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -266,8 +266,9 @@ public class ImportLibrary implements IObservable
     {
         List<ImportContainer> containers = candidates.getContainers();
         if (containers != null) {
+            final int count = containers.size();
             int numDone = 0;
-            for (int index = 0; index < containers.size(); index++) {
+            for (int index = 0; index < count; index++) {
                 ImportContainer ic = containers.get(index);
                 ImportTarget target = config.getTarget();
                 if (target != null) {
@@ -291,7 +292,7 @@ public class ImportLibrary implements IObservable
                 }
 
                 try {
-                    importImage(ic, config.parallelUpload.get(), index, numDone, containers.size());
+                    importImage(ic, config.parallelUpload.get(), index, numDone, count);
                     numDone++;
                 } catch (Throwable t) {
                     String message = "Error on import";

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -271,7 +271,7 @@ public class ImportLibrary implements IObservable
         if (containers != null) {
             final int count = containers.size();
             ExecutorService filesetThreadPool, uploadThreadPool;
-            filesetThreadPool = Executors.newFixedThreadPool(config.parallelFileset.get());
+            filesetThreadPool = Executors.newFixedThreadPool(Math.min(count, config.parallelFileset.get()));
             uploadThreadPool  = Executors.newFixedThreadPool(config.parallelUpload.get());
             try {
                 final List<Callable<Boolean>> threads = new ArrayList<>(count);

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -278,6 +278,15 @@ public class ImportLibrary implements IObservable
                 for (int index = 0; index < count; index++) {
                     final ImportContainer ic = containers.get(index);
                     final ImportTarget target = config.getTarget();
+                    if (config.checksumAlgorithm.get() != null) {
+                        ic.setChecksumAlgorithm(config.checksumAlgorithm.get());
+                    }
+                    final ExecutorService uploadThreadPoolFinal = uploadThreadPool;
+                    final int indexFinal = index;
+                    threads.add(new Callable<Boolean>() {
+                        @Override
+                        public Boolean call() {
+                            try {
                     if (target != null) {
                         try {
                             IObject obj = target.load(store, ic);
@@ -294,15 +303,6 @@ public class ImportLibrary implements IObservable
                             throw new RuntimeException("Failed to load target", e);
                         }
                     }
-                    if (config.checksumAlgorithm.get() != null) {
-                        ic.setChecksumAlgorithm(config.checksumAlgorithm.get());
-                    }
-                    final ExecutorService uploadThreadPoolFinal = uploadThreadPool;
-                    final int indexFinal = index;
-                    threads.add(new Callable<Boolean>() {
-                        @Override
-                        public Boolean call() {
-                            try {
                                 importImage(ic, uploadThreadPoolFinal, indexFinal);
                                 return true;
                             } catch (Throwable t) {

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -268,6 +268,10 @@ public class ImportLibrary implements IObservable
         if (containers != null) {
             final int count = containers.size();
             int numDone = 0;
+            ExecutorService filesetThreadPool, uploadThreadPool;
+            filesetThreadPool = Executors.newFixedThreadPool(config.parallelFileset.get());
+            uploadThreadPool  = Executors.newFixedThreadPool(config.parallelUpload.get());
+            try {
             for (int index = 0; index < count; index++) {
                 ImportContainer ic = containers.get(index);
                 ImportTarget target = config.getTarget();
@@ -309,6 +313,14 @@ public class ImportLibrary implements IObservable
                     } else {
                         log.info("Continuing after error");
                     }
+                }
+            }
+            } finally {
+                if (filesetThreadPool != null) {
+                    filesetThreadPool.shutdown();
+                }
+                if (uploadThreadPool != null) {
+                    uploadThreadPool.shutdown();
                 }
             }
         }

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -267,7 +267,6 @@ public class ImportLibrary implements IObservable
         List<ImportContainer> containers = candidates.getContainers();
         if (containers != null) {
             final int count = containers.size();
-            int numDone = 0;
             ExecutorService filesetThreadPool, uploadThreadPool;
             filesetThreadPool = Executors.newFixedThreadPool(config.parallelFileset.get());
             uploadThreadPool  = Executors.newFixedThreadPool(config.parallelUpload.get());
@@ -296,8 +295,7 @@ public class ImportLibrary implements IObservable
                     }
 
                     try {
-                        importImage(ic, uploadThreadPool, index, numDone, count);
-                        numDone++;
+                        importImage(ic, uploadThreadPool, index, count);
                     } catch (Throwable t) {
                         String message = "Error on import";
                         if (t instanceof ServerError) {
@@ -489,7 +487,7 @@ public class ImportLibrary implements IObservable
     public List<Pixels> importImage(final ImportContainer container, int index, int numDone, int total) throws Throwable {
         final ExecutorService threadPool = Executors.newSingleThreadExecutor();
         try {
-            return importImage(container, threadPool, index, numDone, total);
+            return importImage(container, threadPool, index, total);
         } finally {
             threadPool.shutdown();
         }
@@ -502,8 +500,6 @@ public class ImportLibrary implements IObservable
      * @param threadPool The pool of threads to use in file upload.
      * @param index Index of the import in a set. <code>0</code> is safe if
      * this is a singular import.
-     * @param numDone Number of imports completed in a set. <code>0</code> is
-     * safe if this is a singular import.
      * @param total Total number of imports in a set. <code>1</code> is safe
      * if this is a singular import.
      * @return List of Pixels that have been imported.
@@ -516,7 +512,7 @@ public class ImportLibrary implements IObservable
      * @since OMERO Beta 4.2.1.
      */
     public List<Pixels> importImage(final ImportContainer container, ExecutorService threadPool,
-            int index, int numDone, int total)
+            int index, int total)
             throws FormatException, IOException, Throwable
     {
         HandlePrx handle;

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -596,6 +596,9 @@ public class ImportLibrary implements IObservable
                 final Map.Entry<Integer, String> outcome = threadQueue.take().get();
                 checksumArray[outcome.getKey()] = outcome.getValue();
             } catch (ExecutionException ee) {
+                for (final Future<Map.Entry<Integer, String>> outcome : outcomes) {
+                    outcome.cancel(true);
+                }
                 throw ee.getCause();
             }
         }

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -287,22 +287,22 @@ public class ImportLibrary implements IObservable
                         @Override
                         public Boolean call() {
                             try {
-                    if (target != null) {
-                        try {
-                            IObject obj = target.load(store, ic);
-                            if (!(obj instanceof Annotation)) {
-                                ic.setTarget(obj);
-                            } else {
-                                // This is likely a "post-processing" annotation
-                                // so that we don't have to resolve the target
-                                // until later.
-                                ic.getCustomAnnotationList().add((Annotation) obj);
-                            }
-                        } catch (Exception e) {
-                            log.error("Could not load target: {}", target);
-                            throw new RuntimeException("Failed to load target", e);
-                        }
-                    }
+                                if (target != null) {
+                                    try {
+                                        IObject obj = target.load(store, ic);
+                                        if (!(obj instanceof Annotation)) {
+                                            ic.setTarget(obj);
+                                        } else {
+                                            // This is likely a "post-processing" annotation
+                                            // so that we don't have to resolve the target
+                                            // until later.
+                                            ic.getCustomAnnotationList().add((Annotation) obj);
+                                        }
+                                    } catch (Exception e) {
+                                        log.error("Could not load target: {}", target);
+                                        throw new RuntimeException("Failed to load target", e);
+                                    }
+                                }
                                 importImage(ic, uploadThreadPoolFinal, indexFinal);
                                 return true;
                             } catch (Throwable t) {

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -595,11 +595,11 @@ public class ImportLibrary implements IObservable
             try {
                 final Map.Entry<Integer, String> outcome = threadQueue.take().get();
                 checksumArray[outcome.getKey()] = outcome.getValue();
-            } catch (ExecutionException ee) {
+            } catch (InterruptedException | ExecutionException e) {
                 for (final Future<Map.Entry<Integer, String>> outcome : outcomes) {
                     outcome.cancel(true);
                 }
-                throw ee.getCause();
+                throw e instanceof ExecutionException ? e.getCause() : e;
             }
         }
         final List<String> checksums = Arrays.asList(checksumArray);

--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -297,29 +297,29 @@ public class ImportLibrary implements IObservable
                     final ExecutorService uploadThreadPoolFinal = uploadThreadPool;
                     final int indexFinal = index;
                     filesetThreads.add(new Callable<Boolean>() {
-                                           @Override
-                                           public Boolean call() {
-                    try {
-                        importImage(ic, uploadThreadPoolFinal, indexFinal, count);
-                        return true;
-                    } catch (Throwable t) {
-                        String message = "Error on import";
-                        if (t instanceof ServerError) {
-                            final ServerError se = (ServerError) t;
-                            if (StringUtils.isNotBlank(se.message)) {
-                                message += ": " + se.message;
+                        @Override
+                        public Boolean call() {
+                            try {
+                                importImage(ic, uploadThreadPoolFinal, indexFinal, count);
+                                return true;
+                            } catch (Throwable t) {
+                                String message = "Error on import";
+                                if (t instanceof ServerError) {
+                                    final ServerError se = (ServerError) t;
+                                    if (StringUtils.isNotBlank(se.message)) {
+                                        message += ": " + se.message;
+                                    }
+                                }
+                                log.error(message, t);
+                                if (!config.contOnError.get()) {
+                                    log.info("Exiting on error");
+                                    return false;
+                                } else {
+                                    log.info("Continuing after error");
+                                    return true;
+                                }
                             }
                         }
-                        log.error(message, t);
-                        if (!config.contOnError.get()) {
-                            log.info("Exiting on error");
-                            return false;
-                        } else {
-                            log.info("Continuing after error");
-                            return true;
-                        }
-                    }
-                }
                     });
                 }
                 try {

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -549,6 +549,7 @@ public class CommandLineImporter {
         config.sendReport.set(false);
         config.contOnError.set(false);
         config.parallelUpload.set(1);
+        config.parallelFileset.set(1);
         config.debug.set(false);
         config.encryptedConnection.set(false);
 
@@ -616,6 +617,9 @@ public class CommandLineImporter {
         LongOpt parallelUpload =
                 new LongOpt("parallel-upload", LongOpt.REQUIRED_ARGUMENT, null, 27);
 
+        LongOpt parallelFileset =
+                new LongOpt("parallel-fileset", LongOpt.REQUIRED_ARGUMENT, null, 28);
+
         // DEPRECATED OPTIONS
         LongOpt minutesWaitDeprecated =
                 new LongOpt("minutes_wait", LongOpt.REQUIRED_ARGUMENT, null, 86);
@@ -654,7 +658,8 @@ public class CommandLineImporter {
                                 exclude, target, noStatsInfo,
                                 noUpgradeCheck, qaBaseURL,
                                 outputFormat, encryptedConnection,
-                                parallelUpload, plateName, plateName2,
+                                parallelUpload, parallelFileset,
+                                plateName, plateName2,
                                 plateDescription, plateDescription2,
                                 noThumbnailsDeprecated,
                                 checksumAlgorithmDeprecated,
@@ -819,9 +824,15 @@ public class CommandLineImporter {
                 break;
             }
             case 27: {
-                String parallelArg = g.getOptarg();
-                log.info("Setting parallel upload: {}", parallelArg);
-                config.parallelUpload.set(Integer.valueOf(parallelArg));
+                String parallelFArg = g.getOptarg();
+                log.info("Setting parallel upload: {}", parallelFArg);
+                config.parallelUpload.set(Integer.valueOf(parallelFArg));
+                break;
+            }
+            case 28: {
+                String parallelUArg = g.getOptarg();
+                log.info("Setting parallel fileset: {}", parallelUArg);
+                config.parallelFileset.set(Integer.valueOf(parallelUArg));
                 break;
             }
             // ADVANCED END ---------------------------------------------------

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -1,9 +1,10 @@
 /*
- *   Copyright (C) 2009-2016 University of Dundee & Open Microscopy Environment.
+ *   Copyright (C) 2009-2018 University of Dundee & Open Microscopy Environment.
  *   All rights reserved.
  *
  *   Use is subject to license terms supplied in LICENSE.txt
  */
+
 package ome.formats.importer.cli;
 
 import gnu.getopt.Getopt;
@@ -547,6 +548,7 @@ public class CommandLineImporter {
         config.sendLogFile.set(false);
         config.sendReport.set(false);
         config.contOnError.set(false);
+        config.parallelUpload.set(1);
         config.debug.set(false);
         config.encryptedConnection.set(false);
 
@@ -611,6 +613,9 @@ public class CommandLineImporter {
         LongOpt encryptedConnection =
                 new LongOpt("encrypted", LongOpt.REQUIRED_ARGUMENT, null, 26);
 
+        LongOpt parallelUpload =
+                new LongOpt("parallel-upload", LongOpt.REQUIRED_ARGUMENT, null, 27);
+
         // DEPRECATED OPTIONS
         LongOpt minutesWaitDeprecated =
                 new LongOpt("minutes_wait", LongOpt.REQUIRED_ARGUMENT, null, 86);
@@ -649,7 +654,7 @@ public class CommandLineImporter {
                                 exclude, target, noStatsInfo,
                                 noUpgradeCheck, qaBaseURL,
                                 outputFormat, encryptedConnection,
-                                plateName, plateName2,
+                                parallelUpload, plateName, plateName2,
                                 plateDescription, plateDescription2,
                                 noThumbnailsDeprecated,
                                 checksumAlgorithmDeprecated,
@@ -811,6 +816,12 @@ public class CommandLineImporter {
                 String encryptedArg = g.getOptarg();
                 log.info("Setting encrypted: {}", encryptedArg);
                 config.encryptedConnection.set(Boolean.valueOf(encryptedArg));
+                break;
+            }
+            case 27: {
+                String parallelArg = g.getOptarg();
+                log.info("Setting parallel upload: {}", parallelArg);
+                config.parallelUpload.set(Integer.valueOf(parallelArg));
                 break;
             }
             // ADVANCED END ---------------------------------------------------

--- a/components/blitz/src/ome/formats/importer/util/ProportionalTimeEstimatorImpl.java
+++ b/components/blitz/src/ome/formats/importer/util/ProportionalTimeEstimatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2013-2018 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -64,7 +64,7 @@ public class ProportionalTimeEstimatorImpl implements TimeEstimator {
      */
     public void stop() {
         sw.stop();
-        totalTime += sw.getTime();
+        updateStats();
     }
 
     /**
@@ -72,6 +72,14 @@ public class ProportionalTimeEstimatorImpl implements TimeEstimator {
      */
     public void stop(long uploadedBytes) {
         sw.stop();
+        updateStats(uploadedBytes);
+    }
+
+    private void updateStats() {
+        totalTime += sw.getTime();
+    }
+
+    private void updateStats(long uploadedBytes) {
         totalTime += sw.getTime();
         totalBytes += uploadedBytes;
         imageContainerSize -= uploadedBytes;
@@ -89,5 +97,4 @@ public class ProportionalTimeEstimatorImpl implements TimeEstimator {
     public long getUploadTimeLeft() {
         return timeLeft;
     }
-
 }

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -452,6 +452,9 @@ class ImportControl(BaseControl):
         add_advjava_argument(
             "--parallel-upload", metavar="COUNT",
             help="Number of file upload threads to run at the same time")
+        add_advjava_argument(
+            "--parallel-fileset", metavar="COUNT",
+            help="Number of fileset candidates to import at the same time")
 
         # Unsure on these.
         add_python_argument(

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -449,6 +449,9 @@ class ImportControl(BaseControl):
         add_advjava_argument(
             "--checksum-algorithm", nargs="?", metavar="TYPE",
             help="Alternative hashing mechanisms balancing speed & accuracy")
+        add_advjava_argument(
+            "--parallel-upload", metavar="COUNT",
+            help="Number of file upload threads to run at the same time")
 
         # Unsure on these.
         add_python_argument(

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #
-# Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2014-2018 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -1220,3 +1220,27 @@ path: test.tsv
 
         # TBD
         # assert self.get_object(out, 'Image')
+
+    def testParallelUpload(self, tmpdir, capfd):
+        """Test parallel file upload"""
+
+        # write a pattern file into a new subdirectory
+        subdir = tmpdir.mkdir('ParallelUpload-' + self.uuid())
+        pattern_file = subdir.join('fakes.pattern')
+        pattern_file.write('image-T<0-9>.fake')
+
+        # write fake planes for pattern file
+        for timepoint in range(0, 10):
+            file = 'image-T{0}.fake'.format(timepoint)
+            subdir.join(file).write('')
+
+        # set arguments for parallel upload of pattern file with planes
+        self.args += ['--parallel-upload', '3']
+        self.args += [str(pattern_file)]
+
+        # do import
+        out, err = self.do_import(capfd)
+
+        # check that the pattern file was imported
+        image = self.get_object(out, 'Image')
+        assert image.name.val == 'fakes.pattern'

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -1231,8 +1231,8 @@ path: test.tsv
 
         # write fake planes for pattern file
         for timepoint in range(0, 10):
-            file = 'image-T{0}.fake'.format(timepoint)
-            subdir.join(file).write('')
+            filename = 'image-T{0}.fake'.format(timepoint)
+            subdir.join(filename).write('')
 
         # set arguments for parallel upload of pattern file with planes
         self.args += ['--parallel-upload', '3']
@@ -1244,3 +1244,27 @@ path: test.tsv
         # check that the pattern file was imported
         image = self.get_object(out, 'Image')
         assert image.name.val == 'fakes.pattern'
+
+    def testParallelFileset(self, tmpdir, capfd):
+        """Test parallel fileset import"""
+
+        # set arguments for parallel import of fake images
+        self.args += ['--parallel-fileset', '3']
+
+        # write fake images into a new subdirectory
+        subdir = tmpdir.mkdir('ParallelFileset-' + self.uuid())
+        filenames = set()
+        for index in range(0, 10):
+            filename = 'image-{0}.fake'.format(index)
+            filenames.add(filename)
+            file = subdir.join(filename)
+            file.write('')
+            self.args += [str(file)]
+
+        # do import
+        out, err = self.do_import(capfd)
+
+        # check that the image files were imported
+        images = self.get_objects(out, 'Image')
+        imagenames = set([image.name.val for image in images])
+        assert filenames == imagenames


### PR DESCRIPTION
# What this PR does

Allows image imports to proceed in parallel. The default is single-threaded but the user may specify numbers of threads to use.

# Testing this PR

`bin/omero import --parallel-upload=4 --parallel-fileset=4 MyImages`

`--parallel-upload` should help for images with many small files. `--parallel-fileset` should help when importing many separate filesets. Either or both may be omitted but it probably makes sense to set the latter no smaller than the former. There is some overhead so these should not be set much higher than is helpful.

- https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_import/TestImport/testParallelUpload/
- https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_import/TestImport/testParallelFileset/

To work around https://trello.com/c/OML4OoYE/232-bug-race-condition-on-import use of https://github.com/openmicroscopy/openmicroscopy/pull/5833 should help.

Import failures will be awkward in a multi-threaded context but it is worth checking that behavior is at least acceptable.

# User interface

I suggest that we document this as an *experiment* for power users to test out. Over the course of experience with IDR submissions and the like we can determine if a short `-j` option that simply sets both options to the same value is the way to go or if some other friendly interface would be better.

# Related reading

https://trello.com/c/BPrkScBc/36-file-upload-should-be-faster
https://trello.com/c/SUCmFw9J/491-add-short-j-option-for-parallel-import