### PR TITLE
deprecate importer option useFullPath / userFullPath

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportConfig.java
+++ b/components/blitz/src/ome/formats/importer/ImportConfig.java
@@ -133,6 +133,7 @@ public class ImportConfig {
     public final BoolValue checkUpgrade;
 
     public final BoolValue useCustomImageNaming;
+    @Deprecated
     public final BoolValue useFullPath;
     public final IntValue numOfDirectories;
 
@@ -558,6 +559,7 @@ public class ImportConfig {
     /**
      * @return ini user full path
      */
+    @Deprecated
     public boolean getUserFullPath() {
         return ini.getUserFullPath();
     }
@@ -565,6 +567,7 @@ public class ImportConfig {
     /**
      * @param b ini user full path
      */
+    @Deprecated
     public void setUserFullPath(boolean b) {
         ini.setUserFullPath(b);
     }

--- a/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
+++ b/components/blitz/src/ome/formats/importer/util/IniFileLoader.java
@@ -401,12 +401,14 @@ public class IniFileLoader {
         userPrefs.node("UI").putInt("yOffset", bounds.y);
     }
 
+    @Deprecated
     public boolean getUserFullPath()
     {
     	if (userPrefs == null) return true;
 	    return userPrefs.node("UI").getBoolean("userFullPath", true);
     }
 
+    @Deprecated
     public void setUserFullPath(boolean b)
     {
     	if (userPrefs != null)


### PR DESCRIPTION
Deprecates unused importer options `useFullPath` and `userFullPath`. They are ignored by our code and not mentioned in our documentation.