### PR TITLE
Populate metadata deprecation

### DIFF
--- a/components/tools/OmeroPy/bin/omero
+++ b/components/tools/OmeroPy/bin/omero
@@ -15,6 +15,11 @@ import os
 import stat
 import sys
 
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+# Assuming a CLI user never wants to see development details
+# such as code that has been deprecated.
+
 
 def not_root():
     """

--- a/components/tools/OmeroPy/src/omero/plugins/metadata.py
+++ b/components/tools/OmeroPy/src/omero/plugins/metadata.py
@@ -13,6 +13,7 @@ import mimetypes
 import os
 import re
 import sys
+import warnings
 
 import omero
 from omero.cli import BaseControl
@@ -628,6 +629,11 @@ class MetadataControl(BaseControl):
 
 try:
     if "OMERO_DEV_PLUGINS" in os.environ:
+        warnings.warn(
+            "This module is deprecated as of OMERO 5.4.8. Use the metadata"
+            " CLI plugin available from"
+            " https://pypi.org/project/omero-metadata/ instead.",
+            DeprecationWarning)
         register("metadata", MetadataControl, HELP)
 except NameError:
     if __name__ == "__main__":

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -33,6 +33,7 @@ from getpass import getpass
 from getopt import getopt, GetoptError
 from itertools import izip
 from collections import defaultdict
+import warnings
 
 import omero.clients
 from omero import CmdError
@@ -59,6 +60,11 @@ from populate_roi import ThreadPool
 
 log = logging.getLogger("omero.util.populate_metadata")
 
+warnings.warn(
+    "This module is deprecated as of OMERO 5.4.8. Use the module"
+    " in the omero-metadata project available from"
+    " https://pypi.org/project/omero-metadata/ instead.",
+    DeprecationWarning)
 
 def usage(error):
     """Prints usage so that we don't have to. :)"""

--- a/components/tools/OmeroPy/src/omero/util/populate_metadata.py
+++ b/components/tools/OmeroPy/src/omero/util/populate_metadata.py
@@ -66,6 +66,7 @@ warnings.warn(
     " https://pypi.org/project/omero-metadata/ instead.",
     DeprecationWarning)
 
+
 def usage(error):
     """Prints usage so that we don't have to. :)"""
     cmd = sys.argv[0]


### PR DESCRIPTION
This deprecates the metadata modules distributed as part of OMERO.py. The content of these classes  has been migrated to https://github.com/ome/omero-metadata available from PyPI and future updates/fixes/improvements will be carried out there.

Upstream tests should remain functional and passing but any usage of the modules e.g. when using the CLI plugin via

```
OMERO_DEV_PLUGINS=true bin/omero metadata -h
```

should display the deprecation warning.

See also discussion at https://github.com/ome/omero-parade/issues/47#issuecomment-414400502
