### PR TITLE
Populate dataset webclient

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -351,7 +351,7 @@
                     var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
                     var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
                     var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child' manager.image.id %}";
-                    var query = "image-{{ manager.image.id }}";
+                    var query = "Image-{{ manager.image.id }}";
                     {% endif %}
 
                     var showBulkAnnTooltip = function(data) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -349,6 +349,8 @@
                     {% elif manager.image %}
                     var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
                     var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
+                    var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child.image' manager.image.id %}";
+                    var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child.image' manager.image.id %}";
                     var query = "Image-{{ manager.image.id }}";
                     {% endif %}
 
@@ -387,6 +389,8 @@
                         if (expanded && $("#bulk_annotations_table").is(":empty")) {
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
                         }
                     });
 
@@ -398,6 +402,8 @@
                         if ($("#bulk_annotations_table").is(":empty")) {
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
+                            loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
                         }
                     }
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -389,8 +389,10 @@
                         if (expanded && $("#bulk_annotations_table").is(":empty")) {
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
-                            loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
-                            loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
+                            {% if manager.image %}
+                                loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
+                                loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
+                            {% endif %}
                         }
                     });
 
@@ -402,8 +404,10 @@
                         if ($("#bulk_annotations_table").is(":empty")) {
                             loadBulkAnnotations(screenQuery, query, showBulkAnnTooltip);
                             loadBulkAnnotations(plateQuery, query, showBulkAnnTooltip);
-                            loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
-                            loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
+                            {% if manager.image %}
+                                loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
+                                loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
+                            {% endif %}
                         }
                     }
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -349,8 +349,8 @@
                     {% elif manager.image %}
                     var screenQuery = "{% url 'webgateway_object_table_query' 'Screen.plateLinks.child.wells.wellSamples.image' manager.image.id %}";
                     var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
-                    var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child.image' manager.image.id %}";
-                    var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child.image' manager.image.id %}";
+                    var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
+                    var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child' manager.image.id %}";
                     var query = "Image-{{ manager.image.id }}";
                     {% endif %}
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -351,7 +351,7 @@
                     var plateQuery = "{% url 'webgateway_object_table_query' 'Plate.wells.wellSamples.image' manager.image.id %}";
                     var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
                     var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child' manager.image.id %}";
-                    var query = "Image-{{ manager.image.id }}";
+                    var query = "image-{{ manager.image.id }}";
                     {% endif %}
 
                     var showBulkAnnTooltip = function(data) {

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -352,6 +352,7 @@
                     var projectQuery = "{% url 'webgateway_object_table_query' 'Project.datasetLinks.child.imageLinks.child' manager.image.id %}";
                     var datasetQuery = "{% url 'webgateway_object_table_query' 'Dataset.imageLinks.child' manager.image.id %}";
                     var query = "Image-{{ manager.image.id }}";
+                    var query2 = "image-{{ manager.image.id }}";
                     {% endif %}
 
                     var showBulkAnnTooltip = function(data) {
@@ -392,6 +393,8 @@
                             {% if manager.image %}
                                 loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
                                 loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
+                                loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
+                                loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
                             {% endif %}
                         }
                     });
@@ -407,6 +410,8 @@
                             {% if manager.image %}
                                 loadBulkAnnotations(projectQuery, query, showBulkAnnTooltip);
                                 loadBulkAnnotations(datasetQuery, query, showBulkAnnTooltip);
+                                loadBulkAnnotations(projectQuery, query2, showBulkAnnTooltip);
+                                loadBulkAnnotations(datasetQuery, query2, showBulkAnnTooltip);
                             {% endif %}
                         }
                     }


### PR DESCRIPTION
## Summary 

Previously opened as https://github.com/openmicroscopy/openmicroscopy/pull/5691, but the metadata population logic has now been filtered out of OMERO.py into an independent component which can be released in isolation (see #5831).

This change cherry-picks the changes at the Webclient level for displaying Tables on P/D/I hierarchy. Minimally, when clicking on the Tables tab on an image, two additional queries are performed to load the bulk annotations at either the Project and/or at the Dataset level.

## Testing

Two IDR studies have been imported under the public user of https://web-proxy.openmicroscopy.org/east-web/webclient/: the experimentA of [idr0021](https://idr.openmicroscopy.org/webclient/?show=project-51) and the screenB of [idr0008](https://idr.openmicroscopy.org/webclient/?show=screen-206).

For each study, the bulk annotations have been populated using the annotation.csv files under the metadata repositories ([idr0021](https://github.com/IDR/idr0021-lawo-pericentriolarmaterial) and [idr0008](https://github.com/IDR/idr0008-rohn-actinome)) and [omero-metadata:0.2.2](https://pypi.org/project/omero-metadata/0.2.2/)

Tables should now load when expanding the corresponding tab in the right-hand panel for:
- Images under the `idr0021` project
- Wells under the `idr0008` screen (current behavior)
