### PR TITLE
add %thread% expansion option for omero.fs.repo.path

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -1075,6 +1075,18 @@ public class ManagedRepositoryI extends PublicRepositoryI
         }
 
         /**
+         * Expand {@code %thread%} to the name of the current thread.
+         * @param prefix path component text preceding the expansion term, may be empty
+         * @param suffix path component text following the expansion term, may be empty
+         * @return entire replaced path component, may be unchanged to be revisited,
+         * or {@code null} if it has been wholly processed; otherwise it will be created
+         */
+        @SuppressWarnings("unused")  /* used by create() via Method.invoke */
+        public String expandThread(String prefix, String suffix) {
+            return prefix + serverPaths.getPathSanitizer().apply(Thread.currentThread().getName()) + suffix;
+        }
+
+        /**
          * Expand and create the template path.
          * @return the path
          * @throws ServerError if the path could not be expanded and created

--- a/components/blitz/test/ome/services/blitz/test/utests/ManagedRepositoryITest.java
+++ b/components/blitz/test/ome/services/blitz/test/utests/ManagedRepositoryITest.java
@@ -232,6 +232,14 @@ public class ManagedRepositoryITest extends MockObjectTestCase {
     }
 
     @Test
+    public void testExpandTemplateThread() throws ServerError {
+        String expected = Thread.currentThread().getName();
+        EventContext ecStub = newEventContext();
+        String actual = this.tmri.expandTemplate("%thread%", ecStub);
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
     public void testExpandTemplateEscape() throws ServerError {
         String expected = "%%";
         EventContext ecStub = newEventContext();

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -575,6 +575,7 @@ omero.search.ram_buffer_size=64
 #    %session%      c3fdd5d8-831a-40ff-80f2-0ba5baef448a
 #    %sessionId%    592
 #    %perms%        rw----
+#    %thread%       Blitz-0-Ice.ThreadPool.Server-3
 #    /              path separator
 #    //             end of root-owned directories
 #


### PR DESCRIPTION
# What this PR does

Adds a new `%thread%` option for setting in `omero.fs.repo.path`.

# Testing this PR

Use `bin/omero config set omero.fs.repo.path ...` to set the path to other than the default of `%user%_%userId%//%year%-%month%/%day%/%time%`. Include `%thread%` in that new path, restart the server, do concurrent imports and see how the thread is reflected in the paths created in `ManagedRepository/`.

# Related reading

https://docs.openmicroscopy.org/omero/5.4.7/sysadmins/fs-upload-configuration.html#template-path (does not yet include this)
https://trello.com/c/OML4OoYE/232-bug-race-condition-on-import