### PR TITLE
getShapeStatsRestricted_test_example

### DIFF
--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -248,6 +248,25 @@ for roi in result.rois:
             print "  ", key, value,
         print ""
 
+# Get Pixel Intensities for ROIs
+# ==============================
+result = roi_service.findByImage(imageId, None)
+shape_ids = []
+for roi in result.rois:
+    for s in roi.copyShapes():
+        shape_ids.append(s.id.val)
+ch_index = 0
+# Z/T will only be used if a shape doesn't have Z/T set
+the_z = 0
+the_t = 0
+stats = roi_service.getShapeStatsRestricted(shape_ids, the_z, the_t, [ch_index])
+for s in stats:
+    print "Points", s.pointsCount[ch_index],
+    print "Min", s.min[ch_index],
+    print "Mean", s.mean[ch_index],
+    print "Max", s.max[ch_index],
+    print "Sum", s.max[ch_index],
+    print "StdDev", s.stdDev[ch_index]
 
 # Remove shape from ROI
 # =====================

--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -255,18 +255,18 @@ shape_ids = []
 for roi in result.rois:
     for s in roi.copyShapes():
         shape_ids.append(s.id.val)
-ch_index = 0
+ch_idx = 0
 # Z/T will only be used if a shape doesn't have Z/T set
 the_z = 0
 the_t = 0
-stats = roi_service.getShapeStatsRestricted(shape_ids, the_z, the_t, [ch_index])
+stats = roi_service.getShapeStatsRestricted(shape_ids, the_z, the_t, [ch_idx])
 for s in stats:
-    print "Points", s.pointsCount[ch_index],
-    print "Min", s.min[ch_index],
-    print "Mean", s.mean[ch_index],
-    print "Max", s.max[ch_index],
-    print "Sum", s.max[ch_index],
-    print "StdDev", s.stdDev[ch_index]
+    print "Points", s.pointsCount[ch_idx],
+    print "Min", s.min[ch_idx],
+    print "Mean", s.mean[ch_idx],
+    print "Max", s.max[ch_idx],
+    print "Sum", s.max[ch_idx],
+    print "StdDev", s.stdDev[ch_idx]
 
 # Remove shape from ROI
 # =====================


### PR DESCRIPTION
# What this PR does

Since we are now using roi_servivce.getShapeStatsRestricted() in the training workshops,
need to add it to docs (see https://github.com/openmicroscopy/ome-documentation/pull/1895) and same code to examples.
Also added an integration test.

# Testing this PR

1. Training examples tests should be green
1. Same for integration test.
