### PR TITLE
for import fix prefix template path expansion bug

### DIFF
--- a/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/components/blitz/src/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -1130,7 +1130,7 @@ public class ManagedRepositoryI extends PublicRepositoryI
                     /* try to expand the term */
                     final String oldPattern = pattern;
                     final boolean isTryCreateDirectory = createDirectories &&
-                            !(TEMPLATE_TERM.matcher(prefix).matches() || TEMPLATE_TERM.matcher(suffix).matches());
+                            !(TEMPLATE_TERM.matcher(prefix).find() || TEMPLATE_TERM.matcher(suffix).find());
                     while (true) {
                         try {
                             if (parameters == null) {


### PR DESCRIPTION
# What this PR does

Fix the bug that template path terms are not expanded if they follow `%time%`, `%increment%`, `%subdirs%` in that same path component.

# Testing this PR

Adjust `omero.fs.repo.path` to paths that have been observed not to expand properly and see where newly imported files are put.

Note that  `%time%`, `%increment%`, `%subdirs%` may not be placed together in the same path component.

# Related reading

https://docs.openmicroscopy.org/omero/5.4.7/sysadmins/fs-upload-configuration.html#template-path
https://github.com/openmicroscopy/openmicroscopy/pull/5833#issuecomment-415763603