### PR TITLE
Bump Bio-Formats version to 5.9.2

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -936,7 +936,7 @@ product.name=OMERO.server
 #############################################
 
 org.bioformats=ome
-versions.bioformats=5.9.1
+versions.bioformats=5.9.2-rc1
 
 ##
 versions.JHotDraw=7.0.9

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -936,7 +936,7 @@ product.name=OMERO.server
 #############################################
 
 org.bioformats=ome
-versions.bioformats=5.9.2-rc1
+versions.bioformats=5.9.2
 
 ##
 versions.JHotDraw=7.0.9


### PR DESCRIPTION
In preparation of OMERO 5.4.8-rc1, this PR bumps the Bio-Format version to 5.9.2.

In terms of testing:
- functional testing can be performed by importing one (or multiple) files of the modified formats (`deltavision`, `gatan`, `mrc`) into a server with this PR included  and confirming the bug fixes/improvements. See https://github.com/ome/bio-formats-documentation/pull/50 or
https://github.com/openmicroscopy/bioformats/milestone/66?closed=1 for the full details
- serialization testing: similar to https://github.com/openmicroscopy/openmicroscopy/pull/5818, this PR should not break existing memo files