### PR TITLE
Revert "Revert "travis: disable `integration`""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ before_install:
     - export PATH=$PATH:$HOME/.local/bin
     - if [[ $BUILD == 'build-python' ]]; then travis_retry pip install --user flake8==2.4.0 pytest==2.7.3; fi
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-flake8; fi
-    - if [[ $BUILD == 'integration' ]]; then git clone git://github.com/openmicroscopy/omero-test-infra .omero; fi
 
 # retries the build due to:
 # https://github.com/travis-ci/travis-ci/issues/2507
@@ -52,7 +51,6 @@ install:
 script:
     - if [[ $BUILD == 'build-python' ]]; then ./components/tools/travis-build py-test; fi
     - if [[ $BUILD == 'build-java' ]]; then ./components/tools/travis-build java-test; fi
-    - if [[ $BUILD == 'integration' ]]; then .omero/docker srv; fi
 
 notifications:
   slack:


### PR DESCRIPTION
This reverts commit 3377bafe8bde8970b5ac6729b9e8e4586b279af5.

Even though gh-5830 passed gh-5828 is failing. I'm close to giving up for a while on integration tests in travis. Sorry for the noise.

cc: @sbesson 