### PR TITLE
Blitzgateway close all services

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1931,6 +1931,14 @@ class _BlitzGateway (object):
         self._proxies = NoProxies()
         logger.info("closed connection (uuid=%s)" % str(self._sessionUuid))
 
+    def closeServices(self):
+        """
+        Terminates all services (proxies) of the current session.
+        """
+        for proxy in self._proxies.values():
+            proxy.close()
+        self._proxies = NoProxies()
+
     def _createProxies(self):
         """
         Creates proxies to the server services. Called on connection or


### PR DESCRIPTION
# What this PR does

Adds a `closeServices` method to the Python Blitzgateway.

Running the `render` plugin (which uses the Blitzgateway) in parallel on a large dataset fails after while with an error indicating that too many services are left open. The gateway can't be closed because it closes the session too. A method which only closes the open services is needed. 

There might already be a similar method in the Blitzgateway, but it's basically impossible to find anything in a 10k+ lines file.

I'm currently testing this (as part of the render plugin) on test51 to generate the thumbnails for the HPA dataset.
