### PR TITLE
Bugfixes for RC2

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ImagesImporter.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/ImagesImporter.java
@@ -80,6 +80,15 @@ public class ImagesImporter
 		this.context = context;
 		this.loaderID = loaderID;
 	}
+	
+    /**
+     * Get the ImportableObject corresponding to this ImagesImporter
+     * 
+     * @return See above.
+     */
+    public ImportableObject getImportableObject() {
+        return context;
+    }
 
 	/** 
 	 * Starts the import.

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/util/LightFileImportComponent.java
@@ -1042,7 +1042,10 @@ public class LightFileImportComponent implements PropertyChangeListener,
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         String name = evt.getPropertyName();
-        if (Status.FILES_SET_PROPERTY.equals(name)) {
+        if (Status.SCANNING_PROPERTY.equals(name)) {
+            firePropertyChange(Status.SCANNING_PROPERTY, evt.getOldValue(), evt.getNewValue());
+        }
+        else if (Status.FILES_SET_PROPERTY.equals(name)) {
             if (isCancelled()) {
                 return;
             }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterComponent.java
@@ -660,8 +660,7 @@ class ImporterComponent
 			ImporterUIElement element;
 			while (i.hasNext()) {
 				element = i.next();
-				if (element.hasImportToCancel())
-					toImport.add(element);
+				toImport.add(element);
 			}
 			if (toImport.size() > 0) {
 				i = toImport.iterator();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterControl.java
@@ -347,22 +347,6 @@ class ImporterControl
 	 */
 	boolean isMaster() { return view.isMaster(); }
 
-    /**
-     * Disable the Cancel All button if there are no cancellable imports.
-     */
-    private void checkDisableCancelAllButtons() {
-        final ImporterAction cancelAction = actionsMap.get(CANCEL_BUTTON);
-        if (!cancelAction.isEnabled()) {
-            return;
-        }
-        for (final ImporterUIElement importerUIElement : view.getImportElements()) {
-        	if (importerUIElement.hasImportToCancel()) {
-                return;
-            }
-        }
-        cancelAction.setEnabled(false);
-	}
-
         /**
          * Reacts to property changes.
          * @see PropertyChangeListener#propertyChange(PropertyChangeEvent)
@@ -414,9 +398,6 @@ class ImporterControl
             } else if (ImportDialog.PROPERTY_GROUP_CHANGED.equals(name)) {
                     GroupData newGroup = (GroupData) evt.getNewValue();
                     model.setUserGroup(newGroup);
-            } else if (Status.FILE_IMPORT_STARTED_PROPERTY.equals(name) ||
-                    FileImportComponentI.CANCEL_IMPORT_PROPERTY.equals(name)) {
-                checkDisableCancelAllButtons();
             } else if (Status.IMPORT_DONE_PROPERTY.equals(name)) {
                     model.onImportComplete((FileImportComponentI) evt.getNewValue());
             } else if (Status.UPLOAD_DONE_PROPERTY.equals(name)) {

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterModel.java
@@ -546,7 +546,7 @@ class ImporterModel
             for (ImagesImporter imp : loaders.values()) {
                 ImportableObject io = imp.getImportableObject();
                 for (ImportableFile f : io.getFiles()) {
-                    if (impf.getFile().getName().equals(f.getFile().getName())
+                    if (impf.toString().equals(f.toString())
                             && io.skipThumbnails())
                         return false;
                 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -72,8 +72,8 @@ class ImporterUIElementLight extends ImporterUIElement {
     private JLabel cancelled = new JLabel("0");
     private JLabel cancelledLabel = new JLabel("Cancelled:");
     
-    private boolean isScanning = true;
-    
+    private Boolean isScanning = null;
+
     @Override
     FileImportComponentI buildComponent(ImportableFile importable,
             boolean browsable, boolean singleGroup, int index,
@@ -111,7 +111,7 @@ class ImporterUIElementLight extends ImporterUIElement {
     private void buildGUI() {
         
         // init
-        scanningBusy.setBusy(true);
+        scanningBusy.setBusy(false);
         
         upload.setBorderPainted(true);
         upload.setMinimum(0);
@@ -219,10 +219,16 @@ class ImporterUIElementLight extends ImporterUIElement {
                 complete = c;
         }
 
-        if (!isScanning) {
-            scanningBusy.setBusy(false);
-            scanningBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
+        if (isScanning != null) {
+            if (isScanning) {
+                scanningBusy.setBusy(true);
+            }
+            else {
+                scanningBusy.setBusy(false);
+                scanningBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
+            }
         }
+        
         
         int cancelled = super.cancelled();
         
@@ -284,9 +290,12 @@ class ImporterUIElementLight extends ImporterUIElement {
             int id = Integer.parseInt(tmp[0]);
             int step = Integer.parseInt(tmp[1]);
             importStatus.put(id, step);
-            
-            if (isScanning)
+            if (isScanning != null && isScanning)
                 isScanning = false;
+        }
+        else if (Status.SCANNING_PROPERTY.equals(name)) {
+            if (isScanning == null)
+                isScanning = true;
         }
         
         SwingUtilities.invokeLater(new Runnable() {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -272,6 +272,8 @@ public class ThumbnailLoader extends BatchCallTree {
                 }
             } else {
                 thumbnail = WriterImage.bytesToImage(thumbnailData);
+                if (thumbnail == null) 
+                    thumbnail = Factory.createDefaultThumbnail("Error");
             }
             // Convert thumbnail to whatever
             currentThumbnail = new ThumbnailData(pxd.getImage().getId(),

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -229,7 +229,7 @@ public class ThumbnailLoader extends BatchCallTree {
                         } catch (ApiUsageException ex) {
                             // Can't get the thumbnail and/or service
                             Image thumbnail = Factory
-                                    .createDefaultThumbnail("");
+                                    .createDefaultThumbnail("Can't render");
                             currentThumbnail = new ThumbnailData(pxd.getImage()
                                     .getId(), thumbnail, userId, true);
                             LogMessage msg = new LogMessage(
@@ -258,10 +258,12 @@ public class ThumbnailLoader extends BatchCallTree {
         return configService;
     }
 
-    private void handleBatchCall(ThumbnailStorePrx store, PixelsData pxd, long userId) {
-        // If image has pyramids, check to see if image is ready for loading as a thumbnail.
+    private void handleBatchCall(ThumbnailStorePrx store, PixelsData pxd,
+            long userId) {
+        // If image has pyramids, check to see if image is ready for loading as
+        // a thumbnail.
+        Image thumbnail = null;
         try {
-            Image thumbnail;
             byte[] thumbnailData = loadThumbnail(store, pxd, userId);
             if (thumbnailData == null || thumbnailData.length == 0) {
                 // Find out why the thumbnail is not ready on the server
@@ -272,14 +274,15 @@ public class ThumbnailLoader extends BatchCallTree {
                 }
             } else {
                 thumbnail = WriterImage.bytesToImage(thumbnailData);
-                if (thumbnail == null) 
-                    thumbnail = Factory.createDefaultThumbnail("Error");
             }
+        } catch (Exception e) {
+            context.getLogger().error(this, e.getMessage());
+        } finally {
+            if (thumbnail == null)
+                thumbnail = Factory.createDefaultThumbnail("Can't render");
             // Convert thumbnail to whatever
             currentThumbnail = new ThumbnailData(pxd.getImage().getId(),
                     thumbnail, userId, true);
-        } catch (Exception e) {
-            context.getLogger().error(this, e.getMessage());
         }
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/util/image/geom/Factory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/image/geom/Factory.java
@@ -262,7 +262,10 @@ public class Factory
 			int yTxt = sizeY/2-fontMetrics.getHeight();
 			g.setColor(Color.WHITE);
 			g.setFont(g.getFont().deriveFont(Font.BOLD));
-			g.drawString(text, xTxt, yTxt);
+			for (String line : text.split("\n")) {
+			    g.drawString(line, xTxt, yTxt);
+			    yTxt += g.getFontMetrics().getHeight();
+			}
 			g.dispose();
 		}
 		return thumbPix;


### PR DESCRIPTION
# What this PR does

Fixes some bugs noticed during RC1 testing:

- Importer: Don't request thumbnails if the "skip thumbnails" flag has been set.
- Don't crash Insight if the ThumbnailService can't be initialized for a certain image (e. g. if there is no thumbnail available for an image in a read-only group), just show black thumbnail instead.

Still outstanding:

- ~~Thumbnail doesn't get updated after rendering settings change (save and save-to-all)~~ This seems to be already fixed by @rgozim PRs #5845 

# Related reading

https://docs.google.com/spreadsheets/d/1SDXHxHpWQQ3VBpsGAOXdpZ4H1JdSMTQZHEu3Eg1CAQk/edit#gid=1885911056

