### PR TITLE
adjust section titles in Insight import dialog options tab

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -183,7 +183,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 	private static final String TEXT_FILE_NAMING = "File Naming";
 
 	/** Text for metadata pane title */
-	private static final String TEXT_SKIP_COMPUTE_TITLE = "Import speed-up";
+	private static final String TEXT_SKIP_COMPUTE_TITLE = "Import Speedup";
 	
 	/** Text for metadata pane */
     private static final String TEXT_SKIP_COMPUTE = "Shorten the import by skipping...";

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/ImportDialog.java
@@ -180,7 +180,7 @@ public class ImportDialog extends ClosableTabbedPaneComponent
 			"Import the selected files or directories";
 
 	/** Text for metadata pane */
-	private static final String TEXT_FILE_NAMING = "File Naming";
+	private static final String TEXT_FILE_NAMING = "File Naming & Tags";
 
 	/** Text for metadata pane title */
 	private static final String TEXT_SKIP_COMPUTE_TITLE = "Import Speedup";


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/2630707/45156862-4ea01880-b1d7-11e8-8f76-790e694100c4.png)

After:

![after](https://user-images.githubusercontent.com/2630707/45156875-55c72680-b1d7-11e8-8b87-74abfeadf7dd.png)

Now the titles look a bit more consistent and adding tags isn't hidden away.