### PR TITLE
import: add --readers flag and unit tests

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -620,6 +620,9 @@ public class CommandLineImporter {
         LongOpt parallelFileset =
                 new LongOpt("parallel-fileset", LongOpt.REQUIRED_ARGUMENT, null, 28);
 
+        LongOpt readers =
+                new LongOpt("readers", LongOpt.REQUIRED_ARGUMENT, null, 29);
+
         // DEPRECATED OPTIONS
         LongOpt minutesWaitDeprecated =
                 new LongOpt("minutes_wait", LongOpt.REQUIRED_ARGUMENT, null, 86);
@@ -659,6 +662,7 @@ public class CommandLineImporter {
                                 noUpgradeCheck, qaBaseURL,
                                 outputFormat, encryptedConnection,
                                 parallelUpload, parallelFileset,
+                                readers,
                                 plateName, plateName2,
                                 plateDescription, plateDescription2,
                                 noThumbnailsDeprecated,
@@ -928,7 +932,8 @@ public class CommandLineImporter {
                 config.contOnError.set(true);
                 break;
             }
-            case 'l': {
+            case 'l':
+            case 29: {
                 config.readersPath.set(g.getOptarg());
                 break;
             }

--- a/components/tools/OmeroPy/src/omero/plugins/import.py
+++ b/components/tools/OmeroPy/src/omero/plugins/import.py
@@ -399,7 +399,7 @@ class ImportControl(BaseControl):
             "-c", action="store_true",
             help="Continue importing after errors (**)")
         add_java_argument(
-            "-l",
+            "-l", "--readers",
             help="Use the list of readers rather than the default (**)",
             metavar="READER_FILE")
         add_java_argument(

--- a/components/tools/OmeroPy/test/unit/clitest/readers/no_fakes.txt
+++ b/components/tools/OmeroPy/test/unit/clitest/readers/no_fakes.txt
@@ -1,0 +1,1 @@
+loci.formats.in.MinimalTiffReader

--- a/components/tools/OmeroPy/test/unit/clitest/readers/only_fakes.txt
+++ b/components/tools/OmeroPy/test/unit/clitest/readers/only_fakes.txt
@@ -1,0 +1,1 @@
+loci.formats.in.FakeReader


### PR DESCRIPTION
This is in addition to the short `-l` form.

# Testing this PR

1. double check the unit tests and their status
1. create a readers.txt for testing, e.g `echo loci.formats.in.FakeReader > /tmp/readers.txt`
1. try out `bin/omero import -f --readers=/tmp/readers.txt` in addition to `... -l /tmp/readers.txt ...`