### PR TITLE
Lookupnames

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -126,6 +126,12 @@ public class LookupNames
      * */
     public static final String SERVER_5_4_8_OR_LATER = "5.4.8 or later";
     
+    /** Maximum plane width for non pyramid images **/
+    public static final String MAX_PLANE_WIDTH = "MAX_PLANE_WIDTH";
+    
+    /** Maximum plane height for non pyramid images **/
+    public static final String MAX_PLANE_HEIGHT = "MAX_PLANE_HEIGHT";
+    
     /** Field to access the <code>Name of the software</code>. */
     public static final String SOFTWARE_NAME = "SoftwareName";
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -120,6 +120,12 @@ public class LookupNames
     /** Field to access the <code>Version</code> information. */
     public static final String VERSION = "Version";
 
+    /** 
+     * Field to check if the server version is 5.4.8 or later.
+     * TODO: Can be removed for >= 5.5.0 release
+     * */
+    public static final String SERVER_5_4_8_OR_LATER = "5.4.8 or later";
+    
     /** Field to access the <code>Name of the software</code>. */
     public static final String SOFTWARE_NAME = "SoftwareName";
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -50,6 +50,7 @@ import org.openmicroscopy.shoola.env.data.login.LoginService;
 import org.openmicroscopy.shoola.env.data.login.UserCredentials;
 
 import omero.ServerError;
+import omero.api.IConfigPrx;
 import omero.gateway.LoginCredentials;
 import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSAccessException;
@@ -589,6 +590,14 @@ public class DataServicesFactory
 
         // TODO: Can be removed for >= 5.5.0 release
         container.getRegistry().bind(LookupNames.SERVER_5_4_8_OR_LATER, VersionCompare.compare(version, "5.4.8") >= 0);
+        
+        IConfigPrx cs = omeroGateway.getGateway().getConfigService(new SecurityContext(exp.getGroupId()));
+        try {
+            container.getRegistry().bind(LookupNames.MAX_PLANE_WIDTH, cs.getConfigValue("omero.pixeldata.max_plane_width"));
+            container.getRegistry().bind(LookupNames.MAX_PLANE_HEIGHT, cs.getConfigValue("omero.pixeldata.max_plane_height"));
+        } catch (ServerError e2) {
+            registry.getLogger().warn(this, "Could not access ConfigService");
+        }
 
         //Upgrade check only if client and server are compatible
         omeroGateway.isUpgradeRequired(name);
@@ -613,7 +622,7 @@ public class DataServicesFactory
         registry.bind(LookupNames.CURRENT_USER_DETAILS, exp);
         registry.bind(LookupNames.IMAGE_QUALITY_LEVEL, 
         		determineImageQuality(uc.getSpeedLevel()));
-        
+
         try {
             // Load the omero client properties from the server
             List agents = (List) registry.lookup(LookupNames.AGENTS);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -593,8 +593,10 @@ public class DataServicesFactory
         
         IConfigPrx cs = omeroGateway.getGateway().getConfigService(new SecurityContext(exp.getGroupId()));
         try {
-            container.getRegistry().bind(LookupNames.MAX_PLANE_WIDTH, cs.getConfigValue("omero.pixeldata.max_plane_width"));
-            container.getRegistry().bind(LookupNames.MAX_PLANE_HEIGHT, cs.getConfigValue("omero.pixeldata.max_plane_height"));
+            String val = cs.getConfigValue("omero.pixeldata.max_plane_width");
+            container.getRegistry().bind(LookupNames.MAX_PLANE_WIDTH, val != null ? Integer.parseInt(val) : 3192);
+            val = cs.getConfigValue("omero.pixeldata.max_plane_height");
+            container.getRegistry().bind(LookupNames.MAX_PLANE_HEIGHT, val != null ? Integer.parseInt(val) : 3192);
         } catch (ServerError e2) {
             registry.getLogger().warn(this, "Could not access ConfigService");
         }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -67,6 +67,7 @@ import org.openmicroscopy.shoola.env.rnd.RenderingControl;
 import org.openmicroscopy.shoola.env.ui.UserNotifier;
 import org.openmicroscopy.shoola.svc.proxy.ProxyUtil;
 import org.openmicroscopy.shoola.util.CommonsLangUtils;
+import org.openmicroscopy.shoola.util.VersionCompare;
 import org.openmicroscopy.shoola.util.ui.IconManager;
 import org.openmicroscopy.shoola.util.ui.MessageBox;
 import org.openmicroscopy.shoola.util.ui.NotificationDialog;
@@ -585,6 +586,9 @@ public class DataServicesFactory
         	omeroGateway.logout();
         	return;
         }
+
+        // TODO: Can be removed for >= 5.5.0 release
+        container.getRegistry().bind(LookupNames.SERVER_5_4_8_OR_LATER, VersionCompare.compare(version, "5.4.8") >= 0);
 
         //Upgrade check only if client and server are compatible
         omeroGateway.isUpgradeRequired(name);

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -22,7 +22,6 @@
 package org.openmicroscopy.shoola.env.data.views.calls;
 
 import ome.conditions.ResourceError;
-import omero.ApiUsageException;
 import omero.ServerError;
 import omero.api.IConfigPrx;
 import omero.api.RawPixelsStorePrx;
@@ -35,11 +34,11 @@ import omero.gateway.model.ImageData;
 import omero.gateway.model.PixelsData;
 import omero.log.LogMessage;
 
+import org.openmicroscopy.shoola.env.LookupNames;
 import org.openmicroscopy.shoola.env.data.OmeroImageService;
 import org.openmicroscopy.shoola.env.data.model.ThumbnailData;
 import org.openmicroscopy.shoola.env.data.views.BatchCall;
 import org.openmicroscopy.shoola.env.data.views.BatchCallTree;
-import org.openmicroscopy.shoola.util.VersionCompare;
 import org.openmicroscopy.shoola.util.image.geom.Factory;
 import org.openmicroscopy.shoola.util.image.io.WriterImage;
 
@@ -70,11 +69,6 @@ import java.util.HashSet;
  * @since OME2.2
  */
 public class ThumbnailLoader extends BatchCallTree {
-
-    /**
-     * Version of OMERO.server with {@code getThumbnailWithoutDefault}
-     */
-    private static final String VERSION_THUMBNAIL_NO_DEFAULT = "5.4.8";
 
     /**
      * The images for which we need thumbnails.
@@ -373,9 +367,10 @@ public class ThumbnailLoader extends BatchCallTree {
                 store.setRenderingDefId(rndDefId);
         }
 
-        if (VersionCompare.compare(context.getGateway().getServerVersion(), VERSION_THUMBNAIL_NO_DEFAULT) >= 0) {
+        if ((boolean) context.lookup(LookupNames.SERVER_5_4_8_OR_LATER)) {
             // If the client is connecting to a server with version 5.4.8 or greater, use the thumbnail
             // loading function that doesn't return a clock.
+            // TODO: Can be removed for >= 5.5.0 release
             return store.getThumbnailWithoutDefault(omero.rtypes.rint(sizeX),
                     omero.rtypes.rint(sizeY));
         } else {

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -381,17 +381,18 @@ public class ThumbnailLoader extends BatchCallTree {
 
     /**
      * Returns whether a pyramid should be used for the given {@link PixelsData}.
-     * This usually implies that this is a "Big image" and therefore will
-     * need tiling.
+     * This usually implies that this is a "Big image" and therefore will need
+     * tiling.
      *
      * @param pxd
      * @return
      */
-    private boolean requiresPixelsPyramid(PixelsData pxd) throws ServerError, DSOutOfServiceException {
-        int maxWidth = Integer.parseInt(getConfigService()
-                .getConfigValue("omero.pixeldata.max_plane_width"));
-        int maxHeight = Integer.parseInt(getConfigService()
-                .getConfigValue("omero.pixeldata.max_plane_height"));
+    private boolean requiresPixelsPyramid(PixelsData pxd) throws ServerError,
+            DSOutOfServiceException {
+        int maxWidth = context.lookup(LookupNames.MAX_PLANE_WIDTH) != null ? (Integer) context
+                .lookup(LookupNames.MAX_PLANE_WIDTH) : 3192;
+        int maxHeight = context.lookup(LookupNames.MAX_PLANE_HEIGHT) != null ? (Integer) context
+                .lookup(LookupNames.MAX_PLANE_HEIGHT) : 3192;
         return pxd.getSizeX() * pxd.getSizeY() > maxWidth * maxHeight;
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -380,21 +380,16 @@ public class ThumbnailLoader extends BatchCallTree {
     }
 
     /**
-     * Returns whether a pyramid should be used for the given {@link PixelsData}
-     * . This usually implies that this is a "Big image" and therefore will need
+     * Returns whether a pyramid should be used for the given {@link PixelsData}.
+     * This usually implies that this is a "Big image" and therefore will need
      * tiling.
      *
      * @param pxd
-     * @return
+     * @return See above.
      */
-    private boolean requiresPixelsPyramid(PixelsData pxd) throws ServerError,
-            DSOutOfServiceException {
-        int maxWidth = context.lookup(LookupNames.MAX_PLANE_WIDTH) != null ? Integer
-                .parseInt((String) context.lookup(LookupNames.MAX_PLANE_WIDTH))
-                : 3192;
-        int maxHeight = context.lookup(LookupNames.MAX_PLANE_HEIGHT) != null ? Integer
-                .parseInt((String) context.lookup(LookupNames.MAX_PLANE_HEIGHT))
-                : 3192;
+    private boolean requiresPixelsPyramid(PixelsData pxd) {
+        int maxWidth = (Integer) context.lookup(LookupNames.MAX_PLANE_WIDTH);
+        int maxHeight = (Integer) context.lookup(LookupNames.MAX_PLANE_HEIGHT);
         return pxd.getSizeX() * pxd.getSizeY() > maxWidth * maxHeight;
     }
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/ThumbnailLoader.java
@@ -380,8 +380,8 @@ public class ThumbnailLoader extends BatchCallTree {
     }
 
     /**
-     * Returns whether a pyramid should be used for the given {@link PixelsData}.
-     * This usually implies that this is a "Big image" and therefore will need
+     * Returns whether a pyramid should be used for the given {@link PixelsData}
+     * . This usually implies that this is a "Big image" and therefore will need
      * tiling.
      *
      * @param pxd
@@ -389,10 +389,12 @@ public class ThumbnailLoader extends BatchCallTree {
      */
     private boolean requiresPixelsPyramid(PixelsData pxd) throws ServerError,
             DSOutOfServiceException {
-        int maxWidth = context.lookup(LookupNames.MAX_PLANE_WIDTH) != null ? (Integer) context
-                .lookup(LookupNames.MAX_PLANE_WIDTH) : 3192;
-        int maxHeight = context.lookup(LookupNames.MAX_PLANE_HEIGHT) != null ? (Integer) context
-                .lookup(LookupNames.MAX_PLANE_HEIGHT) : 3192;
+        int maxWidth = context.lookup(LookupNames.MAX_PLANE_WIDTH) != null ? Integer
+                .parseInt((String) context.lookup(LookupNames.MAX_PLANE_WIDTH))
+                : 3192;
+        int maxHeight = context.lookup(LookupNames.MAX_PLANE_HEIGHT) != null ? Integer
+                .parseInt((String) context.lookup(LookupNames.MAX_PLANE_HEIGHT))
+                : 3192;
         return pxd.getSizeX() * pxd.getSizeY() > maxWidth * maxHeight;
     }
 


### PR DESCRIPTION
# What this PR does

Reduce the number of calls to the `ConfigService` by requesting the values for server version and max plane size once at the login stage and storing them as LookupNames.

