### PR TITLE
Added null check for settingsLastUpdated in ThumbnailCtx to prevent NPE

### DIFF
--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -526,6 +526,12 @@ public class ThumbnailCtx
             pixelsIdMetadataLastModifiedTimeMap.get(pixelsId);
         Timestamp settingsLastUpdated =
             pixelsIdSettingsLastModifiedTimeMap.get(pixelsId);
+        
+        if (log.isDebugEnabled())
+        {
+            log.debug("Thumb time: " + metadataLastUpdated);
+            log.debug("Settings time: " + settingsLastUpdated);
+        }
 
         if (metadataLastUpdated == null) {
            return true;
@@ -533,12 +539,6 @@ public class ThumbnailCtx
 
         if (settingsLastUpdated == null) {
             return false;
-        }
-
-        if (log.isDebugEnabled())
-        {
-            log.debug("Thumb time: " + metadataLastUpdated);
-            log.debug("Settings time: " + settingsLastUpdated);
         }
 
         return settingsLastUpdated.after(metadataLastUpdated);

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -526,14 +526,21 @@ public class ThumbnailCtx
             pixelsIdMetadataLastModifiedTimeMap.get(pixelsId);
         Timestamp settingsLastUpdated =
             pixelsIdSettingsLastModifiedTimeMap.get(pixelsId);
+
+        if (metadataLastUpdated == null) {
+           return true;
+        }
+
+        if (settingsLastUpdated == null) {
+            return false;
+        }
+
         if (log.isDebugEnabled())
         {
             log.debug("Thumb time: " + metadataLastUpdated);
             log.debug("Settings time: " + settingsLastUpdated);
         }
-        if (metadataLastUpdated == null) {
-           return true;
-        }
+
         return settingsLastUpdated.after(metadataLastUpdated);
     }
 


### PR DESCRIPTION
# What this PR does

Prevent exception when attempting to load a thumbnail whilst pyramid generation is in progress

```
omero.InternalException
    serverStackTrace = "ome.conditions.InternalException:  Wrapped Exception: (java.lang.NullPointerException):
                        null
                        	at ome.services.ThumbnailCtx.dirtyMetadata(ThumbnailCtx.java:537)
                        	at ome.services.ThumbnailCtx.isThumbnailCached(ThumbnailCtx.java:578)
                        	at ome.services.ThumbnailBean.retrieveThumbnail(ThumbnailBean.java:1215)
                        	at ome.services.ThumbnailBean.getThumbnailWithoutDefault(ThumbnailBean.java:1114)
```

# Testing this PR

Using Insight:

1. Import a 4K or 8K image and wait for import to complete
2. In file explorer (or terminal) navigate to your omero.data.dir and delete the generated `_pyramid` file 
3. Attempt to view the imported image in Insight