### PR TITLE
Move default values for max_plane_w/h to container.xml

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/LookupNames.java
@@ -127,10 +127,10 @@ public class LookupNames
     public static final String SERVER_5_4_8_OR_LATER = "5.4.8 or later";
     
     /** Maximum plane width for non pyramid images **/
-    public static final String MAX_PLANE_WIDTH = "MAX_PLANE_WIDTH";
+    public static final String MAX_PLANE_WIDTH = "/services/Thumbnailing/non_pyramid_max_plane_width";
     
     /** Maximum plane height for non pyramid images **/
-    public static final String MAX_PLANE_HEIGHT = "MAX_PLANE_HEIGHT";
+    public static final String MAX_PLANE_HEIGHT = "/services/Thumbnailing/non_pyramid_max_plane_height";
     
     /** Field to access the <code>Name of the software</code>. */
     public static final String SOFTWARE_NAME = "SoftwareName";

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/DataServicesFactory.java
@@ -594,9 +594,11 @@ public class DataServicesFactory
         IConfigPrx cs = omeroGateway.getGateway().getConfigService(new SecurityContext(exp.getGroupId()));
         try {
             String val = cs.getConfigValue("omero.pixeldata.max_plane_width");
-            container.getRegistry().bind(LookupNames.MAX_PLANE_WIDTH, val != null ? Integer.parseInt(val) : 3192);
+            if (val != null)
+                container.getRegistry().bind(LookupNames.MAX_PLANE_WIDTH, Integer.parseInt(val));
             val = cs.getConfigValue("omero.pixeldata.max_plane_height");
-            container.getRegistry().bind(LookupNames.MAX_PLANE_HEIGHT, val != null ? Integer.parseInt(val) : 3192);
+            if (val != null)
+                container.getRegistry().bind(LookupNames.MAX_PLANE_HEIGHT, Integer.parseInt(val));
         } catch (ServerError e2) {
             registry.getLogger().warn(this, "Could not access ConfigService");
         }

--- a/components/insight/config/container.xml
+++ b/components/insight/config/container.xml
@@ -115,10 +115,12 @@
     -->
     <entry name="/services/Thumbnailing/fetchMediumSpeed" type="double">0.5</entry>
     
-    <!-- Default value for the max plane width which doesn't require pyramids - can be overwritten by the server  -->
+    <!-- Default value for the max plane width which does not require pyramids - 
+         will be overwritten if set server side -->
     <entry name="/services/Thumbnailing/non_pyramid_max_plane_width" type="integer">3192</entry>
     
-    <!-- Default value for the max plane height which doesn't require pyramids - can be overwritten by the server -->
+    <!-- Default value for the max plane height which does not require pyramids - 
+         will be overwritten if set server side -->
     <entry name="/services/Thumbnailing/non_pyramid_max_plane_height" type="integer">3192</entry>
     
     <!-- Rendering Engine configuration.

--- a/components/insight/config/container.xml
+++ b/components/insight/config/container.xml
@@ -115,6 +115,11 @@
     -->
     <entry name="/services/Thumbnailing/fetchMediumSpeed" type="double">0.5</entry>
     
+    <!-- Default value for the max plane width which doesn't require pyramids - can be overwritten by the server  -->
+    <entry name="/services/Thumbnailing/non_pyramid_max_plane_width" type="integer">3192</entry>
+    
+    <!-- Default value for the max plane height which doesn't require pyramids - can be overwritten by the server -->
+    <entry name="/services/Thumbnailing/non_pyramid_max_plane_height" type="integer">3192</entry>
     
     <!-- Rendering Engine configuration.
          NOTE: All the following entries for the Rendering Engine will


### PR DESCRIPTION
# What this PR does

Moves the client side default value for non pyramid max plane width / height to the container.xml.
Addresses @jburel 's comment on https://github.com/openmicroscopy/openmicroscopy/pull/5852#pullrequestreview-154494677 
