### PR TITLE
import: better handle parallel stdout/stderr

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
+++ b/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
@@ -54,7 +54,7 @@ public class LoggingImportMonitor implements IObserver
         return old;
     }
 
-    public void update(IObservable importLibrary, ImportEvent event)
+    public synchronized void update(IObservable importLibrary, ImportEvent event)
     {
         if (event instanceof IMPORT_DONE) {
             IMPORT_DONE ev = (IMPORT_DONE) event;

--- a/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
+++ b/components/blitz/src/ome/formats/importer/cli/LoggingImportMonitor.java
@@ -223,15 +223,12 @@ public class LoggingImportMonitor implements IObserver
                 String exclude) {
 
             System.err.println("Other imported objects:");
-            System.err.print("Fileset:");
-            System.err.println(fid);
+            System.err.println("Fileset:" + fid);
             for (String kls : collect.keySet()) {
                 if (exclude == null || !kls.equals(exclude)) {
                     List<Long> ids = collect.get(kls);
                     for (Long id : ids) {
-                        System.err.print(kls);
-                        System.err.print(":");
-                        System.err.println(id);
+                        System.err.println(String.format("%s:%d", kls, id));
                     }
                 }
             }
@@ -272,11 +269,8 @@ public class LoggingImportMonitor implements IObserver
             ListMultimap<String, Long> collect = getObjectIdMap(ev);
             for (String kls : collect.keySet()) {
                 List<Long> ids = collect.get(kls);
-                System.out.print("  ");
-                System.out.print(kls);
-                System.out.print(": [");
-                System.out.print(Joiner.on(",").join(ids));
-                System.out.println("]");
+                System.out.println(String.format("  %s: [%s]", kls,
+                    Joiner.on(",").join(ids)));
             }
         }
 
@@ -298,9 +292,7 @@ public class LoggingImportMonitor implements IObserver
                 kls = "Image";
             }
             List<Long> ids = collect.get(kls);
-            System.out.print(kls);
-            System.out.print(":");
-            System.out.println(Joiner.on(",").join(ids));
+            System.out.println(String.format("%s:%s", kls, Joiner.on(",").join(ids)));
 
             otherImportedObjects(ev.fileset.getId().getValue(), collect, kls);
         }


### PR DESCRIPTION
The various calls to `System.{out,err}.print()` (no `ln`)
allow multiple different threads to interleave their logging,
leading to output like:

```
Image:Image:2460
2461
```

This PR reduces the individual calls to System.{out,err} and synchronizes the `update`  method.


# Testing this PR

 1. perform multiple parallel imports, e.g. `time for x in $(seq 11 50); do time omero import -T Dataset:name:fake-$x *.fake --parallel-fileset=3 >$x.out 2>$x.err; done`
 2. checkout the output for lines *not* matching `Image:\d+`
 3. with this PR, that should not happen; _without_ the PR, it does occasionally. 

# Related reading

1. https://ci.openmicroscopy.org/view/Failing/job/OMERO-DEV-merge-integration-Python27/968/testReport/OmeroPy.test.integration.clitest.test_import/TestImport/testParallelFileset/

Note: this does not *yet* solve interleaving of YAML output, etc.