### PR TITLE
Simplified retrieveThumbnail and added call to iUpdate.saveObject

### DIFF
--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -865,9 +865,8 @@ public class ThumbnailBean extends AbstractLevel2Service
         try {
             if (thumbMetaData == null) {
                 throw new ValidationException("Missing thumbnail metadata.");
-            } else if (ctx.dirtyMetadata(pixels.getId()) &&
-                    thumbMetaData.getDetails().getOwner() != null) {
-                // Increment the version of the thumbnail so that its
+            } else if (ctx.dirtyMetadata(pixels.getId())&&
+                thumbMetaData.getDetails().getOwner() != null) {// Increment the version of the thumbnail so that its
                 // update event has a timestamp equal to or after that of
                 // the rendering settings. FIXME: This should be
                 // implemented using IUpdate.touch() or similar once that

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1117,14 +1117,15 @@ public class ThumbnailBean extends AbstractLevel2Service
         ctx.loadAndPrepareMetadata(pixelsIds, dimensions);
 
         // If this comes back null, don't have a thumbnail yet
-        thumbnailMetadata = ctx.getMetadataSimple(pixelsId);
-        if (thumbnailMetadata == null) {
+        Thumbnail metadata = ctx.getMetadataSimple(pixelsId);
+        if (metadata == null) {
             // We don't have a thumbnail to load, lets try to create it
             // and then return it
-            thumbnailMetadata = ctx.createThumbnailMetadata(pixels, dimensions);
+            metadata = ctx.createThumbnailMetadata(pixels, dimensions);
+            return retrieveThumbnailDirect(metadata, null, null);
         }
 
-        byte[] value = retrieveThumbnail(thumbnailMetadata);
+        byte[] value = retrieveThumbnail(metadata);
         // I don't really know why this is here, no iquery calls being that I can see...
         iQuery.clear();//see #11072
         return value;
@@ -1336,10 +1337,21 @@ public class ThumbnailBean extends AbstractLevel2Service
         if (rewriteMetadata) {
             thumbnailMetadata = local;
         }
+        return retrieveThumbnailDirect(local, theZ, theT);
+    }
 
-        BufferedImage image = createScaledImage(local, theZ, theT);
+    /**
+     * Creates a thumbnail in memory and returns the bytes.
+     *
+     * @param metadata thumbnail metadata
+     * @param theZ Optical section to retrieve a thumbnail for.
+     * @param theT Timepoint to retrieve a thumbnail for.
+     * @return byte array of image data
+     */
+    private byte[] retrieveThumbnailDirect(Thumbnail metadata, Integer theZ, Integer theT) {
+        BufferedImage image = createScaledImage(metadata, theZ, theT);
         if (image == null) {
-            image = new BufferedImage(local.getSizeX(), local.getSizeY(),
+            image = new BufferedImage(metadata.getSizeX(), metadata.getSizeY(),
                     BufferedImage.TYPE_INT_RGB);
         }
 
@@ -1358,6 +1370,7 @@ public class ThumbnailBean extends AbstractLevel2Service
             }
         }
     }
+
 
     /* (non-Javadoc)
      * @see ome.api.ThumbnailStore#getThumbnailForSectionDirect(int, int, java.lang.Integer, java.lang.Integer)

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -475,18 +475,8 @@ public class ThumbnailCtx
      */
     public Thumbnail getMetadata(long pixelsId) throws NoThumbnail
     {
-        Thumbnail thumbnail = pixelsIdMetadataMap.get(pixelsId);
-        if (thumbnail == null && securitySystem.isGraphCritical(null)) // maythrow
-        {
-            Pixels pixels = pixelsIdPixelsMap.get(pixelsId);
-            long ownerId = pixels.getDetails().getOwner().getId();
-            throw new ResourceError(String.format(
-                    "The user id:%s may not be the owner id:%d. The owner " +
-                    "has not viewed the Pixels set id:%d and thumbnail " +
-                    "metadata is missing.", userId, ownerId, pixelsId));
-        }
-        else if (thumbnail == null)
-        {
+        Thumbnail thumbnail = getMetadataSimple(pixelsId);
+        if (thumbnail == null) {
             throw new NoThumbnail(
                     "Fatal error retrieving thumbnail metadata for Pixels " +
                     "set id:" + pixelsId);
@@ -501,16 +491,19 @@ public class ThumbnailCtx
      * @return returns null if the thumbnail metadata can't be found
      */
     public Thumbnail getMetadataSimple(long pixelsId) throws ResourceError {
-        Thumbnail thumbnail = pixelsIdMetadataMap.get(pixelsId);
-        if (thumbnail == null && securitySystem.isGraphCritical(null)) {
-            Pixels pixels = pixelsIdPixelsMap.get(pixelsId);
-            long ownerId = pixels.getDetails().getOwner().getId();
-            throw new ResourceError(String.format(
-                    "The user id:%s may not be the owner id:%d. The owner " +
-                            "has not viewed the Pixels set id:%d and thumbnail " +
-                            "metadata is missing.", userId, ownerId, pixelsId));
+        if (!pixelsIdMetadataMap.containsKey(pixelsId)) {
+           if (securitySystem.isGraphCritical(null)) {
+               Pixels pixels = pixelsIdPixelsMap.get(pixelsId);
+               long ownerId = pixels.getDetails().getOwner().getId();
+               throw new ResourceError(String.format(
+                       "The user id:%s may not be the owner id:%d. The owner " +
+                               "has not viewed the Pixels set id:%d and thumbnail " +
+                               "metadata is missing.", userId, ownerId, pixelsId));
+           } else {
+               return null;
+           }
         }
-        return thumbnail;
+        return pixelsIdMetadataMap.get(pixelsId);
     }
 
     /**

--- a/components/server/src/ome/services/ThumbnailCtx.java
+++ b/components/server/src/ome/services/ThumbnailCtx.java
@@ -568,6 +568,23 @@ public class ThumbnailCtx
         }
     }
 
+    public boolean isThumbnailLoadable(long pixelsId) {
+        if (!pixelsIdMetadataMap.containsKey(pixelsId)) {
+            return false;
+        }
+
+        try {
+            Thumbnail metadata = pixelsIdMetadataMap.get(pixelsId);
+            boolean dirtyMetadata = dirtyMetadata(pixelsId);
+            boolean thumbnailExists = thumbnailService.getThumbnailExists(metadata);
+            return !dirtyMetadata && thumbnailExists;
+        } catch (IOException e) {
+            String s = "Could not check if thumbnail is on disk: ";
+            log.error(s, e);
+            throw new ResourceError(s + e.getMessage());
+        }
+    }
+
     /**
      * Checks to see if a thumbnail is in the on disk cache or not.
      *
@@ -576,12 +593,13 @@ public class ThumbnailCtx
      */
     public boolean isThumbnailCached(long pixelsId)
     {
-        Thumbnail metadata = pixelsIdMetadataMap.get(pixelsId);
-        if (metadata == null) {
+        if (!pixelsIdMetadataMap.containsKey(pixelsId)) {
             return false;
         }
+
         try
         {
+            Thumbnail metadata = pixelsIdMetadataMap.get(pixelsId);
             boolean dirtyMetadata = dirtyMetadata(pixelsId);
             boolean thumbnailExists =
                 thumbnailService.getThumbnailExists(metadata);


### PR DESCRIPTION
# What this PR does

Fixes a bug where changing rendering settings for the owner of an image results in a separate users from not being able to view the updated image.