### PR TITLE
Fixed bug identified by Will

### DIFF
--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -865,7 +865,8 @@ public class ThumbnailBean extends AbstractLevel2Service
         try {
             if (thumbMetaData == null) {
                 throw new ValidationException("Missing thumbnail metadata.");
-            } else if (ctx.dirtyMetadata(pixels.getId())) {
+            } else if (ctx.dirtyMetadata(pixels.getId()) &&
+                    thumbMetaData.getDetails().getOwner() != null) {
                 // Increment the version of the thumbnail so that its
                 // update event has a timestamp equal to or after that of
                 // the rendering settings. FIXME: This should be


### PR DESCRIPTION
# What this PR does

Fixs bug were viewing an image that has edited rendering settings, belonging to user 1, as user 2  results in no thumbnail loading.

This PR adds code to run `_createThumbnail` to increment metadata version before going compressing and saving an image to disk. Furthermore, it triggers Added iUpdate.saveObject after compressThumbnailToDisk completes to keep db in sync with what is in cache/disk.

# Testing this PR

As TB1 in Insight
1. Import an image
2. Edit that images colour channels and save
3. Take note of the ImageID of the image you just edited

As TB2 in Webclient
1. Navigate to `baseurl/webclient/render_thumbnail/imageID/`
2. Image should load on screen


Second test:
As TB1 in Insight
1. Import a big image, skip thumbnail. Don't view the image or thumbnail
As TB2 in Insight For that test, you will need a build from insight from few days ago (mainly due to #5865)
1. Open the Image. This will trigger the pyramid generation, (you will have to cancel the loading this is due a bug in insight  outside the scope of this PR)
2. Re-open the image. 
3. Check that the bird eye view is correctly displayed

