### PR TITLE
Load default size thumbnail

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/imviewer/view/ImViewerModel.java
@@ -3028,9 +3028,6 @@ class ImViewerModel
 	{
 		loaders.remove(BIRD_EYE_VIEW);
 		getBrowser().setBirdEyeView(image);
-		if (scaled) {
-		    fireBirdEyeViewRetrieval(false);
-		}
 	}
 
 	/** 


### PR DESCRIPTION
# What this PR does

Load the default size image for the bird eye view

# Testing this PR
In insight
* Import as tb1 in read-only group. Skip thumbnail 
* Log in as tb2 and view the image. The pyramid will be generated. Click cancel (this is known bug in insight)
* Check that no thumbnail is created on disk
* Re-open the image when the pyramid generation is finished
* Check that a thumbnail is displayed in the birdeye view
* Check that no thumbnail is created on disk
* Log in as tb1 and view the image
* Check that only one thumbnail is created on disk

A 5.4.7 client against a 5.4.8 server will create 2 thumbnails, this is the normal behaviour

cc @joshmoore 