### PR TITLE
QA 21746: fix open with of PDF

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -137,6 +137,8 @@ public class OpenObjectLoader
                         this); 
     		}
     	} else {
+    	    //Make sure originalImage is set to false in that case
+    	    originalImage = false;
     		FileAnnotationData fa = (FileAnnotationData) object;
     		path += UIUtilities.replaceNonWordCharacters(fa.getFileName());
     		f = new File(path);


### PR DESCRIPTION
# What this PR does

The problem will only occur if container.xml has been modified to always open the image using the original format instead of OME-TIFF
The side effect. The flag was used too for any file e.g. PDF file
Leading to the exception reported

This PR makes sure the original flag is set to  false for non image file.


# Testing this PR
* Change `` <entry name="/services/OpenWith/Original" type="boolean">false</entry>`` by
`` <entry name="/services/OpenWith/Original" type="boolean">true</entry>``

* Launch insight
* Log in as user-1 for example
* Go to "Attachments" section in the left-hand panel
* Expand "Other files"
* Select a PDF for example. 
* Right click and Select OpenWith > Other.
* Select Adobe for example
* The file should be downloaded locally and opens in the selected application

# Related reading
https://www.openmicroscopy.org/qa2/qa/feedback/21746/
