### PR TITLE
have server dispose() of graphics contexts it creates

### DIFF
--- a/components/server/src/ome/logic/AWTScaleService.java
+++ b/components/server/src/ome/logic/AWTScaleService.java
@@ -1,7 +1,5 @@
 /*
- * ome.logic.QueryImpl
- *
- *   Copyright 2006 University of Dundee. All rights reserved.
+ *   Copyright 2006-2018 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -58,6 +56,7 @@ public class AWTScaleService implements IScale {
         // graphics2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
         // RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         graphics2D.drawImage(image, 0, 0, thumbWidth, thumbHeight, null);
+        graphics2D.dispose();
         return thumbImage;
     }
 }

--- a/components/server/src/ome/logic/JavaImageScalingService.java
+++ b/components/server/src/ome/logic/JavaImageScalingService.java
@@ -1,7 +1,5 @@
 /*
- * ome.logic.JavaImageScalingService
- *
- *   Copyright 2006-2015 University of Dundee. All rights reserved.
+ *   Copyright 2006-2018 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
 
@@ -65,6 +63,7 @@ public class JavaImageScalingService implements IScale {
                             RenderingHints.VALUE_ANTIALIAS_OFF));
             g.drawImage(image, 0, 0, thumbWidth, thumbHeight, 0, 0,
                     image.getWidth(), image.getHeight(), null);
+            g.dispose();
         }
         s1.stop();
         return toReturn;


### PR DESCRIPTION
# What this PR does

Unless an AWT `Graphics` instance was provided by another owner (e.g., AWT asked for a repaint) they should be `dispose()`d so that resources are recovered promptly, otherwise it can be a while before finalizers run. Insight is riddled with this problem (e.g., it may not have been realized that `BufferedImage.getGraphics()` can eat memory in this way, it's hardly intuitively named) but this PR focuses on correcting just the server's few usages.

# Testing this PR

Thumbnails should still generate and render just fine.