### PR TITLE
reduce Memoizer logging

### DIFF
--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -106,7 +106,6 @@
   <!-- Quieting blitz startup -->
   <logger name="net.sf.ehcache" level="ERROR"/>
   <logger name="loci" level="INFO"/><!-- Bio-Formats -->
-  <logger name="loci.formats.Memoizer" level="DEBUG"/>
   <logger name="ucar" level="WARN"/><!-- NetCDF -->
 
   <!-- BUILD ////////////////////////////////////////////////////////////////// -->


### PR DESCRIPTION
# What this PR does

Reverts commit f8d159ed463ef920666deb06f019ca8ade3a6860 to reduce the large amount of memoizer logging when we import plates, etc. The memoizer is now quite stable and understood and logging can still easily be increased by those who wish to.

# Testing this PR

Compare import logs for plates imported with and without this PR and see that this PR stops the `loci.formats.Memoizer` DEBUG lines from appearing.