### PR TITLE
fix minor "annotation" typos

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/util/roi/model/ROIShape.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/util/roi/model/ROIShape.java
@@ -277,7 +277,7 @@ public class ROIShape
     }
     
     /**
-     * Set the annoations of the ROIShape from the map provided.
+     * Set the annotations of the ROIShape from the map provided.
      * @param map see above.
      */
     public void setAnnotations(Map<AnnotationKey, Object> map) 

--- a/components/server/src/ome/services/search/AnnotatedWith.java
+++ b/components/server/src/ome/services/search/AnnotatedWith.java
@@ -151,7 +151,7 @@ public class AnnotatedWith extends SearchAction {
                         + annotation);
             }
 
-            // If we have an example of the given annoation, then we can
+            // If we have an example of the given annotation, then we can
             // fetch it directly and don't need to use the fetchAnnotationsCopy
             // collection.
             for (Class ac : values.fetchAnnotations) {

--- a/components/tools/OmeroM/src/annotations/getAnnotations.m
+++ b/components/tools/OmeroM/src/annotations/getAnnotations.m
@@ -8,7 +8,7 @@ function annotations = getAnnotations(session, ids, type, varargin)
 %
 %      annotations = getAnnotations(session, ids, type);
 %      annotations = getAnnotations(session, ids, type, 'group', groupId);
-%        returns annoations from the input group specfied by groupId.
+%        returns annotations from the input group specfied by groupId.
 %
 % See also: GETANNOTATIONTYPES, GETDOUBLEANNOTATIONS, GETCOMMENTANNOTATIONS,
 % GETFILEANNOTATIONS, GETLONGANNOTATIONS, GETTAGANNOTATIONS,

--- a/components/tools/OmeroPy/src/omero/plugins/delete.py
+++ b/components/tools/OmeroPy/src/omero/plugins/delete.py
@@ -17,7 +17,7 @@ HELP = """Delete OMERO data.
 Remove entire graphs of data based on the ID of the top-node.
 
 By default linked tag, file and term annotations are not deleted.
-To delete linked annoations they must be explicitly included.
+To delete linked annotations they must be explicitly included.
 
 Examples:
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -422,7 +422,7 @@ def testUnlinkAnnotation(author_testimg_generated):
     assert dataset.getAnnotation(TESTANN_NS) is None
 
 
-def testAnnoationCount(author_testimg_generated):
+def testAnnotationCount(author_testimg_generated):
     """ Test get annotations counts """
 
     img = author_testimg_generated


### PR DESCRIPTION
# What this PR does

Corrects a few consistent typos of "annotation".

# Testing this PR

For me the most obvious arises from, `bin/omero delete -h | grep ^To`

Also note https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/987/testReport/OmeroPy.test.integration.gatewaytest/test_annotation/testAnnoationCount/history/ vs https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-python/988/testReport/OmeroPy.test.integration.gatewaytest/test_annotation/testAnnotationCount/history/.