### PR TITLE
Metadata54 5.4.8

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/ui/OpenObjectLoader.java
@@ -137,6 +137,8 @@ public class OpenObjectLoader
                         this); 
     		}
     	} else {
+    	    //Make sure originalImage is set to false in that case
+    	    originalImage = false;
     		FileAnnotationData fa = (FileAnnotationData) object;
     		path += UIUtilities.replaceNonWordCharacters(fa.getFileName());
     		f = new File(path);

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1272,8 +1272,8 @@ public class ThumbnailBean extends AbstractLevel2Service
             //Saving of thumbnailMetadata already happened in _createThumbnail
             //if owner != settings but not for owner == settings
             //This could be moved to _createThumbnail
-            if  (thumbnailMetadata.getDetails().getOwner().getId() ==
-                 settings.getDetails().getOwner().getId()) {
+            if (thumbnailMetadata.getDetails().getOwner().getId().equals(
+                 settings.getDetails().getOwner().getId())) {
                 iUpdate.saveObject(thumbnailMetadata);
             }
         } catch (ReadOnlyGroupSecurityViolation | IOException e) {

--- a/components/server/src/ome/services/ThumbnailBean.java
+++ b/components/server/src/ome/services/ThumbnailBean.java
@@ -1260,7 +1260,7 @@ public class ThumbnailBean extends AbstractLevel2Service
 
         // If we get here we can assume the thumbnail just needs created
         // and saved to disk
-        if (thumbMetaData.getId() == null) {
+        if (thumbnailMetadata.getId() == null) {
             try {
                 return convertThumbnailToBytes(image, false);
             } catch (IOException e) {
@@ -1268,8 +1268,14 @@ public class ThumbnailBean extends AbstractLevel2Service
             }
         }
         try {
-            compressThumbnailToDisk(thumbMetaData, image, false);
-            iUpdate.saveObject(thumbMetaData);
+            compressThumbnailToDisk(thumbnailMetadata, image, false);
+            //Saving of thumbnailMetadata already happened in _createThumbnail
+            //if owner != settings but not for owner == settings
+            //This could be moved to _createThumbnail
+            if  (thumbnailMetadata.getDetails().getOwner().getId() ==
+                 settings.getDetails().getOwner().getId()) {
+                iUpdate.saveObject(thumbnailMetadata);
+            }
         } catch (ReadOnlyGroupSecurityViolation | IOException e) {
             String msg = "Thumbnail could not be written to disk. Returning without caching";
             log.warn(msg, e);
@@ -1283,7 +1289,7 @@ public class ThumbnailBean extends AbstractLevel2Service
         // If we get here the compressThumbnailToDisk method above succeeded and
         // we can load the thumbnail from disk
         try {
-            return ioService.getThumbnail(thumbMetaData);
+            return ioService.getThumbnail(thumbnailMetadata);
         } catch (IOException e) {
             log.error("Could not obtain thumbnail", e);
             throw new ResourceError(e.getMessage());


### PR DESCRIPTION
Includes the last PRs from the [5.4.8](http://www.openmicroscopy.org/2018/09/24/omero-5-4-8.html) release of OMERO into `metadata54`. These were missed from #5860.

Once Travis is green, this will be merged and built as IDR-OMERO 0.5.2 and deployed on `test52`