### PR TITLE
BlitzGateway OriginalFile as a Python file-like object

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2556,10 +2556,8 @@ class _BlitzGateway (object):
 
     def createRawFileStore(self):
         """
-        Creates a new raw file store.
-        This service is special in that it does not get cached inside
-        BlitzGateway so every call to this function returns a new object,
-        avoiding unexpected inherited states.
+        Gets a reference to the raw file store on this connection object or
+        creates a new one if none exists.
 
         :return:    omero.gateway.ProxyObjectWrapper
         """
@@ -2648,10 +2646,8 @@ class _BlitzGateway (object):
 
     def createRawPixelsStore(self):
         """
-        Creates a new raw pixels store.
-        This service is special in that it does not get cached inside
-        BlitzGateway so every call to this function returns a new object,
-        avoiding unexpected inherited states.
+        Gets a reference to the raw pixels store on this connection object or
+        creates a new one if none exists.
 
         :return:    omero.gateway.ProxyObjectWrapper
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5289,6 +5289,10 @@ class _OriginalFileWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         Caller must call close() on the file object after use.
         This can be done automatically by using the object as a
         ContextManager.
+        For example:
+
+            with f.asFileObj() as fo:
+                content = fo.read()
 
         :return:    File-like object wrapping the OriginalFile
         :rtype:     File-like object

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5256,6 +5256,9 @@ class _OriginalFileAsFileObj(object):
     def close(self):
         self.rfs.close()
 
+    def __iter__(self):
+        return self.originalfile.getFileInChunks(self.bufsize)
+
     def __enter__(self):
         return self
 

--- a/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
+++ b/components/tools/OmeroPy/src/omero/gateway/scripts/testdb_create.py
@@ -9,6 +9,7 @@
 
 """
 
+from StringIO import StringIO
 import omero
 from omero.rtypes import rstring
 
@@ -272,3 +273,17 @@ class TestDBHelper(object):
             planeGen(), imageName, sizeZ=sizeZ, sizeC=sizeC, sizeT=sizeT,
             dataset=ds)
         return image
+
+    def createTestFile(self, parentpath, filename, content):
+        """
+        Creates an OriginalFile with the supplied content
+
+        @param parentpath:  Parent directory of the file
+        @param filename:    Filename
+        @param content:     String containing the content of the file
+        @return:            OriginalFileWrapper
+        """
+        sio = StringIO(content)
+        f = self.gateway.createOriginalFileFromFileObj(
+            sio, parentpath, filename, len(content))
+        return f

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
@@ -13,6 +13,7 @@
 
 """
 
+import Ice
 import omero
 import os
 import pytest
@@ -196,7 +197,7 @@ class TestWrapper(object):
         with f.asFileObj() as f2:
             assert f2.read() == 'abcdefghijklmnopqrstuvwxyz'
         # Verify close was automatically called
-        with pytest.raises(omero.ApiUsageException):
+        with pytest.raises(Ice.ObjectNotExistException):
             f2.read()
 
     def testOriginalFileWrapperAsFileObjMultiple(self, gatewaywrapper):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
@@ -13,7 +13,6 @@
 
 """
 
-import Ice
 import omero
 import os
 import pytest
@@ -191,7 +190,7 @@ class TestWrapper(object):
 
         with f.asFileObj() as f2:
             assert f2.read() == content
-        # Verify closed was automatically called
+        # Verify close was automatically called
         with pytest.raises(omero.ApiUsageException):
             f2.read()
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
@@ -194,11 +194,13 @@ class TestWrapper(object):
         assert fobj.read() == ''
         fobj.close()
 
-        with f.asFileObj() as f2:
-            assert f2.read() == 'abcdefghijklmnopqrstuvwxyz'
+    def testOriginalFileWrapperAsFileObjContextManager(self, gatewaywrapper):
+        f = self.createTestFile(gatewaywrapper)
+        with f.asFileObj() as fobj:
+            assert fobj.read() == 'abcdefghijklmnopqrstuvwxyz'
         # Verify close was automatically called
         with pytest.raises(Ice.ObjectNotExistException):
-            f2.read()
+            fobj.read()
 
     def testOriginalFileWrapperAsFileObjMultiple(self, gatewaywrapper):
         # Test that multiple file objects are allowed

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
@@ -207,8 +207,9 @@ class TestWrapper(object):
         # https://trello.com/c/lC8hFFix/522
         f1 = self.createTestFile(gatewaywrapper)
         f2 = self.createTestFile(gatewaywrapper)
-        with f1.asFileObj() as fobj1, f2.asFileObj() as fobj2:
-            assert fobj1.rfs.getFileId().val != fobj2.rfs.getFileId().val
+        with f1.asFileObj() as fobj1:
+            with f2.asFileObj() as fobj2:
+                assert fobj1.rfs.getFileId().val != fobj2.rfs.getFileId().val
 
     def testSetters(self, gatewaywrapper):
         """


### PR DESCRIPTION
# What this PR does
Adds a Python read-only file-like object to BlitzGateway OriginalFiles. This allows OriginalFiles to be read straight from OMERO by many Python classes without having to download and save them.

# Testing this PR
1. Upload an OriginalFile
2. Fetch the file in the BlitzGateway
```
f = conn.getObject('OriginalFile', FILEID)
```
3. Pass `f.asFileObj()` to a Python utility that accepts file-like objects. This should be closed after use, and a ContextManager is provided to make this easier. Examples:

## YAML file
```
import yaml
fo = f.asFileObj()
d = yaml.load(fo)
print(d)
fo.close()
```
## Matlab data file `.mat`
```
from scipy.io import loadmat
fo = f.asFileObj()
d = loadmat(fo)
print(d)
fo.close()
```
## CSV file
```
import pandas as pd
with f.asFileObj() as fo:
    csv = pd.read_csv(fo)
    print(csv)
```
## Excel file
```
import pandas as pd
with  f.asFileObj() as fo:
    xl = pd.read_excel(fo)
    print(xl)
```

# Related reading
- https://trello.com/c/N7Xtxk1c/512-file-like-originalfile