### PR TITLE
add Javadoc links to developer docs for graph operations

### DIFF
--- a/components/server/src/ome/services/graphs/package.html
+++ b/components/server/src/ome/services/graphs/package.html
@@ -18,5 +18,10 @@ can be used to specify what should be deleted (ome.services.delete), exported
 
 <!-- Put @see and @since tags down here. -->
 
+@see <a href="https://docs.openmicroscopy.org/latest/omero/developers/Server/ObjectGraphs.html">
+  Model graph operations</a>
+@see <a href="https://docs.openmicroscopy.org/latest/omero/developers/Server/GraphsImpl.html">
+  Java classes for model graph operations</a>
+
 </body>
 </html>


### PR DESCRIPTION
Just adds a couple of useful doc links for developers wondering how the model graph traversal code might work.