### PR TITLE
Set log level as per comments.

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py
@@ -22,7 +22,7 @@ def upgradeCheck(url):
             check = UpgradeCheck("web", url=url)
             check.run()
             if check.isUpgradeNeeded():
-                logger.error(
+                logger.warn(
                     "Upgrade is available. Please visit"
                     " https://downloads.openmicroscopy.org/latest/omero/.\n")
             else:


### PR DESCRIPTION
# What this PR does

Sets the OMERO.web "upgrade available" log level to WARNING as per the comments.

The comments state:

https://github.com/openmicroscopy/openmicroscopy/blob/ffa5419fb669871f959973f68b2c3fa0e4e2b576/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py#L11-L12

But the current log level being written during this event is "ERROR", cf https://github.com/openmicroscopy/openmicroscopy/blob/ffa5419fb669871f959973f68b2c3fa0e4e2b576/components/tools/OmeroWeb/omeroweb/webadmin/webadmin_utils.py#L25

# Testing this PR

1. required setup

An OMERO.web instance of 5.4.7 or earlier.

2. actions to perform

Include this change in your OMERO.web instance.

** wait a significant amount of time (not sure how long), or set the registry_agent to `test` from "web" at :22 https://github.com/openmicroscopy/openmicroscopy/pull/5876/files#diff-efc629ff0988b6ea20c18ab0cb7adf64R22 which will cause the registry to re-set the counter, as counting hits/agent type**

Start the server, ** log into OMERO.web ** view the OMEROweb.log.

3. expected observations

A log message as follows is written (WARNING level):

`{date} {time} WARNI [ omeroweb.webadmin.webadmin_utils] (proc.31994) upgradeCheck():26 Upgrade is available. Please visit https://downloads.openmicroscopy.org/latest/omero/.`

# Related reading

n/a

1. background for understanding this PR

n/a

2. what this PR assists, fixes, or otherwise affects

OMERO.web logging (level)