### PR TITLE
OMERO.py Sphinx API documentation: drop sphinx.ext.pngmath

### DIFF
--- a/docs/sphinx-api/conf.py
+++ b/docs/sphinx-api/conf.py
@@ -28,7 +28,7 @@ author = u'The Open Microscopy Environment'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.pngmath']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.todo', 'sphinx.ext.coverage']
 
 autodoc_default_flags = ['members', 'undoc-members', 'private-members']
 # General information about the project.


### PR DESCRIPTION
This extension has been deprecated and dropped from Sphinx. Building the OMERO.py apidoc target with a recent version of Sphinx currently leads to failure.

This commit removes the extension from the list in conf.py as there seem to be no current usage. The alternate route is to use the replacement extension: `sphinx.ext.imgmath`.

Test: - this should fix https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-build/ which is building the Sphinx OMERO.py API documentation with Sphinx 1.8.1
