### PR TITLE
ImportCandidates bugfix

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -621,7 +621,9 @@ public class ImportCandidates extends DirectoryWalker
             public void removeSelfIfSingular() {
                 int users = theyUseMe.size();
                 int used = iUseThem.size();
-                if (used <= 1 && users > 0) {
+                if (used < users) {
+                    // remove only if this file has more users
+                    // than it uses other associated files itself
                     groups.remove(key);
                 }
             }


### PR DESCRIPTION
Replaced by #5877
----------


# What this PR does

Prevents that files are getting ignored, although they might still be needed by other filesets.
E.g. this happens if a `*.dv.log` file is associated with more than one`*.dv` files (in which case the following dv files could be silently skipped).

# Testing this PR

Check that the integration test #5877 makes sense, that it fails without this PR and that it passes with this PR included.
We should also manually test some other file formats which can have multiple associated files to make sure this change doesn't have any unexpected side effects.

# Related reading

https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8595
