### PR TITLE
Adding a leading space to the check status message after email send.

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webadmin/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webadmin/views.py
@@ -1077,7 +1077,7 @@ def email(request, conn=None, **kwargs):
                     'start_time': datetime.datetime.now()}
             form = EmailForm(experimenter_list, group_list, conn, request)
             context['non_field_errors'] = ("Email sent."
-                                           "Check status in activities.")
+                                           " Check status in activities.")
         else:
             context['non_field_errors'] = "Email wasn't sent."
 


### PR DESCRIPTION
# What this PR does

Fixes a missing leading space when OMERO.web responds to a "send email" dialogue.

![missing_space](https://user-images.githubusercontent.com/2727871/46399379-7491dd80-c6ef-11e8-8dcc-0acc15b9aca6.png)


# Testing this PR

1. required setup
Any OMERO.web instance with a user configured with a valid email address.

2. actions to perform
Apply the diff in this PR.
Send an email via the web admin panel to a valid user with a valid email address.

3. expected observations
The message should read "Email sent. Check status in activities.", instead of the original "Email sent.Check status in activities."

# Related reading

Link to cards, tickets, other PRs:
n/a

1. background for understanding this PR
n/a

2. what this PR assists, fixes, or otherwise affects
Missing whitespace in response message in OMERO.web.