### PR TITLE
Importerui bugfix

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/FailedImportDialog.java
@@ -161,8 +161,8 @@ public class FailedImportDialog extends JDialog {
             }
         });
 
-        getRootPane().setLayout(new BorderLayout());
-        getRootPane().add(con, BorderLayout.CENTER);
+        getContentPane().setLayout(new BorderLayout());
+        getContentPane().add(con, BorderLayout.CENTER);
 
         pack();
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/view/ImporterUIElementLight.java
@@ -238,7 +238,7 @@ class ImporterUIElementLight extends ImporterUIElement {
         // if there are many imports to cancel this might take a while; in that
         // case until all cancellations went through there might have been another
         // upload happened so this could sum up to something > super.totalToImport
-        if (uploaded + cancelled + super.countFailure >= super.totalToImport) {
+        if (super.isDone()) {
             uploadBusy.setBusy(false);
             uploadBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         }  else {
@@ -248,7 +248,7 @@ class ImporterUIElementLight extends ImporterUIElement {
         processed.setValue(complete);
         processed.setMaximum(uploaded);
         processedBusy.setText(complete + "/" + uploaded);
-        if (complete + cancelled + super.countFailure >= super.totalToImport) {
+        if (super.isDone()) {
             processedBusy.setBusy(false);
             processedBusy.setIcon(IconManager.getInstance().getIcon(IconManager.APPLY));
         } else {


### PR DESCRIPTION
# What this PR does

Two small bugfixes of the lightweight importer ui:

- The content of the failed import dialog was added to the root pane instead of the content pane, which causes problems on Windows and Linux (drop down of the file selection combo box didn't work).
- If multiple files are selected of which some fail to import and some are skipped the spinners in the lightweight ui kept spinning although the import was already finished.

# Testing this PR

Import the files from QA 21768 selecting all files (not the directory) .After the import finished:
- Check that the upload and process spinners stop.
- Click on "Show failed" and check that the dialog works.

