### PR TITLE
Ignore owner when checking omero.data.dir is accessible

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -16,7 +16,6 @@
 import re
 import os
 import sys
-import stat
 import platform
 import datetime
 import Ice

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1513,18 +1513,9 @@ present, the user will enter a console""")
             self.ctx.die(8, "FATAL: OMERO directory does not exist: %s"
                          % pathobj)
 
-        owner = os.stat(filepath)[stat.ST_UID]
-        if owner == 0:
-            msg = ""
-            msg += "FATAL: OMERO directory which needs to be writeable"\
-                " belongs to root: %s\n" % filepath
-            msg += "Please use \"chown -R NEWUSER %s\" and run as then"\
-                " run %s as NEWUSER" % (filepath, sys.argv[0])
-            self.ctx.die(9, msg)
-        else:
-            if not os.access(filepath, mask):
-                self.ctx.die(10, "FATAL: Cannot access %s, a required"
-                             " file/directory for OMERO" % filepath)
+        if not os.access(filepath, mask):
+            self.ctx.die(10, "FATAL: Cannot access %s, a required"
+                         " file/directory for OMERO" % filepath)
 
     def check_access(self, mask=os.R_OK | os.W_OK, config=None):
         """Check that 'var' is accessible by the current user."""


### PR DESCRIPTION
# What this PR does

The owner/permissions check on the OMERO data dir is too strict, for example it will fail if owned by root even if it is group accessible.

# Testing this PR

1. Create a new OMERO data dir
2. Make it owned by `root`
3. Change the group of the data dir to one that the user that will be running OMERO.server is a member of
4. Make the OMERO data dir group readable/writeable
5. Start the server and it should work!

# Related reading
- https://trello.com/c/qndSyho7/532-omero-admin-datadir-owner-check-is-too-strict