### PR TITLE
Fix typo in omero.web.ui.metadata_panes description

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -727,7 +727,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
           ']'),
          json.loads,
          ("Manage Metadata pane accordion. This functionality is limited to"
-          " the exiting sections.")],
+          " the existing sections.")],
     "omero.web.ui.right_plugins":
         ["RIGHT_PLUGINS",
          ('[["Acquisition",'


### PR DESCRIPTION
Fixes a typo in the web docs for the `omero.web.ui.metadata_panes` property https://docs.openmicroscopy.org/omero/5.4.9/sysadmins/config.html#std:property-omero.web.ui.metadata_panes