### PR TITLE
Add context-manager to BlitzGateway

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1573,6 +1573,26 @@ class _BlitzGateway (object):
         # The properties we are setting through the interface
         self.setIdentity(username, passwd, not clone)
 
+    def __enter__(self):
+        """
+        Enter a context manager, connect if necesaary
+        Raise Exception if not connected
+
+        with BlitzGateway('user', 'password', host='host') as conn:
+            print list(conn.getObjects('Project'))
+        """
+        if not self._connected:
+            r = self.connect()
+            if not r:
+                raise Exception("Connect failed")
+        return self
+
+    def __exit__(self, *args):
+        """
+        Exit a context manager, close connection
+        """
+        self.close()
+
     def _register_service(self, service_string, stack):
         """
         Register the results of traceback.extract_stack() at the time


### PR DESCRIPTION
# What this PR does

Turns BlitzGateway into a context manager. Alternative implementation of https://github.com/openmicroscopy/openmicroscopy/pull/5885

# Testing this PR

BlitzGateway has two constructors which may behave unintuitively when it comes to whether they're connected or not https://trello.com/c/zebaFaV2/315-blitzgatewayuser-password-hosthost-doesnt-work#comment-5a53a0f87568cf14764cd556

All-in-one:
```
from omero.gateway import BlitzGateway
with BlitzGateway('user', 'pass', host='example.openmicroscopy.org') as conn:
    print list(conn.getObjects('Project'))
    assert conn._connected
assert not conn._connected
```
Using an existing client:
```
import omero
client = omero.client('example.openmicroscopy.org')
client.createSession('user', 'pass')

with BlitzGateway(client_obj=client) as conn:
    print list(conn.getObjects('Project'))
    assert conn._connected
assert not conn._connected
# client.getSession() should throw "ClientError: No session available"
```