### PR TITLE
improve error if attempting graph operation with no targets

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1944,6 +1944,8 @@ class GraphControl(CmdControl):
             if exc:
                 opt.excludeType = exc
 
+        if args.obj is None or not args.obj:
+            self.ctx.die(440, "no object targets supplied for graph operation")
         commands, forces = zip(*args.obj)
         show = not (args.force or args.dry_run)
         needsForce = any(forces)


### PR DESCRIPTION
When OMERO.cli users attempt chgrp, chown, etc. but without specifying any target object, do not give a nasty stack trace. See https://trello.com/c/LHtMPy8y/69-bug-chmod-with-no-arguments-fails for details.