### PR TITLE
check syntax of key names in loading configuration from file

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -576,7 +576,7 @@ re-run"""
         _new = parts[1]
         if _key in config.keys():
             _old = config[_key]
-        elif search(r'[\s=]', _key):
+        elif search(r'[\s]', _key):
             self.ctx.die(506, 'Illegal property name: {}'.format(_key))
         else:
             _old = None

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -264,7 +264,7 @@ class PrefsControl(WriteableConfigControl):
         from re import search
 
         if search(r'[\s]', key):
-            self.ctx.die(506, 'Illegal property name: {}'.format(key))
+            self.ctx.die(506, 'Illegal property name: {0}'.format(key))
 
     @with_config
     def all(self, args, config):

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -482,11 +482,18 @@ class PrefsControl(WriteableConfigControl):
             self.ctx.die(954, "%s: Failed to edit %s"
                          % (getattr(re, "pid", "Unknown"), temp_file))
         args.NAME = config.default()
+        old_config = dict(config)
         self.drop(args, config)
         args.file = [open(str(temp_file), "r")]
         args.q = True
-        self.load(args, config)
-        remove_path(temp_file)
+        try:
+            self.load(args, config)
+        except Exception as e:
+            for key, value in old_config.items():
+                config[key] = value
+            raise e
+        finally:
+            remove_path(temp_file)
 
     @with_config
     def version(self, args, config):

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -576,7 +576,7 @@ re-run"""
         _new = parts[1]
         if _key in config.keys():
             _old = config[_key]
-        elif search(r'[^A-Za-z0-9._-]', _key):
+        elif search(r'[\s=]', _key):
             self.ctx.die(506, 'Illegal property name: {}'.format(_key))
         else:
             _old = None

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -542,6 +542,8 @@ re-run"""
         config["omero.config.upgraded"] = "4.2.0"
 
     def handle_line(self, line, config, keys):
+        from re import search
+
         line = line.strip()
         if not line or line.startswith("#"):
             return None
@@ -558,6 +560,8 @@ re-run"""
         _new = parts[1]
         if _key in config.keys():
             _old = config[_key]
+        elif search(r'[^A-Za-z0-9._-]', _key):
+            self.ctx.die(506, 'Illegal property name: {}'.format(_key))
         else:
             _old = None
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -207,14 +207,16 @@ class TestPrefs(object):
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=BC")
 
-    @pytest.mark.parametrize('validkeyvalue',
-        ['A=B','A=B=C', 'A.B=C.D', "A.B='C.D'"])
+    @pytest.mark.parametrize(
+        'validkeyvalue',
+        [('A', 'B'), ('A', 'B=C'), ('A.B', 'C.D'), ('A.B', "'C.D'")])
     def testLoadWhitelist(self, capsys, validkeyvalue):
+        valid_key, valid_value = validkeyvalue
         to_load = create_path()
-        to_load.write_text("%s\n" % validkeyvalue)
+        to_load.write_text("%s=%s\n" % (valid_key, valid_value))
         self.invoke("load %s" % to_load)
-        self.invoke("get")
-        self.assertStdoutStderr(capsys, out="%s" % validkeyvalue)
+        self.invoke("get %s" % valid_key)
+        self.assertStdoutStderr(capsys, out=valid_value)
 
     @pytest.mark.parametrize(
         ('invalidline', 'invalidkey'),

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -158,6 +158,10 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys)
         self.invoke("keys")
         self.assertStdoutStderr(capsys, out="A")
+        self.invoke("set C D=E")
+        self.assertStdoutStderr(capsys)
+        self.invoke("keys")
+        self.assertStdoutStderr(capsys, out="A\nC")
 
     def testVersion(self, capsys):
         self.invoke("version")
@@ -203,10 +207,18 @@ class TestPrefs(object):
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=BC")
 
+    @pytest.mark.parametrize('validkeyvalue',
+        ['A=B','A=B=C', 'A.B=C.D', "A.B='C.D'"])
+    def testLoadWhitelist(self, capsys, validkeyvalue):
+        to_load = create_path()
+        to_load.write_text("%s\n" % validkeyvalue)
+        self.invoke("load %s" % to_load)
+        self.invoke("get")
+        self.assertStdoutStderr(capsys, out="%s" % validkeyvalue)
+
     @pytest.mark.parametrize(
         ('invalidline', 'invalidkey'),
         [('E F G', 'E F G'),
-         ('E=F=G', 'E=F'),
          ('E = F', 'E')])
     def testLoadInvalidKey(self, capsys, invalidline, invalidkey):
         self.invoke("set A B")

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -50,7 +50,9 @@ class TestPrefs(object):
                 e.strip() == err)
 
     def invoke(self, s):
-        self.cli.invoke(self.args + s.split(), strict=True)
+        if isinstance(s, basestring):
+            s = s.split()
+        self.cli.invoke(self.args + s, strict=True)
 
     def testHelp(self):
         self.invoke("-h")
@@ -234,6 +236,22 @@ class TestPrefs(object):
             capsys, err="Illegal property name: %s" % invalidkey)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=B")
+
+    @pytest.mark.parametrize(
+        'valid_key_value',
+        [('A', 'B'), ('A', 'B=C'), ('A.B', 'C.D'), ('A.B', "'C.D'")])
+    def testSetWhitelist(self, capsys, valid_key_value):
+        valid_key, valid_value = valid_key_value
+        self.invoke(["set", valid_key, valid_value])
+        self.invoke(["get", valid_key])
+        self.assertStdoutStderr(capsys, out=valid_value)
+
+    @pytest.mark.parametrize('invalid_key', ['E F', 'E '])
+    def testSetInvalidKey(self, capsys, invalid_key):
+        with pytest.raises(NonZeroReturnCode):
+            self.invoke(["set", invalid_key, "test"])
+        self.assertStdoutStderr(
+            capsys, err="Illegal property name: %s" % invalid_key.strip())
 
     def testSetFromFile(self, capsys):
         to_load = create_path()

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -204,15 +204,20 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out="A=BC")
 
     @pytest.mark.parametrize(
-        'invalidkeys', ['E F G', 'E=F=G', 'A = B'])
-    def testLoadInvalidKey(self, capsys, invalidkeys):
+        ('invalidline', 'invalidkey'),
+        [('E F G', 'E F G'),
+         ('E=F=G', 'E=F'),
+         ('E = F', 'E')])
+    def testLoadInvalidKey(self, capsys, invalidline, invalidkey):
         self.invoke("set A B")
         self.assertStdoutStderr(capsys)
 
         to_load = create_path()
-        to_load.write_text("C=D\n%s\nH=I\n" % invalidkeys)
+        to_load.write_text("C=D\n%s\nH=I\n" % invalidline)
         with pytest.raises(NonZeroReturnCode):
             self.invoke("load %s" % to_load)
+        self.assertStdoutStderr(
+            capsys, err="Illegal property name: %s" % invalidkey)
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=B")
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -203,6 +203,19 @@ class TestPrefs(object):
         self.invoke("get")
         self.assertStdoutStderr(capsys, out="A=BC")
 
+    @pytest.mark.parametrize(
+        'invalidkeys', ['E F G', 'E=F=G', 'A = B'])
+    def testLoadInvalidKey(self, capsys, invalidkeys):
+        self.invoke("set A B")
+        self.assertStdoutStderr(capsys)
+
+        to_load = create_path()
+        to_load.write_text("C=D\n%s\nH=I\n" % invalidkeys)
+        with pytest.raises(NonZeroReturnCode):
+            self.invoke("load %s" % to_load)
+        self.invoke("get")
+        self.assertStdoutStderr(capsys, out="A=B")
+
     def testSetFromFile(self, capsys):
         to_load = create_path()
         to_load.write_text("Test")


### PR DESCRIPTION
Adds some checks for configuration property keys for obviously wrong characters. Review https://trello.com/c/o33zUcPZ/6-valid-chars-in-omero-config-keys where @manics found that they could accidentally apply `bin/omero config load` to set all kinds of nonsense. This PR does not fix all possible ways of setting daft keys but it does address that particular workflow for until we get around to something more comprehensive.