### PR TITLE
Fix bug where rtype was being passed to frontend causing a json parsing error

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/marshal.py
@@ -51,7 +51,7 @@ def eventContextMarshal(event_context):
               'memberOfGroups', 'leaderOfGroups',
               'adminPrivileges']:
             if (hasattr(event_context, a)):
-                ctx[a] = getattr(event_context, a)
+                ctx[a] = unwrap(getattr(event_context, a))
 
     perms = event_context.groupPermissions
     encoder = get_encoder(perms.__class__)


### PR DESCRIPTION


# What this PR does
The bug is this: when a session is created for a user by an admin, then when a user utilizes that session (using bsession=*** in the url), eventContextMarshal will return an rtype for 'sudoerName', which the front end then fails to parse. This PR adds an unwrap statement to make the parsing work correctly.

# Testing this PR

1. required setup
Have omero and omeroweb running.
Have an omero admin user
Have an omero non-admin user

2. actions to perform
Use the admin users's credentials to create an omero session on behalf of the other user
Navigate to <omeroweb>/webclient?bsession=<session_uuid>&server=1

3. expected observations
This should cause an error without the change and no error with the change.

# Related reading

Link to cards, tickets, other PRs:

1. background for understanding this PR
No specific information required. 

2. what this PR assists, fixes, or otherwise affects
Fixes an issue where an rtype is being passed to the client which fails to parse it. 