### PR TITLE
Add context to fullviewer link in preview panel

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -367,6 +367,14 @@
               window.open(url + "?" + vpQuery, '_blank');
               return false;
             });
+
+            var parent = OME.getParentId();
+            if (parent) {
+              if (parent.split('-')[0] === 'dataset') {
+                var $btn = $("#preview_open_viewer");
+                $btn.prop('href', $btn.prop('href') + '?' + parent.replace('-', '='));
+              }
+            }
         });
     </script>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -368,6 +368,9 @@
               return false;
             });
 
+            // Find the current "parent" based on the combined jsTree context
+            // of selected, opened, and related nodes.  This parent will then
+            // be used to provide context when opening image viewers.
             var parent = OME.getParentId();
             if (parent) {
               if (parent.split('-')[0] === 'dataset') {


### PR DESCRIPTION
# What this PR does

The metadata general panel includes parent object context when opening the default full viewer via the "Full Viewer" button. This PR extends the same functionality to the metadata preview panel.

# Testing this PR

1. OMERO.web should be available

2. Navigating to an Image in a Dataset should result in identical full viewer links, containing the Dataset context, when on both the general and preview panels.

# Related reading

N/A