### PR TITLE
Public login button

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -635,6 +635,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "and link to it with the OMERO logo.")],
     "omero.web.login_view":
         ["LOGIN_VIEW", "weblogin", str, None],
+    "omero.web.user_dropdown":
+        ["USER_DROPDOWN",
+         "true",
+         parse_boolean,
+         ("Whether or not to include a user dropdown in the base template."
+          " Particularly useful when used in combination with the OMERO.web"
+          " public user where logging in may not make sense.")],
     "omero.web.staticfile_dirs":
         ["STATICFILES_DIRS",
          '[]',

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -212,3 +212,5 @@ class render_response(omeroweb.decorators.render_response):
             c_plugins.append({
                 "label": label, "include": include, "plugin_id": plugin_id})
         context['ome']['center_plugins'] = c_plugins
+
+        context['ome']['user_dropdown'] = settings.USER_DROPDOWN

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -127,6 +127,9 @@ class render_response(omeroweb.decorators.render_response):
         }}
 
         context.setdefault('ome', {})   # don't overwrite existing ome
+        connector = request.session.get('connector')
+        if connector is not None:
+            context['ome']['is_public_user'] = connector.is_public
         context['ome']['eventContext'] = eventContextMarshal(
             conn.getEventContext())
         context['ome']['user'] = conn.getUser

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
@@ -18,6 +18,16 @@
 -->
 {% endcomment %}
 
+{% if ome.is_public_user %}
+    <div id="public_login_button">
+        <a href="{% url 'weblogin' %}">
+            <div id="show_public_login_button">
+                <img src="{% static 'webclient/image/personal32.png' %}"/>
+                <span>Login</span>
+            </div>
+        </a>
+    </div>
+{% else %}
     <div id="user_dropdown">
         <div id="show_user_dropdown">
             <img src="{% url 'wamyphoto' %}" />
@@ -34,3 +44,4 @@
 			<li id="logout">{% include "webclient/base/includes/logout.html" %}</li>
         </ul>
     </div>
+{% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/user_dropdown.html
@@ -18,6 +18,7 @@
 -->
 {% endcomment %}
 
+{% if ome.user_dropdown %}
 {% if ome.is_public_user %}
     <div id="public_login_button">
         <a href="{% url 'weblogin' %}">
@@ -44,4 +45,5 @@
 			<li id="logout">{% include "webclient/base/includes/logout.html" %}</li>
         </ul>
     </div>
-{% endif %}
+{% endif %}{# ome.is_public_user #}
+{% endif %}{# ome.user_dropdown #}

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -880,6 +880,7 @@ li.menu_back a {
             padding-right:12px;
             font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
             font-weight:500;
+            color: hsl(210, 20%, 80%);
         }
 
 		/* Actual Dropdown */

--- a/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/static/webgateway/css/ome.header.css
@@ -69,7 +69,7 @@
  }
 	
 	
-	#middle_header_left a, #show_user_dropdown { 
+	#middle_header_left a, #show_user_dropdown, #public_login_button {
 		color: hsl(210,20%,80%);
 		font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
 		font-weight:500;
@@ -78,7 +78,7 @@
 		font-size:1.2em;
 	}
 	
-	#middle_header_left ul a:hover, #user_dropdown:hover {
+	#middle_header_left ul a:hover, #user_dropdown:hover, #public_login_button:hover {
 		text-decoration:none;
 		color:white;
 		background-color:rgba(255,255,255,.1);
@@ -110,7 +110,7 @@
 		} 
 
 
-			#middle_header_left li a, #show_user_dropdown{
+			#middle_header_left li a, #show_user_dropdown, #show_public_login_button {
 				display: block;
 				padding: .9em 1em 1.1em;
 			}
@@ -830,7 +830,7 @@ li.menu_back a {
 
 	/* User */
 
-	#user_dropdown {
+	#user_dropdown, #public_login_button {
 		cursor:pointer;
 		float:left;
 		position:relative;
@@ -841,7 +841,7 @@ li.menu_back a {
 		/* Link for User Dropdown */
 		
 		
-		#show_user_dropdown img{
+		#show_user_dropdown img, #show_public_login_button img {
 			-webkit-box-shadow: 0 1px 0 rgba(255,255,255,.2);
 			
 			-webkit-box-shadow: 0 1px 0 rgba(255,255,255,0.2); /* Saf3.0+, Chrome */
@@ -873,7 +873,14 @@ li.menu_back a {
 			font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
 			font-weight:500;
 		}
-	
+
+        #show_public_login_button span {
+            position:relative;
+            padding-left:2px;
+            padding-right:12px;
+            font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
+            font-weight:500;
+        }
 
 		/* Actual Dropdown */
 		


### PR DESCRIPTION
# What this PR does

When logged in as the public user the standard user profile is displayed in the top right hand corner of the main OMERO.web user interface. If a user wants to log in they have to semi-confusingly log out the public user in order to get to the log in page. This PR adds public user status to the OMERO.web request context and conditionally renders the user profile button as a more user friendly "Login" button instead when using the public user.

![image](https://user-images.githubusercontent.com/487082/47841909-06eed500-ddb3-11e8-84ec-2b87c3be5a5c.png)

# Testing this PR

1. OMERO.web with a public user enabled should be available

2. When logged in as the public user a "Login" button should be displayed, otherwise the standard profile dropdown.

![image](https://user-images.githubusercontent.com/487082/47842077-8d0b1b80-ddb3-11e8-9205-788821ff4400.png)

# Related reading

N/A