### PR TITLE
Don't set trustStore properties if empty

### DIFF
--- a/components/server/src/ome/security/KeyAndTrustStoreConfiguration.java
+++ b/components/server/src/ome/security/KeyAndTrustStoreConfiguration.java
@@ -42,9 +42,17 @@ public class KeyAndTrustStoreConfiguration implements InitializingBean {
                 log.warn("Overwriting existing trust store: " + oldTrustStore);
             }
         }
-        System.setProperty(JAVAX_NET_SSL_TRUST_STORE, trustStore);
-        System.setProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD,
-                trustStorePassword);
+        if (trustStore == null || trustStore.length() < 1) {
+            log.error("trustStore property is empty, not setting");
+        } else {
+            System.setProperty(JAVAX_NET_SSL_TRUST_STORE, trustStore);
+        }
+        if (trustStorePassword == null || trustStorePassword.length() < 1) {
+            log.error("trustStorePassword property is empty, not setting");
+        } else {
+            System.setProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD,
+                               trustStorePassword);
+        }
 
         if (oldKeyStore != null) {
             if (oldKeyStore.equals(keyStore)) {

--- a/components/server/src/ome/security/KeyAndTrustStoreConfiguration.java
+++ b/components/server/src/ome/security/KeyAndTrustStoreConfiguration.java
@@ -7,6 +7,7 @@
 
 package ome.security;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -42,12 +43,12 @@ public class KeyAndTrustStoreConfiguration implements InitializingBean {
                 log.warn("Overwriting existing trust store: " + oldTrustStore);
             }
         }
-        if (trustStore == null || trustStore.length() < 1) {
+        if (StringUtils.isEmpty(trustStore)) {
             log.error("trustStore property is empty, not setting");
         } else {
             System.setProperty(JAVAX_NET_SSL_TRUST_STORE, trustStore);
         }
-        if (trustStorePassword == null || trustStorePassword.length() < 1) {
+        if (StringUtils.isEmpty(trustStorePassword)) {
             log.error("trustStorePassword property is empty, not setting");
         } else {
             System.setProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD,

--- a/components/server/src/ome/security/KeyAndTrustStoreConfiguration.java
+++ b/components/server/src/ome/security/KeyAndTrustStoreConfiguration.java
@@ -44,12 +44,12 @@ public class KeyAndTrustStoreConfiguration implements InitializingBean {
             }
         }
         if (StringUtils.isEmpty(trustStore)) {
-            log.error("trustStore property is empty, not setting");
+            log.warn("trustStore property is empty, not setting");
         } else {
             System.setProperty(JAVAX_NET_SSL_TRUST_STORE, trustStore);
         }
         if (StringUtils.isEmpty(trustStorePassword)) {
-            log.error("trustStorePassword property is empty, not setting");
+            log.warn("trustStorePassword property is empty, not setting");
         } else {
             System.setProperty(JAVAX_NET_SSL_TRUST_STORE_PASSWORD,
                                trustStorePassword);


### PR DESCRIPTION
# What this PR does

[`etc/omero.properties`](https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.9/etc/omero.properties#L142-L150) sets `omero.security.trustStore` and `omero.security.trustStorePassword` to empty. OMERO sets the corresponding system properties to empty.

Setting the system properties appears to override the default system truststore, leading to errors when a client attempts to verify a server.

This PR simply prints out an error instead of setting these properties to empty.

# Testing this PR

The easiest way is to get an OMERO build that supports AWS S3 imports since the minio client attempts to verify the S3 server. Without this PR S3 imports will fail on CentOS 7 (you'll need to check the server side import log to confirm the error) unless you set:
- `omero.security.trustStore=/etc/pki/ca-trust/extracted/java/cacerts`
- `omero.security.trustStorePassword=changeit`

These are the defaults for the Java trust-store on CentOS 7. You will have to figure out the corresponding values for other operating systems.

If this PR is included the two properties above are not required. The Blitz log will contain
```
2018-11-02 16:58:32,925 ERROR [                          omero.security] (
main) trustStore property is empty, not setting
2018-11-02 16:58:32,925 ERROR [                          omero.security] (
main) trustStorePassword property is empty, not setting
```

Note. east-ci is currently setup with these two properties. It should be possible to remove them if this PR is included.