### PR TITLE
ImageJ manual workflow

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/fsimporter/chooser/LocationDialog.java
@@ -21,6 +21,8 @@
  */
 package org.openmicroscopy.shoola.agents.fsimporter.chooser;
 
+import ij.IJ;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Container;
@@ -893,11 +895,6 @@ class LocationDialog extends JDialog implements ActionListener,
 	 */
 	private void close()
 	{
-		int plugin = ImporterAgent.runAsPlugin();
-		if (plugin == LookupNames.IMAGE_J
-				|| plugin == LookupNames.IMAGE_J_IMPORT) {
-			return;
-		}
 		setVisible(false);
 		dispose();
 	}
@@ -909,7 +906,10 @@ class LocationDialog extends JDialog implements ActionListener,
 	int centerLocation()
 	{
 		UIUtilities.centerAndShow(this);
-		return userSelectedActionCommandId;
+		int settings = userSelectedActionCommandId;
+		//reset 
+		userSelectedActionCommandId = CMD_CLOSE;
+		return settings;
 	}
 
 	/**
@@ -936,7 +936,6 @@ class LocationDialog extends JDialog implements ActionListener,
 			int commandId = Integer.parseInt(actionCommand);
 
 			DataObject newDataObject = null;
-
 			switch (commandId) {
 				case CMD_CREATE_PROJECT:
 					newDataObject = new ProjectData();

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
@@ -220,7 +220,7 @@ public class SaveResultsDialog
                     + CommonsLangUtils.LINE_SEPARATOR+
                     "saved in OMERO to the OMERO server? "+CommonsLangUtils.LINE_SEPARATOR+
                     "If Yes, the ROIs and results will be saved on the new images. "+CommonsLangUtils.LINE_SEPARATOR+
-                    "If No, the ROIs and resulst will be saved on the original images.");
+                    "If No, the ROIs and results will be saved on the original images.");
             MessageBox box = new MessageBox(this, "Import images", buf.toString());
             if (box.centerMsgBox() == MessageBox.YES_OPTION) {
                  result = new ResultsObject(toImport);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2018 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,6 @@
  */
 package org.openmicroscopy.shoola.agents.treeviewer.util;
 
-import ij.IJ;
 import ij.ImagePlus;
 import ij.WindowManager;
 
@@ -217,11 +216,11 @@ public class SaveResultsDialog
         ResultsObject result;
         if (toImport.size() > 0) { //ask if they want to import the image
             StringBuffer buf = new StringBuffer();
-            buf.append("Do you wish to import any selected images not already "
+            buf.append("Import any selected images not already "
                     + CommonsLangUtils.LINE_SEPARATOR+
                     "saved in OMERO to the OMERO server? "+CommonsLangUtils.LINE_SEPARATOR+
-                    "The ROI and results will be saved on the new images. "+CommonsLangUtils.LINE_SEPARATOR+
-                    "The ROI and resullst will be saved on the original images.");
+                    "If Yes, the ROIs and results will be saved on the new images. "+CommonsLangUtils.LINE_SEPARATOR+
+                    "If No, the ROIs and resulst will be saved on the original images.");
             MessageBox box = new MessageBox(this, "Import images", buf.toString());
             if (box.centerMsgBox() == MessageBox.YES_OPTION) {
                  result = new ResultsObject(toImport);

--- a/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/agents/treeviewer/util/SaveResultsDialog.java
@@ -156,7 +156,10 @@ public class SaveResultsDialog
                 img = new FileObject(plus);
                 if (img.getOMEROID() < 0 || img.isNewImage()) {
                     toImport.add(img);
-                  //check if there are associated files
+                    if (img.isNewImage()) {
+                        images.add(img);
+                    }
+                    //check if there are associated files
                     int[] values = WindowManager.getIDList();
                     String path = img.getAbsolutePath();
                     if (path != null) {
@@ -169,7 +172,9 @@ public class SaveResultsDialog
                             }
                         }
                     }
-                } else images.add(img);
+                } else {
+                    images.add(img);
+                }
             }
         } else {
             int[] values = WindowManager.getIDList();
@@ -187,6 +192,9 @@ public class SaveResultsDialog
                             List<FileObject> l = img.getAssociatedFiles();
                             if (CollectionUtils.isEmpty(l)) {
                                 toImport.add(img);
+                                if (img.isNewImage()) {
+                                    images.add(img);
+                                }
                             }
                             int id = plus.getID();
                             for (int j = 0; j < values.length; j++) {
@@ -211,7 +219,9 @@ public class SaveResultsDialog
             StringBuffer buf = new StringBuffer();
             buf.append("Do you wish to import any selected images not already "
                     + CommonsLangUtils.LINE_SEPARATOR+
-                    "saved in OMERO to the OMERO server?");
+                    "saved in OMERO to the OMERO server? "+CommonsLangUtils.LINE_SEPARATOR+
+                    "The ROI and results will be saved on the new images. "+CommonsLangUtils.LINE_SEPARATOR+
+                    "The ROI and resullst will be saved on the original images.");
             MessageBox box = new MessageBox(this, "Import images", buf.toString());
             if (box.centerMsgBox() == MessageBox.YES_OPTION) {
                  result = new ResultsObject(toImport);
@@ -220,6 +230,7 @@ public class SaveResultsDialog
                  result.setTableName(nameField.getText());
                  TreeViewerAgent.getRegistry().getEventBus().post(
                          new SaveResultsEvent(result, true));
+                 images.clear();
             }
         }
         if (images.size() > 0) {


### PR DESCRIPTION
# What this PR does

Add option to save roi and results on the original image

# Testing this PR

* Open an image in ImageJ
* Crop the image for example
* Draw a shape on the cropped image and add it to the data manager
* Click Save ROIs
* Message should indicate to save the image on the newly created if yes is selected. If no is selected the ROI should be saved on the original image. The same is true for the measurements.


# Related reading

See https://trello.com/c/t2O0BP32/19-fiji-manual-workflow-review

cc @pwalczysko 