### PR TITLE
CLI handles being given directory instead of file argument.

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -325,12 +325,14 @@ class ExistingFile(FileType):
     an existing file.
     """
     def __call__(self, s):
-        if s != "-" and not os.path.exists(s):
-            raise ArgumentTypeError("File does not exist: %s" % s)
-        if s != "-":
-            return FileType.__call__(self, s)
-        else:
+        if s == "-":
             return s
+        p = path(s)
+        if not p.exists():
+            raise ArgumentTypeError("File does not exist: %s" % s)
+        elif not p.isfile():
+            raise ArgumentTypeError("Path is not a file: %s" % s)
+        return FileType.__call__(self, s)
 
 
 class DirectoryType(FileType):


### PR DESCRIPTION
# What this PR does

Fixes the nasty stack trace when giving OMERO.cli the name of a directory where it expected a file.

# Testing this PR

`bin/omero config load /etc`

should now better match the kind of error as from,

`bin/omero admin cleanse /etc/hosts`

# Related reading

https://trello.com/c/S0h8tKMv/527-cli-bin-omero-config-load-dir-fails