### PR TITLE
Have importer-cli more concisely report bad server hostname.

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -992,6 +992,9 @@ public class CommandLineImporter {
                     transfer, exclusions, minutesToWait);
             c.setImportOutput(outputChoice);
             rc = c.start();
+        } catch (Ice.DNSException dnse) {
+            log.error("Failed to look up domain name: {}", dnse.host);
+            rc = 2;
         } catch (Throwable t) {
             log.error("Error during import process.", t);
             rc = 2;


### PR DESCRIPTION
# What this PR does

Suppresses the stack trace printed for when `importer-cli` cannot look up a host name in the DNS.

# Testing this PR

Try `importer-cli` with `-s` options for good host names and bad ones like `-s wibble.wobble`. See that the bad host name error is not attached to a ginormous stack trace.

# Related reading

https://trello.com/c/THscwVDC/32-cli-report-wrong-server-nicely
https://docs.openmicroscopy.org/latest/omero5.4/users/cli/import.html#command-line-importer