### PR TITLE
CLI diagnostics: make clear when OMERO log file is empty

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1015,6 +1015,8 @@ OMERO Diagnostics (%s) %s
         else:
             if not p.exists():
                 self.ctx.out("n/a")
+            elif not p.size:
+                self.ctx.out("empty")
             else:
                 warn_regex = ('(-! )?[\d\-/]+\s+[\d:,.]+\s+([\w.]+:\s+)?'
                               'warn(i(ng:)?)?\s')


### PR DESCRIPTION
# What this PR does

CLI diagnostics report log files that have a bit of text in them as "0.0 KB" which can be tempting to misread as "empty file" when just glancing through. This PR adjusts the output so that empty files look clearly different.

# Testing this PR

Try having some `var/log/*` files with nothing in and some with just a bit in and see that you can tell the difference from `bin/omero admin diagnostics`.

# Related reading

https://trello.com/c/qxJpamya/60-highlight-master-log-entries