### PR TITLE
Have import log include specific report of target container.

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportLibrary.java
+++ b/components/blitz/src/ome/formats/importer/ImportLibrary.java
@@ -291,6 +291,12 @@ public class ImportLibrary implements IObservable
                                     try {
                                         IObject obj = target.load(store, ic);
                                         if (!(obj instanceof Annotation)) {
+                                            Class <? extends IObject> targetClass = obj.getClass();
+                                            while (targetClass.getSuperclass() != IObject.class) {
+                                                targetClass = targetClass.getSuperclass().asSubclass(IObject.class);
+                                            }
+                                            log.info("Import target specifies container: {}:{}",
+                                                    targetClass.getSimpleName(), obj.getId().getValue());
                                             ic.setTarget(obj);
                                         } else {
                                             // This is likely a "post-processing" annotation


### PR DESCRIPTION
# What this PR does

https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8518&start=50#p19654 -

> Is there a way how I can get the dataset ID back after the bulk import?

This PR includes that information in what the CLI importer reports to the user.

# Testing this PR

Try CLI imports using the `-T` option. Check that the specific target container is printed to the console during import. For bonus points, check that the container is reported even if the importing user does not have permission to put images into that container. On `eel` an easy way is to have `user-2` import into `read-only-1` then have `user-4` try importing to that same target container.

# Related reading

https://docs.openmicroscopy.org/latest/omero5.4/users/cli/import-target.html