### PR TITLE
CLI: obj map-set can delete keys

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/obj.py
+++ b/components/tools/OmeroPy/src/omero/plugins/obj.py
@@ -295,7 +295,7 @@ class MapSetTxAction(NonFieldTxAction):
 
         if argc == 4:
             name = self.tx_cmd.arg_list[3]
-            current = filter(lambda nv: nv and nv.name != name, current)
+            current = [nv for nv in current if nv and nv.name != name]
             setattr(self.obj, field, current)
         else:
             name, value = self.tx_cmd.arg_list[3:]

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#
-# Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
+# Copyright (C) 2014-2018 University of Dundee & Open Microscopy Environment.
 # All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -364,6 +363,18 @@ class TestObj(CLITest):
         state = self.go()
         val = state.get_row(0)
         assert val == "bar"
+
+        self.args = self.login_args() + [
+            "obj", "map-set", ann, "mapValue", "foo"]
+        state = self.go()
+        ann2 = state.get_row(0)
+        assert ann == ann2
+
+        self.args = self.login_args() + [
+            "obj", "map-get", ann, "mapValue", "foo"]
+        state = self.go()
+        val = state.get_row(0)
+        assert val is None
 
     def test_nulling(self):
         self.args = self.login_args() + [


### PR DESCRIPTION
# What this PR does

Extends the CLI plugin to be able to delete keys from map annotations.

# Testing this PR

`omero obj map-set MapAnnotation:1234 mapValue mykey` now deletes any `mykey` entry from the map annotation with ID 1234. It is not an error if the key does not exist in the map.

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-Python27/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_obj/TestObj/test_map_mods/ should pass.

# Related reading

https://trello.com/c/XHVymmdY/43-delete-a-map-key