### PR TITLE
Replace all usages of DefaultMetadataOptions by DynamicMetadataOptions

### DIFF
--- a/components/blitz/src/ome/formats/importer/ImportCandidates.java
+++ b/components/blitz/src/ome/formats/importer/ImportCandidates.java
@@ -25,7 +25,7 @@ import loci.formats.IFormatReader;
 import loci.formats.MissingLibraryException;
 import loci.formats.UnknownFormatException;
 import loci.formats.UnsupportedCompressionException;
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import ome.formats.ImageNameMetadataStore;
 import ome.formats.importer.util.ErrorHandler;
@@ -423,7 +423,7 @@ public class ImportCandidates extends DirectoryWalker
                 reader.close();
                 reader.setMetadataStore(new ImageNameMetadataStore());
                 reader.setMetadataOptions(
-                        new DefaultMetadataOptions(METADATA_LEVEL));
+                        new DynamicMetadataOptions(METADATA_LEVEL));
                 reader.setId(path);
                 format = reader.getFormat();
                 usedFiles = getOrderedFiles();

--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -19,7 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import loci.formats.meta.MetadataStore;
 import ome.formats.OMEROMetadataStoreClient;
@@ -170,7 +170,7 @@ public class CommandLineImporter {
             store = config.createStore();
             store.logVersionInfo(config.getIniVersionNumber());
             reader.setMetadataOptions(
-                    new DefaultMetadataOptions(MetadataLevel.ALL));
+                    new DynamicMetadataOptions(MetadataLevel.ALL));
 
             library = new ImportLibrary(store, reader,
                     transfer, exclusions, minutesToWait);

--- a/components/blitz/src/ome/formats/importer/cli/ImportCloser.java
+++ b/components/blitz/src/ome/formats/importer/cli/ImportCloser.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import loci.formats.meta.MetadataStore;
 import ome.formats.OMEROMetadataStoreClient;

--- a/components/blitz/test/ome/formats/utests/MetadataValidatorTest.java
+++ b/components/blitz/test/ome/formats/utests/MetadataValidatorTest.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 import loci.common.DataTools;
 import loci.formats.FormatException;
-import loci.formats.in.DefaultMetadataOptions;
+import loci.formats.in.DynamicMetadataOptions;
 import loci.formats.in.MetadataLevel;
 import ome.formats.Index;
 import ome.formats.OMEROMetadataStoreClient;
@@ -138,10 +138,10 @@ public class MetadataValidatorTest
                 new BlitzInstanceProvider(minimalStore.getEnumerationProvider()));
         wrapper = new OMEROWrapper(config);
         wrapper.setMetadataOptions(
-                new DefaultMetadataOptions(MetadataLevel.ALL));
+                new DynamicMetadataOptions(MetadataLevel.ALL));
         minimalWrapper = new OMEROWrapper(config);
         minimalWrapper.setMetadataOptions(
-                new DefaultMetadataOptions(MetadataLevel.MINIMUM));
+                new DynamicMetadataOptions(MetadataLevel.MINIMUM));
         wrapper.setMetadataStore(store);
         store.setReader(wrapper.getImageReader());
         minimalStore.setReader(minimalWrapper.getImageReader());


### PR DESCRIPTION
## What this PR does

Noticed while https://github.com/openmicroscopy/openmicroscopy/pull/5896 and reviewing the current divergence between the `metadata54` branch of openmicroscopy and the latest 5.4.9 release - see https://github.com/openmicroscopy/openmicroscopy/compare/v5.4.9...metadata54.

File differences between the IDR branch and the latest mailine tag can be classified into 3 groups:
1. scripts are disabled into IDR
1. IDR still uses a custom Bio-Formats version - related to the `ImportCandidates` unit tests exclusion
1. IDR uses `DynamicMetadataOptions` rather than `DefaultMetadataOptions`. The former is a more generic implementation of the MetadataOptions allowing support for key/value pairs.

This PR proposes to further reduce this divergence by switching the mainline OMERO `ImportCandidates` API to use `DynamicMetadataOptions`.  The class is identical on the mainline Bio-Formats as well as IDR Bio-Formats - https://github.com/openmicroscopy/bioformats/compare/v5.9.2...IDR:IDR-0.5.2.

## Testing this PR

Changes should only be happening client-side and there is currently no mechanism to allow key/value pair options to be passed to `ImportCandidates`. Thus I expect passing unit and integration tests to be the main item to review. Memo files of a 5.4.9 server should not be affected (although this might be worth checking).

As per https://github.com/openmicroscopy/openmicroscopy/blob/v5.4.9/components/blitz/src/ome/formats/importer/ImportCandidates.java#L113, there is a way to control the `MetadataLevel` within the ImportCandidates via system property although I do not know of a reader where the list of files would vary depending on this level.