### PR TITLE
admin diagnostics: report byte file sizes for small log files

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -993,7 +993,7 @@ OMERO Diagnostics (%s) %s
 
     def _sz_str(self, sz):
         if sz < 1000:
-            return "{} bytes".format(sz)
+            return "{0} bytes".format(sz)
         for x in ["KB", "MB", "GB"]:
             sz /= 1000
             if sz < 1000:

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -993,7 +993,7 @@ OMERO Diagnostics (%s) %s
 
     def _sz_str(self, sz):
         if sz < 1000:
-            return "{0} bytes".format(sz)
+            return "{0} B".format(sz)
         for x in ["KB", "MB", "GB"]:
             sz /= 1000
             if sz < 1000:

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -992,6 +992,8 @@ OMERO Diagnostics (%s) %s
         """ % ("="*80, control_name, VERSION, "="*80))
 
     def _sz_str(self, sz):
+        if sz < 1000:
+            return "{} bytes".format(sz)
         for x in ["KB", "MB", "GB"]:
             sz /= 1000
             if sz < 1000:


### PR DESCRIPTION
# What this PR does

Reports sizes of small log files in bytes.

# Testing this PR

`bin/omero admin diagnostics` with some small non-empty log files.

# Related reading

https://github.com/openmicroscopy/openmicroscopy/pull/5901#pullrequestreview-174784794