### PR TITLE
Allow cli_login to be used without closing session

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1554,10 +1554,12 @@ def cli_login(*args, **kwargs):
     passed to onecmd
 
     kwargs:
-      - keep_alive
+      - keep_alive (keep alive interval, default 300)
+      - close (close afterwards, default True)
     """
 
     keep_alive = kwargs.get("keep_alive", 300)
+    close_after = kwargs.get("close", True)
     try:
         cli = omero.cli.CLI()
         cli.loadplugins()
@@ -1573,7 +1575,8 @@ def cli_login(*args, **kwargs):
                 raise Exception("Failed to login")
         yield cli
     finally:
-        cli.close()
+        if close_after:
+            cli.close()
 
 
 def argv(args=sys.argv):

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1577,6 +1577,7 @@ def cli_login(*args, **kwargs):
         yield cli
     finally:
         cli.close()
+        client.stopKeepAlive()
 
 
 def argv(args=sys.argv):

--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1555,7 +1555,7 @@ def cli_login(*args, **kwargs):
 
     kwargs:
       - keep_alive (keep alive interval, default 300)
-      - close (close afterwards, default True)
+      - close (close session afterwards, default True)
     """
 
     keep_alive = kwargs.get("keep_alive", 300)
@@ -1566,17 +1566,17 @@ def cli_login(*args, **kwargs):
         login = ["-q", "login"]
         login.extend(list(args))
         cli.onecmd(login)
+        client = cli.get_client()
+        if not client:
+            raise Exception("Failed to login")
+        if not close_after:
+            client.getSession().detachOnDestroy()
         if keep_alive is not None:
-            client = cli.get_client()
-            if client is not None:
-                keep_alive = int(keep_alive)
-                client.enableKeepAlive(keep_alive)
-            else:
-                raise Exception("Failed to login")
+            keep_alive = int(keep_alive)
+            client.enableKeepAlive(keep_alive)
         yield cli
     finally:
-        if close_after:
-            cli.close()
+        cli.close()
 
 
 def argv(args=sys.argv):


### PR DESCRIPTION
If a CLI session is created outside of the script calling `cli_login` it's annoying for the session to be closed. `cli_login` is still a useful function as it handles all the usual CLI login steps.

Note this may be broken: For some reason using `with cli_login(close=True) as cli:` in a python script causes the script to hang when it's finished (I've added `print "Finished"` to verify it hangs at the very end and not just after the cli_login step).