### PR TITLE
OMERO.web default log can be changed to stdout

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -140,6 +140,11 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'standard'
         },
+        'stdout': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard'
+        },
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
@@ -342,6 +347,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("A boolean that turns on/off debug mode. "
           "Use debug mode only in development, not in production, as it logs "
           "sensitive and confidential information in plaintext.")],
+    "omero.web.default_log_handlers":
+        ["DEFAULT_LOG_HANDLERS",
+         "[\"default\"]",
+         json.loads,
+         ("Names of built-in log handlers, such as `\"default\"` for the "
+          "default rotating file handler or `\"stdout\"` to log to stdout, "
+          "for example when running in the foreground "
+          "(`omero web start --foreground`)")],
     "omero.web.secret_key":
         ["SECRET_KEY",
          None,
@@ -1031,6 +1044,9 @@ process_custom_settings(sys.modules[__name__], 'INTERNAL_SETTINGS_MAPPING')
 process_custom_settings(sys.modules[__name__], 'CUSTOM_SETTINGS_MAPPINGS',
                         'DEPRECATED_SETTINGS_MAPPINGS')
 process_custom_settings(sys.modules[__name__], 'DEVELOPMENT_SETTINGS_MAPPINGS')
+
+LOGGING['loggers']['']['handlers'] = sys.modules[__name__].DEFAULT_LOG_HANDLERS
+
 
 if not DEBUG:  # from CUSTOM_SETTINGS_MAPPINGS  # noqa
     LOGGING['loggers']['django.request']['level'] = 'INFO'


### PR DESCRIPTION
OMERO.web can be configured to send its default logs to stdout instead of a file. This is useful when running in the foreground, for example in Docker. The default behaviour is unchanged.

For example:
```
omero config set omero.web.default_log_handlers '["stdout"]'
omero web start --foreground
```
You can also have multiple loggers `'["default", "stdout"]'`

Ideally this would be reviewed by someone who understands exactly how settings and logging works in Django.