### PR TITLE
Adding --as-default to CLI omero user joingroup

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -2264,6 +2264,12 @@ class UserGroupControl(BaseControl):
 
         return u.id.val, u
 
+    def set_users_default_group_by_user_id(self, admin, group, users):
+        import omero
+        for user in list(users):
+            admin.setDefaultGroup(omero.model.ExperimenterI(user, False), group)
+            self.ctx.out("Set the default group of user %s to group %s" % (user, group.id.val))
+
     def addusersbyid(self, admin, group, users):
         import omero
         for user in list(users):

--- a/components/tools/OmeroPy/src/omero/plugins/user.py
+++ b/components/tools/OmeroPy/src/omero/plugins/user.py
@@ -99,6 +99,9 @@ class UserControl(UserGroupControl):
         group.add_argument(
             "--as-owner", action="store_true", default=False,
             help="Join the group(s) as an owner")
+        group.add_argument(
+            "--as-default", action="store_true", default=False,
+            help="Sets the group as the user's default group")
 
         leavegroup = parser.add(
             sub, self.leavegroup, "Leave one or more groups")
@@ -341,6 +344,28 @@ class UserControl(UserGroupControl):
 
         uid, username = self.parse_userid(a, args)
         [gid, groups] = self.list_groups(a, args, use_context=False)
+
+        # The list `groups` has members removed by filter_groups if the uid
+        # is already a member, so counting them here.
+        number_of_groups_passed = len(groups)
+
+        # so doing this logic before that group list filtering.
+        if args.as_default:
+            # check if there's only one group defined
+            if number_of_groups_passed == 1:
+                # If that's the case, set that to be the default group
+                # which will happen in the rest of the function.
+                pass
+            else:
+                if number_of_groups_passed > 1:
+                    # Message to user that we can only set the default group if only one group
+                    # is supplied as an argument.
+                    self.ctx.out("--as-default requires a single group ID to be supplied.")
+                    # Exit the function making no changes.
+                    return None
+
+        # Performing the count and funtion exit above, so we don't even hit this
+        # if we don't need to, since it would print statements about group membership.
         groups = self.filter_groups(groups, uid, args.as_owner, True)
 
         for group in groups:
@@ -348,6 +373,8 @@ class UserControl(UserGroupControl):
                 self.addownersbyid(a, group, [uid])
             else:
                 self.addusersbyid(a, group, [uid])
+            if args.as_default:
+                self.set_users_default_group_by_user_id(a, group, [uid])
 
     def leavegroup(self, args):
         c = self.ctx.conn(args)


### PR DESCRIPTION
Adding a parameter to set a user's default group when joining a new group, and a helper function to set the default group for a user.

Ideally the CLI should also allow an ad-hoc "set group" command on it's own, but I see this as an incremental improvement towards that goal, and it certainly answers the use case I have for adding users to a group and setting that to be the default group in one command.

# What this PR does

Allows a CLI user to set the default group of a user when adding the user to a group.

# Testing this PR

1. required setup

Apply the diff in this PR.

2. actions to perform

Identify a group which your test user does not belong to.

Issue a CLI command with the new `--as-default` flag like so, with 103 as an example:

```
omero user joingroup --group-id 103 --as-default
```

Then issue a further 

```
omero user joingroup --group-id 103
```

3. expected observations
Output like the following should appear, if the user was not already a member of the group.

```
Set the default group of user 793 to group 153
```

Then 

```
793 is already in group 103
```

# Related reading

Link to cards, tickets, other PRs: https://trello.com/c/sjEk7VQG/487-cli-manage-group-and-user-missing-features

1. background for understanding this PR

2. what this PR assists, fixes, or otherwise affects

The missing ability to set the default group of a user by the CLI.
