### PR TITLE
Keep a large base font size configured in browser from breaking tag dialog

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -2646,7 +2646,6 @@ button#id_add_new_tag {
     height: 25px;
 }
 div#id_move_tags {
-    float: left;
     width: 40px;
     padding: 120px 0 40px;
     margin: 10px;
@@ -2663,7 +2662,10 @@ div#id_move_tags button {
     -moz-box-shadow: 0px 1px 0px rgba(255,255,255,1);
     -webkit-box-shadow: 0px 1px 0px rgba(255,255,255,1);
     box-shadow: 0px 1px 0px rgba(255,255,255,1);
-    
+}
+
+div.tag_selection_container {
+    display: flex;
 }
 /* wrapper is a hack to make overflow:hidden work with .selectable()
    without it items become deselected when scrollbar is clicked */

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/tags_form.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/tags_form.html
@@ -33,8 +33,9 @@
 
     <h1>{% trans "Select from available tags" %}:</h1>
 
+    <div class="tag_selection_container">
 
-    <div style="float: left;">
+    <div>
 
         <h1>{% trans "Available Tags" %}: <span id="id_tags_selected"></span></h1>
 {% comment %}Spaces in placeholder are important so user can input the actual placeholder text without it getting removed{% endcomment %}
@@ -65,12 +66,14 @@
 
     </div>
 
-    <div style="float: left;">
+    <div>
 
         <h1>{% trans "Selected Tags" %}:</h1>
         <div class="tag_selection_wrapper">
             <div id="id_selected_tags" class="tag_selection"></div>
         </div>
+
+    </div>
 
     </div>
 


### PR DESCRIPTION
# What this PR does

When a minimum font size of 12px or larger is configured in the browser, the second list box in the tagging dialog wraps and appears misaligned below where it should be. This PR changes the CSS to keep the list boxes aligned independent of any configured minimum font size.

Dialog with 13px minimum font size configured:
![screen shot 2018-11-23 at 09 25 04](https://user-images.githubusercontent.com/197099/48933780-d73e7300-ef01-11e8-99af-18a3eb6945e8.png)

With this PR included:
![screen shot 2018-11-23 at 09 37 59](https://user-images.githubusercontent.com/197099/48934248-80399d80-ef03-11e8-94e9-6c277bb59ff2.png)


# Testing

To set the minimum font size in Chrome, go to Settings>Appearance>Customize Fonts>Minimum font size
