### PR TITLE
move clients' graph requests onto background threads

### DIFF
--- a/components/blitz/src/omero/cmd/SessionI.java
+++ b/components/blitz/src/omero/cmd/SessionI.java
@@ -147,7 +147,14 @@ public class SessionI implements _SessionOperations {
 
     public void submit_async(AMD_Session_submit __cb, omero.cmd.Request req,
             Ice.Current current) {
-        submit_async(__cb, req, current, null); // null == USER priority
+        final Executor.Priority priority;
+        if (req instanceof GraphQuery) {
+            priority = Executor.Priority.BACKGROUND;
+        } else {
+            /* defaults to Priority.USER */
+            priority = null;
+        }
+        submit_async(__cb, req, current, priority);
     }
 
     public void submit_async(AMD_Session_submit __cb, omero.cmd.Request req,


### PR DESCRIPTION
When clients submit async requests without a priority set they are assigned the usual default. This PR instead defaults graph requests like move and delete to be confined to the background threads that #5839 introduced to the server. See https://trello.com/c/fEtAzcrB/528-move-chgrp-chown-to-executorprioritybackground.