### PR TITLE
CLI: further restrict names of configuration properties

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -263,7 +263,7 @@ class PrefsControl(WriteableConfigControl):
     def assert_valid_property_name(self, key):
         from re import search
 
-        if search(r'[\s]', key):
+        if search(r'[^A-Za-z0-9._-]', key):
             self.ctx.die(506, 'Illegal property name: {0}'.format(key))
 
     @with_config

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -223,6 +223,7 @@ class TestPrefs(object):
     @pytest.mark.parametrize(
         ('invalidline', 'invalidkey'),
         [('E F G', 'E F G'),
+         ('E!F=G', 'E!F'),
          ('E = F', 'E')])
     def testLoadInvalidKey(self, capsys, invalidline, invalidkey):
         self.invoke("set A B")
@@ -246,7 +247,7 @@ class TestPrefs(object):
         self.invoke(["get", valid_key])
         self.assertStdoutStderr(capsys, out=valid_value)
 
-    @pytest.mark.parametrize('invalid_key', ['E F', 'E '])
+    @pytest.mark.parametrize('invalid_key', ['E F', 'E!F', 'E '])
     def testSetInvalidKey(self, capsys, invalid_key):
         with pytest.raises(NonZeroReturnCode):
             self.invoke(["set", invalid_key, "test"])


### PR DESCRIPTION
# What this PR does

Limits config key names to only certain characters.

# Testing this PR

First commit should fail Travis, next commit should pass.

# Related reading

Discussion on #5889.