### PR TITLE
Add incubator/bioformats-urlreader maven package

### DIFF
--- a/components/insight/ivy.xml
+++ b/components/insight/ivy.xml
@@ -73,6 +73,10 @@
         <exclude org="org.slf4j"/>
         <exclude org="commons-logging"/>
     </dependency>
+
+    <!-- OME Incubator -->
+    <dependency org="org.openmicroscopy" name="bioformats-urlreader" rev="0.1.0-SNAPSHOT"/>
+
     <!-- importer -->
     <dependency org="org.slf4j" name="slf4j-api" rev="${versions.slf4j}"/>
     <dependency org="ch.qos.logback" name="logback-classic" rev="${versions.logback}"/>

--- a/components/romio/ivy.xml
+++ b/components/romio/ivy.xml
@@ -24,5 +24,7 @@
     </dependency>
     <!-- Other -->
     <dependency org="commons-io" name="commons-io" rev="${versions.commons-io}"/>
+    <!-- OME Incubator -->
+    <dependency org="org.openmicroscopy" name="bioformats-urlreader" rev="0.1.0-SNAPSHOT"/>
   </dependencies>
 </ivy-module>

--- a/components/tools/OmeroJava/ivy.xml
+++ b/components/tools/OmeroJava/ivy.xml
@@ -41,6 +41,9 @@
     <dependency org="${org.bioformats}" name="formats-gpl" rev="${versions.bioformats}" transitive="true">
         <exclude org="org.slf4j"/>
     </dependency>
+
+    <!-- OME Incubator -->
+    <dependency org="org.openmicroscopy" name="bioformats-urlreader" rev="0.1.0-SNAPSHOT"/>
   </dependencies>
 </ivy-module>
 

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -76,6 +76,11 @@
           m2compatible="true"
           root="https://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
+      <ibiblio name="ome-incubator-bioformats-urlreader" cache="maven"
+          usepoms="true" useMavenMetadata="true"
+          m2compatible="true"
+          root="https://gitlab.com/api/v4/projects/9664262/packages/maven"/>
+
       <ibiblio name="unidata.releases" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
@@ -94,6 +99,7 @@
         <resolver ref="user-maven"/>
         <resolver ref="maven"/>
         <resolver ref="ome-artifactory"/>
+        <resolver ref="ome-incubator-bioformats-urlreader"/>
         <resolver ref="zeroc"/>
     </chain>
 


### PR DESCRIPTION
Includes the external BioFormats reader https://gitlab.com/openmicroscopy/incubator/bioformats-urlreader/ in the CI build. Requires BioFormats `6.0.0-SNAPSHOT` with https://github.com/openmicroscopy/bioformats/pull/3279.
