### PR TITLE
Disable refresh button while existing refresh in progress

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.tree.js
@@ -351,6 +351,10 @@ $(function() {
         });
         // Clear refreshPathsReverse after selection has been restored
         refreshPathsReverse = [];
+        // Re-enable the refresh button as it may have been disabled to
+        // prevent race conditions occurring from multiple clicks in quick
+        // succession.
+        $('#refreshButton').removeAttr("disabled");
     })
 
     // Setup jstree

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/data/containers.html
@@ -732,6 +732,12 @@
         });
 
         $('#refreshButton').click(function() {
+            // Ensure the button cannot be clicked again while we are
+            // performing a refresh.  The "refresh.jstree" event handler
+            // is in ome.tree.js and will be responsible for enabling the
+            // button again.
+            event.target.disabled = true;
+
             // Grab the paths to the items that are currently selected, for restoration later
             var selections = inst.get_selected();
 


### PR DESCRIPTION
# What this PR does

Having multiple refreshes of the tree in flight at one time can result
in JavaScript errors, duplicate elements in the tree, and other race
condition like behaviour.  This disables the button while the refresh is
in progress.

Previously it was possible to create situations such as the following
by being rather aggressive with the mouse clicks:

![image](https://user-images.githubusercontent.com/487082/49431125-a1707880-f7a4-11e8-839b-b47e368e0ae5.png)

# Testing this PR

1. OMERO.web with a reasonable amount of data loaded. Preferably with a read-only or read-annotate group with data from multiple users.

2. Double or multi-click the "Refresh" button in the left hand panel above the tree

3. No duplicate sets of the hierarchy

**Known issue:** This PR does not guard against refreshes that can be triggered while the tree is in the middle of performing other loading actions. Hitting refresh during these periods may result in JavaScript errors being printed to the console.

