### PR TITLE
glacier2: support ice websockets for client connections

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1093,8 +1093,8 @@ present, the user will enter a console""")
             '@omero.ports.prefix@': config.get('omero.ports.prefix', ''),
             '@omero.ports.ssl@': config.get('omero.ports.ssl', '4064'),
             '@omero.ports.tcp@': config.get('omero.ports.tcp', '4063'),
-            '@omero.ports.wss@': config.get('omero.ports.wss', '4443'),
-            '@omero.ports.ws@': config.get('omero.ports.ws', '4480'),
+            '@omero.ports.wss@': config.get('omero.ports.wss', '4066'),
+            '@omero.ports.ws@': config.get('omero.ports.ws', '4065'),
             '@omero.ports.registry@': config.get(
                 'omero.ports.registry', '4061'),
             '@omero.master.host@': config.get('omero.master.host', config.get(

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1093,6 +1093,8 @@ present, the user will enter a console""")
             '@omero.ports.prefix@': config.get('omero.ports.prefix', ''),
             '@omero.ports.ssl@': config.get('omero.ports.ssl', '4064'),
             '@omero.ports.tcp@': config.get('omero.ports.tcp', '4063'),
+            '@omero.ports.wss@': config.get('omero.ports.wss', '4443'),
+            '@omero.ports.ws@': config.get('omero.ports.ws', '4480'),
             '@omero.ports.registry@': config.get(
                 'omero.ports.registry', '4061'),
             '@omero.master.host@': config.get('omero.master.host', config.get(

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1094,7 +1094,6 @@ present, the user will enter a console""")
             '@omero.ports.ssl@': config.get('omero.ports.ssl', '4064'),
             '@omero.ports.tcp@': config.get('omero.ports.tcp', '4063'),
             '@omero.ports.wss@': config.get('omero.ports.wss', '4443'),
-            '@omero.ports.ws@': config.get('omero.ports.ws', '4480'),
             '@omero.ports.registry@': config.get(
                 'omero.ports.registry', '4061'),
             '@omero.master.host@': config.get('omero.master.host', config.get(

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1094,6 +1094,7 @@ present, the user will enter a console""")
             '@omero.ports.ssl@': config.get('omero.ports.ssl', '4064'),
             '@omero.ports.tcp@': config.get('omero.ports.tcp', '4063'),
             '@omero.ports.wss@': config.get('omero.ports.wss', '4443'),
+            '@omero.ports.ws@': config.get('omero.ports.ws', '4480'),
             '@omero.ports.registry@': config.get(
                 'omero.ports.registry', '4061'),
             '@omero.master.host@': config.get('omero.master.host', config.get(

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1101,6 +1101,16 @@ present, the user will enter a console""")
                 'Ice.Default.Host', '127.0.0.1'))
             }
 
+        client_transports = config.get('omero.client.icetransports', 'ssl,tcp')
+        client_endpoints = [
+            '{tp} -p {prefix}{port}'.format(
+                tp=clienttp,
+                prefix=substitutions['@omero.ports.prefix@'],
+                port=substitutions['@omero.ports.{tp}@'.format(tp=clienttp)],
+            )
+            for clienttp in client_transports.split(',')]
+        substitutions['@omero.client.endpoints@'] = ':'.join(client_endpoints)
+
         def copy_template(input_file, output_dir):
             """Replace templates"""
 

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -233,7 +233,7 @@ def check_ice_config(topdir, prefix='', ssl=4064, **kwargs):
     assert matches == ["omero.port=%s%s" % (prefix, ssl)]
 
 
-def check_default_xml(topdir, prefix='', tcp=4063, ssl=4064, wss=4443,
+def check_default_xml(topdir, prefix='', tcp=4063, ssl=4064, ws=4065, wss=4066,
                       **kwargs):
     routerport = (
         '<variable name="ROUTERPORT"    value="%s%s"/>' % (prefix, ssl))
@@ -241,8 +241,9 @@ def check_default_xml(topdir, prefix='', tcp=4063, ssl=4064, wss=4443,
         '<variable name="INSECUREROUTER" value="OMERO.Glacier2'
         '/router:tcp -p %s%s -h @omero.host@"/>' % (prefix, tcp))
     client_endpoints = (
-        'client-endpoints="ssl -p ${ROUTERPORT}:tcp -p %s%s:wss -p %s%s"'
-        % (prefix, tcp, prefix, wss))
+        'client-endpoints='
+        '"ssl -p ${ROUTERPORT}:tcp -p %s%s:wss -p %s%s:ws -p %s%s"'
+        % (prefix, tcp, prefix, wss, prefix, ws))
     for key in ['default.xml', 'windefault.xml']:
         s = path(topdir / "etc" / "grid" / key).text()
         assert routerport in s
@@ -336,8 +337,10 @@ class TestRewrite(object):
     @pytest.mark.parametrize('registry', [None, 111])
     @pytest.mark.parametrize('tcp', [None, 222])
     @pytest.mark.parametrize('ssl', [None, 333])
-    @pytest.mark.parametrize('wss', [None, 444])
-    def testExplicitPorts(self, registry, ssl, tcp, wss, prefix, monkeypatch):
+    @pytest.mark.parametrize('ws', [None, 444])
+    @pytest.mark.parametrize('wss', [None, 555])
+    def testExplicitPorts(self, registry, ssl, tcp, ws, wss, prefix,
+                          monkeypatch):
         """
         Test the omero.ports.xxx configuration properties during the generation
         of the configuration files
@@ -355,6 +358,8 @@ class TestRewrite(object):
             kwargs["tcp"] = tcp
         if ssl:
             kwargs["ssl"] = ssl
+        if ws:
+            kwargs["ws"] = ws
         if wss:
             kwargs["wss"] = wss
         for (k, v) in kwargs.iteritems():

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -347,11 +347,13 @@ class TestRewrite(object):
     @pytest.mark.parametrize('registry', [None, 111])
     @pytest.mark.parametrize('tcp', [None, 222])
     @pytest.mark.parametrize('ssl', [None, 333])
-    @pytest.mark.parametrize('ws', [None, 444])
-    @pytest.mark.parametrize('wss', [None, 555])
-    @pytest.mark.parametrize('transports', [None, ('ssl', 'tcp', 'wss', 'ws')])
-    def testExplicitPorts(self, registry, ssl, tcp, ws, wss, prefix,
-                          transports, monkeypatch):
+    @pytest.mark.parametrize('ws_wss_transports', [
+        (None, None, None),
+        (444, None, ('ssl', 'tcp', 'wss', 'ws')),
+        (None, 555, ('ssl', 'tcp', 'wss', 'ws')),
+    ])
+    def testExplicitPorts(self, registry, ssl, tcp, prefix,
+                          ws_wss_transports, monkeypatch):
         """
         Test the omero.ports.xxx and omero.client.icetransports
         configuration properties during the generation
@@ -359,8 +361,7 @@ class TestRewrite(object):
         """
 
         # Skip the JVM settings calculation for this test
-        monkeypatch.setattr(omero.install.jvmcfg, "adjust_settings",
-                            lambda x, y: {})
+        ws, wss, transports = ws_wss_transports
         kwargs = {}
         if prefix:
             kwargs["prefix"] = prefix

--- a/components/tools/OmeroPy/test/unit/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_admin.py
@@ -233,15 +233,16 @@ def check_ice_config(topdir, prefix='', ssl=4064, **kwargs):
     assert matches == ["omero.port=%s%s" % (prefix, ssl)]
 
 
-def check_default_xml(topdir, prefix='', tcp=4063, ssl=4064, **kwargs):
+def check_default_xml(topdir, prefix='', tcp=4063, ssl=4064, wss=4443,
+                      **kwargs):
     routerport = (
         '<variable name="ROUTERPORT"    value="%s%s"/>' % (prefix, ssl))
     insecure_routerport = (
         '<variable name="INSECUREROUTER" value="OMERO.Glacier2'
         '/router:tcp -p %s%s -h @omero.host@"/>' % (prefix, tcp))
     client_endpoints = (
-        'client-endpoints="ssl -p ${ROUTERPORT}:tcp -p %s%s"'
-        % (prefix, tcp))
+        'client-endpoints="ssl -p ${ROUTERPORT}:tcp -p %s%s:wss -p %s%s"'
+        % (prefix, tcp, prefix, wss))
     for key in ['default.xml', 'windefault.xml']:
         s = path(topdir / "etc" / "grid" / key).text()
         assert routerport in s
@@ -335,7 +336,8 @@ class TestRewrite(object):
     @pytest.mark.parametrize('registry', [None, 111])
     @pytest.mark.parametrize('tcp', [None, 222])
     @pytest.mark.parametrize('ssl', [None, 333])
-    def testExplicitPorts(self, registry, ssl, tcp, prefix, monkeypatch):
+    @pytest.mark.parametrize('wss', [None, 444])
+    def testExplicitPorts(self, registry, ssl, tcp, wss, prefix, monkeypatch):
         """
         Test the omero.ports.xxx configuration properties during the generation
         of the configuration files
@@ -353,6 +355,8 @@ class TestRewrite(object):
             kwargs["tcp"] = tcp
         if ssl:
             kwargs["ssl"] = ssl
+        if wss:
+            kwargs["wss"] = wss
         for (k, v) in kwargs.iteritems():
             self.cli.invoke(
                 ["config", "set", "omero.ports.%s" % k, "%s" % v],

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -25,10 +25,10 @@ omero.ports.ssl=4064
 omero.ports.tcp=4063
 
 # The Glacier2 WSS port number to use
-omero.ports.wss=4443
+omero.ports.wss=4066
 
 # The Glacier2 WS port number to use
-omero.ports.ws=4480
+omero.ports.ws=4065
 
 # The IceGrid registry port number to use
 omero.ports.registry=4061

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -19,8 +19,8 @@
 # configuration properties. Restricting to "ssl" will prevent all non-encrypted
 # connections to the OMERO server.
 #
-# Additionally, there are two experimental values: "ws" and "wss" for unecrypted
-# and encrypted, respectively. The ports that #are opened are controlled by the
+# Additionally, there are two experimental values: "ws" and "wss" for unencrypted
+# and encrypted, respectively. The ports that are opened are controlled by the
 # omero.ports.ws and omero.ports.wss configuration properties. To enable all
 # possible protocols use: "ssl,tcp,wss,ws". When using websockets behind a web
 # server like nginx, additional configuration may be needed.

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -14,6 +14,9 @@
 ##
 ## Properties marked with "DEVELOPMENT" should not be used in production.
 
+# Comma separated list of ice transports available to clients (ssl,tcp,wss,ws)
+omero.client.icetransports=ssl,tcp
+
 # The prefix to apply to all port numbers (SSL, TCP, registry) used by the
 # server
 omero.ports.prefix=

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -27,6 +27,9 @@ omero.ports.tcp=4063
 # The Glacier2 WSS port number to use
 omero.ports.wss=4443
 
+# The Glacier2 WS port number to use
+omero.ports.ws=4480
+
 # The IceGrid registry port number to use
 omero.ports.registry=4061
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -14,7 +14,16 @@
 ##
 ## Properties marked with "DEVELOPMENT" should not be used in production.
 
-# Comma separated list of ice transports available to clients (ssl,tcp,wss,ws)
+# Comma separated list of Ice transports available to clients. The default
+# value ("ssl,tcp") restricts Ice to using the omero.ports.ssl and omero.ports.tcp
+# configuration properties. Restricting to "ssl" will prevent all non-encrypted
+# connections to the OMERO server.
+#
+# Additionally, there are two experimental values: "ws" and "wss" for unecrypted
+# and encrypted, respectively. The ports that #are opened are controlled by the
+# omero.ports.ws and omero.ports.wss configuration properties. To enable all
+# possible protocols use: "ssl,tcp,wss,ws". When using websockets behind a web
+# server like nginx, additional configuration may be needed.
 omero.client.icetransports=ssl,tcp
 
 # The prefix to apply to all port numbers (SSL, TCP, registry) used by the
@@ -24,13 +33,15 @@ omero.ports.prefix=
 # The Glacier2 SSL port number to use
 omero.ports.ssl=4064
 
-# The Glacier2 TCP port number to use
+# The Glacier2 TCP port number to use (unencrytped)
 omero.ports.tcp=4063
 
+# DEVELOPMENT
 # The Glacier2 WSS port number to use
 omero.ports.wss=4066
 
-# The Glacier2 WS port number to use
+# DEVELOPMENT
+# The Glacier2 WS port number to use (unecrypted)
 omero.ports.ws=4065
 
 # The IceGrid registry port number to use

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -33,7 +33,7 @@ omero.ports.prefix=
 # The Glacier2 SSL port number to use
 omero.ports.ssl=4064
 
-# The Glacier2 TCP port number to use (unencrytped)
+# The Glacier2 TCP port number to use (unencrypted)
 omero.ports.tcp=4063
 
 # DEVELOPMENT

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -15,15 +15,17 @@
 ## Properties marked with "DEVELOPMENT" should not be used in production.
 
 # Comma separated list of Ice transports available to clients. The default
-# value ("ssl,tcp") restricts Ice to using the omero.ports.ssl and omero.ports.tcp
-# configuration properties. Restricting to "ssl" will prevent all non-encrypted
-# connections to the OMERO server.
+# value ("ssl,tcp") instructs Ice to open the ports specified by the
+# omero.ports.ssl and omero.ports.tcp properties. Restricting to "ssl"
+# will prevent all non-encrypted connections to the OMERO server.
 #
-# Additionally, there are two experimental values: "ws" and "wss" for unencrypted
-# and encrypted, respectively. The ports that are opened are controlled by the
-# omero.ports.ws and omero.ports.wss configuration properties. To enable all
-# possible protocols use: "ssl,tcp,wss,ws". When using websockets behind a web
-# server like nginx, additional configuration may be needed.
+# Additionally, there are two experimental values for using websockets:
+# "ws" and "wss" for unencrypted and encrypted, respectively. The ports
+# that are opened are controlled by the omero.ports.ws and omero.ports.wss
+# properties. To enable all possible protocols use: "ssl,tcp,wss,ws".
+#
+# Note: When using websockets behind a web server like nginx, additional
+# configuration may be needed.
 omero.client.icetransports=ssl,tcp
 
 # The prefix to apply to all port numbers (SSL, TCP, registry) used by the

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -27,9 +27,6 @@ omero.ports.tcp=4063
 # The Glacier2 WSS port number to use
 omero.ports.wss=4443
 
-# The Glacier2 WS port number to use
-omero.ports.ws=4480
-
 # The IceGrid registry port number to use
 omero.ports.registry=4061
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -24,6 +24,12 @@ omero.ports.ssl=4064
 # The Glacier2 TCP port number to use
 omero.ports.tcp=4063
 
+# The Glacier2 WSS port number to use
+omero.ports.wss=4443
+
+# The Glacier2 WS port number to use
+omero.ports.ws=4480
+
 # The IceGrid registry port number to use
 omero.ports.registry=4061
 

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -48,7 +48,7 @@
 
     <node name="master">
       <server-instance template="Glacier2Template"
-        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@:ws -p @omero.ports.prefix@@omero.ports.ws@"
+        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@"
         server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -48,7 +48,7 @@
 
     <node name="master">
       <server-instance template="Glacier2Template"
-        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@"
+        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@:ws -p @omero.ports.prefix@@omero.ports.ws@"
         server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -48,7 +48,7 @@
 
     <node name="master">
       <server-instance template="Glacier2Template"
-        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@"
+        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@:ws -p @omero.ports.prefix@@omero.ports.ws@"
         server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -48,7 +48,7 @@
 
     <node name="master">
       <server-instance template="Glacier2Template"
-        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@:ws -p @omero.ports.prefix@@omero.ports.ws@"
+        client-endpoints="@omero.client.endpoints@"
         server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>

--- a/etc/templates/grid/windefault.xml
+++ b/etc/templates/grid/windefault.xml
@@ -57,7 +57,7 @@
 
     <node name="master">
       <server-instance template="Glacier2Template"
-        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@:ws -p @omero.ports.prefix@@omero.ports.ws@"
+        client-endpoints="@omero.client.endpoints@"
         server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>

--- a/etc/templates/grid/windefault.xml
+++ b/etc/templates/grid/windefault.xml
@@ -57,7 +57,7 @@
 
     <node name="master">
       <server-instance template="Glacier2Template"
-        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@"
+        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@"
         server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>

--- a/etc/templates/grid/windefault.xml
+++ b/etc/templates/grid/windefault.xml
@@ -57,7 +57,7 @@
 
     <node name="master">
       <server-instance template="Glacier2Template"
-        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@"
+        client-endpoints="ssl -p ${ROUTERPORT}:tcp -p @omero.ports.prefix@@omero.ports.tcp@:wss -p @omero.ports.prefix@@omero.ports.wss@:ws -p @omero.ports.prefix@@omero.ports.ws@"
         server-endpoints="tcp -h @omero.master.host@"/>
       <server-instance template="BlitzTemplate" index="0" config="default"/>
       <server-instance template="IndexerTemplate" index="0"/>


### PR DESCRIPTION
Adds Ice 3.6+ websockets to the list of protocols that Glacier2 listens on. This should allow the OMERO binary protocol to be proxied via a standard web-server. Details: https://doc.zeroc.com/ice/3.7/client-side-features/proxies/proxy-and-endpoint-syntax#id-.ProxyandEndpointSyntaxv3.7-WSEndpointSyntax

Example of connecting directly to the OMERO websocket port from the Python client :
```
import omero.clients
c = omero.client(args=['--Ice.Default.Router=OMERO.Glacier2/router:ws -p 4465 -h localhost'])
c.createSession('root','omero')
```

More interesting example: proxy omero server via Nginx location `/omero`. Replace `<OMERO-SERVER-IP>` in `nginx-proxy-wss.conf`:
```
user  nginx;
worker_processes  1;

error_log  /var/log/nginx/error.log warn;
pid        /var/run/nginx.pid;

events {
    worker_connections  1024;
}

http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for"';

    access_log  /var/log/nginx/access.log  main;

    sendfile        on;
    #tcp_nopush     on;

    keepalive_timeout  65;

    #gzip  on;

    map $http_upgrade $connection_upgrade {
        default upgrade;
        '' close;
    }
    server {
        listen 80 default_server;
        server_name  $hostname;
        location /omero {
            proxy_pass http://<OMERO-SERVER-IP>:4065;
            proxy_http_version 1.1;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection $connection_upgrade;
            proxy_read_timeout 86400;
        }
    }
}
```
Run nginx:
`docker run -it --rm --link omero:omero -v $PWD/ngi-proxy-wss.conf:/etc/nginx/nginx.conf -p 10080:80 nginx`

And configure your client:
```
import omero.clients
c = omero.client(args=['--Ice.Default.Router=OMERO.Glacier2/router:ws -p 10080 -h localhost -r /omero'])
c.createSession('root','omero')
```
To test more robustly run OMERO.server in Docker and only expose the ws/wss ports, or if you're using nginx don't expose any OMERO ports at all, to validate that the client isn't secretly connecting to the standard 4063/4064 ports.

See https://trello.com/c/RQU4nsUX/582-support-omeroserver-websockets-http-https and the latest testing instructions in https://github.com/openmicroscopy/openmicroscopy/pull/5927#issuecomment-456452087