### PR TITLE
Set Hasher in BlitzGateway.createOriginalFileFromFileObj

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4008,6 +4008,11 @@ class _BlitzGateway (object):
         h.update(fo.read())
         shaHast = h.hexdigest()
         originalFile.setHash(rstring(shaHast))
+
+        chk = omero.model.ChecksumAlgorithmI()
+        chk.setValue(rstring(omero.model.enums.ChecksumAlgorithmSHA1160))
+        originalFile.setHasher(chk)
+
         originalFile = updateService.saveAndReturnObject(
             originalFile, self.SERVICE_OPTS)
 


### PR DESCRIPTION
`BlitzGateway.createOriginalFileFromFileObj` (and related methods) create OriginalFiles with a SHA1 checksum, but they don't set the property that indicates the checksum algorithm.

# Testing this PR

1. Create files using Python `BlitzGateway.createOriginalFileFrom*` methods
2. Check the created OriginalFiles have a non-null Hasher.