### PR TITLE
Have test ignore unexpected enum values added by other tests.

### DIFF
--- a/components/tools/OmeroJava/test/integration/ConfigurationServiceTest.java
+++ b/components/tools/OmeroJava/test/integration/ConfigurationServiceTest.java
@@ -280,6 +280,13 @@ public class ConfigurationServiceTest extends AbstractServerTest {
        String type = param.getType();
        Set<String> original = param.getOriginal();
        List<IObject> fromDB = svc.allEnumerations(type);
+       final Iterator<IObject> dbValues = fromDB.iterator();
+       while (dbValues.hasNext()) {
+           /* Other tests may have added new values. */
+           if (getEnumValue(dbValues.next()).startsWith("test_")) {
+               dbValues.remove();
+           }
+       }
        int total = 0;
        if (type.endsWith("EventTypeI")) {
            //Bootstrap event is added to the DB during the init process


### PR DESCRIPTION
# What this PR does

Have the Java enumeration integration tests ignore unexpected enumeration values added by Python integration tests.

# Testing this PR

https://web-proxy.openmicroscopy.org/east-ci/job/OMERO-test-integration/lastCompletedBuild/testngreports/integration/ConfigurationServiceTest/ should pass.