### PR TITLE
Web requirements

### DIFF
--- a/components/tools/OmeroWeb/requirements-py27-all-noice.txt
+++ b/components/tools/OmeroWeb/requirements-py27-all-noice.txt
@@ -1,8 +1,9 @@
 # Python installation requirements for OMERO.web
 # ==============================================
 #
-#     pip install -r requirements-py27.txt
+#     pip install -r requirements-py27-all-noice.txt
 #
 
-zeroc-ice>3.5,<3.7
+numpy>=1.9
+Pillow<3.4
 -r requirements-py27-noice.txt

--- a/components/tools/OmeroWeb/requirements-py27-noice.txt
+++ b/components/tools/OmeroWeb/requirements-py27-noice.txt
@@ -1,0 +1,12 @@
+# Python installation requirements for OMERO.web
+# ==============================================
+#
+#     pip install -r requirements-py27-noice.txt
+#
+
+Django>=1.8,<1.9
+django-pipeline==1.3.20
+gunicorn>=19.3
+
+omero-marshal==0.5.4
+django-redis>=4.4,<4.9


### PR DESCRIPTION
# What this PR does

Introduce new files so we can use wheel

# Testing this PR

Check that travis is green
# Related reading

While working on omeroweb-install, I realised that we cannot use the new zeroc-ice-py wheels and the requirements file. 
This PR introduces new requirements files so we do not install python bindings via pip