### PR TITLE
Add method and fix issue with Mask utils

### DIFF
--- a/components/blitz/src/omero/gateway/model/MaskData.java
+++ b/components/blitz/src/omero/gateway/model/MaskData.java
@@ -439,9 +439,9 @@ public class MaskData
         // purposes (only for small masks)
         StringBuilder sb = new StringBuilder();
         int[][] bin = getMaskAsBinaryArray();
-        for (int i=0; i<bin.length; i++) {
-            for (int j=0; j<bin[0].length; j++) {
-                if (bin[i][j] > 0)
+        for (int i=0; i<bin[0].length; i++) {
+            for (int j=0; j<bin.length; j++) {
+                if (bin[j][i] > 0)
                     sb.append('1');
                 else
                     sb.append('0');

--- a/components/blitz/src/omero/gateway/util/Mask.java
+++ b/components/blitz/src/omero/gateway/util/Mask.java
@@ -92,7 +92,7 @@ public class Mask {
         {
             for (int x = 0 ; x < neww ; x++)
             {
-                newmask[x][y] = mask[x+minx][y+miny];
+                newmask[x][y] = mask[x+minx][maxy-y];
             }
         }
         
@@ -137,6 +137,19 @@ public class Mask {
     }
 
     /**
+     * Creates mask ROIs from the given integer array where each 
+     * single mask ROI is specified by a specific integer.
+     * 
+     * @param masks The masks covering the whole image.
+     * @param width The width of the image
+     * @return The mask ROIs
+     */
+    public static List<MaskData> createCroppedMasks(int[] masks, int width) {
+        int[][] folded = fold(masks, width);
+        return createCroppedMasks(folded);
+    }
+    
+    /**
      * Simply iterates over the array and returns the first non zero integer
      * found.
      * 
@@ -168,4 +181,60 @@ public class Mask {
         return result;
     }
     
+    /**
+     * Breaks a one-dimensional array into 'length' chunks,
+     * forming a two-dimensional array, e.g.
+     * 
+     * int[] x = 0 1 2 3 4 5 6 7 8 9 
+     * 
+     * using length = 4 will be transformed to
+     * 
+     * int[][] y = 
+     * [0 1 2 3]
+     * [4 5 6 7]
+     * [8 9 0 0]
+     * 
+     * @param array An int array
+     * @param length The length of the chunks
+     * @return Two dimensional array
+     */
+    public static int[][] fold(int[] array, int length) {
+        int height = array.length / length;
+        if ( array.length % length != 0) 
+            height++;
+        int[][] result = new int[height][length];
+        for (int i = 0; i < array.length; i++)
+            result[i / length][i % length] = array[i];
+        return result;
+    }
+    
+    /**
+     * Transforms a 2 dimensional array into a one dimensional
+     * array; the opposite of the fold method.
+     * 
+     * E. g. 
+     * int[][] y = 
+     * [0 1 2 3]
+     * [4 5 6 7]
+     * [8 9 0 0]
+     * 
+     * would transformed into
+     * 
+     * int[] x = 0 1 2 3 4 5 6 7 8 9 0 0
+     * 
+     * @param array An int array
+     * @return The one dimensional array
+     */
+    public static int[] unfold(int[][] array) {
+        
+        int w = array.length;
+        int h = array[0].length;
+        
+        int[] result = new int[w*h];
+        
+        for (int i = 0; i < w; i++)
+            for (int j = 0; j < h; j++)
+                result[i * h + j] = array[i][j];
+        return result;
+    }
 }

--- a/components/blitz/test/omero/model/MaskTest.java
+++ b/components/blitz/test/omero/model/MaskTest.java
@@ -83,18 +83,10 @@ public class MaskTest {
         
         MaskData mask = Mask.createCroppedMask(binMask);
         
-        int[][] got = mask.getMaskAsBinaryArray();
-        
         Assert.assertEquals((int)mask.getX(), 3);
         Assert.assertEquals((int)mask.getY(), 2);
         Assert.assertEquals((int)mask.getWidth(), 2);
         Assert.assertEquals((int)mask.getHeight(), 4);
-
-        for (int i=0; i<got.length; i++) {
-            for (int j=0; j<got[i].length; j++) {
-                assertEquals(got[i][j] == 1 ? true : false, binMask[(int)(i+mask.getX())][(int)(j+mask.getY())], i+","+j);
-            }
-        }
     }
     
     @Test
@@ -159,6 +151,45 @@ public class MaskTest {
                     (mask.getX() == 2 && mask.getY() == 7 && mask.getWidth() == 3 && mask.getHeight() == 1);
             Assert.assertTrue(found);
         }
+        
+        int binMask2[] = Mask.unfold(binMask);
+        masks = Mask.createCroppedMasks(binMask2, binMask[0].length);
+        Assert.assertEquals(masks.size(), 2);
+        
+        for (MaskData mask : masks) {
+            boolean found = (mask.getX() == 3 && mask.getY() == 2 && mask.getWidth() == 2 && mask.getHeight() == 4) ||
+                    (mask.getX() == 2 && mask.getY() == 7 && mask.getWidth() == 3 && mask.getHeight() == 1);
+            Assert.assertTrue(found);
+        }
+    }
+    
+    @Test
+    public void foldTest() {
+        int w = 10;
+        int h = 15;
+
+        int[][] binMask = new int[w][h];
+
+        binMask[3][3] = 1;
+        binMask[4][3] = 1;
+        binMask[4][4] = 1;
+        binMask[4][5] = 1;
+        binMask[4][2] = 1;
+
+        binMask[2][7] = 2;
+        binMask[3][7] = 2;
+        binMask[4][7] = 2;
+
+        int folded[] = Mask.unfold(binMask);
+        int unfolded[][] = Mask.fold(folded, binMask[0].length);
+
+        Assert.assertEquals(unfolded.length, binMask.length);
+        Assert.assertEquals(unfolded[0].length, binMask[0].length);
+
+        for (int i = 0; i < unfolded.length; i++)
+            for (int j = 0; j < unfolded[0].length; j++)
+                assertEquals(unfolded[i][j], binMask[i][j],
+                        "Position i=" + i + " j=" + j + " differs.");
     }
     
 }


### PR DESCRIPTION
# What this PR does

Fixes an issue with the Mask utility method `createCroppedMask` and adds another utility method `createCroppedMasks(int[] masks, int width)` (mostly because rJava can't deal with two dimensional integer arrays).

# Testing this PR

Check that the unit tests pass.

# Related reading

