### PR TITLE
redirect to login_view after logout

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -333,10 +333,10 @@ def logout(request, conn=None, **kwargs):
                 logger.error('Exception during logout.', exc_info=True)
         finally:
             request.session.flush()
-        return HttpResponseRedirect(reverse("weblogin"))
+        return HttpResponseRedirect(reverse(settings.LOGIN_VIEW))
     else:
         context = {
-            'url': reverse('weblogout'),
+            'url': reverse(settings.LOGIN_VIEW),
             'submit': "Do you want to log out?"}
         t = template_loader.get_template(
             'webgateway/base/includes/post_form.html')

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -20,7 +20,6 @@
 """
 Tests webclient login
 """
-import sys
 from django.conf import settings
 from django.conf.urls import url
 from django.utils.importlib import import_module
@@ -43,9 +42,11 @@ class CustomWebclientLoginView(WebclientLoginView):
 
 urlpatterns = import_module(settings.ROOT_URLCONF).urlpatterns
 urlpatterns += [
-    url(r'^test_login/$', CustomWebclientLoginView.as_view(), name="test_weblogin"),
+    url(r'^test_login/$',
+        CustomWebclientLoginView.as_view(), name="test_weblogin"),
 ]
-    
+
+
 class TestLogin(IWebTest):
     """
     Tests login

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -20,6 +20,13 @@
 """
 Tests webclient login
 """
+import sys
+from django.conf import settings
+from django.conf.urls import url
+from django.utils.importlib import import_module
+from django.test.utils import override_settings
+
+from omeroweb.webclient.views import WebclientLoginView
 
 from omeroweb.testlib import IWebTest, post, get
 from django.core.urlresolvers import reverse
@@ -30,6 +37,15 @@ import pytest
 tag_url = reverse('load_template', kwargs={'menu': 'usertags'})
 
 
+class CustomWebclientLoginView(WebclientLoginView):
+    pass
+
+
+urlpatterns = import_module(settings.ROOT_URLCONF).urlpatterns
+urlpatterns += [
+    url(r'^test_login/$', CustomWebclientLoginView.as_view(), name="test_weblogin"),
+]
+    
 class TestLogin(IWebTest):
     """
     Tests login
@@ -83,3 +99,21 @@ class TestLogin(IWebTest):
         if len(redirect) == 0:
             redirect = reverse('webindex')
         assert rsp['Location'].endswith(redirect)
+
+    @override_settings(ROOT_URLCONF=__name__, LOGIN_VIEW='test_weblogin')
+    def test_login_view(self):
+        """
+        Test that a successful logout redirects to custom login view
+        """
+        django_client = self.django_root_client
+        request_url = reverse('test_weblogin')
+        data = {
+            'server': 1,
+            'username': self.ctx.userName,
+            'password': self.ctx.userName,
+        }
+        rsp = post(django_client, request_url, data, status_code=302)
+        request_url = reverse('weblogout')
+        rsp = post(django_client, request_url, {}, status_code=302)
+        assert rsp['Location'].endswith(reverse('test_weblogin'))
+        assert not rsp['Location'].endswith(reverse('weblogin'))


### PR DESCRIPTION
# What this PR does

Fix invalid redirection after logout. This is only exposed when developer has to customise the view


# Testing this PR

There were no test prior to that fix.

Without fix test is should fail as follow
```
>       assert rsp['Location'].endswith(reverse('test_weblogin'))
E       assert <built-in method endswith of str object at 0x112f11db0>('/test_login/')
E        +  where <built-in method endswith of str object at 0x112f11db0> = 'http://testserver/webclient/login/'.endswith
E        +  and   '/test_login/' = reverse('test_weblogin')
```
