### PR TITLE
omero.web.django_additional_settings

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -777,6 +777,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
          parse_boolean,
          ("If True, cors_origin_whitelist will not be used and all origins "
           "will be authorized to make cross-site HTTP requests.")],
+
+    "omero.web.django_additional_settings":
+        ["DJANGO_ADDITIONAL_SETTINGS",
+         "[]",
+         json.loads,
+         ("Additional Django settings as list of key-value tuples. "
+          "Use this to set or override Django settings that aren't managed by "
+          "OMERO.web. E.g. ``[\"CUSTOM_KEY\", \"CUSTOM_VALUE\"]``")],
 }
 
 DEPRECATED_SETTINGS_MAPPINGS = {
@@ -1277,6 +1285,9 @@ SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 # Tue  2 Nov 2010 11:03:18 GMT -- ticket:3228
 # MIDDLEWARE_CLASSES: A tuple of middleware classes to use.
 MIDDLEWARE_CLASSES = sort_properties_to_tuple(MIDDLEWARE_CLASSES_LIST)  # noqa
+
+for k, v in DJANGO_ADDITIONAL_SETTINGS:  # noqa
+    setattr(sys.modules[__name__], k, v)
 
 
 # Load server list and freeze


### PR DESCRIPTION
# What this PR does

Adds a new web property `omero.web.django_additional_settings`. This is a list of `[DJANGO_PROPERTY_NAME, json-value]` pairs that can be used to set or override Django settings that aren't managed by OMERO.web.

# Testing this PR

For example, if you install an additional non-ome web app and need to set some settings [(e.g. advanced whitenoise settings)](http://whitenoise.evans.io/en/stable/django.html#available-settings):
- without this PR you need to make code changes to `omeroweb/settings.py`
- with this PR you just add the property to `omero.web.django_additional_settings`:
```
omero config append omero.web.django_additional_settings '["WHITENOISE_STATIC_PREFIX", "/static/"]'
```

Another example: https://github.com/openmicroscopy/openmicroscopy/pull/5289 added settings to support CORS headers in the optional `django-cors-headers` app. This could have been done without a PR using this property.

One more example: completely override the OMERO.web log configuration and log to stdout:
```
omero config append --set omero.web.django_additional_settings '["LOGGING",
    {
      "version": 1,
      "disable_existing_loggers": false,
      "formatters": {
        "standard": {
          "format": "%(asctime)s %(levelname)5.5s [%(name)40.40s] (proc.%(process)5.5d) %(funcName)s():%(lineno)d %(message)s"
        }
      },
      "handlers": {
        "console": {
          "level": "DEBUG",
          "class": "logging.StreamHandler",
          "formatter": "standard"
        }
      },
      "loggers": {
        "": {
          "handlers": ["console"],
          "level": "DEBUG",
          "propagate": true
        }
      }
    }
  ]'
```