### PR TITLE
annotate_map_supports_namespace

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2287,7 +2287,8 @@ def annotate_map(request, conn=None, **kwargs):
     if annId is None and len(data) > 0:
         ann = omero.gateway.MapAnnotationWrapper(conn)
         ann.setValue(data)
-        ns = request.POST.get('ns', omero.constants.metadata.NSCLIENTMAPANNOTATION)
+        ns = request.POST.get('ns',
+                              omero.constants.metadata.NSCLIENTMAPANNOTATION)
         ann.setNs(ns)
         ann.save()
         for k, objs in oids.items():

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2287,7 +2287,8 @@ def annotate_map(request, conn=None, **kwargs):
     if annId is None and len(data) > 0:
         ann = omero.gateway.MapAnnotationWrapper(conn)
         ann.setValue(data)
-        ann.setNs(omero.constants.metadata.NSCLIENTMAPANNOTATION)
+        ns = request.POST.get('ns', omero.constants.metadata.NSCLIENTMAPANNOTATION)
+        ann.setNs(ns)
         ann.save()
         for k, objs in oids.items():
             for obj in objs:

--- a/components/tools/OmeroWeb/test/integration/test_annotate.py
+++ b/components/tools/OmeroWeb/test/integration/test_annotate.py
@@ -50,7 +50,7 @@ class TestMapAnnotations(IWebTest):
         if ds_id is not None:
             data['dataset'] = ds_id
         if ann_id is not None:
-            data['annId'] = ann_id;
+            data['annId'] = ann_id
         post(django_client, request_url, data)
 
     def test_annotate_map(self):


### PR DESCRIPTION
# What this PR does

This allows users to specify the namespace of map annotations created via POST to 
```/webclient/annotate_map/``` as requested in https://www.openmicroscopy.org/community/viewtopic.php?f=6&t=8655

# Testing this PR

 - Test that creating and editing map annotations in webclient still works as before (unchanged)
 - In webclient, open devtools in the browser and enter the sample code below into the console, updating e.g. project ID or use image ID to create a new Map Annotation on that object with the specified key-value pairs and namespace (ns). Should get an 'OK' popup, then reload the right panel for that object to see if the Map Annotation has been created with the correct namespace.
 - Doing this without the ```ns``` option should create a client-editable map annotation (can edit in webclient).

```
$.post("/webclient/annotate_map/",
    {mapAnnotation: '[["testKey","testValue"],["ABC","abc"]]',
     project: "123",
     ns: "test.webclient.api"})
  .done(function( data ) {
    alert( "OK" );
  });
```