### PR TITLE
Fix configuration unicode usage

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -500,7 +500,9 @@ class Context:
         Prints text to a given string, capturing any exceptions.
         """
         try:
-            stream.write(str(text))
+            if isinstance(text, unicode):
+                text = text.encode("utf-8")
+            stream.write(text)
             if newline:
                 stream.write("\n")
             else:

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -25,8 +25,7 @@ sys = __import__("sys")
 
 import xml.dom.minidom
 
-from xml.etree.ElementTree import XML, Element, SubElement, Comment
-from xml.etree.ElementTree import tostring
+from xml.etree.ElementTree import XML, Element, ElementTree, SubElement, Comment
 from omero_ext import portalocker
 import json
 
@@ -329,7 +328,9 @@ class ConfigXml(object):
     def write_element(self, icegrid):
         temp_file = path.path(self.filename + ".temp")
         try:
-            temp_file.write_text(tostring(icegrid, "utf-8"))
+            # Copying etree usage from ome-model
+            with open(temp_file, "w") as o:
+                ElementTree(icegrid).write(o, encoding="UTF-8")
             if sys.platform == "win32":
                 os.remove(self.filename)
             temp_file.rename(self.filename)
@@ -417,6 +418,9 @@ class ConfigXml(object):
         if props is None:
             props = SubElement(self.XML, "properties", {"id": default})
             SubElement(props, "property", name=self.KEY, value=self.VERSION)
+
+        if not isinstance(value, unicode):
+           value = value.decode("utf-8")
 
         for x in props.findall("./property"):
             if x.attrib["name"] == key:

--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -25,7 +25,9 @@ sys = __import__("sys")
 
 import xml.dom.minidom
 
-from xml.etree.ElementTree import XML, Element, ElementTree, SubElement, Comment
+from xml.etree.ElementTree import (
+    XML, Element, ElementTree, SubElement, Comment, tostring
+)
 from omero_ext import portalocker
 import json
 
@@ -420,7 +422,7 @@ class ConfigXml(object):
             SubElement(props, "property", name=self.KEY, value=self.VERSION)
 
         if not isinstance(value, unicode):
-           value = value.decode("utf-8")
+            value = value.decode("utf-8")
 
         for x in props.findall("./property"):
             if x.attrib["name"] == key:

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -472,6 +472,7 @@ class PrefsControl(WriteableConfigControl):
         except NonZeroReturnCode:
             raise
         except Exception, e:
+            self.ctx.dbg(traceback.format_exc())
             self.ctx.die(968, "Cannot read %s: %s" % (args.file, e))
         for key, value in new_config.items():
             config[key] = value

--- a/components/tools/OmeroPy/src/omero/util/__init__.py
+++ b/components/tools/OmeroPy/src/omero/util/__init__.py
@@ -859,6 +859,9 @@ def edit_path(path_or_obj, start_text):
             editor = "Notepad.exe"
         else:
             editor = "vi"
+
+    if isinstance(start_text, unicode):
+        start_text = start_text.encode("utf-8")
     f.write_text(start_text)
 
     # If absolute, then use the path

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -36,7 +36,7 @@ class TestPrefs(object):
         self.cli = CLI()
         self.cli.register("config", PrefsControl, HELP)
         self.p = create_path()
-        self.args = ["config", "--source", "%s" % self.p]
+        self.args = ["-d1", "config", "--source", "%s" % self.p]
 
     def config(self):
         return ConfigXml(filename=str(self.p))

--- a/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
+++ b/components/tools/OmeroPy/test/unit/clitest/test_prefs.py
@@ -466,3 +466,18 @@ class TestPrefs(object):
         self.assertStdoutStderr(capsys, out=defaults)
         self.invoke("parse --file=%s --keys --no-web" % cfg)
         self.assertStdoutStderr(capsys, out=keys)
+
+    @pytest.mark.parametrize("data", (
+        (u"omero.ldap.base=ou=ascii\n", "ascii2"),
+        (u"omero.ldap.base=ou=ascii\n", "unicodé"),
+        (u"omero.ldap.base=ou=unicodé\n", "ascii"),
+        (u"omero.ldap.base=ou=unicodé\n", "unicodé2"),
+    ))
+    def testUnicode(self, tmpdir, capsys, data):
+        input, update = data
+        cfg = tmpdir.join("test.cfg")
+        cfg.write(input.encode("utf-8"), "wb")
+        self.invoke("load %s" % cfg)
+        self.invoke("get omero.ldap.base")
+        self.invoke("set omero.ldap.base %s" % update)
+        self.invoke("get omero.ldap.base")


### PR DESCRIPTION
`bin/omero config set` and `load` calls failed spectacularly when
presented with unicode characters. Hand-editing etc/grid/config.xml
allowed the values to propagate to Java. This PR attempts to allow
these values to be set via the command-line.

# Testing this PR (for the keen)

Following the IRC conversation:

 1. setup an organization unit with a unicode value
 2. try to set omero.ldap.base to match the OU from the CLI
 3. start the server and create a user in that OU

# Related reading

see: https://trello.com/c/WO3qatIc/589-bug-bin-omero-config-doesnt-handle-unicode-values

