### PR TITLE
add failing integration test for import target canLink()

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -864,6 +864,7 @@ class TestImport(CLITest):
             assert dataset.id.val == dataset_oldest.id.val
         else:
             assert dataset.id.val > dataset_newest.id.val
+            assert dataset.name.val == name
 
     @pytest.mark.parametrize("kls", ("Project", "Plate", "Image"))
     def testBadTargetArgument(self, kls, tmpdir, capfd):


### PR DESCRIPTION
Adds an integration test that should pass once https://trello.com/c/kWgFImSC/450-bug-import-target is fixed. See https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-broken/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_import/. At present we should expect a failure iff `is_owns_newest` is False.