### PR TITLE
Python gateway secure

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -1488,7 +1488,7 @@ class _BlitzGateway (object):
 
     def __init__(self, username=None, passwd=None, client_obj=None, group=None,
                  clone=False, try_super=False, host=None, port=None,
-                 extra_config=None, secure=False, anonymous=True,
+                 extra_config=None, secure=True, anonymous=True,
                  useragent=None, userip=None):
         """
         Create the connection wrapper.

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -453,7 +453,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "sessions/#using-cached-sessions>` for more details.")],
     "omero.web.secure":
         ["SECURE",
-         "false",
+         "true",
          parse_boolean,
          ("Force all backend OMERO.server connections to use SSL.")],
     "omero.web.session_cookie_age":


### PR DESCRIPTION
# What this PR does

Python BlitzGateway and OMERO.web default to using secure connections.

Previously the defaults for secure/insecure were confusing: https://trello.com/c/pJuzsmKU/441-bug-blitzgateway-connconnect

This makes both default to secure. The main advantage is you can connect to any OMERO.server with just the standard 4064 port exposed or forwarded, you no-longer need to remember to set secure.

# Testing this PR

Everything should continue to just work. You should be able to connect to servers from the BlitzGateway and OMERO.web with or without 4063 exposed with no change in configuration, previously the default configuration would have failed if 4063 was blocked.