### PR TITLE
Java SSL fix for command-line importer

### DIFF
--- a/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
+++ b/components/blitz/src/ome/formats/importer/cli/CommandLineImporter.java
@@ -159,14 +159,6 @@ public class CommandLineImporter {
                 // config.requestFromUser(); // stdin if anything missing.
                 usage(); // EXITS TODO this should check for a "quiet" flag
             }
-
-            if (config.checkUpgrade.get()) {
-                config.isUpgradeNeeded();
-            }
-            else
-            {
-                log.debug("UpgradeCheck disabled.");
-            }
             store = config.createStore();
             store.logVersionInfo(config.getIniVersionNumber());
             reader.setMetadataOptions(
@@ -174,6 +166,12 @@ public class CommandLineImporter {
 
             library = new ImportLibrary(store, reader,
                     transfer, exclusions, minutesToWait);
+
+            if (config.checkUpgrade.get()) {
+                config.isUpgradeNeeded();
+            } else {
+                log.debug("UpgradeCheck disabled.");
+            }
         }
 
         Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -70,11 +70,6 @@ import Glacier2.PermissionDeniedException;
 import Glacier2.SessionNotExistException;
 import Ice.Current;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-
-import org.apache.commons.lang.StringUtils;
-
 /**
  * Central client-side blitz entry point. This class uses solely Ice
  * functionality to provide access to blitz (as opposed to also using Spring)
@@ -209,18 +204,31 @@ public class client {
     static {
         final String property = "jdk.tls.disabledAlgorithms";
         final String value = Security.getProperty(property);
-        if (StringUtils.isNotBlank(value)) {
+        if (!(value == null || value.trim().isEmpty())) {
             final List<String> algorithms = new ArrayList<>();
             boolean isChanged = false;
-            for (final String algorithm : Splitter.on(',').trimResults().split(value)) {
-                if ("anon".equals(algorithm.toLowerCase())) {
+            for (String algorithm : value.split(",")) {
+                algorithm = algorithm.trim();
+                if (algorithm.isEmpty()) {
+                    /* ignore */
+                } else if ("anon".equals(algorithm.toLowerCase())) {
                     isChanged = true;
                 } else {
                     algorithms.add(algorithm);
                 }
             }
             if (isChanged) {
-                Security.setProperty(property, Joiner.on(", ").join(algorithms));
+                boolean needsComma = false;
+                final StringBuilder newValue = new StringBuilder();
+                for (final String algorithm : algorithms) {
+                    if (needsComma) {
+                        newValue.append(", ");
+                    } else {
+                        needsComma = true;
+                    }
+                    newValue.append(algorithm);
+                }
+                Security.setProperty(property, newValue.toString());
             }
         }
     }

--- a/components/blitz/src/omero/client.java
+++ b/components/blitz/src/omero/client.java
@@ -203,6 +203,28 @@ public class client {
     // Creation
     // =========================================================================
 
+    /**
+     * Ensure that anonymous cipher suites are enabled in the JRE.
+     */
+    static {
+        final String property = "jdk.tls.disabledAlgorithms";
+        final String value = Security.getProperty(property);
+        if (StringUtils.isNotBlank(value)) {
+            final List<String> algorithms = new ArrayList<>();
+            boolean isChanged = false;
+            for (final String algorithm : Splitter.on(',').trimResults().split(value)) {
+                if ("anon".equals(algorithm.toLowerCase())) {
+                    isChanged = true;
+                } else {
+                    algorithms.add(algorithm);
+                }
+            }
+            if (isChanged) {
+                Security.setProperty(property, Joiner.on(", ").join(algorithms));
+            }
+        }
+    }
+
     private static Properties defaultRouter(String host, int port) {
         Properties p = new Properties();
         p.setProperty("omero.host", host);
@@ -400,24 +422,6 @@ public class client {
             for (String key : propertyMap.keySet()) {
                 System.out.println(String.format("%s=%s", key,
                         propertyMap.get(key)));
-            }
-        }
-
-        // Ensure that anonymous cipher suites are enabled in JRE
-        final String property = "jdk.tls.disabledAlgorithms";
-        final String value = Security.getProperty(property);
-        if (StringUtils.isNotBlank(value)) {
-            final List<String> algorithms = new ArrayList<>();
-            boolean isChanged = false;
-            for (final String algorithm : Splitter.on(',').trimResults().split(value)) {
-                if ("anon".equals(algorithm.toLowerCase())) {
-                    isChanged = true;
-                } else {
-                    algorithms.add(algorithm);
-                }
-            }
-            if (isChanged) {
-                Security.setProperty(property, Joiner.on(", ").join(algorithms));
             }
         }
 

--- a/history.rst
+++ b/history.rst
@@ -5,13 +5,6 @@
 OMERO version history
 =====================
 
-5.4.11 (???? 2019)
-------------------
-
-This release extends the OMERO 5.4.10 fix for the login issue for Java
-clients. It addresses the problem for users of the command-line importer
-such as the ``bin/omero import`` Python plugin.
-
 5.4.10 (January 2019)
 ---------------------
 

--- a/history.rst
+++ b/history.rst
@@ -15,12 +15,12 @@ such as the ``bin/omero import`` Python plugin.
 5.4.10 (January 2019)
 ---------------------
 
-This release addresses a login issue for Java clients such as OMERO.insight.
-New releases of Java include a change to the
+This release addresses a login issue for Java clients such as
+OMERO.insight. New releases of Java include a change to the
 ``java.security`` file that disables anonymous cipher suites. This
 change causes ``SSLHandshakeException`` when the client attempts to
-authenticate to OMERO.blitz. The OMERO 5.4.10 release has some clients check
-the security property ``jdk.tls.disabledAlgorithms`` for the value
+authenticate to OMERO.blitz. The OMERO 5.4.10 release has some clients
+check the security property ``jdk.tls.disabledAlgorithms`` for the value
 "anon" and remove it if present thus allowing authentication to proceed.
 
 5.4.9 (October 2018)

--- a/history.rst
+++ b/history.rst
@@ -5,8 +5,8 @@
 OMERO version history
 =====================
 
-5.4.11 (January 2019)
----------------------
+5.4.11 (???? 2019)
+------------------
 
 This release extends the OMERO 5.4.10 fix for the login issue for Java
 clients. It addresses the problem for users of the command-line importer

--- a/history.rst
+++ b/history.rst
@@ -5,14 +5,21 @@
 OMERO version history
 =====================
 
+5.4.11 (January 2019)
+---------------------
+
+This release extends the OMERO 5.4.10 fix for the login issue for Java
+clients. It addresses the problem for users of the command-line importer
+such as the ``bin/omero import`` Python plugin.
+
 5.4.10 (January 2019)
 ---------------------
 
-This release addresses a login issue for Java clients such as Insight
-and ``bin/omero import``. New releases of Java include a change to the
+This release addresses a login issue for Java clients such as OMERO.insight.
+New releases of Java include a change to the
 ``java.security`` file that disables anonymous cipher suites. This
 change causes ``SSLHandshakeException`` when the client attempts to
-authenticate to OMERO.blitz. The OMERO 5.4.10 release has clients check
+authenticate to OMERO.blitz. The OMERO 5.4.10 release has some clients check
 the security property ``jdk.tls.disabledAlgorithms`` for the value
 "anon" and remove it if present thus allowing authentication to proceed.
 


### PR DESCRIPTION
Extends the 5.4.10 Java SSL fix to `bin/omero import ...`. See #5947 and https://trello.com/c/MywCIQL9/60-omero-cli-import.

* Moves the `omero.client` fix even earlier in execution.
* Has import initialize `omero.client` before doing upgrade check.