### PR TITLE
show roi

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5784,6 +5784,17 @@ class _RoiWrapper (BlitzObjectWrapper):
             params.add('image_id', rlong(opts['image']))
         return (query, clauses, params)
 
+    def getImage(self):
+        """
+        Returns the Image for this ROI.
+
+        :return:    The Image
+        :rtype:     :class:`ImageWrapper`
+        """
+
+        if self._obj.image is not None:
+            return ImageWrapper(self._conn, self._obj.image)
+
 RoiWrapper = _RoiWrapper
 
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -270,10 +270,7 @@ class Show(object):
                 first_obj, attributes=attributes
             )
 
-        if first_obj == "roi" and first_selected is not None:
-            first_obj = "image"
-            first_selected = first_selected.getImage()
-        elif first_obj == "well":
+        if first_obj == "well":
             # Wells aren't in the tree, so we need to look up the parent
             well_sample = first_selected.getWellSample()
             parent_node = None
@@ -303,6 +300,11 @@ class Show(object):
             ]
             first_selected = parent_node
         else:
+            # If show=roi, selected object will be Image
+            if first_obj == "roi":
+                first_obj = "image"
+                first_selected = first_selected.getImage()
+
             # Tree hierarchy open to first selected object.
             self._initially_open = [
                 '%s-%s' % (first_obj, first_selected.getId())

--- a/components/tools/OmeroWeb/omeroweb/webclient/show.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/show.py
@@ -61,7 +61,7 @@ class Show(object):
     # List of supported object types
     SUPPORTED_OBJECT_TYPES = (
         'project', 'dataset', 'image', 'screen', 'plate', 'tag',
-        'acquisition', 'run', 'well', 'tagset'
+        'acquisition', 'run', 'well', 'tagset', 'roi'
     )
 
     # Regular expression which declares the format for a "path" used either
@@ -270,7 +270,10 @@ class Show(object):
                 first_obj, attributes=attributes
             )
 
-        if first_obj == "well":
+        if first_obj == "roi" and first_selected is not None:
+            first_obj = "image"
+            first_selected = first_selected.getImage()
+        elif first_obj == "well":
             # Wells aren't in the tree, so we need to look up the parent
             well_sample = first_selected.getWellSample()
             parent_node = None

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -151,7 +151,6 @@ class TestShow(IWebTest):
 
         return (project, roi)
 
-
     @pytest.fixture(params=[1, 2])
     def tag(self, request):
         """Returns a new OMERO TagAnnotation with required fields set."""
@@ -553,7 +552,8 @@ class TestShow(IWebTest):
         }
 
     @pytest.fixture
-    def project_dataset_image_roi_show_request(self, project_dataset_image_roi):
+    def project_dataset_image_roi_show_request(self,
+                                               project_dataset_image_roi):
         """
         Returns a simple GET request object with the 'show' query string
         variable set in the form ("roi-id").


### PR DESCRIPTION
# What this PR does

Supports ```webclient/?show=roi-123```.

See https://trello.com/c/Ph6glKiK/599-rfe-url-to-specific-roi
(from https://www.openmicroscopy.org/community/viewtopic.php?f=4&t=8672).


# Testing this PR:

1. Choose and ROI ID and go to ```webclient/show=roi-ID```, which should load the correct image in the webclient.
1. show test should pass