### PR TITLE
script results viewer

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/activities/activitiesContent.html
@@ -270,7 +270,7 @@
                                                     {% ifequal v.type "Image" %}
                                                         <!-- View Image -->
                                                         <li class="btn_view">
-                                                            <a href="#" onClick="return window.open('{% url 'webgateway.views.full_viewer' v.id %}', '_blank');"
+                                                            <a href="#" onClick="return window.open('{% url 'web_image_viewer' v.id %}', '_blank');"
                                                             title="Open Image in Viewer">View Image</a>
                                                         </li>
                                                     {% endifequal %}


### PR DESCRIPTION
# What this PR does

This uses the configured webclient image viewer for viewing images from script results, instead of using the older 'webgateway' viewer.

# Testing this PR

1. Run a script that creates an image (e.g. Combine_Images)
1. The "View Image" button on the script results should launch iviewer if configured.