### PR TITLE
Fix Preview open viewer with rendering defs

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_preview.html
@@ -363,8 +363,8 @@
               var vpQuery = OME.preview_viewport.getQuery();
               // remove &zm=50
               vpQuery = vpQuery.replace("&zm=" + OME.preview_viewport.getZoom(), "");
-
-              window.open(url + "?" + vpQuery, '_blank');
+              var hasQuery = url.indexOf('?') > -1;
+              window.open(url + (hasQuery ? "&" : "?") + vpQuery, '_blank');
               return false;
             });
 


### PR DESCRIPTION
This fixes an issue I noticed where opening the image viewer (e.g. old viewer OR iviewer) from the Preview panel would ignore the current rendering settings because the url creation doesn't take account of the ```?dataset=1``` already in the URL so that we get ```?dataset=1?c=...``` instead of ```?dataset=1&c=...```. 

E.g. see the bug at http://idr.openmicroscopy.org/webclient/?show=image-1920093 (adjust settings in Preview panel the hit ```Full Viewer``` in preview panel).

To test:
 - Open an Image that is in a Dataset (no bug with HCS images) in the Preview panel
 - Adjust rendering settings
 - Click ```Full Viewer`` and check that iviewer respects the rendering settings.