### PR TITLE
Add client downloads links to omeroweb login page

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -678,6 +678,18 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "For example: ``'{\"redirect\": [\"webindex\"], \"viewname\":"
           " \"load_template\", \"args\":[\"userdata\"], \"query_string\":"
           " {\"experimenter\": -1}}'``")],
+
+    "omero.web.login.show_client_downloads":
+        ["SHOW_CLIENT_DOWNLOADS",
+         "true",
+         parse_boolean,
+         ("Whether to link to official client downloads on the login page")],
+    "omero.web.login.client_downloads_base":
+        ["CLIENT_DOWNLOAD_LATEST_BASE",
+         'https://downloads.openmicroscopy.org/latest/omero',
+         str,
+         ("Base URL for latest client downloads")],
+
     "omero.web.apps":
         ["ADDITIONAL_APPS",
          '[]',

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -686,9 +686,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Whether to link to official client downloads on the login page")],
     "omero.web.login.client_downloads_base":
         ["CLIENT_DOWNLOAD_LATEST_BASE",
-         'https://downloads.openmicroscopy.org/latest/omero',
+         'https://downloads.openmicroscopy.org/latest/omero{major}.{minor}',
          str,
-         ("Base URL for latest client downloads")],
+         ("Base URL for latest client downloads. "
+          "Template parameters ``{major}`` ``{minor}`` ``{patch}`` will be "
+          "substituted with the current OMERO.web version.")],
 
     "omero.web.apps":
         ["ADDITIONAL_APPS",

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -129,6 +129,15 @@
 
     </form>
 
+    {% if show_download_links %}
+    <div id="client-downloads">
+      <p>Download OMERO.insight:<p>
+      <div><a href="{{ download_client_mac }}">Mac OS X</a></div>
+      <div><a href="{{ download_client_win }}">Windows</a></div>
+      <div><a href="{{ download_client_linux }}">Linux</a></div>
+    </div>
+    {% endif %}
+
     {% endblock %}
 </div>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -129,15 +129,6 @@
 
     </form>
 
-    {% if show_download_links %}
-    <div id="client-downloads">
-      <p>Download OMERO.insight:<p>
-      <div><a href="{{ download_client_mac }}">Mac OS X</a></div>
-      <div><a href="{{ download_client_win }}">Windows</a></div>
-      <div><a href="{{ download_client_linux }}">Linux</a></div>
-    </div>
-    {% endif %}
-
     {% endblock %}
 </div>
 
@@ -147,6 +138,13 @@
 		&copy; 2007-{{ build_year }} University of Dundee &amp; Open Microscopy Environment<br/>
 		OMERO is distributed under the terms of the GNU GPL.
 		For more information, visit <a href="https://www.openmicroscopy.org">openmicroscopy.org</a><br/>
+
+        {% if show_download_links %}
+            Download OMERO.insight for
+            <a href="{{ download_client_mac }}">Mac OS X</a>,
+            <a href="{{ download_client_win }}">Windows</a>,
+            <a href="{{ download_client_linux }}">Linux</a><br>
+        {% endif %}
 
         <img src="{% static 'webgateway/img/OME_logo_grey_110.png' %}"/>
     </p>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -261,8 +261,10 @@ class WebclientLoginView(LoginView):
 
         context['show_download_links'] = settings.SHOW_CLIENT_DOWNLOADS
         if settings.SHOW_CLIENT_DOWNLOADS:
-            ver = '.'.join(omero_version.split('.', 2)[:2])
-            latest = settings.CLIENT_DOWNLOAD_LATEST_BASE + ver
+            ver = re.match('(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).*',
+                           omero_version)
+            latest = settings.CLIENT_DOWNLOAD_LATEST_BASE.format(
+                **ver.groupdict())
             context['download_client_mac'] = latest + '/insight-mac.zip'
             context['download_client_win'] = latest + '/insight-win.zip'
             context['download_client_linux'] = latest + '/insight-linux.zip'

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -259,6 +259,14 @@ class WebclientLoginView(LoginView):
                 context['public_enabled'] = True
                 context['public_login_redirect'] = redirect
 
+        context['show_download_links'] = settings.SHOW_CLIENT_DOWNLOADS
+        if settings.SHOW_CLIENT_DOWNLOADS:
+            ver = '.'.join(omero_version.split('.', 2)[:2])
+            latest = settings.CLIENT_DOWNLOAD_LATEST_BASE + ver
+            context['download_client_mac'] = latest + '/insight-mac.zip'
+            context['download_client_win'] = latest + '/insight-win.zip'
+            context['download_client_linux'] = latest + '/insight-linux.zip'
+
         t = template_loader.get_template(self.template)
         c = Context(request, context)
         rsp = t.render(c)


### PR DESCRIPTION
# What this PR does

Adds download links to the latest compatible insight release. Enabled by default, can be disabled by setting `omero.web.login.show_client_downloads=false`. The download base URL can be changed using `omero.web.login.client_downloads_base`

Closes https://github.com/openmicroscopy/openmicroscopy/issues/4657

- [x] CSS styling

\[I would've tried the new [draft PR feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/) but it's not working on this repo\]