### PR TITLE
OMERO Python gateway: allow to set rendering of inactive channels

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -8556,35 +8556,38 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
     @assert_re()
     def set_active_channels(self, channels, windows=None, colors=None,
-                            invertMaps=None, reverseMaps=None, noRE=False):
+                            invertMaps=None, reverseMaps=None, noRE=False,
+                            set_inactive=False):
         """
-        Sets the active channels on the rendering engine.
-        Also sets rendering windows and channel colors
-        (for channels that are active)
+        Sets the active channels on the rendering engine. Also sets rendering
+        windows and channel colors
 
         Examples:
         # Turn first channel ON, others OFF
         image.setActiveChannels([1])
-        # First OFF, second ON, windows and colors for both
+        # First OFF, second ON, windows and colors for the active channel
         image.setActiveChannels(
-            [-1, 2], [[20, 300], [50, 500]], ['00FF00', 'FF0000'])
+            [-1, 2], windows=[[20, 300], [50, 500]],
+            colors=['00FF00', 'FF0000'])
         # Second Channel ON with windows. All others OFF
         image.setActiveChannels([2], [[20, 300]])
 
-        :param channels:    List of active channel indexes ** 1-based index **
-        :type channels:     List of int
-        :param windows:     Start and stop values for active channel rendering
-                            settings
-        :type windows:      List of [start, stop].
-                            [[20, 300], [None, None], [50, 500]].
-                            Must be list for each channel
-        :param colors:      List of colors. ['F00', None, '00FF00'].
-                            Must be item for each channel
-        :param invertMaps:  List of boolean (or None). If True/False then
-                            set/remove reverseIntensityMap on channel
-        :param noRE:        If True Channels will not have rendering engine
-                            enabled. In this case, calling channel.getColor()
-                            or getWindowStart() etc. will return None.
+        :param channels:     List of active channel indexes ** 1-based index **
+        :type channels:      List of int
+        :param windows:      Start and stop values for active channel rendering
+                             settings
+        :type windows:       List of [start, stop].
+                             [[20, 300], [None, None], [50, 500]].
+                             Must be list for each channel
+        :param colors:       List of colors. ['F00', None, '00FF00'].
+                             Must be item for each channel
+        :param invertMaps:   List of boolean (or None). If True/False then
+                             set/remove reverseIntensityMap on channel
+        :param noRE:         If True Channels will not have rendering engine
+                             enabled. In this case, calling channel.getColor()
+                             or getWindowStart() etc. will return None.
+        :param set_inactive: If True, deactivated channels will have windows,
+                             colors and reverse maps settings applied.
         """
         if reverseMaps is not None:
             warnings.warn(
@@ -8597,7 +8600,11 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         idx = 0     # index of windows/colors args above
         for c in range(len(self.getChannels(noRE=noRE))):
             self._re.setActive(c, (c+1) in channels, self._conn.SERVICE_OPTS)
-            if (c+1) in channels:
+            if set_inactive:
+                update_channel = ((c + 1) in abs_channels)
+            else:
+                update_channel = ((c + 1) in channels)
+            if update_channel:
                 if (invertMaps is not None and
                         invertMaps[idx] is not None):
                     self.setReverseIntensity(c, invertMaps[idx])

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -522,6 +522,46 @@ class TestRDefs (object):
         g = gatewaywrapper.gateway
         assert not g._assert_unregistered("testSetActiveChannelsWithRE")
 
+    @pytest.mark.parametrize('set_inactive', [True, False])
+    def test_set_active_channels_set_inactive(
+        self, gatewaywrapper, set_inactive):
+        """
+        Tests set_active_channels method with rendering engine
+        """
+        # Clean potentially customized default
+        self.image.clearDefaults()
+        self.image._closeRE()
+        self.image = gatewaywrapper.getTestImage()
+        c0wmin = self.image.getChannels()[0].getWindowMin()
+        self.channels = self.image.getChannels()
+        assert self.c0color != 'F0F000'
+        assert self.c1color != '000F0F'
+        assert c0wmin != 0
+        self.image.set_active_channels(
+            [1, -2], windows=[[0.0, 1631.0], [409.0, 5015.0]],
+            colors=[u'F0F000', u'000F0F'], set_inactive=set_inactive)
+        self.channels = self.image.getChannels()
+        assert len(self.channels) == 2, 'bad channel count on image #%d' \
+            % self.TESTIMG_ID
+        assert self.channels[0].isActive()
+        assert not self.channels[1].isActive()
+        assert self.channels[0].getColor().getHtml() == 'F0F000'
+        if set_inactive:
+            assert self.channels[1].getColor().getHtml() == '000F0F'
+        else:
+            assert self.channels[1].getColor().getHtml() != '000F0F'
+        assert self.channels[0].getWindowStart() == 0
+        assert self.channels[0].getWindowEnd() == 1631.0
+        if set_inactive:
+            assert self.channels[1].getWindowStart() == 409.0
+            assert self.channels[1].getWindowEnd() == 5015.0
+        else:
+            assert self.channels[1].getWindowStart() != 409.0
+            assert self.channels[1].getWindowEnd() != 5015.0
+        self.image._closeRE()
+        g = gatewaywrapper.gateway
+        assert not g._assert_unregistered("testSetActiveChannelsWithRE")
+
     def testUnregisterService(self, gatewaywrapper):
         """
         Tests if the service is unregistered after closing the

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -524,7 +524,7 @@ class TestRDefs (object):
 
     @pytest.mark.parametrize('set_inactive', [True, False])
     def test_set_active_channels_set_inactive(
-        self, gatewaywrapper, set_inactive):
+            self, gatewaywrapper, set_inactive):
         """
         Tests set_active_channels method with rendering engine
         """


### PR DESCRIPTION
## What this PR does

This addresses an issue noticed while applying the CLI render plugin to recent IDR studies.  The `render set` command wraps the `set_active_channels` API of the Python gateway. The current behavior of this API is that if a channel is disabled (by setting `-index` in the `channels` list), its rendering settings are never updated by this API.

While this in inline with the docstring contract (although incorrect the example fixed here), the original motivation is unclear. All the arguments for setting channel rendering  (`colors`, `windows`, `invertMaps`) handle `None` as way to skip updating the relevant settings. Thus the following API call unambiguously communicates the fact a second channel should be disabled with no other rendering change:

```
gateway.set([1, -2], windows=[[0.0, 255.0], None], colors=['FFF0000', None])
```

A contrario, if a caller made the effort to pass rendering settings for the disabled channel, these parameters are completely ignored at the moment:

```
gateway.set([1, -2], windows=[[0.0, 255.0], [10.0, 20.0], colors=['FFF0000', '00FF00'])
```

Additionally there is no other high-level way using the gateway to modify rendering settings of disabled channels

## Proposed changes

61f4cf9 proposes a minimal non-breaking approach by adding an extra key/value argument allowing the consume to choose  the behavior for disabled channels. If `false` (default), the current behavior is unchanged and disabled channels are only disabled. If `true`, all valid rendering settings are also applied to the disabled channels if applicable.

Other options might be worth discussing including adding additional `ImageWrapper` or `Channelwrapper` API to be able to manipulate channel rendering settings like lookup tables.

## Testing this PR

1e6c8b3 adds an integration tests covering the expectation of this API (incl. the simple testing of the channel disabling functionality). https://github.com/search?q=set_active_channels+user%3Aome+user%3Aopenmicroscopy+user%3AIDR&type=Code lists the known internal places that consume this API and should be reviewed with these changes in mind.