### PR TITLE
OMERO.web feedback can be disabled

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/feedback/templates/500-nosubmit.html
+++ b/components/tools/OmeroWeb/omeroweb/feedback/templates/500-nosubmit.html
@@ -1,0 +1,16 @@
+{% extends "base_error.html" %}
+{% load i18n %}
+
+{% block content %}
+    <div id="form-500">   <!-- This div used for 500 dialog box (handling ajaxError) -->
+        <h1>{% trans "Server Error." %} <em>(500)</em></h1>
+
+        <p class="error">{% trans "The server encountered an internal error and was unable to complete your request. Please contact your system administrator with the error message below." %}</p>
+
+        {% if error %}<ul class="errorlist"><li>{{ error }}</li></ul>{% endif %}
+
+        <textarea rows="10" cols="60">
+          {{ error500 }}
+        </textarea>
+    </div>
+{% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/feedback/templates/disabled.html
+++ b/components/tools/OmeroWeb/omeroweb/feedback/templates/disabled.html
@@ -23,7 +23,7 @@
     {% block content %}
       <div>
         <h1>Feedback is disabled on this server</h1>
-        <p>Please contact your system administrator or the <a href="https://www.openmicroscopy.org/support/">Openmicroscopy Environment</a></p>
+        <p>Please contact your system administrator or the <a href="https://www.openmicroscopy.org/support/">Open Microscopy Environment</a></p>
     {% endblock %}
     </div>
 

--- a/components/tools/OmeroWeb/omeroweb/feedback/templates/disabled.html
+++ b/components/tools/OmeroWeb/omeroweb/feedback/templates/disabled.html
@@ -1,0 +1,32 @@
+{% extends "webgateway/core_html.html" %}
+{% load i18n %}
+
+{% block link %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "feedback/css/layout.css" %}" type="text/css" />
+{% endblock %}
+
+{% block title %}
+    {% trans "OMERO.web - support" %}
+{% endblock %}
+
+{% block head %}
+    {{ block.super }}
+    {% include "webgateway/base/includes/shortcut_icon.html" %}
+{% endblock %}
+
+{% block body %}
+<div class="bodyWrapper">
+    <div><h1>
+        <a href="#" onClick="window.close()">{% trans "Close" %}</a>
+    </h1>
+    {% block content %}
+      <div>
+        <h1>Feedback is disabled on this server</h1>
+        <p>Please contact your system administrator or the <a href="https://www.openmicroscopy.org/support/">Openmicroscopy Environment</a></p>
+    {% endblock %}
+    </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/components/tools/OmeroWeb/omeroweb/feedback/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/urls.py
@@ -35,4 +35,6 @@ urlpatterns = patterns(
     url(r'^comment/', views.send_comment, name="csend"),
     url(r'^thanks/', TemplateView.as_view(template_name='thanks.html'),
         name="fthanks"),
+    url(r'^disabled/', TemplateView.as_view(template_name='disabled.html'),
+        name="feedback_disabled"),
 )

--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -61,7 +61,7 @@ def get_user_agent(request):
 
 ###############################################################################
 def send_feedback(request):
-    if not settings.FEEDBACK_ERROR_ENABLE:
+    if not settings.FEEDBACK_ERROR_ENABLED:
         return HttpResponseRedirect(reverse("feedback_disabled"))
 
     error = None
@@ -104,7 +104,7 @@ def send_feedback(request):
 
 
 def send_comment(request):
-    if not settings.FEEDBACK_COMMENT_ENABLE:
+    if not settings.FEEDBACK_COMMENT_ENABLED:
         return HttpResponseRedirect(reverse("feedback_disabled"))
 
     error = None

--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -61,6 +61,9 @@ def get_user_agent(request):
 
 ###############################################################################
 def send_feedback(request):
+    if not settings.FEEDBACK_ERROR_ENABLE:
+        return HttpResponseRedirect(reverse("feedback_disabled"))
+
     error = None
     form = ErrorForm(data=request.POST.copy())
     if form.is_valid():
@@ -101,6 +104,9 @@ def send_feedback(request):
 
 
 def send_comment(request):
+    if not settings.FEEDBACK_COMMENT_ENABLE:
+        return HttpResponseRedirect(reverse("feedback_disabled"))
+
     error = None
     form = CommentForm()
 

--- a/components/tools/OmeroWeb/omeroweb/feedback/views.py
+++ b/components/tools/OmeroWeb/omeroweb/feedback/views.py
@@ -179,9 +179,13 @@ def handler500(request):
     if request.is_ajax():
         return HttpResponseServerError(error500)
 
-    form = ErrorForm(initial={'error': error500})
-    context = {'form': form}
-    t = template_loader.get_template('500.html')
+    if settings.FEEDBACK_ERROR_ENABLED:
+        form = ErrorForm(initial={'error': error500})
+        context = {'form': form}
+        t = template_loader.get_template('500.html')
+    else:
+        context = {'error500': error500}
+        t = template_loader.get_template('500-nosubmit.html')
     c = RequestContext(request, context)
     return HttpResponseServerError(t.render(c))
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -643,17 +643,19 @@ CUSTOM_SETTINGS_MAPPINGS = {
           " Particularly useful when used in combination with the OMERO.web"
           " public user where logging in may not make sense.")],
     "omero.web.feedback.comment.enabled":
-        ["FEEDBACK_COMMENT_ENABLE",
+        ["FEEDBACK_COMMENT_ENABLED",
          "true",
          parse_boolean,
          ("Enable the feedback form for comments. "
-          "These comments are sent directly to the OME team.")],
+          "These comments are sent to the URL in ``omero.qa.feedback`` "
+          "(OME team by default).")],
     "omero.web.feedback.error.enabled":
-        ["FEEDBACK_ERROR_ENABLE",
+        ["FEEDBACK_ERROR_ENABLED",
          "true",
          parse_boolean,
          ("Enable the feedback form for errors. "
-          "These errors are sent directly to the OME team.")],
+          "These errors are sent to the URL in ``omero.qa.feedback`` "
+          "(OME team by default).")],
     "omero.web.staticfile_dirs":
         ["STATICFILES_DIRS",
          '[]',

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -642,6 +642,18 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Whether or not to include a user dropdown in the base template."
           " Particularly useful when used in combination with the OMERO.web"
           " public user where logging in may not make sense.")],
+    "omero.web.feedback.comment.enable":
+        ["FEEDBACK_COMMENT_ENABLE",
+         "true",
+         parse_boolean,
+         ("Enable the feedback form for comments. "
+          "These comments are sent directly to the OME team.")],
+    "omero.web.feedback.error.enable":
+        ["FEEDBACK_ERROR_ENABLE",
+         "true",
+         parse_boolean,
+         ("Enable the feedback form for errors. "
+          "These errors are sent directly to the OME team.")],
     "omero.web.staticfile_dirs":
         ["STATICFILES_DIRS",
          '[]',

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -642,13 +642,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("Whether or not to include a user dropdown in the base template."
           " Particularly useful when used in combination with the OMERO.web"
           " public user where logging in may not make sense.")],
-    "omero.web.feedback.comment.enable":
+    "omero.web.feedback.comment.enabled":
         ["FEEDBACK_COMMENT_ENABLE",
          "true",
          parse_boolean,
          ("Enable the feedback form for comments. "
           "These comments are sent directly to the OME team.")],
-    "omero.web.feedback.error.enable":
+    "omero.web.feedback.error.enabled":
         ["FEEDBACK_ERROR_ENABLE",
          "true",
          parse_boolean,


### PR DESCRIPTION
# What this PR does

The IDR is receiving a lot of spam through the feedback form. This adds two properties to disable it:
- `omero.web.feedback.comment.enabled`: controls feedback through the top-right `Send Feedback` menu option, default `true`
- `omero.web.feedback.error.enabled`, controls feedback when an error occurs, default `true`

# Testing this PR

- Set `omero.web.feedback.comment.enabled` `false`. The `Send Feedback` menu item should take you to a "please contact" page
- Set `omero.web.feedback.error.enabled` `false`. Generate a 500 error, submitting the error should lead to a "please contact" page

