### PR TITLE
Have Python integration tests for search briefly pause for indexing.

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -141,7 +141,7 @@ class TestSearch(ITest):
         res = owner.sf.getQueryService().findAllByQuery(sql, p)
         assert 5 == len(res)
 
-    def _3164_search(self, searcher, runs=10, pause=1):
+    def _3164_search(self, searcher):
         texts = ("*earch", "*rch", "search tif", "search",
                  "test", "tag", "ta*", "search_test",
                  "s .tif", ".tif", "tif", "*tif")
@@ -154,7 +154,6 @@ class TestSearch(ITest):
         search.addOrderByAsc("name")
         search.setAllowLeadingWildcard(True)
 
-        for r in range(runs):
             failed = {}
             for text in texts:
                 search.byFullText(str(text))
@@ -164,10 +163,8 @@ class TestSearch(ITest):
                     sz = 0
                 if 5 != sz:
                     failed[text] = sz
-            if not failed:
-                break
-            print "Failed run %i with %i fails" % (r + 1, len(failed))
-            time.sleep(pause)
+            if failed:
+                print "%i fails" % len(failed)
 
         return failed
 

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -131,14 +131,11 @@ class TestSearch(ITest):
             self.index(images[-1])
         time.sleep(self.wait)
 
-        p = omero.sys.Parameters()
-        p.map = {}
-        p.map["oids"] = omero.rtypes.rlist(im.id for im in images)
+        p = omero.sys.ParametersI()
+        p.addIds(im.id for im in images)
 
-        sql = "select im from Image im "\
-            "where im.id in (:oids) " \
-            "order by im.id asc"
-        res = owner.sf.getQueryService().findAllByQuery(sql, p)
+        hql = "FROM Image WHERE id IN (:ids)"
+        res = owner.sf.getQueryService().findAllByQuery(hql, p)
         assert 5 == len(res)
 
     def _3164_search(self, searcher):

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -146,8 +146,7 @@ class TestSearch(ITest):
                  "test", "tag", "ta*", "search_test",
                  "s .tif", ".tif", "tif", "*tif")
 
-        # Commented out to pass flake8 but these patterns may no longer
-        # be broken with recent chnages to search. (cgb)
+        # Commented out to pass flake8.
         # BROKEN = ("*test*.tif", "search*tif", "s*.tif", "*.tif")
 
         search = searcher.sf.createSearchService()

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -154,18 +154,17 @@ class TestSearch(ITest):
         search.addOrderByAsc("name")
         search.setAllowLeadingWildcard(True)
 
-            failed = {}
-            for text in texts:
-                search.byFullText(str(text))
-                if search.hasNext():
-                    sz = len(search.results())
-                else:
-                    sz = 0
-                if 5 != sz:
-                    failed[text] = sz
-            if failed:
-                print "%i fails" % len(failed)
-
+        failed = {}
+        for text in texts:
+            search.byFullText(str(text))
+            if search.hasNext():
+                sz = len(search.results())
+            else:
+                sz = 0
+            if 5 != sz:
+                failed[text] = sz
+        if failed:
+            print "%i fails" % len(failed)
         return failed
 
     def _3164_assert(self, failed):

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -18,6 +18,9 @@ import time
 
 class TestSearch(ITest):
 
+    # Compare with the configured value of omero.search.cron.
+    wait = 3
+
     def test2541(self):
         """
         Search for private data from another user
@@ -29,6 +32,7 @@ class TestSearch(ITest):
         tag.ns = omero.rtypes.rstring(uuid)
         tag = self.update.saveAndReturnObject(tag)
         self.root.sf.getUpdateService().indexObject(tag)
+        time.sleep(self.wait)
         q = searcher.sf.getQueryService()
         r = q.findAllByFullText("TagAnnotation", uuid, None)
         assert 0 == len(r)
@@ -86,6 +90,7 @@ class TestSearch(ITest):
             tag = self.update.saveAndReturnObject(tag)
             self.index(tag)
             tags.append(tag.ns.val)
+        time.sleep(self.wait)
 
         search = self.client.sf.createSearchService()
         search.onlyType("TagAnnotation")
@@ -124,6 +129,7 @@ class TestSearch(ITest):
 
             images.append(owner.sf.getUpdateService().saveAndReturnObject(img))
             self.index(images[-1])
+        time.sleep(self.wait)
 
         p = omero.sys.Parameters()
         p.map = {}
@@ -194,6 +200,7 @@ class TestSearch(ITest):
             t.setTextValue(omero.rtypes.rstring(uuid))
             t = u.sf.getUpdateService().saveAndReturnObject(t)
             self.root.sf.getUpdateService().indexObject(t)  # Index
+            time.sleep(self.wait)
 
             # And try to read it back as the leader and the admin
             for sf, who in ((a.sf, "grp-admin"), (self.root.sf, "sys-admin")):
@@ -226,6 +233,7 @@ class TestSearch(ITest):
         cann.textValue = omero.rtypes.rstring(uuid)
         cann = update.saveAndReturnObject(cann)
         self.root.sf.getUpdateService().indexObject(cann)
+        time.sleep(self.wait)
 
         rv = query.findAllByFullText(
             "CommentAnnotation", "%s" % uuid, None)
@@ -244,6 +252,7 @@ class TestSearch(ITest):
         images = self.import_fake_file(name=uuid, client=client)
         image = images[0]
         self.root.sf.getUpdateService().indexObject(image)
+        time.sleep(self.wait)
         search = client.sf.createSearchService()
         search.onlyType("Image")
         search.setAllowLeadingWildcard(True)
@@ -294,6 +303,7 @@ class TestSearch(ITest):
         csv.write("Header1,Header2\nGFP\n100.0\n")
         image = self.attached_image(
             uuid, client, str(csv), "text/csv")
+        time.sleep(self.wait)
 
         search = client.sf.createSearchService()
         try:
@@ -313,6 +323,7 @@ class TestSearch(ITest):
         txt.write("crazy")
         image = self.attached_image(
             uuid, client, str(txt), "text/plain")
+        time.sleep(self.wait)
 
         search = client.sf.createSearchService()
         try:
@@ -333,6 +344,7 @@ class TestSearch(ITest):
         tag.textValue = omero.rtypes.rstring(word)
         tag = client.sf.getUpdateService().saveAndReturnObject(tag)
         self.root.sf.getUpdateService().indexObject(tag)
+        time.sleep(self.wait)
 
         search = client.sf.createSearchService()
         search.onlyType("TagAnnotation")
@@ -373,6 +385,7 @@ class TestSearch(ITest):
         client = self.new_client()
         proj = self.make_project(name, client=client)
         self.root.sf.getUpdateService().indexObject(proj)
+        time.sleep(self.wait)
 
         search = client.sf.createSearchService()
         search.onlyType("Project")
@@ -398,6 +411,7 @@ class TestSearch(ITest):
         proj.linkAnnotation(ann)
         proj = client.sf.getUpdateService().saveAndReturnObject(proj)
         self.root.sf.getUpdateService().indexObject(proj)
+        time.sleep(self.wait)
 
         search = client.sf.createSearchService()
         search.onlyType("Project")


### PR DESCRIPTION
# What this PR does

The Python integration tests add new data to OMERO then search for it. They are flaky. This PR adds brief pauses to tests to give OMERO time to index the new data.

# Testing this PR

See if this PR improves https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-Python27/lastCompletedBuild/testReport/OmeroPy.test.integration.test_search/TestSearch/history/.

# Related reading

https://trello.com/c/wPBnTfPU/50-flaky-tests