### PR TITLE
Reduce pause in Java integration search tests.

### DIFF
--- a/components/tools/OmeroJava/test/integration/gateway/SearchFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/SearchFacilityTest.java
@@ -71,7 +71,7 @@ public class SearchFacilityTest extends GatewayTest {
         super.setUp();
         initData();
         // wait a little bit for the search indexer
-        Thread.sleep(30000);
+        Thread.sleep(3000);
     }
 
     @Test


### PR DESCRIPTION
# What this PR does

The indexer should not need very long to index new data. This PR reduces the search facility test's wait for the setup data to become available.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-java/lastCompletedBuild/testngreports/integration.gateway/SearchFacilityTest/testSearch/ should remain green.

# Related reading

#4483