### PR TITLE
Api get roi

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/api/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/api/urls.py
@@ -283,6 +283,14 @@ api_rois = url(r'^v(?P<api_version>%s)/m/rois/$' % versions,
 GET all rois, using omero-marshal to generate json
 """
 
+api_roi = url(
+    r'^v(?P<api_version>%s)/m/rois/(?P<object_id>[0-9]+)/$' % versions,
+    views.RoiView.as_view(),
+    name='api_roi')
+"""
+ROI url to GET or DELETE a single ROI
+"""
+
 api_image_rois = url(
     r'^v(?P<api_version>%s)/m/images/'
     '(?P<image_id>[0-9]+)/rois/$' % versions,
@@ -326,5 +334,6 @@ urlpatterns = patterns(
     api_well,
     api_plate_screens,
     api_rois,
+    api_roi,
     api_image_rois,
 )

--- a/components/tools/OmeroWeb/omeroweb/api/views.py
+++ b/components/tools/OmeroWeb/omeroweb/api/views.py
@@ -368,6 +368,18 @@ class WellView(ObjectView):
         return marshalled
 
 
+class RoiView(ObjectView):
+    """Handle access to an individual ROI to GET or DELETE it."""
+
+    OMERO_TYPE = 'Roi'
+
+    def get_opts(self, request, **kwargs):
+        """Add extra parameters to the opts dict."""
+        opts = super(RoiView, self).get_opts(request, **kwargs)
+        opts['load_shapes'] = True
+        return opts
+
+
 class ObjectsView(ApiView):
     """Base class for listing objects."""
 
@@ -668,6 +680,12 @@ class RoisView(ObjectsView):
     """Handles GET for /rois/ to list available ROIs with Shapes."""
 
     OMERO_TYPE = 'Roi'
+
+    # Urls to add to marshalled object. See ProjectsView for more details
+    urls = {
+        'url:roi': {'name': 'api_roi',
+                    'kwargs': {'object_id': 'OBJECT_ID'}}
+    }
 
     def get_opts(self, request, **kwargs):
         """Add extra parameters to the opts dict."""


### PR DESCRIPTION
# What this PR does

This adds support for GET and DELETE of a single ROI at ```/api/v0/m/rois/{ID}/```
I found this missing functionality to be useful in recent iviewer work on ROIs.

# Testing this PR

1. Go to ```/api/v0/m/rois/{ID}/``` with an ROI ID and you should get ROI JSON with shapes loaded
1. Tests should be passing
