### PR TITLE
Drop all targets and usage of OME Artifactory for publishing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -396,11 +396,6 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
         </copy>
     </target>
 
-    <target name="release-hudson" depends="check-ivy"
-            description="Saves to the hudson repository for dependent builds">
-        <iterate buildpathref="all.buildpath" target="artifactory"/>
-    </target>
-
     <target name="release-training" description="Produces a zip with the examples/Training files">
         <zip destfile="${omero.home}/target/OMERO.training-${omero.version}.zip">
             <zipfileset dir="${omero.home}/examples/Training" prefix="OMERO.training-${omero.version}" includes="**" excludes="markup.py"/>

--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -480,17 +480,6 @@ omero.version=${omero.version}
         <!-- empty by default -->
     </target>
 
-    <target name="artifactory" depends="prepare">
-        <ivy:settings id="ivy.${ant.project.name}.artifactory" file="${etc.dir}/ivysettings.xml"/>
-        <ivy:resolve file="ivy.xml" type="jar,egg" conf="client" settingsRef="ivy.${ant.project.name}.artifactory" log="quiet"/>
-        <publishArtifact
-            resolver="artifactory-publish"
-            settingsRef="ivy.${ant.project.name}.artifactory"
-            haltonmissing="false"
-            publishivy="false"
-            conf="client"/>
-    </target>
-
     <target name="clean">
         <delete dir="${target.dir}"/>
     </target>

--- a/etc/build.properties
+++ b/etc/build.properties
@@ -27,8 +27,6 @@ javadoc.maxmem=1050m
 exe4j.home=/opt/exe4j
 package-extra=true
 
-artifactory.username=hudson
-artifactory.username=SECRET
 artifactory.baseurl=https://artifacts.openmicroscopy.org/artifactory
 artifactory.repository=ome.staging
 

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -23,9 +23,6 @@
 
   <settings defaultResolver="${omero.resolver}"/>
 
-  <credentials host="artifacts.openmicroscopy.org" realm="Artifactory Realm"
-        username="${artifactory.username}" passwd="${artifactory.password}"/>
-
   <caches default="local" defaultCacheDir="${ivy.settings.dir}/../lib/cache">
       <!-- local is intended for all products built from this repository,
            while maven is for any stable, unchanging jar that is being


### PR DESCRIPTION
Following the extraction of the Java components out of this repository, the deployment logic is also unnecessary. All read usages of the Artifactory for retrieving JARs should be preserved.

The OMERO release jobs which were previously pushing artifacts will need to be modified accordingly.
