### PR TITLE
Web logout redirects to configured login page

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -634,7 +634,11 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "the OMERO logo. You will need to host the image somewhere else "
           "and link to it with the OMERO logo.")],
     "omero.web.login_view":
-        ["LOGIN_VIEW", "weblogin", str, None],
+        ["LOGIN_VIEW",
+         "weblogin",
+         str,
+         ("The Django view name used for login. Use this to provide an "
+          "alternative login workflow.")],
     "omero.web.user_dropdown":
         ["USER_DROPDOWN",
          "true",

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -343,7 +343,7 @@ def logout(request, conn=None, **kwargs):
                 logger.error('Exception during logout.', exc_info=True)
         finally:
             request.session.flush()
-        return HttpResponseRedirect(reverse("weblogin"))
+        return HttpResponseRedirect(reverse(settings.LOGIN_VIEW))
     else:
         context = {
             'url': reverse('weblogout'),

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -20,7 +20,6 @@
 """
 Tests webclient login
 """
-import sys
 from django.conf import settings
 from django.conf.urls import url
 from django.utils.importlib import import_module
@@ -43,9 +42,11 @@ class CustomWebclientLoginView(WebclientLoginView):
 
 urlpatterns = import_module(settings.ROOT_URLCONF).urlpatterns
 urlpatterns += [
-    url(r'^test_login/$', CustomWebclientLoginView.as_view(), name="test_weblogin"),
+    url(r'^test_login/$',
+        CustomWebclientLoginView.as_view(), name="test_weblogin"),
 ]
-    
+
+
 class TestLogin(IWebTest):
     """
     Tests login

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -20,6 +20,13 @@
 """
 Tests webclient login
 """
+import sys
+from django.conf import settings
+from django.conf.urls import url
+from django.utils.importlib import import_module
+from django.test.utils import override_settings
+
+from omeroweb.webclient.views import WebclientLoginView
 
 from omeroweb.testlib import IWebTest, post, get
 from django.core.urlresolvers import reverse
@@ -30,6 +37,15 @@ import pytest
 tag_url = reverse('load_template', kwargs={'menu': 'usertags'})
 
 
+class CustomWebclientLoginView(WebclientLoginView):
+    pass
+
+
+urlpatterns = import_module(settings.ROOT_URLCONF).urlpatterns
+urlpatterns += [
+    url(r'^test_login/$', CustomWebclientLoginView.as_view(), name="test_weblogin"),
+]
+    
 class TestLogin(IWebTest):
     """
     Tests login
@@ -83,3 +99,21 @@ class TestLogin(IWebTest):
         if len(redirect) == 0:
             redirect = reverse('webindex')
         assert rsp['Location'].endswith(redirect)
+
+    @override_settings(ROOT_URLCONF=__name__, LOGIN_VIEW='test_weblogin')
+    def test_login_view(self):
+        """
+        Test that a successful logout redirects to custom login view
+        """
+        django_client = self.django_root_client
+        request_url = reverse('test_weblogin')
+        data = {
+            'server': 1,
+            'username': self.ctx.userName,
+            'password': self.ctx.userName,
+        }
+        rsp = post(django_client, request_url, data, status_code=302)
+        request_url = reverse('weblogout')
+        rsp = post(django_client, request_url, {}, status_code=302)
+        assert rsp['Location'].endswith(reverse('test_weblogin'))
+        assert not rsp['Location'].endswith(reverse('weblogin'))


### PR DESCRIPTION
OMERO.web allows the login page to be replaced with an alternative Django view: https://docs.openmicroscopy.org/omero/5.4.10/sysadmins/config.html#omero-web-login-view

This view is used by the default login check https://github.com/openmicroscopy/openmicroscopy/blob/v5.5.0-m3/components/tools/OmeroWeb/omeroweb/decorators.py#L122
but the logout view doesn't take this property into account

# Testing this PR

1. Set an alternative login view `omero config set omero.web.login_view someotherviewname`
2. Logout
3. Check that you are directed to the configure view, and not the default login view

I've also added some docs for the `omero.web.login_view` property