### PR TITLE
OmeroPy: don't look for bin/omero in .git

### DIFF
--- a/components/tools/OmeroPy/src/omero/testlib/__init__.py
+++ b/components/tools/OmeroPy/src/omero/testlib/__init__.py
@@ -172,7 +172,7 @@ class ITest(object):
                     # find OMERO dist by searching for bin/omero
                     # exclude OmeroPy as is a source
                     if (str(t.dirname().dirname().basename())
-                            not in ('OmeroPy', 'build', 'target') and
+                            not in ('OmeroPy', 'build', 'target', '.git') and
                             str(t.basename()) == 'omero' and
                             str(t.dirname().basename()) == 'bin'):
                         dist = t.dirname().dirname()


### PR DESCRIPTION
The `travers` method walks up from the current directory looking
for a subdirectory that contains `bin/omero`. Unfortunately, that
holds true for .git as well. A better fix would likely be to not
check more deeply than 1 or 2 subdirectories.

see: https://github.com/manics/openmicroscopy/commit/040878c07f05a77855fd483315279908fba4ad61#commitcomment-32511555