### PR TITLE
fix minor typo in integration test

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -150,9 +150,9 @@ class TestDownload(IWebTest):
         }
         get(self.django_client, request_url, data, status_code=404)
 
-    def test_attachement_download(self):
+    def test_attachment_download(self):
         """
-        Download of attachement.
+        Download of attachment.
         """
 
         images = self.import_fake_file()


### PR DESCRIPTION
# What this PR does

Simply fixes a typo among our web integration tests.

# Testing this PR

https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration-Python27/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_download/TestDownload/ should pass.