### PR TITLE
in version history note restriction on config property names

### DIFF
--- a/history.rst
+++ b/history.rst
@@ -23,6 +23,9 @@ separate repositories:
 
 This has the goal of enabling more fine-grained releases.
 
+A new restriction is that the names of server configuration properties
+may include only letters, numbers and the symbols ".", "_", "-".
+
 5.5.0-m2 (December 2018)
 ------------------------
 


### PR DESCRIPTION
# What this PR does

Adds a note to our version history about when the configuration name property restriction was added. In due course it also needs mentioning in our more obvious documentation.

# Related reading

https://github.com/openmicroscopy/openmicroscopy/pull/5919