### PR TITLE
Enable omero-build to use this repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     - git
 
 install:
-    - git clone git://github.com/openmicroscopy/omero-test-infra .omero
+    - git clone -b srv-compose git://github.com/joshmoore/omero-test-infra .omero
 
 script:
     - .omero/docker srv

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     - git
 
 install:
-    - git clone -b srv-compose git://github.com/joshmoore/omero-test-infra .omero
+    - git clone git://github.com/openmicroscopy/omero-test-infra .omero
 
 script:
     - .omero/docker srv

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,23 +64,7 @@ RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 #
 #     https://trello.com/c/rPstbt4z/216-open-ssl-110
 #
-# RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
-
-
-# Temp: Build jars locally
-########RUN git clone git://github.com/ome/omero-gradle-plugins /tmp/omero-gradle-plugins
-########RUN cd /tmp/omero-gradle-plugins && git submodule update --init
-########RUN cd /tmp/omero-gradle-plugins && ./build.sh
-
-########RUN git clone git://github.com/ome/omero-build /tmp/omero-build
-########WORKDIR /tmp/omero-build
-########RUN git submodule update --init
-########RUN ./build.sh
-########WORKDIR /src
-########USER root
-########RUN apt-get update -y && apt-get install -y vim
-########USER omero
-# End Temp
+RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
 
 # Reproduce jenkins build
 RUN env BUILD_NUMBER=1 OMERO_BRANCH=develop bash docs/hudson/OMERO.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ARG RUN_IMAGE=openmicroscopy/omero-${COMPONENT}:latest
 
 
 FROM ${BUILD_IMAGE} as build
+USER root
 RUN apt-get update \
  && apt-get install -y ant \
       python-pip python-tables python-virtualenv python-yaml python-jinja2 \
@@ -32,7 +33,7 @@ RUN apt-get update \
 # TODO: unpin pip when possible
 # openjdk:8 is "stretch" or Debian 9
 RUN pip install https://github.com/ome/zeroc-ice-py-debian9/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
-RUN adduser omero
+RUN id 1000 || useradd -u 1000 -ms /bin/bash build
 
 # TODO: would be nice to not need to copy .git since it invalidates the build frequently and takes more time
 COPY .git /src/.git
@@ -51,8 +52,8 @@ COPY sql /src/sql
 COPY test.xml /src/
 COPY LICENSE.txt /src/
 COPY history.rst /src/
-RUN chown -R omero /src
-USER omero
+RUN chown -R 1000 /src
+USER 1000
 WORKDIR /src
 ENV ICE_CONFIG=/src/etc/ice.config
 RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 #
 #     https://trello.com/c/rPstbt4z/216-open-ssl-110
 #
-RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
+# RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
 
 # Reproduce jenkins build
 RUN env BUILD_NUMBER=1 OMERO_BRANCH=develop bash docs/hudson/OMERO.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
       zlib1g-dev python-pillow python-numpy python-sphinx \
       libssl-dev libbz2-dev libmcpp-dev libdb++-dev libdb-dev \
       zeroc-ice-all-dev \
- && pip install --upgrade 'pip<10' setuptools
+ && pip install --upgrade 'pip<10' setuptools flake8==2.4.0 pytest==2.7.3
 # TODO: unpin pip when possible
 # openjdk:8 is "stretch" or Debian 9
 RUN pip install https://github.com/ome/zeroc-ice-py-debian9/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl

--- a/build.xml
+++ b/build.xml
@@ -454,7 +454,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     <target name="copy-client" depends="init">
         <mkdir dir="${dist.dir}/lib/client"/>
         <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
-        <ivy:resolve file="ivy.xml" type="jar,egg,bundle" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
+        <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="client" pattern="${dist.dir}/lib/client/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
         <mkdir dir="${dist.dir}/share/client"/>
         <ivy:report conf="client" todir="${dist.dir}/share/client"
@@ -465,7 +465,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     <target name="copy-server" depends="init">
         <mkdir dir="${dist.dir}/lib/server"/>
         <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
-        <ivy:resolve file="ivy.xml" type="jar,egg,bundle" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
+        <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="server" pattern="${dist.dir}/lib/server/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
         <mkdir dir="${dist.dir}/share/server"/>
         <ivy:report conf="server" todir="${dist.dir}/share/server"

--- a/components/tools/OmeroFS/ivy.xml
+++ b/components/tools/OmeroFS/ivy.xml
@@ -1,4 +1,4 @@
-<ivy-module version="1.0">
+<ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -26,7 +26,9 @@
   </publications>
   <dependencies>
     <!-- Internal -->
-    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}" changing="true" conf="server->server"/>
+    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}" transitive="false">
+	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
+    </dependency>
   </dependencies>
 </ivy-module>
 

--- a/components/tools/OmeroJava/ivy.xml
+++ b/components/tools/OmeroJava/ivy.xml
@@ -1,4 +1,4 @@
-<ivy-module version="1.0" xmlns:m="http://ant.apache.org/ivy/maven">
+<ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -31,7 +31,10 @@
     -->
   </publications>
   <dependencies>
-    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
+    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}">
+	    <artifact name="omero-blitz" type="jar" ext="jar"/>
+	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
+    </dependency>
     <dependency org="org.openmicroscopy" name="omero-common-test" rev="${versions.omero-common-test}"/>
   </dependencies>
 </ivy-module>

--- a/components/tools/OmeroPy/ivy.xml
+++ b/components/tools/OmeroPy/ivy.xml
@@ -27,7 +27,7 @@
   <dependencies>
     <!-- Internal -->
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}" transitive="false">
-	    <artifact name="omero-blitz" ext="zip" e:classifier="python"/>
+	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
     </dependency>
   </dependencies>
 </ivy-module>

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -123,18 +123,7 @@ build_cpp()
 integration()
 {
     fold start integration
-    if [ "x$TRAVIS_BRANCH" == "x" ]; then
-        FILES=$(git diff --name-only origin/develop...HEAD)
-    else
-        FILES=$(git diff --name-only HEAD...$TRAVIS_BRANCH)
-    fi
-    for x in $(echo "$FILES" | grep OmeroPy/test/integration); do
-        TEST=${x#components/tools/OmeroPy/}
-        export PYTHONPATH=$PYTHONPATH:../target/lib/python
-        ( cd components/tools/OmeroPy/;
-          python setup.py test -t $TEST -m "not broken"
-        )
-    done
+    ./build.py test-integration
     fold end integration
 }
 

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -156,7 +156,7 @@ do
         py-test)
             py_test ;;
         integration)
-            integration ;;
+            py_flake8 && py_test && java_test;;
         all)
             py_flake8 java_build java_test py_test ;;
         *)

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -155,9 +155,7 @@ do
             py_build ;;
         py-test)
             py_test ;;
-        integration)
-            py_flake8 && py_test && java_test;;
-        all)
+        integration | all)
             py_flake8 java_build java_test py_test ;;
         *)
             echo "Invalid argument: \"$arg\"" >&2

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -144,7 +144,7 @@
     <module organisation="zeroc" resolver="ome-resolver"/>
     <module organisation="ome" name="jxrlib-all" resolver="ome-resolver"/>
     <module organisation="ome" resolver="${ome.resolver}"/>
-    <module organisation="org.openmicroscopy" resolver="ome-artifactory"/>
+    <module organisation="org.openmicroscopy" resolver="ome-resolver"/>
   </modules>
 
   <triggers/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -29,7 +29,7 @@
            downloaded -->
       <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"/>
       <cache name="maven" basedir="${maven.repo.local}"
-        artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"
+        artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
         ivyPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].xml"
         lockStrategy="artifact-lock"
         defaultTTL="0ms"/>
@@ -42,11 +42,11 @@
         <ivy pattern="${ivy.settings.dir}/../target/repository/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).xml"/>
     </filesystem>
     <filesystem name="repo" cache="local">
-        <artifact pattern="${ivy.settings.dir}/../lib/repository/[artifact]-[revision].[type]" />
+        <artifact pattern="${ivy.settings.dir}/../lib/repository/[artifact]-[revision](-[classifier]).[type]" />
         <ivy pattern="${ivy.settings.dir}/../lib/repository/[module]-[revision].ivy"/>
     </filesystem>
     <filesystem name="test" checkmodified="true" changingMatcher="regexp" changingPattern=".*SNAPSHOT.*" cache="local">
-        <artifact pattern="${ivy.settings.dir}/../target/test-repository/[artifact]-[revision].[type]" />
+        <artifact pattern="${ivy.settings.dir}/../target/test-repository/[artifact]-[revision](-[classifier]).[type]" />
         <ivy pattern="${ivy.settings.dir}/../target/test-repository/[module]-[revision].xml"/>
     </filesystem>
 
@@ -122,7 +122,7 @@
     <!-- Hudson resolver. Used by hudson to build a central repository -->
     <filesystem name="hudson-repository" cache="local">
         <ivy pattern="${user.home}/.hudson/repository/[organisation]/[module]/ivys/ivy-[revision].xml"/>
-        <artifact pattern="${user.home}/.hudson/repository/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]"/>
+        <artifact pattern="${user.home}/.hudson/repository/[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]"/>
     </filesystem>
 
     <url name="artifactory-publish">
@@ -144,7 +144,7 @@
     <module organisation="zeroc" resolver="ome-resolver"/>
     <module organisation="ome" name="jxrlib-all" resolver="ome-resolver"/>
     <module organisation="ome" resolver="${ome.resolver}"/>
-    <module organisation="org.openmicroscopy" resolver="ome-resolver"/>
+    <module organisation="org.openmicroscopy" resolver="${ome.resolver}"/>
   </modules>
 
   <triggers/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -27,7 +27,8 @@
       <!-- local is intended for all products built from this repository,
            while maven is for any stable, unchanging jar that is being
            downloaded -->
-      <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"/>
+      <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"
+        artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
       <cache name="maven" basedir="${maven.repo.local}"
         artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
         ivyPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].xml"
@@ -71,6 +72,7 @@
       <ibiblio name="ome-artifactory" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
+          pattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
           root="https://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
       <ibiblio name="unidata.releases" cache="maven"
@@ -95,7 +97,7 @@
     </chain>
 
     <!-- Resolver for OME dependencies-->
-    <chain name="ome-resolver" returnFirst="true">
+    <chain name="ome-resolver">
         <resolver ref="user-maven"/>
         <resolver ref="ome-artifactory"/>
     </chain>


### PR DESCRIPTION
In an effort to allow the decoupled submodule repositories
to also be able to use server integration tests in travis,
the relationship between omero-build and this repository
will need to be changed. For example, a PR in omero-server
will need a matching PR in omero-build which will build
all the component jars and then inject them into the Dockerfile
in this repository. This is done by:

 (1) appending the necessary versions to etc/omero.properties:

```
    echo versions.omero-blitz >> etc/omero.properties
```

 (2) using the omero-build image as the base image

```
    --build-arg=BUILD_IMAGE=...name of omero-build image...
```