### PR TITLE
Add int. tests for DataManagerFacility.move() method

### DIFF
--- a/components/tools/OmeroJava/test/integration/gateway/DataManagerFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/DataManagerFacilityTest.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import omero.LockTimeout;
 import omero.RLong;
@@ -353,6 +354,162 @@ public class DataManagerFacilityTest extends GatewayTest {
             }
         }
     }
+    
+    @Test
+    /**
+     * Test the move method by moving annotations from one dataset, project,
+     * etc. to another.
+     * 
+     * @throws Exception
+     */
+    public void testMoveAnnotation() throws Exception {
+        List<DataObject> sources = new ArrayList<DataObject>();
+        DatasetData ds = new DatasetData();
+        ds.setName(UUID.randomUUID().toString());
+        sources.add(datamanagerFacility.saveAndReturnObject(rootCtx, ds));
+        ProjectData proj = new ProjectData();
+        proj.setName(UUID.randomUUID().toString());
+        sources.add(datamanagerFacility.saveAndReturnObject(rootCtx, proj));
+        ScreenData s = new ScreenData();
+        s.setName(UUID.randomUUID().toString());
+        sources.add(datamanagerFacility.saveAndReturnObject(rootCtx, s));
+        PlateData p = new PlateData();
+        p.setName(UUID.randomUUID().toString());
+        sources.add(datamanagerFacility.saveAndReturnObject(rootCtx, p));
+        long imgId = createImage(rootCtx);
+        List<Long> ids = new ArrayList<Long>(1);
+        ids.add(imgId);
+        sources.add(browseFacility.getImages(rootCtx, ids).iterator().next());
+
+        List<DataObject> targets = new ArrayList<DataObject>();
+        ds = new DatasetData();
+        ds.setName(UUID.randomUUID().toString());
+        targets.add(datamanagerFacility.saveAndReturnObject(rootCtx, ds));
+        proj = new ProjectData();
+        proj.setName(UUID.randomUUID().toString());
+        targets.add(datamanagerFacility.saveAndReturnObject(rootCtx, proj));
+        s = new ScreenData();
+        s.setName(UUID.randomUUID().toString());
+        targets.add(datamanagerFacility.saveAndReturnObject(rootCtx, s));
+        p = new PlateData();
+        p.setName(UUID.randomUUID().toString());
+        targets.add(datamanagerFacility.saveAndReturnObject(rootCtx, p));
+        imgId = createImage(rootCtx);
+        ids = new ArrayList<Long>(1);
+        ids.add(imgId);
+        targets.add(browseFacility.getImages(rootCtx, ids).iterator().next());
+
+        Collection<AnnotationData> annos = new ArrayList<AnnotationData>();
+        annos.add(new BooleanAnnotationData(true));
+        annos.add(new DoubleAnnotationData(5d));
+        annos.add(new LongAnnotationData(1));
+        annos.add(new MapAnnotationData());
+        annos.add(new RatingAnnotationData(3));
+        annos.add(new TagAnnotationData("test"));
+        annos.add(new TermAnnotationData("test2"));
+        annos.add(new TextualAnnotationData("test3"));
+        annos.add(new XMLAnnotationData("<test4/>"));
+
+        for (int i = 0; i < sources.size(); i++) {
+            DataObject src = sources.get(i);
+            DataObject tar = targets.get(i);
+            List<AnnotationData> attached = new ArrayList<AnnotationData>();
+            annos.forEach(anno -> {
+                try {
+                    attached.add(datamanagerFacility.attachAnnotation(rootCtx, anno, src));
+                } catch (DSOutOfServiceException | DSAccessException e) {
+                    e.printStackTrace();
+                }
+            });
+            
+            datamanagerFacility.move(rootCtx, attached, src, tar);
+            List<AnnotationData> loaded = metadataFacility.getAnnotations(rootCtx, tar);
+            
+            Assert.assertEquals(attached.size(), loaded.size());
+            Set<Long> check = attached.stream().map(a -> a.getId()).collect(Collectors.toSet());
+            loaded.forEach(a -> Assert.assertTrue(check.contains(a.getId())));
+            
+            List<IObject> del = attached.stream().map(obj -> obj.asIObject()).collect(Collectors.toList());
+            datamanagerFacility.delete(rootCtx, del);
+            Thread.sleep(100);
+        }
+    }
+
+    @Test
+    /**
+     * Test the move method by moving an image from one dataset to another
+     * 
+     * @throws Exception
+     */
+    public void testMoveImage() throws Exception {
+        DatasetData ds1 = new DatasetData();
+        ds1.setName(UUID.randomUUID().toString());
+        ds1 = (DatasetData) datamanagerFacility.saveAndReturnObject(rootCtx,
+                ds1);
+
+        DatasetData ds2 = new DatasetData();
+        ds2.setName(UUID.randomUUID().toString());
+        ds2 = (DatasetData) datamanagerFacility.saveAndReturnObject(rootCtx,
+                ds2);
+
+        long imgId = createImage(rootCtx);
+        ImageData img = browseFacility.getImage(rootCtx, imgId);
+
+        datamanagerFacility.addImagesToDataset(rootCtx,
+                Collections.singleton(img), ds1);
+
+        ds1 = browseFacility
+                .getDatasets(rootCtx, Collections.singleton(ds1.getId()))
+                .iterator().next();
+
+        Assert.assertEquals(ds1.getImages().size(), 1);
+
+        datamanagerFacility.move(rootCtx, Collections.singletonList(img), ds1, ds2);
+
+        ds1 = browseFacility
+                .getDatasets(rootCtx, Collections.singleton(ds1.getId()))
+                .iterator().next();
+        ds2 = browseFacility
+                .getDatasets(rootCtx, Collections.singleton(ds2.getId()))
+                .iterator().next();
+        Assert.assertTrue(ds1.getImages().isEmpty());
+        Assert.assertEquals(ds2.getImages().size(), 1);
+    }
+
+    @Test
+    /**
+     * Test the move method by moving a dataset from one project to another
+     * 
+     * @throws Exception
+     */
+    public void testMoveContainer() throws Exception {
+        ProjectData proj1 = new ProjectData();
+        proj1.setName(UUID.randomUUID().toString());
+        proj1 = (ProjectData) datamanagerFacility.saveAndReturnObject(rootCtx,
+                proj1);
+
+        DatasetData ds = new DatasetData();
+        ds.setName(UUID.randomUUID().toString());
+        ds = datamanagerFacility.createDataset(rootCtx, ds, proj1);
+
+        ProjectData proj2 = new ProjectData();
+        proj2.setName(UUID.randomUUID().toString());
+        proj2 = (ProjectData) datamanagerFacility.saveAndReturnObject(rootCtx,
+                proj2);
+
+        datamanagerFacility.move(rootCtx, Collections.singletonList(ds), proj1, proj2);
+
+        proj1 = browseFacility
+                .getProjects(rootCtx, Collections.singleton(proj1.getId()))
+                .iterator().next();
+        proj2 = browseFacility
+                .getProjects(rootCtx, Collections.singleton(proj2.getId()))
+                .iterator().next();
+        DatasetData dsLoaded = proj2.getDatasets().iterator().next();
+        Assert.assertEquals(dsLoaded.getId(), ds.getId());
+        Assert.assertTrue(proj1.getDatasets().isEmpty());
+    }
+    
     
     @Test
     public void testCreateDataset() throws DSOutOfServiceException, DSAccessException {

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
@@ -37,6 +37,7 @@ import omero.gateway.facility.AdminFacility;
 import omero.gateway.facility.BrowseFacility;
 import omero.gateway.facility.DataManagerFacility;
 import omero.gateway.facility.Facility;
+import omero.gateway.facility.MetadataFacility;
 import omero.gateway.facility.ROIFacility;
 import omero.gateway.facility.RawDataFacility;
 import omero.gateway.facility.ROIFacility;
@@ -83,6 +84,7 @@ public class GatewayTest {
     SearchFacility searchFacility = null;
     TransferFacility transferFacility = null;
     DataManagerFacility datamanagerFacility = null;
+    MetadataFacility metadataFacility = null;
     ROIFacility roiFacility = null;
     TablesFacility tablesFacility = null;
 
@@ -124,6 +126,8 @@ public class GatewayTest {
         searchFacility = Facility.getFacility(SearchFacility.class, gw);
         transferFacility = Facility.getFacility(TransferFacility.class, gw);
         datamanagerFacility = Facility.getFacility(DataManagerFacility.class,
+                gw);
+        metadataFacility = Facility.getFacility(MetadataFacility.class,
                 gw);
         roiFacility = Facility.getFacility(ROIFacility.class,
                 gw);


### PR DESCRIPTION
# What this PR does

Adds the integration tests for  the `DataManagerFacility.move()` method, see https://github.com/ome/omero-java-gateway/pull/3 .

# Testing this PR

Check that the tests make sense and pass.

# Related reading

https://github.com/ome/omero-java-gateway/pull/3


