### PR TITLE
Coupled build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -454,7 +454,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     <target name="copy-client" depends="init">
         <mkdir dir="${dist.dir}/lib/client"/>
         <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
-        <ivy:resolve file="ivy.xml" type="jar,egg,bundle" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
+        <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="client" pattern="${dist.dir}/lib/client/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
         <mkdir dir="${dist.dir}/share/client"/>
         <ivy:report conf="client" todir="${dist.dir}/share/client"
@@ -465,7 +465,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     <target name="copy-server" depends="init">
         <mkdir dir="${dist.dir}/lib/server"/>
         <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
-        <ivy:resolve file="ivy.xml" type="jar,egg,bundle" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
+        <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="server" pattern="${dist.dir}/lib/server/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
         <mkdir dir="${dist.dir}/share/server"/>
         <ivy:report conf="server" todir="${dist.dir}/share/server"

--- a/components/tools/OmeroFS/ivy.xml
+++ b/components/tools/OmeroFS/ivy.xml
@@ -1,4 +1,4 @@
-<ivy-module version="1.0">
+<ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -26,7 +26,9 @@
   </publications>
   <dependencies>
     <!-- Internal -->
-    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}" changing="true" conf="server->server"/>
+    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}" transitive="false">
+	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
+    </dependency>
   </dependencies>
 </ivy-module>
 

--- a/components/tools/OmeroJava/ivy.xml
+++ b/components/tools/OmeroJava/ivy.xml
@@ -1,4 +1,4 @@
-<ivy-module version="1.0" xmlns:m="http://ant.apache.org/ivy/maven">
+<ivy-module version="2.0" xmlns:e="http://ant.apache.org/ivy/extra">
 <!--
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -31,7 +31,10 @@
     -->
   </publications>
   <dependencies>
-    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
+    <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}">
+	    <artifact name="omero-blitz" type="jar" ext="jar"/>
+	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
+    </dependency>
     <dependency org="org.openmicroscopy" name="omero-common-test" rev="${versions.omero-common-test}"/>
   </dependencies>
 </ivy-module>

--- a/components/tools/OmeroPy/ivy.xml
+++ b/components/tools/OmeroPy/ivy.xml
@@ -27,7 +27,7 @@
   <dependencies>
     <!-- Internal -->
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}" transitive="false">
-	    <artifact name="omero-blitz" ext="zip" e:classifier="python"/>
+	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
     </dependency>
   </dependencies>
 </ivy-module>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -144,7 +144,7 @@
     <module organisation="zeroc" resolver="ome-resolver"/>
     <module organisation="ome" name="jxrlib-all" resolver="ome-resolver"/>
     <module organisation="ome" resolver="${ome.resolver}"/>
-    <module organisation="org.openmicroscopy" resolver="ome-artifactory"/>
+    <module organisation="org.openmicroscopy" resolver="ome-resolver"/>
   </modules>
 
   <triggers/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -29,7 +29,7 @@
            downloaded -->
       <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"/>
       <cache name="maven" basedir="${maven.repo.local}"
-        artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].[ext]"
+        artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
         ivyPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].xml"
         lockStrategy="artifact-lock"
         defaultTTL="0ms"/>
@@ -42,11 +42,11 @@
         <ivy pattern="${ivy.settings.dir}/../target/repository/[organisation]/[module]/[revision]/[module]-[revision](-[classifier]).xml"/>
     </filesystem>
     <filesystem name="repo" cache="local">
-        <artifact pattern="${ivy.settings.dir}/../lib/repository/[artifact]-[revision].[type]" />
+        <artifact pattern="${ivy.settings.dir}/../lib/repository/[artifact]-[revision](-[classifier]).[type]" />
         <ivy pattern="${ivy.settings.dir}/../lib/repository/[module]-[revision].ivy"/>
     </filesystem>
     <filesystem name="test" checkmodified="true" changingMatcher="regexp" changingPattern=".*SNAPSHOT.*" cache="local">
-        <artifact pattern="${ivy.settings.dir}/../target/test-repository/[artifact]-[revision].[type]" />
+        <artifact pattern="${ivy.settings.dir}/../target/test-repository/[artifact]-[revision](-[classifier]).[type]" />
         <ivy pattern="${ivy.settings.dir}/../target/test-repository/[module]-[revision].xml"/>
     </filesystem>
 
@@ -122,7 +122,7 @@
     <!-- Hudson resolver. Used by hudson to build a central repository -->
     <filesystem name="hudson-repository" cache="local">
         <ivy pattern="${user.home}/.hudson/repository/[organisation]/[module]/ivys/ivy-[revision].xml"/>
-        <artifact pattern="${user.home}/.hudson/repository/[organisation]/[module]/[type]s/[artifact]-[revision].[ext]"/>
+        <artifact pattern="${user.home}/.hudson/repository/[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]"/>
     </filesystem>
 
     <url name="artifactory-publish">
@@ -144,7 +144,7 @@
     <module organisation="zeroc" resolver="ome-resolver"/>
     <module organisation="ome" name="jxrlib-all" resolver="ome-resolver"/>
     <module organisation="ome" resolver="${ome.resolver}"/>
-    <module organisation="org.openmicroscopy" resolver="ome-resolver"/>
+    <module organisation="org.openmicroscopy" resolver="${ome.resolver}"/>
   </modules>
 
   <triggers/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -27,7 +27,8 @@
       <!-- local is intended for all products built from this repository,
            while maven is for any stable, unchanging jar that is being
            downloaded -->
-      <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"/>
+      <cache name="local" basedir="${ivy.settings.dir}/../lib/cache"
+        artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"/>
       <cache name="maven" basedir="${maven.repo.local}"
         artifactPattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
         ivyPattern="[orgPath]/[module]/[revision]/[artifact]-[revision].xml"
@@ -71,6 +72,7 @@
       <ibiblio name="ome-artifactory" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
+          pattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
           root="https://artifacts.openmicroscopy.org/artifactory/maven/"/>
 
       <ibiblio name="unidata.releases" cache="maven"
@@ -95,7 +97,7 @@
     </chain>
 
     <!-- Resolver for OME dependencies-->
-    <chain name="ome-resolver" returnFirst="true">
+    <chain name="ome-resolver">
         <resolver ref="user-maven"/>
         <resolver ref="ome-artifactory"/>
     </chain>


### PR DESCRIPTION
See also #5968

This PR cherry-picks the relevant build system changes allowing to couple omero-build and openmicroscopy builds without the Travis integration.

With this change it should be possible to do the following:

(0) optionally clean your local `~/.m2` cache

(1) build a version of `omero-blitz`locally e.g. 5.5.0-SNAPSHOT. Make sure the artifact is under `~/.m2/repository/org/openmicroscopy`

(2) append the version to `etc/omero.properties` or add to build `properties`

    echo versions.omero-blitz=5.5.0-SNAPSHOT >> etc/build.properties

(3) build the components from this repository and check the artifacts consume the correct versions

    ./build.py build-dev
