### PR TITLE
Have client search code use non-deprecated setCaseSensitive.

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4545,7 +4545,7 @@ class _BlitzGateway (object):
 
         # Matching OMEROGateway.search()
         search.setAllowLeadingWildcard(True)
-        search.setCaseSentivice(False)
+        search.setCaseSensitive(False)
 
         def parse_time(c, i):
             try:

--- a/components/tools/OmeroPy/src/omero/plugins/search.py
+++ b/components/tools/OmeroPy/src/omero/plugins/search.py
@@ -122,7 +122,7 @@ class SearchControl(HqlControl):
                 try:
                     # Matching OMEROGateway.search()
                     search.setAllowLeadingWildcard(True)
-                    search.setCaseSentivice(False)
+                    search.setCaseSensitive(False)
                     search.onlyType(args.type)
 
                     if args.no_parse:


### PR DESCRIPTION
Responds to https://github.com/ome/omero-blitz/pull/17 by using the new `setCaseSensitive` method in the search API.