### PR TITLE
Unbreak canAnnotate() test now the issue is fixed.

### DIFF
--- a/components/tools/OmeroJava/test/integration/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/PermissionsTest.java
@@ -134,7 +134,7 @@ public class PermissionsTest extends AbstractServerTest {
      * @param annotateeClass the class of which to try annotating an instance
      * @throws Exception unexpected
      */
-    @Test(dataProvider = "annotation classes", groups = "broken")
+    @Test(dataProvider = "annotation classes")
     public void testCanAnnotateConsistency(Class<? extends IObject> annotateeClass)
             throws Exception {
         final Parameters params = new ParametersI().page(0, 1);


### PR DESCRIPTION
Supports https://github.com/ome/omero-server/pull/15 by unbreaking `testCanAnnotateConsistency` at https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-test-integration/lastCompletedBuild/testngreports/integration/PermissionsTest/.