### PR TITLE
test_image_detail: fix fake image import

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
+++ b/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
@@ -95,7 +95,7 @@ class IWebTest(ITest):
         """
         Imports fake image replacing tinyTest. Wavelength not supported yet
         """
-        name = "DV&pixelType=int16&sizeX=20&sizeY=20&sizeZ=5&sizeT=6.fake"
+        name = "DV&pixelType=int16&sizeX=20&sizeY=20&sizeZ=5&sizeT=6"
         images = self.import_fake_file(name=name, client=client)
         return images[0]
 

--- a/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
+++ b/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
@@ -99,8 +99,9 @@ class IWebTest(ITest):
             "This method is deprecated as of OMERO 5.5.0. Use"
             " omero.test_lib.import_fake_file",
             DeprecationWarning)
-        images = self.import_fake_file(client=client,
-            pixelType=int16, sizeX=20, sizeY=20, sizeZ=5, sizeT=6)
+        images = self.import_fake_file(
+            client=client, pixelType="int16", sizeX=20, sizeY=20, sizeZ=5,
+            sizeT=6)
         return images[0]
 
 

--- a/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
+++ b/components/tools/OmeroWeb/omeroweb/testlib/__init__.py
@@ -95,8 +95,12 @@ class IWebTest(ITest):
         """
         Imports fake image replacing tinyTest. Wavelength not supported yet
         """
-        name = "DV&pixelType=int16&sizeX=20&sizeY=20&sizeZ=5&sizeT=6"
-        images = self.import_fake_file(name=name, client=client)
+        warnings.warn(
+            "This method is deprecated as of OMERO 5.5.0. Use"
+            " omero.test_lib.import_fake_file",
+            DeprecationWarning)
+        images = self.import_fake_file(client=client,
+            pixelType=int16, sizeX=20, sizeY=20, sizeZ=5, sizeT=6)
         return images[0]
 
 

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -60,13 +60,13 @@ class TestImgDetail(IWebTest):
             'color': "808080",
             'active': True,
             'window': {
-                'max': 29,
-                'end': 29,
-                'start': -32768,
-                'min': -32768
+                'max': 32767.0,
+                'end': 12.0,
+                'start': -32768.0,
+                'min': -32768.0
             },
             'family': 'linear',
-            'coefficient': 1,
+            'coefficient': 1.0,
             'reverseIntensity': False,
             'inverted': False,
             'emissionWave': None,

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -39,8 +39,9 @@ class TestImgDetail(IWebTest):
         user_name = "%s %s" % (self.user.firstName.val, self.user.lastName.val)
 
         # Import image with metadata and get ImageID
-        images = self.import_fake_file(client=client,
-            pixelType=int16, sizeX=20, sizeY=20, sizeZ=5, sizeT=6)
+        images = self.import_fake_file(
+            client=client, pixelType="int16", sizeX=20, sizeY=20, sizeZ=5,
+            sizeT=6)
         iid = images[0].id.val
         json_url = reverse('webgateway.views.imageData_json', args=[iid])
         data = {}

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -39,8 +39,9 @@ class TestImgDetail(IWebTest):
         user_name = "%s %s" % (self.user.firstName.val, self.user.lastName.val)
 
         # Import image with metadata and get ImageID
-        image = self.import_image_with_metadata(client=self.client)
-        iid = image.id.val
+        images = self.import_fake_file(client=client,
+            pixelType=int16, sizeX=20, sizeY=20, sizeZ=5, sizeT=6)
+        iid = images[0].id.val
         json_url = reverse('webgateway.views.imageData_json', args=[iid])
         data = {}
         img_data = get_json(self.django_client, json_url, data,

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -40,7 +40,7 @@ class TestImgDetail(IWebTest):
 
         # Import image with metadata and get ImageID
         images = self.import_fake_file(
-            client=client, pixelType="int16", sizeX=20, sizeY=20, sizeZ=5,
+            client=self.client, pixelType="int16", sizeX=20, sizeY=20, sizeZ=5,
             sizeT=6)
         iid = images[0].id.val
         json_url = reverse('webgateway.views.imageData_json', args=[iid])

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -56,11 +56,11 @@ class TestImgDetail(IWebTest):
         # Channels metadata
         assert len(img_data['channels']) == 1
         assert img_data['channels'][0] == {
-            'color': "000000",
+            'color': "808080",
             'active': True,
             'window': {
-                'max': 32767,
-                'end': 12,
+                'max': 29,
+                'end': 29,
                 'start': -32768,
                 'min': -32768
             },


### PR DESCRIPTION
Follow-up of db48da5e890e236a3d1915c8024ff04e82eda9cb, the test_lib.import_fake_file() API expects a basename for the fake file and suffixes it with `.fake` internally.

This should fix the `test_marshal.TestImgDetail.test_image_detail` integration test which has been failing recently.