### PR TITLE
Unbreak testImportLinkableTarget as import targets are now fixed.

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -819,7 +819,6 @@ class TestImport(CLITest):
 
     # Check that the dataset chosen for import is the newest
     # to which the user actually has permission to link.
-    @pytest.mark.broken(reason="import target does not yet filter by canLink")
     @pytest.mark.parametrize("is_owns_oldest", [False, True])
     @pytest.mark.parametrize("is_owns_newest", [False, True])
     def testImportLinkableTarget(self, tmpdir, capfd,


### PR DESCRIPTION
Supports https://github.com/ome/omero-blitz/pull/25 by unbreaking `testImportLinkableTarget` to appear among https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-test-integration/lastCompletedBuild/testReport/junit/OmeroPy.test.integration.clitest.test_import/TestImport/.