### PR TITLE
fix annotate files no objects

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2100,6 +2100,8 @@ def annotate_file(request, conn=None, **kwargs):
             break
 
     obj_count = sum([len(selected[types]) for types in selected])
+    if obj_count == 0:
+        raise Http404('Need to specify objects via e.g. ?image=1')
 
     # Get appropriate manager, either to list available Files to add to single
     # object, or list ALL Files (multiple objects)


### PR DESCRIPTION
# What this PR does

See https://www.openmicroscopy.org/qa2/qa/feedback/27403/
Currently, going to ```/webclient/annotate_file/``` with no objects specified with ```?image=1``` will result in an error. Now we handle this as a 404 since this is not a valid URL.
Unfortunately we can't tell from the error above how/why the webclient tried to load the URL without any objects (no contact details).

# Testing this PR

1. Go to ```/webclient/anotate_file/``` and you should see a 404 instead of an error.