### PR TITLE
Remove usage of deprecated request.REQUEST

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1293,7 +1293,7 @@ def load_plate(request, o1_type=None, o1_id=None, conn=None, **kwargs):
                 index = fields[0]
 
         # Show parameter will be well-1|well-2
-        show = request.REQUEST.get('show')
+        show = request.GET.get('show')
         if show is not None:
             wells_to_select = []
             for w in show.split("|"):

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2632,14 +2632,12 @@ def histogram_json(request, iid, theC, conn=None, **kwargs):
                % (maxW, maxH))
         return JsonResponse({"error": msg})
 
-    theZ = int(request.REQUEST.get('theZ', 0))
-    theT = int(request.REQUEST.get('theT', 0))
+    theZ = int(request.GET.get('theZ', 0))
+    theT = int(request.GET.get('theT', 0))
     theC = int(theC)
-    binCount = int(request.REQUEST.get('bins', 256))
+    binCount = int(request.GET.get('bins', 256))
 
     # TODO: handle projection when supported by OMERO
-    # proj = request.REQUEST.get('p', None)
-
     data = image.getHistogram([theC], binCount, theZ=theZ, theT=theT)
     histogram = data[theC]
 

--- a/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/webgateway_cache.py
@@ -616,7 +616,7 @@ class WebGatewayCache (object):
         if len(pre) == 0:
             pre = '0'
         if r:
-            r = r.REQUEST
+            r = r.GET
             c = FN_REGEX.sub('-', r.get('c', ''))
             m = r.get('m', '')
             p = r.get('p', '')


### PR DESCRIPTION
# What this PR does

Fixes deprecation warnings like this:

```
/Users/wmoore/Desktop/OMERO/openmicroscopy/dist/lib/python/omeroweb/webgateway/webgateway_cache.py:619: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  r = r.REQUEST

/usr/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py:126: RemovedInDjango19Warning: `MergeDict` is deprecated, use `dict.update()` instead.
  self._request = datastructures.MergeDict(self.POST, self.GET)

[19/Mar/2019 09:12:59]"GET /webclient/render_image/67136/0/0/?c=1|119:176$00FF00&m=g&p=normal&ia=0&maps=[{%22inverted%22:{%22enabled%22:false}}] HTTP/1.1" 200 2143
```

# Testing this PR

1. Check that images still render OK, histogram shows up in Preview panel OK and Plate loads in centre panel.
