### PR TITLE
Update tests to properly use services for search.

### DIFF
--- a/components/tools/OmeroJava/test/integration/gateway/SearchFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/SearchFacilityTest.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- *  Copyright (C) 2015 University of Dundee. All rights reserved.
+ *  Copyright (C) 2015-2019 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -18,6 +18,7 @@
  *
  *------------------------------------------------------------------------------
  */
+
 package integration.gateway;
 
 import java.util.ArrayList;
@@ -25,6 +26,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import omero.ServerError;
+import omero.api.IUpdatePrx;
 import omero.gateway.SecurityContext;
 import omero.gateway.exception.DSAccessException;
 import omero.gateway.exception.DSOutOfServiceException;
@@ -70,8 +73,7 @@ public class SearchFacilityTest extends GatewayTest {
     protected void setUp() throws Exception {
         super.setUp();
         initData();
-        // wait a little bit for the search indexer
-        Thread.sleep(30000);
+        indexData();
     }
 
     @Test
@@ -145,5 +147,12 @@ public class SearchFacilityTest extends GatewayTest {
         this.screen = createScreen(ctx);
         this.plate = createPlate(ctx, screen);
         this.img = createImage(ctx, ds);
+    }
+
+    private void indexData() throws DSOutOfServiceException, ServerError {
+        final IUpdatePrx iUpdate = gw.getUpdateService(rootCtx);
+        for (final DataObject obj : new DataObject[] {proj, ds, screen, plate, img}) {
+            iUpdate.indexObject(obj.asIObject());
+        }
     }
 }

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -135,7 +135,7 @@ class TestSearch(ITest):
         res = owner.sf.getQueryService().findAllByQuery(sql, p)
         assert 5 == len(res)
 
-    def _3164_search(self, searcher, runs=10, pause=1):
+    def _3164_search(self, searcher):
         texts = ("*earch", "*rch", "search tif", "search",
                  "test", "tag", "ta*", "search_test",
                  "s .tif", ".tif", "tif", "*tif")
@@ -148,7 +148,6 @@ class TestSearch(ITest):
         search.addOrderByAsc("name")
         search.setAllowLeadingWildcard(True)
 
-        for r in range(runs):
             failed = {}
             for text in texts:
                 search.byFullText(str(text))
@@ -158,10 +157,8 @@ class TestSearch(ITest):
                     sz = 0
                 if 5 != sz:
                     failed[text] = sz
-            if not failed:
-                break
-            print "Failed run %i with %i fails" % (r + 1, len(failed))
-            time.sleep(pause)
+            if failed:
+                print "%i fails" % len(failed)
 
         return failed
 

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -140,8 +140,7 @@ class TestSearch(ITest):
                  "test", "tag", "ta*", "search_test",
                  "s .tif", ".tif", "tif", "*tif")
 
-        # Commented out to pass flake8 but these patterns may no longer
-        # be broken with recent chnages to search. (cgb)
+        # Commented out to pass flake8.
         # BROKEN = ("*test*.tif", "search*tif", "s*.tif", "*.tif")
 
         search = searcher.sf.createSearchService()

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -148,18 +148,17 @@ class TestSearch(ITest):
         search.addOrderByAsc("name")
         search.setAllowLeadingWildcard(True)
 
-            failed = {}
-            for text in texts:
-                search.byFullText(str(text))
-                if search.hasNext():
-                    sz = len(search.results())
-                else:
-                    sz = 0
-                if 5 != sz:
-                    failed[text] = sz
-            if failed:
-                print "%i fails" % len(failed)
-
+        failed = {}
+        for text in texts:
+            search.byFullText(str(text))
+            if search.hasNext():
+                sz = len(search.results())
+            else:
+                sz = 0
+            if 5 != sz:
+                failed[text] = sz
+        if failed:
+            print "%i fails" % len(failed)
         return failed
 
     def _3164_assert(self, failed):

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -125,14 +125,11 @@ class TestSearch(ITest):
             images.append(owner.sf.getUpdateService().saveAndReturnObject(img))
             self.index(images[-1])
 
-        p = omero.sys.Parameters()
-        p.map = {}
-        p.map["oids"] = omero.rtypes.rlist(im.id for im in images)
+        p = omero.sys.ParametersI()
+        p.addIds(im.id for im in images)
 
-        sql = "select im from Image im "\
-            "where im.id in (:oids) " \
-            "order by im.id asc"
-        res = owner.sf.getQueryService().findAllByQuery(sql, p)
+        hql = "FROM Image WHERE id IN (:ids)"
+        res = owner.sf.getQueryService().findAllByQuery(hql, p)
         assert 5 == len(res)
 
     def _3164_search(self, searcher):


### PR DESCRIPTION
# What this PR does

Updates search tests to both tidy them up a bit and get them passing reliably with OMERO 5.5.

# Testing this PR

- https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-test-integration/lastCompletedBuild/testngreports/integration.gateway/SearchFacilityTest/
- https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.test_search/TestSearch/history/
- https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_search/TestSearch/history/

# Related reading

Supersedes #5958 and #5959 and relies on fix from https://github.com/ome/omero-server/pull/25 and https://github.com/ome/omero-server/pull/22 to address https://trello.com/c/wPBnTfPU/50-flaky-tests.