### PR TITLE
Web cyberessentials

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -471,6 +471,18 @@ CUSTOM_SETTINGS_MAPPINGS = {
          None,
          leave_none_unset,
          "The name to use for session cookies"],
+    "omero.web.session_cookie_secure":
+        ["SESSION_COOKIE_SECURE",
+         "false",
+         parse_boolean,
+         ("Restrict session cookies to HTTPS only, you are strongly "
+          "recommended to set this to ``true`` in production.")],
+    "omero.web.csrf_cookie_secure":
+        ["CSRF_COOKIE_SECURE",
+         "false",
+         parse_boolean,
+         ("Restrict CSRF cookies to HTTPS only, you are strongly "
+          "recommended to set this to ``true`` in production.")],
     "omero.web.logdir":
         ["LOGDIR", LOGDIR, str, "A path to the custom log directory."],
     "omero.web.secure_proxy_ssl_header":
@@ -1247,6 +1259,10 @@ PIPELINE_JS = {
         'output_filename': 'omeroweb.viewer.min.js',
     }
 }
+
+SESSION_COOKIE_HTTPONLY = True
+# TODO: CSRF_COOKIE_HTTPONLY breaks OMERO.web javascript POSTs
+# CSRF_COOKIE_HTTPONLY = True
 
 CSRF_FAILURE_VIEW = "omeroweb.feedback.views.csrf_failure"
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -485,6 +485,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
          parse_boolean,
          ("Restrict CSRF cookies to HTTPS only, you are strongly "
           "recommended to set this to ``true`` in production.")],
+    "omero.web.csrf_cookie_httponly":
+        ["CSRF_COOKIE_HTTPONLY",
+         "false",
+         parse_boolean,
+         ("Prevent CSRF cookie from being accessed in JavaScript. "
+          "Currently disabled as it breaks background JavaScript POSTs in "
+          "OMERO.web.")],
+
     "omero.web.logdir":
         ["LOGDIR", LOGDIR, str, "A path to the custom log directory."],
     "omero.web.secure_proxy_ssl_header":
@@ -1269,9 +1277,8 @@ PIPELINE_JS = {
     }
 }
 
+# Prevent scripting attacks from obtaining session cookie
 SESSION_COOKIE_HTTPONLY = True
-# TODO: CSRF_COOKIE_HTTPONLY breaks OMERO.web javascript POSTs
-# CSRF_COOKIE_HTTPONLY = True
 
 CSRF_FAILURE_VIEW = "omeroweb.feedback.views.csrf_failure"
 

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -389,7 +389,9 @@ CUSTOM_SETTINGS_MAPPINGS = {
           '{"index": 4, '
           '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
           '{"index": 5, '
-          '"class": "django.contrib.messages.middleware.MessageMiddleware"}'
+          '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
+          '{"index": 6, '
+          '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"}'
           ']'),
          json.loads,
          ('Warning: Only system administrators should use this feature. '
@@ -817,6 +819,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
          parse_boolean,
          ("If True, cors_origin_whitelist will not be used and all origins "
           "will be authorized to make cross-site HTTP requests.")],
+
+    "omero.web.x_frame_options":
+        ["X_FRAME_OPTIONS",
+         "SAMEORIGIN",
+         str,
+         "Whether to allow OMERO.web to be loaded in a frame."
+         ],
 
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",


### PR DESCRIPTION
# What this PR does

Adds Django properties so OMERO.web can be configured to be compliant with Cyberessentials without patching the code. 

These defaults should work in all cases (i.e. no change to behaviour of OMERO.web and standard web-apps).
For production-level security you should set
```
omero.web.session_cookie_secure=true
omero.web.csrf_cookie_secure=true
```
to instruct the browser to only send the CSRF and session cookies over https.

See:
- https://github.com/openmicroscopy/prod-playbooks/blob/cc9146ca91a904ee2699cfbfc14e0e01e4416c67/omero/omero-web-patch-settings.yml
- https://github.com/openmicroscopy/prod-playbooks/pull/154/files
- https://github.com/openmicroscopy/prod-playbooks/pull/153/files
- https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-SESSION_COOKIE_SECURE
- https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-CSRF_COOKIE_SECURE
- https://docs.djangoproject.com/en/1.8/ref/settings/#x-frame-options

# Testing:
- `*_cookie_secure`: Either manually compare this to the changes made on nightshade and demo, or test locally by setting up Nginx with a fake SSL certificate, setting `*_COOKIE_SECURE`, and checking the headers.
- `xframeoptions`: check embedding OMERO.web in an iframe is prohibited by the browser.