### PR TITLE
Warn instead of failing when stale pid successfully removed

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/web.py
+++ b/components/tools/OmeroPy/src/omero/plugins/web.py
@@ -544,7 +544,7 @@ class WebControl(DiagnosticsControl):
         if pid:
             if not self._check_pid(pid, pid_path):
                 pid_path.remove()
-                self.ctx.die(608, "Removed stale %s" % pid_path)
+                self.ctx.err("WARNING: Removed stale %s" % pid_path)
             else:
                 self.ctx.die(606,
                              "[FAILED] OMERO.web already started. "


### PR DESCRIPTION
If a stale django PID file is found and successfully removed continue to start OMERO.web instead of dieing: https://trello.com/c/nYsytx1P/295-omeroweb-doesnt-start-if-an-old-djangopid-file-is-present

# Testing:

1. Configure OMRO.web with a production style configuration (not debug or development).
2. `omero web start`
3. Forcibly kill OMERO.web without giving Django a change to clean-up (`ps -ef` to find Gunicorn parent PID, `kill -9 <Gunicorn parent pid>`, `ps -ef` to verify all Gunicorn processes were killed)
4. `omero web start` should output a warning, then continue to start:
```
WARNING: Removed stale /Users/spli/work/openmicroscopy/dist/var/django.pid
[OK]
```