### PR TITLE
Python websocket client support

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -303,12 +303,14 @@ class BaseClient(object):
         # omero/util/sessions.py may initialise this class with a property-map
         if not host and pmap and 'omero.host' in pmap:
             host = pmap['omero.host']
+        if not port and pmap and 'omero.port' in pmap:
+            port = pmap['omero.port']
         if not host:
             return {}
 
         hostmatch = re.match(
             '(?P<protocol>\\w+)://'
-            '(?P<server>\\w+)'
+            '(?P<server>[^:/]+)'
             '(:(?P<port>\\d+))?'
             '(?P<path>/.*)?$',
             host)

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -213,9 +213,9 @@ class BaseClient(object):
         self._optSetProp(id, "Ice.Plugin.IceSSL", "IceSSL:createIceSSL")
 
         if sys.platform == "darwin":
-            self._optSetProp(id, "IceSSL.Ciphers", "NONE (DH_anon.*AES)")
+            self._optSetProp(id, "IceSSL.Ciphers", "(AES_256) (DH_anon.*AES)")
         else:
-            self._optSetProp(id, "IceSSL.Ciphers", "ADH")
+            self._optSetProp(id, "IceSSL.Ciphers", "HIGH:ADH")
 
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -123,7 +123,10 @@ class BaseClient(object):
         # hosturl overrides all other args
         hosturl = self._check_for_hosturl(host, port, pmap)
         if hosturl:
-            host = hosturl['server']
+            # omero.clients does a lot of mysterious magic autodetection.
+            # If host is set it overrides the endpoint so instead set host to
+            # None and store the host in a separate property omero.url.host
+            host = None
             port = hosturl['port']
             args.append(self._get_endpoint_from_hosturl(hosturl))
 
@@ -137,6 +140,8 @@ class BaseClient(object):
         id.properties.parseCommandLineOptions("omero", args)
         if host:
             id.properties.setProperty("omero.host", str(host))
+        if hosturl:
+            id.properties.setProperty("omero.url.host", hosturl['server'])
         if not port:
             port = id.properties.getPropertyWithDefault(
                 "omero.port", str(omero.constants.GLACIER2PORT))

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -123,7 +123,7 @@ class BaseClient(object):
         # hosturl overrides all other args
         hosturl = self._check_for_hosturl(host, port, pmap)
         if hosturl:
-            host = None
+            host = hosturl['server']
             port = hosturl['port']
             args.append(self._get_endpoint_from_hosturl(hosturl))
 

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -325,13 +325,18 @@ class BaseClient(object):
             if not hosturl['port']:
                 hosturl['port'] = port
             if not hosturl['port']:
-                if hosturl['protocol'] == 'ws':
-                    hosturl['port'] = 80
-                elif hosturl['protocol'] == 'wss':
-                    hosturl['port'] = 443
-                else:
+                default_ports = {
+                    'ws': 80,
+                    'wss': 443,
+                    'tcp': 4063,
+                    'ssl': 4064,
+                }
+                try:
+                    hosturl['port'] = default_ports[hosturl['protocol']]
+                except KeyError:
                     raise omero.ClientError(
                         "Port required for protocol: " + hosturl['protocol'])
+            hosturl['port'] = int(hosturl['port'])
         else:
             hosturl = {}
         return hosturl

--- a/components/tools/OmeroPy/test/unit/test_clients.py
+++ b/components/tools/OmeroPy/test/unit/test_clients.py
@@ -18,6 +18,7 @@ Module documentation
  */
 """
 
+import pytest
 import Ice
 import logging
 import threading
@@ -137,3 +138,58 @@ class TestKeepAlive(object):
         self.mc.assertResources()
         self.mc.enableKeepAlive(-1)
         self.mc.assertNoResources()
+
+
+class TestHostUrlParsing(object):
+    """
+    Test that protocol://host/url parsing works
+    """
+
+    def setup_method(self, method):
+        self.mc = MockClient()
+
+    def teardown_method(self, method):
+        self.mc.__del__()
+
+    def _get_hosturl(self, values):
+        return {
+            'protocol': values[0],
+            'server': values[1],
+            'port': values[2],
+            'path': values[3],
+        }
+
+    @pytest.mark.parametrize('host,port,pmap,expected', [
+        ('test-host', None, {}, None),
+        ('test-host:12345', None, {}, None),
+        ('wss://test', None, {}, ('wss', 'test', 443, None)),
+        ('wss://test:12345', None, {}, ('wss', 'test', 12345, None)),
+        ('wss://test/sub/path', None, {}, ('wss', 'test', 443, '/sub/path')),
+        ('ws://test', None, {}, ('ws', 'test', 80, None)),
+        ('tcp://test', None, {}, ('tcp', 'test', 4063, None)),
+        ('ssl://test', None, {}, ('ssl', 'test', 4064, None)),
+        (None, None, {'omero.host': 'wss://test'},
+            ('wss', 'test', 443, None)),
+        (None, None, {'omero.host': 'wss://test:12345'},
+            ('wss', 'test', 12345, None)),
+        (None, None, {'omero.host': 'wss://test', 'omero.port': '12345'},
+            ('wss', 'test', 12345, None)),
+    ])
+    def test_check_for_hosturl(self, host, port, pmap, expected):
+        hosturl = self.mc._check_for_hosturl(host, port, pmap)
+        if expected:
+            expected_hosturl = self._get_hosturl(expected)
+        else:
+            expected_hosturl = {}
+        assert expected_hosturl == hosturl
+
+    @pytest.mark.parametrize('values,expected', [
+        (('ssl', 'test', 12345, ''),
+         '--Ice.Default.Router=OMERO.Glacier2/router:ssl -p 12345 -h test'),
+        (('wss', 'test', 12345, '/sub/path'),
+         '--Ice.Default.Router=OMERO.Glacier2/router:wss -p 12345 -h test '
+         '-r /sub/path'),
+    ])
+    def test_get_endpoint_from_hosturl(self, values, expected):
+        hosturl = self._get_hosturl(values)
+        assert expected == self.mc._get_endpoint_from_hosturl(hosturl)


### PR DESCRIPTION
# What this PR does

Example of the client changes that could be used to allow connecting to https://github.com/openmicroscopy/openmicroscopy/pull/5927 

# Testing this PR

Setup a server from https://github.com/openmicroscopy/openmicroscopy/pull/5927

This should work:
```python
c = omero.client('wss://localhost:4066')
s = c.createSession(user, password)
```
You can also connect with unencrypted websockets (`ws://`).

Standard connections to port 4064 should work as before:
`c = omero.client('localhost')`