### PR TITLE
Ensure date is padded with 0

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -711,7 +711,7 @@ OME.formatDate = function formatDate(date) {
         return n;
     }
     var d = new Date(date),
-        dt = [d.getFullYear(), padZero(d.getMonth()+1), (d.getDate())].join("-"),
+        dt = [d.getFullYear(), padZero(d.getMonth()+1), padZero(d.getDate())].join("-"),
         tm = [padZero(d.getHours()), padZero(d.getMinutes()), padZero(d.getSeconds())].join(":");
     return dt + " " + tm;
 };


### PR DESCRIPTION
The day component of annotation dates (`On: <date>`) was missing a leading 0 when the day has one digit, see screenshot:
![tmp](https://user-images.githubusercontent.com/1644105/55793325-8c8d5400-5aba-11e9-9c21-a008c6e18e9f.png)
