### PR TITLE
omero.client args: copy args

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -114,10 +114,8 @@ class BaseClient(object):
             # See ticket:5516 To prevent issues on systems where the base
             # class of path.path is unicode, we will encode all unicode
             # strings here.
-            for idx, arg in enumerate(args):
-                if isinstance(arg, unicode):
-                    arg = arg.encode("utf-8")
-                args[idx] = arg
+            args = [arg.encode("utf-8") if isinstance(arg, unicode)
+                    else arg for arg in args]
 
         # Equiv to multiple constructors. #######################
         if id is None:


### PR DESCRIPTION
# What this PR does

Python `omero.client(... args=args)`: don't modify `args` variable

# Testing this PR
```
In [1]: import omero

In [2]: args = ['--Ice.Trace.Network=3']

In [3]: c = omero.client(host='example.openmicroscopy.org', args=args)

In [4]: print(args)
['--Ice.Trace.Network=3']
```
Without this PR the last line will print out `[]`

# Related reading
- https://trello.com/c/1K9kI2Ve/611-python-omeroclients-modifies-input-args