### PR TITLE
Add dependency on omero-gateway jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,17 +66,6 @@ RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 #
 # RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
 
-# Temp: Build jars locally
-USER root
-RUN apt-get install -y gradle
-USER 1000
-RUN git clone -b api_dep git://github.com/dominikl/omero-java-gateway /tmp/omero-gateway
-WORKDIR /tmp/omero-gateway
-RUN DIR=$PWD; (cd /tmp; gradle wrapper --gradle-version=5.2.1; mv .gradle gradle gradlew $DIR)
-RUN ./gradlew publishToMavenLocal
-RUN find ~/.m2 -name omero-gateway*.jar
-WORKDIR /src
-
 # Reproduce jenkins build
 RUN env BUILD_NUMBER=1 OMERO_BRANCH=develop bash docs/hudson/OMERO.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,17 @@ RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 #
 # RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
 
+# Temp: Build jars locally
+USER root
+RUN apt-get install -y gradle
+USER 1000
+RUN git clone -b api_dep git://github.com/dominikl/omero-java-gateway /tmp/omero-gateway
+WORKDIR /tmp/omero-gateway
+RUN DIR=$PWD; (cd /tmp; gradle wrapper --gradle-version=5.2.1; mv .gradle gradle gradlew $DIR)
+RUN ./gradlew publishToMavenLocal
+RUN find ~/.m2 -name omero-gateway*.jar
+WORKDIR /src
+
 # Reproduce jenkins build
 RUN env BUILD_NUMBER=1 OMERO_BRANCH=develop bash docs/hudson/OMERO.sh
 

--- a/components/tools/OmeroJava/ivy.xml
+++ b/components/tools/OmeroJava/ivy.xml
@@ -35,6 +35,7 @@
 	    <artifact name="omero-blitz" type="jar" ext="jar"/>
 	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
     </dependency>
+    <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
     <dependency org="org.openmicroscopy" name="omero-common-test" rev="${versions.omero-common-test}"/>
   </dependencies>
 </ivy-module>

--- a/components/tools/OmeroJava/ivy.xml
+++ b/components/tools/OmeroJava/ivy.xml
@@ -35,7 +35,7 @@
 	    <artifact name="omero-blitz" type="jar" ext="jar"/>
 	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
     </dependency>
-    <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
+    <dependency org="org.openmicroscopy" name="omero-java-gateway" rev="${versions.omero-java-gateway}"/>
     <dependency org="org.openmicroscopy" name="omero-common-test" rev="${versions.omero-common-test}"/>
   </dependencies>
 </ivy-module>

--- a/components/tools/OmeroJava/test.xml
+++ b/components/tools/OmeroJava/test.xml
@@ -13,6 +13,7 @@
     <dependency org="omero" name="omero_client" rev="${omero.version}" changing="true"/>
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
     <dependency org="org.openmicroscopy" name="omero-common" rev="${versions.omero-common-test}"/>
+    <dependency org="org.openmicroscopy" name="omero-java-gateway" rev="${versions.omero-java-gateway}"/>
     <dependency org="velocity" name="velocity-dep" rev="${versions.velocity}"/>
     <dependency org="org.testng" name="testng" rev="${versions.testng}"/>
     <dependency org="org.uncommons" name="reportng" rev="${versions.reportng}"/>

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -74,6 +74,11 @@
           m2compatible="true"
           pattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
           root="https://artifacts.openmicroscopy.org/artifactory/maven/"/>
+      <ibiblio name="ome-staging" cache="maven"
+          usepoms="true" useMavenMetadata="true"
+          m2compatible="true"
+          pattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
+          root="https://artifacts.openmicroscopy.org/artifactory/ome.staging"/>
 
       <ibiblio name="unidata.releases" cache="maven"
           usepoms="true" useMavenMetadata="true"
@@ -100,6 +105,7 @@
     <chain name="ome-resolver">
         <resolver ref="user-maven"/>
         <resolver ref="ome-artifactory"/>
+        <resolver ref="ome-staging"/>
     </chain>
 
     <!-- Resolver for Unidata dependencies-->

--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -74,12 +74,6 @@
           m2compatible="true"
           pattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
           root="https://artifacts.openmicroscopy.org/artifactory/maven/"/>
-      <ibiblio name="ome-staging" cache="maven"
-          usepoms="true" useMavenMetadata="true"
-          m2compatible="true"
-          pattern="[orgPath]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]"
-          root="https://artifacts.openmicroscopy.org/artifactory/ome.staging"/>
-
       <ibiblio name="unidata.releases" cache="maven"
           usepoms="true" useMavenMetadata="true"
           m2compatible="true"
@@ -105,7 +99,6 @@
     <chain name="ome-resolver">
         <resolver ref="user-maven"/>
         <resolver ref="ome-artifactory"/>
-        <resolver ref="ome-staging"/>
     </chain>
 
     <!-- Resolver for Unidata dependencies-->

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -147,4 +147,4 @@ versions.velocity=1.4
 ## Internal dependencies
 versions.omero-blitz=5.5.0-m6
 versions.omero-common-test=5.5.0-m6
-versions.omero-gateway=5.5.0-m1
+versions.omero-java-gateway=5.5.0-m1

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -147,4 +147,4 @@ versions.velocity=1.4
 ## Internal dependencies
 versions.omero-blitz=5.5.0-m7
 versions.omero-common-test=5.5.0-m7
-versions.omero-java-gateway=5.5.0-m1
+versions.omero-java-gateway=5.5.0-m2

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -144,6 +144,7 @@ versions.velocity=1.4
 ### Appended Values
 ###
 
+
 ## Internal dependencies
 versions.omero-blitz=5.5.0-m6
 versions.omero-common-test=5.5.0-m6

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -147,3 +147,4 @@ versions.velocity=1.4
 ## Internal dependencies
 versions.omero-blitz=5.5.0-m6
 versions.omero-common-test=5.5.0-m6
+versions.omero-gateway=5.5.0-m1

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -145,6 +145,6 @@ versions.velocity=1.4
 ###
 
 ## Internal dependencies
-versions.omero-blitz=5.5.0-m6
-versions.omero-common-test=5.5.0-m6
+versions.omero-blitz=5.5.0-m7
+versions.omero-common-test=5.5.0-m7
 versions.omero-java-gateway=5.5.0-m1

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -144,7 +144,6 @@ versions.velocity=1.4
 ### Appended Values
 ###
 
-
 ## Internal dependencies
 versions.omero-blitz=5.5.0-m6
 versions.omero-common-test=5.5.0-m6

--- a/ivy.xml
+++ b/ivy.xml
@@ -10,6 +10,7 @@
   </publications>
   <dependencies>
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
+    <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
     <!-- runtime dependencies from dsl/ivy.xml -->
     <dependency org="janino" name="janino" rev="${versions.janino}"/>
   </dependencies>

--- a/ivy.xml
+++ b/ivy.xml
@@ -10,7 +10,7 @@
   </publications>
   <dependencies>
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
-    <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
+    <dependency org="org.openmicroscopy" name="omero-java-gateway" rev="${versions.omero-java-gateway}"/>
     <!-- runtime dependencies from dsl/ivy.xml -->
     <dependency org="janino" name="janino" rev="${versions.janino}"/>
   </dependencies>


### PR DESCRIPTION
Especially for the tests, it remains necessary to have
access to the omero.gateway packages.

see also:
 * https://github.com/ome/omero-insight/pull/5
 * https://github.com/ome/omero-build/pull/12
 * https://github.com/ome/omero-blitz/pull/33
 * https://github.com/ome/omero-java-gateway/pull/1