### PR TITLE
Batch map annotation

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -128,7 +128,7 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     var html = "";
                     var showHead = true;
                     // If not batch_annotate, add placeholder to create map ann
-                    if (canAnnotate && !batchAnn) {
+                    if (canAnnotate) {
                         if (my_client_map_annotations.length === 0) {
                             showHead = false;
                             my_client_map_annotations = [{}];   // placeholder
@@ -136,13 +136,22 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     }
                     // In batch_annotate view, we show which object each map is linked to
                     var showParent = batchAnn;
-                    html = mapAnnsTempl({'anns': my_client_map_annotations,
+                    if (batchAnn && canAnnotate) {
+                        html += mapAnnsTempl({'anns': [{}],
+                        'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
+                    }
+                    html = html + mapAnnsTempl({'anns': my_client_map_annotations,
                         'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
                     html = html + mapAnnsTempl({'anns': client_map_annotations,
                         'showTableHead': false, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
                     html = html + mapAnnsTempl({'anns': map_annotations,
                         'showTableHead': false, 'showNs': true, 'clientMapAnn': false, 'showParent': showParent});
                     $mapAnnContainer.html(html);
+
+                    // re-use the ajaxdata to set Object IDS data on the parent container
+                    // removing unwanted keys first
+                    delete ajaxdata['type'];
+                    $mapAnnContainer.data('objIds', ajaxdata);
 
                     // Finish up...
                     OME.linkify_element($( "table.keyValueTable" ));

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -127,19 +127,15 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     // Update html...
                     var html = "";
                     var showHead = true;
-                    // If not batch_annotate, add placeholder to create map ann
+                    // If no annotations OR in batch_annotate, add placeholder to create map ann(s)
                     if (canAnnotate) {
-                        if (my_client_map_annotations.length === 0) {
+                        if (my_client_map_annotations.length === 0 || batchAnn) {
                             showHead = false;
-                            my_client_map_annotations = [{}];   // placeholder
+                            my_client_map_annotations.unshift({});   // placeholder
                         }
                     }
                     // In batch_annotate view, we show which object each map is linked to
                     var showParent = batchAnn;
-                    if (batchAnn && canAnnotate) {
-                        html += mapAnnsTempl({'anns': [{}],
-                        'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
-                    }
                     html = html + mapAnnsTempl({'anns': my_client_map_annotations,
                         'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
                     html = html + mapAnnsTempl({'anns': client_map_annotations,

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.right_panel_mapanns_pane.js
@@ -169,7 +169,7 @@ var MapAnnsPane = function MapAnnsPane($element, opts) {
                     }
                     // In batch_annotate view, we show which object each map is linked to
                     var showParent = batchAnn;
-                    html = html + mapAnnsTempl({'anns': my_client_map_annotations,
+                    html = html + mapAnnsTempl({'anns': my_client_map_annotations, 'objCount': objects.length,
                         'showTableHead': showHead, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});
                     html = html + mapAnnsTempl({'anns': client_map_annotations,
                         'showTableHead': false, 'showNs': false, 'clientMapAnn': true, 'showParent': showParent});

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/mapannotations.html
@@ -92,9 +92,10 @@
 
             var annId = $table.attr('data-annId'),
                 url = "{% url 'annotate_map' %}",
-                data = {"{{ manager.obj_type }}": "{{ manager.obj_id }}" },
                 $mapAnnotationSpinner = $(".mapAnnotationSpinner", $table.parent()),
-                tableData = [];
+                tableData = [],
+                // objIds = {'project': [1, 2]}
+                data = $("#mapAnnContainer").data('objIds');
 
             {% if index %}
             // for wells, we need to know index
@@ -109,21 +110,27 @@
                 if ((k == "" || k == "Add Key") && (v == "" || v == "Add Value")) return;
                 tableData.push(rowData);
             });
-            // If we are editing a saved map annotation...
+            // If we are editing a saved map annotation(s)...
             if (annId) {
-                data.annId = annId;
+                data.annId = annId.split(",");
             }
 
             data.mapAnnotation = JSON.stringify(tableData);
 
             saveInProgress = true;
             $mapAnnotationSpinner.show();
-            $.post( url, data)
-                .done(function( data ) {
+            $.ajax({
+                url: url,
+                type: "POST",
+                traditional: true,  // allows multiple values for key. E.g. 'project':1, 'project:2' for objIds
+                data: data,
+                dataType: 'json',
+                success: function( data ) {
                     saveInProgress = false;
                     $mapAnnotationSpinner.hide();
                     $table.attr('data-annId', data.annId);
-                });
+                }
+            });
         };
 
         // start editing a td

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/mapannotations.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/mapannotations.html
@@ -95,7 +95,7 @@
                 $mapAnnotationSpinner = $(".mapAnnotationSpinner", $table.parent()),
                 tableData = [],
                 // objIds = {'project': [1, 2]}
-                data = $("#mapAnnContainer").data('objIds');
+                data = Object.assign({}, $("#mapAnnContainer").data('objIds'));
 
             {% if index %}
             // for wells, we need to know index
@@ -128,7 +128,11 @@
                 success: function( data ) {
                     saveInProgress = false;
                     $mapAnnotationSpinner.hide();
-                    $table.attr('data-annId', data.annId);
+                    if (data.annId != null) {
+                        $table.attr('data-annId', data.annId);
+                    } else {
+                        $table.removeAttr('data-annId');
+                    }
                 }
             });
         };

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -26,7 +26,10 @@
                 <% } %>
 
                 <span class="tooltip_html" style='display:none'>
-                    <b>ID:</b> <%= ann.id %><br />
+                    <% if (ann.parentNames) { %>
+                      You are editing <b><%= ann.parentNames.length %></b> identical Key-Value annotations:
+                    <% } %>
+                    <b>Annotation ID<% if (ann.parentNames) { %>s<% } %>:</b> <%= ann.id %><br />
                     <% if (ann.parentNames) { %>
                         <b>Linked to:</b><br>
                         <% _.each(ann.parentNames, function(pName) { %>
@@ -42,6 +45,11 @@
                             <br /><b>On:</b> <% print(OME.formatDate(ann.link.date)) %>
                         <% } %>
                     <% } %>
+                </span>
+            <% } else if (objCount && objCount > 1) { %>
+                Add annotations to <%= objCount %> objects
+                <span class="tooltip_html" style='display:none'>
+                    Identical Key-Value annotations will be added to each selected object.
                 </span>
             <% } %>
           </th>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -27,7 +27,9 @@
 
                 <span class="tooltip_html" style='display:none'>
                     <% if (ann.parentNames) { %>
-                      You are editing <b><%= ann.parentNames.length %></b> identical Key-Value annotations:
+                      You are
+                      <% print (ann.permissions.canEdit && clientMapAnn ? 'editing' : 'viewing') %>
+                      <b><%= ann.parentNames.length %></b> identical Key-Value annotations:
                     <% } %>
                     <b>Annotation ID<% if (ann.parentNames) { %>s<% } %>:</b> <%= ann.id %><br />
                     <% if (ann.parentNames) { %>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/mapanns_underscore.html
@@ -22,11 +22,17 @@
             <% if (ann.id) { %>
                 Added by: <%= ann.owner.firstName %> <%= ann.owner.lastName %>
                 <% if (showParent && ann.link.parent.name){ %>
-                  <br> To: <%= ann.link.parent.name %>
+                  <br>To: <%= ann.parentNames ? (ann.parentNames.length + " objects") : ann.link.parent.name %>
                 <% } %>
 
                 <span class="tooltip_html" style='display:none'>
                     <b>ID:</b> <%= ann.id %><br />
+                    <% if (ann.parentNames) { %>
+                        <b>Linked to:</b><br>
+                        <% _.each(ann.parentNames, function(pName) { %>
+                            &nbsp <%= pName %><br />
+                        <% }) %>
+                    <% } %>
                     <% if (ann.owner) { %>
                         <b>Owner:</b> <%= ann.owner.firstName %> <%= ann.owner.lastName %>
                     <% } %>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2297,7 +2297,7 @@ def annotate_map(request, conn=None, **kwargs):
 
     # Create a new annotation
     if len(annIds) == 0 and len(data) > 0:
-        duplicate = request.POST.get('duplicate', 'false');
+        duplicate = request.POST.get('duplicate', 'false')
         duplicate.lower() == 'true'
         # For 'client' map annotations, we enforce 1 annotation per object
         if (ns == omero.constants.metadata.NSCLIENTMAPANNOTATION):

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -2292,36 +2292,56 @@ def annotate_map(request, conn=None, **kwargs):
     data = request.POST.get('mapAnnotation')
     data = json.loads(data)
 
-    annId = request.POST.get('annId')
-    # Create a new annotation
-    if annId is None and len(data) > 0:
-        ann = omero.gateway.MapAnnotationWrapper(conn)
-        ann.setValue(data)
-        ns = request.POST.get('ns',
-                              omero.constants.metadata.NSCLIENTMAPANNOTATION)
-        ann.setNs(ns)
-        ann.save()
-        for k, objs in oids.items():
-            for obj in objs:
-                obj.linkAnnotation(ann)
-        annId = ann.getId()
-    # Or update existing annotation
-    elif annId is not None:
-        ann = conn.getObject("MapAnnotation", annId)
-        if len(data) > 0:
-            ann.setValue(data)
-            ann.save()
-            annId = ann.getId()
-        else:
-            # Delete if no data
-            handle = conn.deleteObjects('/Annotation', [annId])
-            try:
-                conn._waitOnCmd(handle)
-            finally:
-                handle.close()
-            annId = None
+    annIds = request.POST.getlist('annId')
+    ns = request.POST.get('ns', omero.constants.metadata.NSCLIENTMAPANNOTATION)
 
-    return {"annId": annId}
+    # Create a new annotation
+    if len(annIds) == 0 and len(data) > 0:
+        duplicate = request.POST.get('duplicate', 'false');
+        duplicate.lower() == 'true'
+        # For 'client' map annotations, we enforce 1 annotation per object
+        if (ns == omero.constants.metadata.NSCLIENTMAPANNOTATION):
+            duplicate = True
+        if duplicate:
+            # Create a new Map Annotation for each object:
+            for k, objs in oids.items():
+                for obj in objs:
+                    ann = omero.gateway.MapAnnotationWrapper(conn)
+                    ann.setValue(data)
+                    ann.setNs(ns)
+                    ann.save()
+                    annIds.append(ann.getId())
+                    obj.linkAnnotation(ann)
+        else:
+            # Create single Map Annotation and link to all objects
+            ann = omero.gateway.MapAnnotationWrapper(conn)
+            ann.setValue(data)
+            ann.setNs(ns)
+            ann.save()
+            annIds.append(ann.getId())
+            for k, objs in oids.items():
+                for obj in objs:
+                    obj.linkAnnotation(ann)
+    # Or update existing annotations
+    else:
+        for annId in annIds:
+            ann = conn.getObject("MapAnnotation", annId)
+            if ann is None:
+                continue
+            if len(data) > 0:
+                ann.setValue(data)
+                ann.save()
+            else:
+                # Delete if no data
+                handle = conn.deleteObjects('/Annotation', [annId])
+                try:
+                    conn._waitOnCmd(handle)
+                finally:
+                    handle.close()
+        if len(data) == 0:
+            annIds = None
+
+    return {"annId": annIds}
 
 
 @login_required()


### PR DESCRIPTION
# What this PR does

See https://trello.com/c/VZqmJCyP/41-batch-add-map-annotations

This supports creating new Map Annotations for multiple selected objects at once.
We create a separate Map Annotation for each object (no 1-to-many links).
When multiple objects with *identical* Map Annotations are selected, the annotations are displayed
as a single annotation to allow editing of all of them in sync.

# Testing this PR

1. Select multiple objects in webclient
1. Under Key-Value pairs tab, you should see a placeholder for creating new Map Annotations.
1. Enter a bunch of Key-Value pairs etc. editing as normal.
1. Select each single object in turn to check that the Key-Value pairs are on each one.
1. Select multiple objects again (possibly even including some that were not selected before, and/or excluding some that were selected before)
1. Identical Map Annotations should appear as a single one, with text above to say the number of objects they are on.
1. The tooltip on these duplicate annotations lists the objects they are linked to.
1. Editing this duplicate again should apply the changes to all objects
1. Editing these Map Annotations individually, when 1 object is selected (not in batch panel), means that they are no-longer identical to the other copies and will not be combined with them when you return to Batch Annotate mode.
1. However, if they are once-again edited to become identical then they will be combined in Batch Annotate panel again.
1. We also allow editing of all other "client" Map Annotations in Batch Annotate panel. Previously, no Key-Value pairs were editable in Batch Annotate panel.

<img width="355" alt="Screen Shot 2019-04-11 at 14 08 22" src="https://user-images.githubusercontent.com/900055/55960275-525fb600-5c64-11e9-9308-5d5c233158db.png">

cc @evenhuis