### PR TITLE
release-clients no longer creates a MATLAB zip.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -332,7 +332,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     <target name="release-src" description="Package the git source tree into openmicroscopy-${omero.plainversion}.zip"
             depends="release-src-embed,release-src-git"/>
 
-    <target name="release-clients" description="Zip the Python, Java, and Matlab zips">
+    <target name="release-clients" description="Zip the Python and Java zips">
         <zip destfile="${omero.home}/target/OMERO.py-${omero.version}.zip">
             <zipfileset dir="${dist.dir}" prefix="OMERO.py-${omero.version}"
                 includes="bin/**,etc/**,lib/python/**,lib/fallback/**,sql/**,share/web/**" excludes="bin/omero"/>


### PR DESCRIPTION
# What this PR does

Adjusts the description text for `release-clients` to no longer mention MATLAB.

# Testing this PR

```shell
ant -p | grep release-clients
```