### PR TITLE
OMERO.py: Use @SECLEVEL=0 for openssl 1.1

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -25,6 +25,7 @@ import logging
 import IceImport
 import Ice
 import re
+import ssl
 import uuid
 
 IceImport.load("Glacier2_Router_ice")
@@ -212,6 +213,8 @@ class BaseClient(object):
 
         if sys.platform == "darwin":
             self._optSetProp(id, "IceSSL.Ciphers", "(AES_256) (DH_anon.*AES)")
+        elif ssl.OPENSSL_VERSION_INFO >= (1, 1):
+            self._optSetProp(id, "IceSSL.Ciphers", "HIGH:ADH:@SECLEVEL=0")
         else:
             self._optSetProp(id, "IceSSL.Ciphers", "HIGH:ADH")
 


### PR DESCRIPTION
# What this PR does

This attempts to automate the client.py workaround from https://docs.openmicroscopy.org/omero/5.4.10/sysadmins/troubleshooting.html#openssl-version by detecting when openssl 1.1 is present

# Testing this PR

- Check login works from an OpenSSL 1.0 Linux system
- Check login works from an OpenSSL 1.1 Linux system

Note I've no idea if this could break other systems now or in the future but I'll list this for review in case someone thinks it's useful. You may want to also test Windows, OS X, different versions of OpenSSL, etc.