### PR TITLE
Lucene search

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4515,7 +4515,7 @@ class _BlitzGateway (object):
         :param created:     :class:`omero.rtime` list or tuple (start, stop)
         :param useAcquisitionDate: if True, then use Image.acquisitionDate
                                    rather than import date for queries.
-        :param rawQuery     If True, the text is passed directly to byFullText()
+        :param rawQuery     If True, text is passed directly to byFullText()
                             without processing. fields is ignored.
         :return:            List of Object wrappers. E.g. :class:`ImageWrapper`
         """

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4505,7 +4505,7 @@ class _BlitzGateway (object):
 
     def searchObjects(self, obj_types, text, created=None, fields=(),
                       batchSize=1000, page=0, searchGroup=None, ownedBy=None,
-                      useAcquisitionDate=False):
+                      useAcquisitionDate=False, rawQuery=True):
         """
         Search objects of type "Project", "Dataset", "Image", "Screen", "Plate"
         Returns a list of results
@@ -4575,10 +4575,14 @@ class _BlitzGateway (object):
             for t in types:
                 def actualSearch():
                     search.onlyType(t().OMERO_CLASS, ctx)
-                    search.byLuceneQueryBuilder(
-                        ",".join(fields),
-                        d_from, d_to, d_type,
-                        text, ctx)
+                    if rawQuery:
+                        # TODO: need to handle dates: d_from, d_to, d_type
+                        search.byFullText(text, ctx)
+                    else:
+                        search.byLuceneQueryBuilder(
+                            ",".join(fields),
+                            d_from, d_to, d_type,
+                            text, ctx)
 
                 timeit(actualSearch)()
                 # get results

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4515,6 +4515,8 @@ class _BlitzGateway (object):
         :param created:     :class:`omero.rtime` list or tuple (start, stop)
         :param useAcquisitionDate: if True, then use Image.acquisitionDate
                                    rather than import date for queries.
+        :param rawQuery     If True, the text is passed directly to byFullText()
+                            without processing. fields is ignored.
         :return:            List of Object wrappers. E.g. :class:`ImageWrapper`
         """
         if not text:

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -4578,7 +4578,8 @@ class _BlitzGateway (object):
                 def actualSearch():
                     search.onlyType(t().OMERO_CLASS, ctx)
                     if rawQuery:
-                        # TODO: need to handle dates: d_from, d_to, d_type
+                        if created is not None and len(created) > 1:
+                            search.onlyCreatedBetween(created[0], created[1])
                         search.byFullText(text, ctx)
                     else:
                         search.byLuceneQueryBuilder(

--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -51,8 +51,9 @@ class BaseSearch(BaseController):
         BaseController.__init__(self, conn)
 
     def search(self, query, onlyTypes, fields, searchGroup, ownedBy,
-               useAcquisitionDate, date=None):
-
+               useAcquisitionDate, date=None, rawQuery=False):
+        # If rawQuery, the raw lucene query is used in search.byFullText()
+        # and fields is ignored.
         # If fields contains 'annotation', we really want to search files too
         # docs.openmicroscopy.org/latest/omero/developers/Modules/Search.html
         fields = set(fields)
@@ -99,7 +100,9 @@ class BaseSearch(BaseController):
                 batchSize=batchSize,
                 searchGroup=searchGroup,
                 ownedBy=ownedBy,
-                useAcquisitionDate=useAcquisitionDate))
+                useAcquisitionDate=useAcquisitionDate,
+                rawQuery=rawQuery),
+                )
             return obj_list
 
         self.containers = {}

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/dusty.css
@@ -561,13 +561,13 @@ button::-moz-focus-inner {
 	    }
 	    
 		.standard_form label {
-			width:25%;
+			padding-right: 5px;
 			display:inline-block;
 			color:hsl(210,10%,50%);
 			font-size:1.2em;
 			text-shadow: 0 1px 0 white;
 			vertical-align: top;
-			margin-top: 3px;
+			margin-top: 4px;
 		}
 		
 		.standard_form input, .standard_form select, .standard_form textarea {

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/css/layout.css
@@ -1760,15 +1760,12 @@
 
 .search_panel {
 	position: relative;
-	padding: 0 8px;
-	min-width: 340px;
+	padding: 0;
 }
 
 .search_panel_header {
 	position: relative;
-	width: 100%;
-	height: 33px;
-	padding: 8px 0;
+	padding: 10px 10px 0 10px;
 }
 
 .search_panel_header__text {
@@ -1785,10 +1782,7 @@
 }
 
 .search_panel_header__text--hints {
-	position: absolute;
-	top: 50%;
-	right: 0;
-  	transform: translateY(-50%);
+	float: right;
 }
 
 .search_tips__button {
@@ -1797,6 +1791,36 @@
 
 .search_tips__image {
 	vertical-align: middle;
+}
+
+.search_panel select {
+	max-width: 55%;
+}
+
+#basic_search input.search {
+	width: calc(100% - 65px);
+    float: right;
+}
+
+#basic_search hr {
+	clear: both;
+	margin: 15px 0 10px 0;
+}
+
+#advanced_search input.advanced_search {
+	width: calc(100% - 6px); 	/* padding & border = 6px */
+	margin: 5px 0;
+}
+
+#advanced_search p {
+	margin: 5px 0;
+}
+
+#advanced_search code {
+	background: #fff;
+	margin: 5px 0;
+	padding: 3px;
+	font-size: 110%;
 }
 
 
@@ -1867,9 +1891,8 @@ ul.criteria_right input{
 }
 
 #searching input[type=submit] {
-	float: none;
-	margin-left: 80px;
-	margin-top: 10px;
+	float: right;
+	margin-top: 2px;
 }
     
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -136,9 +136,14 @@
                 $("#searching_form").ajaxForm({
                     beforeSubmit: function(fields) {
 
+                        var q = '';
+                        if ($('input[name="advanced"]').prop('checked')) {
+                            q = $("input[name='advanced_search']").val();
+                        } else {
+                            q = $("input[name='query']").val();
+                        }
                         // check we have some search query...
-                        var $query = $("input[name='query']"),
-                            q = $.trim($query.val());
+                        q = $.trim(q);
                         if (q.length <= 0) {
                             OME.alert_dialog("Search must contain some text.");
                             return false;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -320,8 +320,8 @@
                     <code>name:Control AND tag:"GFP H2B"</code>
                     <p>
                         See the
-                        <a target="_blank" href="https://docs.openmicroscopy.org/latest/omero/developers/Modules/Search.html">
-                            Search documentation
+                        <a target="_blank" href="https://help.openmicroscopy.org/search.html#advanced">
+                            Advanced Search documentation
                         </a>
                     </p>
                 </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -300,8 +300,9 @@
                 </div>
 
                 <div id="advanced_search">
-                    <input type="checkbox" name="advanced" style="visibility: hidden" />
                     <label for="advanced_search">Advanced:</label>
+                    <!-- Checkbox is checked when user switches to Advanced tab -->
+                    <input type="checkbox" name="advanced" style="visibility: hidden" />
                     <input class="advanced_search" name="advanced_search" value="{{ init.query }}" size="35"/>
                     <p>Enter raw search term, for example:</p>
                     <code>name:Control AND tag:"GFP H2B"</code>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -208,6 +208,14 @@
                         $("#search_ann_type input[type='radio']").prop('checked',false);
                     }
                 });
+
+                $("#searching_tabs").tabs({
+                    activate: function( event, ui ) {
+                        // Checkk hidden checkbox if we're on the 'advanced search' tab
+                        // This will be included in search submitted data
+                        $('input[name="advanced"]').prop('checked', ui.newPanel.attr('id') === 'advanced_search');
+                    }
+                });
         });
     </script>
 
@@ -226,47 +234,89 @@
 
     <form id="searching_form" class="search_panel standard_form" action="{% url 'load_searching' 'form' %}">
 
-        <div class="search_panel_header">
+        <div id="searching_tabs">
+            <ul id="left_panel_tab_list" class="ui-tabs-nav">
+                <li id="explore_tab" class="ui-state-default">
+                    <a href="#basic_search" class="ui-tabs-anchor" title="Explore">Search</a>
+                </li>
+                <li id="tags_tab" class="ui-state-default">
+                    <a href="#advanced_search" class="ui-tabs-anchor" title="Advanced Search">Advanced</a>
+                </li>
+            </ul>
 
-            <div class="search_panel_header__text" >
 
-                <div class="search_panel_header__text--title">
-                    <!-- h2 style has a bottom margin -->
-                    <h2 style="margin-bottom: 0">{% trans "General Search" %}</h2>
+            <div class="search_panel_header">
+
+                <div id="basic_search">
+                    <div class="search_panel_header__text" >
+
+                        <div class="search_panel_header__text--hints" >
+                            <a id="showSearchHints" class="search_tips__button" href="#">Show search hints</a>
+                            <span class="searching_info" data-content="? Single character wildcard<br>* Multiple character wildcard<br>'AND' Results will contain both terms. E.g: GFP AND H2B">
+                                <img class="search_tips__image" src="{% static "webgateway/img/help16.png" %}"/>
+                            </span>
+                        </div>
+                    </div>
+
+                    <div style="clear: both; height: 10px;"></div>
+                    <!-- Hidden hints box shown when the user clicks to show hints -->
+                    <div id="searchHints" style="display: none">
+                        <ul>
+                            <li> <strong> ? </strong> Single character wildcard</li>
+                            <li> <strong> * </strong> Multiple character wildcard</li>
+                            <li> <strong> AND </strong> Results will contain both terms. E.g: GFP AND H2B</li>
+                        </ul>
+                        <br>
+                        <div>
+                            For more info, see the
+                            <a title="Open link in new Tab" target="new" href="http://help.openmicroscopy.org/search.html">
+                                User Help</a>
+                            pages.
+                        </div>
+                    </div>
+
+
+                    <label for="query">{% trans "Search" %}:</label>
+                    <input class="search" name="query" value="{{ init.query }}" size="35"/>
+                    <hr>
+
+                    <label style="white-space:nowrap;">
+                        Restrict by Field:
+                        <span class="searching_info" data-content="Restrict search to specified fields.<br>If none chosen, we search across all fields">
+                            <img src="{% static "webgateway/img/help16.png" %}" />
+                        </span>
+                    </label>
+
+                    <ul class="criteria">
+                        <li><input type="checkbox" name="field" value="name" />{% trans "Name" %}</li>
+                        <li><input type="checkbox" name="field" value="description" />{% trans "Description" %}</li>
+                        <li style="white-space:nowrap;">
+                            <input type="checkbox" name="field" value="annotation" />{% trans "Annotations" %}<span class="searching_info" data-content="Includes file attachments, tags, comments etc">
+                               <img src="{% static "webgateway/img/help16.png" %}" />
+                            </span>
+                        </li>
+                    </ul>
+
                 </div>
 
-                <div class="search_panel_header__text--hints" >
-                    <a id="showSearchHints" class="search_tips__button" href="#">Show search hints</a>
-                    <span class="searching_info" data-content="? Single character wildcard<br>* Multiple character wildcard<br>'AND' Results will contain both terms. E.g: GFP AND H2B">
-                        <img class="search_tips__image" src="{% static "webgateway/img/help16.png" %}"/>
-                    </span>
+                <div id="advanced_search">
+                    <input type="checkbox" name="advanced" style="visibility: hidden" />
+                    <label for="advanced_search">Advanced:</label>
+                    <input class="advanced_search" name="advanced_search" value="{{ init.query }}" size="35"/>
+                    <p>Enter raw search term, for example:</p>
+                    <code>name:Control AND tag:"GFP H2B"</code>
+                    <p>
+                        See the
+                        <a target="_blank" href="https://docs.openmicroscopy.org/latest/omero/developers/Modules/Search.html">
+                            Search documentation
+                        </a>
+                    </p>
                 </div>
-
             </div>
-
-            <!-- Hidden hints box shown when the user clicks to show hints -->
-            <div id="searchHints" style="display: none">
-                <ul>
-                    <li> <strong> ? </strong> Single character wildcard</li>
-                    <li> <strong> * </strong> Multiple character wildcard</li>
-                    <li> <strong> AND </strong> Results will contain both terms. E.g: GFP AND H2B</li>
-                </ul>
-                <br>
-                <div>
-                    For more info, see the
-                    <a title="Open link in new Tab" target="new" href="https://help.openmicroscopy.org/search.html">
-                        User Help</a>
-                    pages.
-                </div>
-            </div>
-
         </div>
 
         <div style="clear:both"></div>
-
-            <label for="query">{% trans "Search" %}:</label>
-            <input class="search" name="query" value="{{ init.query }}" size="35"/>
-
+        <div style="padding: 0 10px">
             <hr>
 
             <label id="criteria">Search for:</label>
@@ -389,7 +439,8 @@
 
             <hr>
 
-        <input id="search_button" type="submit" value="Search" />
+            <input id="search_button" type="submit" value="Search" />
+        </div>
 
     </form>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -296,10 +296,17 @@
                         <li><input type="checkbox" name="field" value="name" />{% trans "Name" %}</li>
                         <li><input type="checkbox" name="field" value="description" />{% trans "Description" %}</li>
                         <li style="white-space:nowrap;">
-                            <input type="checkbox" name="field" value="annotation" />{% trans "Annotations" %}<span class="searching_info" data-content="Includes file attachments, tags, comments etc">
+                            <input id="show_annotations" type="checkbox" />{% trans "Annotations" %}
+                            <span class="searching_info" data-content="Includes file attachments, tags, comments etc">
                                <img src="{% static "webgateway/img/help16.png" %}" />
                             </span>
                         </li>
+                    </ul>
+
+                    <ul id="search_ann_type" class="criteria criteria_right hide">
+                        <li><input type="radio" name="field" value="annotation">All Annotations</li>
+                        <li><input type="radio" name="field" value="file">Files</li>
+                        <li><input type="radio" name="field" value="tag">Tags</li>
                     </ul>
 
                 </div>
@@ -336,32 +343,6 @@
                 <li><input type="checkbox" name="datatype" value="screens" CHECKED />{% trans "Screens" %}</li>
             </ul>
 
-            <hr>
-
-            <label style="white-space:nowrap;">
-                Restrict by Field:
-                <span class="searching_info" data-content="Restrict search to specified fields.<br>If none chosen, we search across all fields">
-                    <img src="{% static "webgateway/img/help16.png" %}" />
-                </span>
-            </label>
-
-            <ul class="criteria">
-                <li><input type="checkbox" name="field" value="name" />{% trans "Name" %}</li>
-                <li><input type="checkbox" name="field" value="description" />{% trans "Description" %}</li>
-                <!-- The Annotations checkbox has no name (not submitted in form). Just shows radio buttons below -->
-                <li style="white-space:nowrap;">
-                    <input id="show_annotations" type="checkbox" />{% trans "Annotations" %}
-                    <span class="searching_info" data-content="Includes file attachments, tags, comments etc">
-                       <img src="{% static "webgateway/img/help16.png" %}" />
-                    </span>
-                </li>
-            </ul>
-
-            <ul id="search_ann_type" class="criteria criteria_right hide">
-                <li><input type="radio" name="field" value="annotation">All Annotations</li>
-                <li><input type="radio" name="field" value="file">Files</li>
-                <li><input type="radio" name="field" value="tag">Tags</li>
-            </ul>
             <hr>
 
             <label>Scope:</label>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1420,6 +1420,10 @@ def load_searching(request, form=None, conn=None, **kwargs):
         if query_search is None:
             return HttpResponse("No search '?query' included")
         query_search = query_search.replace("+", " ")
+        advanced = toBoolean(r.get('advanced'))
+        # If this is an advanced search use 'advanced_search' for query
+        if advanced:
+            query_search = r.get('advanced_search')
         template = "webclient/search/search_details.html"
 
         onlyTypes = r.getlist("datatype")
@@ -1446,7 +1450,7 @@ def load_searching(request, form=None, conn=None, **kwargs):
         # search is carried out and results are stored in
         # manager.containers.images etc.
         manager.search(query_search, onlyTypes, fields, searchGroup, ownedBy,
-                       useAcquisitionDate, date)
+                       useAcquisitionDate, date, rawQuery=advanced)
 
         # if the query is only numbers (separated by commas or spaces)
         # we search for objects by ID


### PR DESCRIPTION
# What this PR does

This was previously opened as https://github.com/openmicroscopy/openmicroscopy/pull/5653
but that couldn't be re-opened so it is replaced by this PR.

See https://trello.com/c/ILIGB0vf/117-rfe-search-cross-feature

# Testing this PR

1. Search using Advanced tab to input raw lucene queries.
1. Switching between Advanced and regular search by switching tabs (without needing to remove search terms from each input)
1. Other form elements should work as before: Search for Project, Dataset Image etc and filter by Group & Owner.
1. Suggestions to improve the UI? Want to give the user some clue as to what advanced search is and how to use it without having to visit the docs pages. Example query shows:
    - usage of ```AND```
    - Searching by different fields and separation of field:query with colon.
    - Usage of double quotes

![screen shot 2018-02-12 at 15 31 39](https://user-images.githubusercontent.com/900055/36104421-e1e77734-1009-11e8-9693-77b385c7f47d.png)

cc @joshmoore I believe you've been requesting this feature for some time?