### PR TITLE
Treat annotation datetimes as UTC for consistency with metadata

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -710,9 +710,13 @@ OME.formatDate = function formatDate(date) {
         }
         return n;
     }
+    // For consistency with the datetimes in metadata_general.html we have to
+    // assume dates should not be converted using the local timezone. This is
+    // because the datetime returned by OMERO may already be in "localtime",
+    // treating it as UTC ensures no local timezone adjustment is made.
     var d = new Date(date),
-        dt = [d.getFullYear(), padZero(d.getMonth()+1), padZero(d.getDate())].join("-"),
-        tm = [padZero(d.getHours()), padZero(d.getMinutes()), padZero(d.getSeconds())].join(":");
+        dt = [d.getUTCFullYear(), padZero(d.getUTCMonth()+1), padZero(d.getUTCDate())].join("-"),
+        tm = [padZero(d.getUTCHours()), padZero(d.getUTCMinutes()), padZero(d.getUTCSeconds())].join(":");
     return dt + " " + tm;
 };
 


### PR DESCRIPTION
`metadata_general.html` displays datetimes "as is", i.e. it appears to assume the datetime returned by OMERO.server is exactly what should be displayed. In contrast `OME.formatDate` assumes the date returned by OMERO.server is UTC and should be converted for local display. By using javascript `Date.getUTC*` instead of the non-UTC methods this ensures the datetime is displayed unchanged, so as to match metadata_general.html

In practice this will often not be the expected time, but in the absence of a known timezone in OMERO.server this should ensure OMERO.web datetimes are consistently wrong.

# Testing:
1. Create a new project
2. Create an annotation (e.g. a comment) on the project
3. Check that the creation times on the project and annotation are similar (i.e. there isn't a timezone discrepancy).

Note this PR does not attempt to resolve the general OMERO problem with timezones.

# Additional info
Background screenshot of debugging the annotation datetime without this PR. It shows that Javascript is treating the datetime as UTC and converting it to localtime:
![Screen Shot 2019-04-18 at 10 32 04](https://user-images.githubusercontent.com/1644105/56352407-1cbc4f00-61c7-11e9-8c31-9b8dceb81c96.png)

- https://github.com/openmicroscopy/openmicroscopy/pull/5786#issuecomment-484155143
- https://trello.com/c/HEXZNdSC/227-omeroweb-default-timezone-is-different-from-omeroserver