### PR TITLE
OMERO.web use client (browser) timezone

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -856,6 +856,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
           "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones "
           "Default ``\"UTC\"``")],
 
+    "omero.web.server_returns_utc":
+        ["OMERO_SERVER_RETURNS_UTC",
+         "true",
+         parse_boolean,
+         ("Should OMERO.server date-times be treated as UTC. If ``true`` "
+          "attempt to do client side local time-zone conversion, If "
+          "``false`` assumes date-times returned by OMERO.server are already "
+          "in localtime.")],
+
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",
          "[]",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -851,10 +851,10 @@ CUSTOM_SETTINGS_MAPPINGS = {
         ["TIME_ZONE",
          "UTC",
          json_or_plain_str,
-         ("Local time zone for this installation. Choices can be found here: "
-          "http://www.postgresql.org/docs/8.1/static/datetime-keywords.html"
-          "#DATETIME-TIMEZONE-SET-TABLE although not all variations may be "
-          "possible on all operating systems. Default ``\"UTC\"``")],
+         ("Time zone for this installation. Choices can be found in the "
+          "``TZ database name`` column of: "
+          "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones "
+          "Default ``\"UTC\"``")],
 
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -847,7 +847,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "Whether to allow OMERO.web to be loaded in a frame."
          ],
 
-    "omero.web.timezone":
+    "omero.web.time_zone":
         ["TIME_ZONE",
          "UTC",
          json_or_plain_str,

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -243,6 +243,18 @@ def identity(x):
     return x
 
 
+def json_or_plain_str(s):
+    """
+    Most omero.web properties are JSON objects but some are plain strings.
+    Use this to allow both JSON objects/strings and plain strings. Obviously
+    this can only be used when the plain string can't also be a JSON object.
+    """
+    try:
+        return json.loads(s)
+    except ValueError:
+        return s
+
+
 def str_slash(s):
     if s is not None:
         s = str(s)
@@ -835,6 +847,15 @@ CUSTOM_SETTINGS_MAPPINGS = {
          "Whether to allow OMERO.web to be loaded in a frame."
          ],
 
+    "omero.web.timezone":
+        ["TIME_ZONE",
+         "UTC",
+         json_or_plain_str,
+         ("Local time zone for this installation. Choices can be found here: "
+          "http://www.postgresql.org/docs/8.1/static/datetime-keywords.html"
+          "#DATETIME-TIMEZONE-SET-TABLE although not all variations may be "
+          "possible on all operating systems. Default ``\"UTC\"``")],
+
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",
          "[]",
@@ -1064,10 +1085,6 @@ report_settings(sys.modules[__name__])
 
 SITE_ID = 1
 
-# Local time zone for this installation. Choices can be found here:
-# http://www.postgresql.org/docs/8.1/static/datetime-keywords.html#DATETIME-TIMEZONE-SET-TABLE
-# although not all variations may be possible on all operating systems.
-TIME_ZONE = 'Europe/London'
 FIRST_DAY_OF_WEEK = 0     # 0-Monday, ... 6-Sunday
 
 # LANGUAGE_CODE: A string representing the language code for this

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -214,3 +214,8 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['center_plugins'] = c_plugins
 
         context['ome']['user_dropdown'] = settings.USER_DROPDOWN
+
+        if settings.OMERO_SERVER_RETURNS_UTC:
+            context['ome']['datetime_suffix'] = 'Z'
+        else:
+            context['ome']['datetime_suffix'] = ''

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -710,13 +710,9 @@ OME.formatDate = function formatDate(date) {
         }
         return n;
     }
-    // For consistency with the datetimes in metadata_general.html we have to
-    // assume dates should not be converted using the local timezone. This is
-    // because the datetime returned by OMERO may already be in "localtime",
-    // treating it as UTC ensures no local timezone adjustment is made.
     var d = new Date(date),
-        dt = [d.getUTCFullYear(), padZero(d.getUTCMonth()+1), padZero(d.getUTCDate())].join("-"),
-        tm = [padZero(d.getUTCHours()), padZero(d.getUTCMinutes()), padZero(d.getUTCSeconds())].join(":");
+        dt = [d.getFullYear(), padZero(d.getMonth()+1), padZero(d.getDate())].join("-"),
+        tm = [padZero(d.getHours()), padZero(d.getMinutes()), padZero(d.getSeconds())].join(":");
     return dt + " " + tm;
 };
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -710,7 +710,8 @@ OME.formatDate = function formatDate(date) {
         }
         return n;
     }
-    var d = new Date(date),
+    // OMERO_DATETIME_SUFFIX: "Z" for UTC, "" for localtime
+    var d = new Date(date + OMERO_DATETIME_SUFFIX),
         dt = [d.getFullYear(), padZero(d.getMonth()+1), padZero(d.getDate())].join("-"),
         tm = [padZero(d.getHours()), padZero(d.getMinutes()), padZero(d.getSeconds())].join(":");
     return dt + " " + tm;

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -498,7 +498,7 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date' data-isodate='{{ manager.dataset.getDate|date:"c" }}Z'></td>
+                        <td id='creation_date' data-isodate='{{ manager.dataset.getDate|date:"c" }}'></td>
                     </tr>
                 </table>
                 </div>
@@ -525,7 +525,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date' data-isodate='{{ manager.project.getDate|date:"c" }}Z'></td>
+                            <td id='creation_date' data-isodate='{{ manager.project.getDate|date:"c" }}'></td>
                         </tr>
                     </table>
                     </div>
@@ -566,15 +566,15 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date' data-isodate='{{ manager.acquisition.getDate|date:"c" }}Z'></td>
+                        <td id='creation_date' data-isodate='{{ manager.acquisition.getDate|date:"c" }}'></td>
                     </tr>
                     <tr>
                         <th>Start Time:</th>
-                        <td data-isodate='{{ manager.acquisition.getStartTime|date:"c" }}Z'></td>
+                        <td data-isodate='{{ manager.acquisition.getStartTime|date:"c" }}'></td>
                     </tr>
                     <tr>
                         <th>End Time:</th>
-                        <td data-isodate='{{ manager.acquisition.getEndTime|date:"c" }}Z'></td>
+                        <td data-isodate='{{ manager.acquisition.getEndTime|date:"c" }}'></td>
                     </tr>
                 </table>
                 </div>
@@ -603,7 +603,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date' data-isodate='{{ manager.plate.getDate|date:"c" }}Z'></td>
+                            <td id='creation_date' data-isodate='{{ manager.plate.getDate|date:"c" }}'></td>
                         </tr>
                         <!--{% comment %}
                         <tr>
@@ -637,7 +637,7 @@
                         <table>
                             <tr>
                                 <th>Creation Date:</th>
-                                <td id='creation_date' data-isodate='{{ manager.screen.getDate|date:"c" }}Z'></td>
+                                <td id='creation_date' data-isodate='{{ manager.screen.getDate|date:"c" }}'></td>
                             </tr>
                             <tr>
                                 <th>Plate Count:</th>
@@ -705,7 +705,7 @@
                     </tr>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date' data-isodate='{{ manager.tag.getDate|date:"c" }}Z'></td>
+                        <td id='creation_date' data-isodate='{{ manager.tag.getDate|date:"c" }}'></td>
                     </tr>
                     <tr>
                         <th>Image Count:</th>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/metadata_general.html
@@ -417,6 +417,12 @@
                     }
 
                 {% endif %}
+
+
+                $('[data-isodate]').each(function() {
+                    $(this).text(OME.formatDate($(this).data('isodate')));
+                });
+
             });
             
     </script>
@@ -492,8 +498,8 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date'>{{ manager.dataset.getDate|date:"Y-m-d H:i:s" }}</td>
-                    </tr>                    
+                        <td id='creation_date' data-isodate='{{ manager.dataset.getDate|date:"c" }}Z'></td>
+                    </tr>
                 </table>
                 </div>
             {% else %}
@@ -519,7 +525,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date'>{{ manager.project.getDate|date:"Y-m-d H:i:s" }}</td>
+                            <td id='creation_date' data-isodate='{{ manager.project.getDate|date:"c" }}Z'></td>
                         </tr>
                     </table>
                     </div>
@@ -560,15 +566,15 @@
                 <table>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date'>{{ manager.acquisition.getDate|date:"Y-m-d H:i:s" }}</td>
+                        <td id='creation_date' data-isodate='{{ manager.acquisition.getDate|date:"c" }}Z'></td>
                     </tr>
                     <tr>
                         <th>Start Time:</th>
-                        <td>{{ manager.acquisition.getStartTime|date:"Y-m-d H:i:s" }}</td>
+                        <td data-isodate='{{ manager.acquisition.getStartTime|date:"c" }}Z'></td>
                     </tr>
                     <tr>
                         <th>End Time:</th>
-                        <td>{{ manager.acquisition.getEndTime|date:"Y-m-d H:i:s" }}</td>
+                        <td data-isodate='{{ manager.acquisition.getEndTime|date:"c" }}Z'></td>
                     </tr>
                 </table>
                 </div>
@@ -597,7 +603,7 @@
                     <table>
                         <tr>
                             <th>Creation Date:</th>
-                            <td id='creation_date'>{{ manager.plate.getDate|date:"Y-m-d H:i:s" }}</td>
+                            <td id='creation_date' data-isodate='{{ manager.plate.getDate|date:"c" }}Z'></td>
                         </tr>
                         <!--{% comment %}
                         <tr>
@@ -631,8 +637,8 @@
                         <table>
                             <tr>
                                 <th>Creation Date:</th>
-                                <td id='creation_date'>{{ manager.screen.getDate|date:"Y-m-d H:i:s" }}</td>
-                            </tr>                    
+                                <td id='creation_date' data-isodate='{{ manager.screen.getDate|date:"c" }}Z'></td>
+                            </tr>
                             <tr>
                                 <th>Plate Count:</th>
                                 <td id='child_count'>{{ manager.screen.countChildren }} {% plural manager.screen.countChildren 'plate' 'plates' %}</td>
@@ -699,7 +705,7 @@
                     </tr>
                     <tr>
                         <th>Creation Date:</th>
-                        <td id='creation_date'>{{ manager.tag.getDate|date:"Y-m-d H:i:s" }}</td>
+                        <td id='creation_date' data-isodate='{{ manager.tag.getDate|date:"c" }}Z'></td>
                     </tr>
                     <tr>
                         <th>Image Count:</th>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base.html
@@ -30,6 +30,11 @@
     <!-- required for the script_launch html below -->
     {% include "webclient/base/includes/script_launch_head.html" %}
 
+    <!-- Required for client-side javascript timezone calculations -->
+    <script type="text/javascript">
+        var OMERO_DATETIME_SUFFIX = "{{ ome.datetime_suffix }}";
+    </script>
+
     <script type="text/javascript" src="{% static "webclient/javascript/ome.webclient.actions.js"|add:url_suffix %}"></script>
 
     <!-- The following are required by the right-hand panel, E.g. annotations/metadata_general.html -->

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/base_container.html
@@ -49,6 +49,11 @@
     <!-- required for the script_launch html below -->
     {% include "webclient/base/includes/script_launch_head.html" %}
 
+    <!-- Required for client-side javascript timezone calculations -->
+    <script type="text/javascript">
+        var OMERO_DATETIME_SUFFIX = "{{ ome.datetime_suffix }}";
+    </script>
+
     <script type="text/javascript" src="{% static "webclient/javascript/ome.webclient.actions.js"|add:url_suffix %}"></script>
     <script src="{% static 'webclient/javascript/jquery.infieldlabel-0.1.js' %}" type="text/javascript"></script>
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/tree.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/tree.py
@@ -457,7 +457,7 @@ def marshal_datasets(conn, project_id=None, orphaned=False, group_id=-1,
 def _marshal_date(time):
     try:
         d = datetime.fromtimestamp(time/1000)
-        return d.isoformat() + 'Z'
+        return d.isoformat()
     except ValueError:
         return ''
 

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -1903,7 +1903,7 @@ class TestTree(ITest):
         dataset = project_hierarchy_userA_groupA[2]
         images = project_hierarchy_userA_groupA[4:6]
         utcAcq = 1444129810716
-        acqDate = '2015-10-06T12:10:10Z'
+        acqDate = '2015-10-06T11:10:10'
         for i in images:
             # get Creation date and set Acquisition Date.
             utcCreate = i.details.creationEvent._time.val

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -1910,7 +1910,7 @@ class TestTree(ITest):
             i.setAcquisitionDate(rtime(utcAcq))
         images = conn.getUpdateService().saveAndReturnArray(images)
         # All images created at same time
-        utcCreate = datetime.fromtimestamp(utcCreate/1000).isoformat() + 'Z'
+        utcCreate = datetime.fromtimestamp(utcCreate/1000).isoformat()
         extraValues = {'acqDate': acqDate,
                        'date': utcCreate}
         expected = expected_images(userA, images,

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -166,7 +166,7 @@ def annotate_project(ann, project, user):
 
 def expected_date(time):
     d = datetime.fromtimestamp(time/1000)
-    return d.isoformat() + 'Z'
+    return d.isoformat()
 
 
 def expected_experimenter(experimenter):


### PR DESCRIPTION
# What this PR does

This is an alternative solution to https://github.com/openmicroscopy/openmicroscopy/pull/5786 (and it reverts https://github.com/openmicroscopy/openmicroscopy/pull/6009)
@pwalczysko @will-moore 

This PR moves all OMERO.web datetime processing to the client browser using Javascript, which can optionally take account of the client's timezone. In cases where the timestamps were previously rendered with Django they are now stored as a `data-isodate` HTML attribute, and are automatically converted for display by `OME.formatDate`.

# Two configurations should be tested

## 1. All timestamps are UTC

The assumption is that the backend OMERO.server stores all timestamps in UTC. The timestamps are then converted to the client browsers local timezone for display. This is done client-side using Javascript, the OMERO.web server does not need to care about the client's locality, and this should therefore work for clients in multiple timezones.

OMERO.web configuration (this is the default in this PR):
```
omero config set omero.web.server_returns_utc true
```

### Current timezone
Open a browser. Create objects (e.g. projects, annotations) in OMERO.web. Check that the displayed timestamps are as expected. If they are not please verify that OMERO.server really is using UTC by requesting the timestamps using the OMERO API (e.g. Python BlitzGateway) and checking the raw timestamps.

### Different timezone
Fly to Australia, if you are using a Mac your laptop may auto-configure itself for the new timezone, otherwise update it in system preferences. If this is not possible you may be able to simulate a different timezone, e.g. On OS X with Chrome:
```
mkdir $HOME/chrome-profile
TZ='Australia/ACT' open -na "Google Chrome" --args "--user-data-dir=$HOME/chrome-profile"
```
Look at the objects created in the previous step, the timestamps should be adjusted to the new timezone. Note you can only have one instance of chrome using this custom profile directory.


## 2. Timestamps are localtime

The assumption is that the backend OMERO.server stores all timestamps in the client's timezone. Therefore no conversion is done when it is displayed in the browser. Obviously if you have clients in multiple timezones, of if the server timezone is not the same as the clients, they will all see the wrong time.

OMERO.web configuration:
```
omero config set omero.web.server_returns_utc false
```

As before open a browser in your current and different timezones. You should see that the displayed timestamps are always the same.

# Other notes
This PR changes the default OMERO.web timezone to `UTC` since nothing else really makes sense. I'm not sure if it makes sense for it to be configurable, but I guess there's no harm.

# Background

- https://github.com/openmicroscopy/openmicroscopy/pull/5786#issuecomment-484155143
- https://trello.com/c/HEXZNdSC/227-omeroweb-default-timezone-is-different-from-omeroserver
