### PR TITLE
CLI reads JAR properties

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -87,6 +87,8 @@ if OMERODIR is not None:
 else:
     OMERODIR = OMEROCLI.dirname().dirname().dirname()
 
+OMERO_COMPONENTS = ['common', 'model', 'romio', 'renderer', 'server', 'blitz']
+
 COMMENT = re.compile("^\s*#")
 RELFILE = re.compile("^\w")
 LINEWSP = re.compile("^\s*\w+\s+")
@@ -1352,18 +1354,40 @@ class CLI(cmd.Cmd, Context):
         return subprocess.Popen(args, env=env, cwd=self._cwd(cwd),
                                 stdout=stdout, stderr=stderr)
 
-    def readDefaults(self):
+    def get_config_property_lines(self, root_path):
+        """
+        Construct a generator providing each line of the configuration
+        property files from OMERO components then from the top level.
+        Trailing whitespace is stripped from each line.
+        """
+        jar_root = root_path / 'lib' / 'server'
+        for component in OMERO_COMPONENTS:
+            from zipfile import ZipFile, is_zipfile, BadZipfile
+            jar_name = jar_root / 'omero-{}.jar'.format(component)
+            if is_zipfile(jar_name):
+                config_name = 'omero-{}.properties'.format(component)
+                try:
+                    with ZipFile(jar_name, 'r') as jar_file:
+                        with jar_file.open(config_name, 'r') as config:
+                            for line in iter(config.readline, ''):
+                                yield line.rstrip()
+                except (BadZipfile, IOError, KeyError):
+                    pass
+        # etc/omero.properties comes last because it may contain "### END"
         try:
-            f = path(self._cwd(None)) / "etc" / "omero.properties"
-            f = f.open()
-            output = "".join(f.readlines())
-            f.close()
-        except:
-            if self.isdebug:
-                raise
-            print "No omero.properties found"
-            output = ""
-        return output
+            file_path = root_path / 'etc' / 'omero.properties'
+            with open(file_path, 'r') as config:
+                for line in iter(config.readline, ''):
+                    yield line.rstrip()
+        except IOError:
+            pass
+
+    def readDefaults(self):
+        lines = self.get_config_property_lines(path(self._cwd(None)))
+        defaults = "".join([line + '\n' for line in lines])
+        if not defaults:
+            print "No properties files found for OMERO default configuration."
+        return defaults
 
     def parsePropertyFile(self, data, output):
         for line in output.splitlines():

--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -246,28 +246,28 @@ class PropertyParser(object):
 
     def parse_lines(self, lines):
         """Parse the properties from the given configuration file lines"""
-            for line in lines:
-                if line.endswith("\n"):
-                    line = line[:-1]
+        for line in lines:
+            if line.endswith("\n"):
+                line = line[:-1]
 
-                if line.startswith(STOP):
-                    self.cleanup()
-                    break
-                if self.black_list(line):
-                    self.cleanup()
-                    continue
-                elif not line.strip():
-                    self.cleanup()
-                    continue
-                elif line.startswith("#"):
-                    self.append(line)
-                elif "=" in line and self.curr_a != ESCAPED:
-                    self.detect(line)
-                elif line.endswith("\\"):
-                    self.cont(line[:-1])
-                else:
-                    self.cont(line)
-            self.cleanup()  # Handle no newline at end of file
+            if line.startswith(STOP):
+                self.cleanup()
+                break
+            if self.black_list(line):
+                self.cleanup()
+                continue
+            elif not line.strip():
+                self.cleanup()
+                continue
+            elif line.startswith("#"):
+                self.append(line)
+            elif "=" in line and self.curr_a != ESCAPED:
+                self.detect(line)
+            elif line.endswith("\\"):
+                self.cont(line[:-1])
+            else:
+                self.cont(line)
+        self.cleanup()  # Handle no newline at end of file
         return self.properties
 
     def black_list(self, line):

--- a/components/tools/OmeroPy/src/omero/install/config_parser.py
+++ b/components/tools/OmeroPy/src/omero/install/config_parser.py
@@ -239,7 +239,14 @@ class PropertyParser(object):
     def parse_file(self, argv=None):
         """Parse the properties from the input configuration file"""
         try:
-            for line in fileinput.input(argv):
+            self.parse_lines(fileinput.input(argv))
+        finally:
+            fileinput.close()
+        return self.properties
+
+    def parse_lines(self, lines):
+        """Parse the properties from the given configuration file lines"""
+            for line in lines:
                 if line.endswith("\n"):
                     line = line[:-1]
 
@@ -261,8 +268,6 @@ class PropertyParser(object):
                 else:
                     self.cont(line)
             self.cleanup()  # Handle no newline at end of file
-        finally:
-            fileinput.close()
         return self.properties
 
     def black_list(self, line):

--- a/components/tools/OmeroPy/src/omero/plugins/db.py
+++ b/components/tools/OmeroPy/src/omero/plugins/db.py
@@ -160,17 +160,12 @@ class DatabaseControl(BaseControl):
         return replace_method
 
     def _db_profile(self):
-        return "psql"  # Quick fix
-        import re
-        server_lib = self.ctx.dir / "lib" / "server"
-        model_jars = server_lib.glob("omero-model.jar")
-        if len(model_jars) != 1:
-            self.ctx.die(200, "Invalid omero-model.jar state: %s"
-                         % ",".join(model_jars))
-        model_jar = model_jars[0]
-        model_jar = str(model_jar.basename())
-        match = re.search("model-(.*?).jar", model_jar)
-        return match.group(1)
+        from omero.install.config_parser import PropertyParser
+        property_lines = self.ctx.get_config_property_lines(self.dir)
+        for property in PropertyParser().parse_lines(property_lines):
+            if property.key == 'omero.db.profile':
+                return property.val
+        raise KeyError('Configuration key not set: omero.db.profile')
 
     def _sql_directory(self, db_vers, db_patch):
         """

--- a/components/tools/OmeroPy/src/omero/plugins/prefs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/prefs.py
@@ -414,15 +414,13 @@ class PrefsControl(WriteableConfigControl):
                 self.ctx.out(k)
 
     def parse(self, args):
-        if args.file:
-            args.file.close()
-            cfg = path(args.file.name)
-        else:
-            cfg = self.dir / "etc" / "omero.properties"
-
         from omero.install.config_parser import PropertyParser
         pp = PropertyParser()
-        pp.parse_file(str(cfg.abspath()))
+        if args.file:
+            args.file.close()
+            pp.parse_file(str(path(args.file.name).abspath()))
+        else:
+            pp.parse_lines(self.ctx.get_config_property_lines(self.dir))
 
         # Parse PSQL profile file
         for p in pp:


### PR DESCRIPTION
# What this PR does

Adjusts OMERO.cli to include in `omero.properties` reading the various `omero-*.properties` from the decoupled build's JARs.

# Testing this PR

CI should pass even with #6004 included.

It would also be worth testing `bin/omero config parse --rst` which generates https://docs.openmicroscopy.org/latest/omero/sysadmins/config.html.