### PR TITLE
use Guava method in server test helper

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -144,6 +144,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
@@ -2404,27 +2405,8 @@ public class AbstractServerTest extends AbstractTest {
      * @see ome.testing.DataProviderBuilder#addBoolean(boolean)
      */
     private static Boolean[][] provideEveryBooleanCombination(int argCount) {
-        // TODO: Once we use Guava 19 we can use Collections.nCopies and Lists.cartesianProduct instead of this manual approach.
-        if (argCount < 1) {
-            throw new IllegalArgumentException("argument count must be strictly positive");
-        }
-        final Boolean[][] testArguments = new Boolean[1 << argCount][];
-        int testNum = 0;
-        testArguments[testNum] = new Boolean[argCount];
-        Arrays.fill(testArguments[testNum], false);
-        while (++testNum < testArguments.length) {
-            testArguments[testNum] = Arrays.copyOf(testArguments[testNum - 1], argCount);
-            int argNum = argCount - 1;
-            while (true) {
-                if (testArguments[testNum][argNum]) {
-                    testArguments[testNum][argNum--] = false;
-                } else {
-                    testArguments[testNum][argNum] = true;
-                    break;
-                }
-            }
-        }
-        return testArguments;
+        return Lists.cartesianProduct(Collections.nCopies(argCount, ImmutableList.of(false, true)))
+                .stream().map(args -> args.stream().toArray(Boolean[]::new)).toArray(Boolean[][]::new);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -7,7 +7,6 @@ package integration;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -136,7 +135,6 @@ import omero.sys.Roles;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.util.ResourceUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -147,7 +145,6 @@ import org.testng.annotations.DataProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.io.Files;
 
 /**
  * Base test for integration tests.


### PR DESCRIPTION
This PR rewrites `AbstractServerTest.provideEveryBooleanCombination` in a manner that assumes both Java 8 and Guava ≥ 19. It simplifies our code, leaving the complexity to third parties, while testing the decoupled build dependencies by requiring that OmeroJava isn't still running on Guava 17 as from OMERO 5.4. The method's return value, hence the state of [OMERO-test-integration](https://web-proxy.openmicroscopy.org/west-ci/job/OMERO-test-integration/), should be unaffected.