### PR TITLE
Re-activate 'integration' for '.omero/docker srv'

### DIFF
--- a/.omeroci/98-ssl.py
+++ b/.omeroci/98-ssl.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# Script which is placed into the Docker image to perform pre-start config
+# see:
+# - https://trello.com/c/rPstbt4z/216-open-ssl-110
+# - https://github.com/openmicroscopy/openmicroscopy/pull/5998
+
+
+from subprocess import checked_call
+
+
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+checked_call([OMERO, 'config', 'set', '--', "omero.glacier2.IceSSL.Ciphers",
+              "ADH:!LOW:!MD5:!EXP:!3DES:@STRENGTH:@SECLEVEL=0")

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,20 +58,15 @@ WORKDIR /src
 ENV ICE_CONFIG=/src/etc/ice.config
 RUN sed -i "s/^\(omero\.host\s*=\s*\).*\$/\1omero/" /src/etc/ice.config
 
-# The following may be necessary depending on
-# which images you are using. See the following
-# card for more info:
-#
-#     https://trello.com/c/rPstbt4z/216-open-ssl-110
-#
-# RUN sed -i 's/\("IceSSL.Ciphers".*ADH[^"]*\)/\1:@SECLEVEL=0/' /src/components/tools/OmeroPy/src/omero/clients.py /src/etc/templates/grid/templates.xml
 
 # Reproduce jenkins build
 RUN env BUILD_NUMBER=1 OMERO_BRANCH=develop bash docs/hudson/OMERO.sh
 
+
 FROM ${RUN_IMAGE} as run
 RUN rm -rf /opt/omero/server/OMERO.server
 COPY --chown=omero-server:omero-server --from=build /src/dist /opt/omero/server/OMERO.server
+COPY .omeroci/98-ssl.py /startup/
 USER root
 RUN yum install -y git
 USER omero-server

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -41,13 +41,6 @@ java_test()
         fold end $dir
     done
 
-    # Check for the use of '%' in the SQL templates. Since they are later passed through a python
-    # format statement, any use must be escaped as '%%'.  FIXME: this needs migrating
-    if [[ "2" -ne $(git grep -E '[^%]%[^%]' components/dsl/resources/ome/dsl/  | wc -l) ]]; then exit 2; fi
-
-    # Check for IDE auto-import of certainly unintended Java package.
-    git grep -q '^import edu\.emory\.mathcs\.backport\.' && exit 2
-
     # make sure that the current db script has no code-generated
     # foreign key names in it
     dist/bin/omero db script --password ome -f- | grep -LiE "fk[a-z]*[0-9]+[a-z0-9]{5}" && {

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -156,9 +156,9 @@ do
         py-test)
             py_test ;;
         integration)
-            py_flake8 java_build java_test py_test integration ;;
+            py_flake8 && java_build && java_test && py_test && integration ;;
         all)
-            py_flake8 java_build java_test py_test ;;
+            py_flake8 && java_build && java_test && py_test ;;
         *)
             echo "Invalid argument: \"$arg\"" >&2
             exit 1

--- a/components/tools/travis-build
+++ b/components/tools/travis-build
@@ -155,7 +155,9 @@ do
             py_build ;;
         py-test)
             py_test ;;
-        integration | all)
+        integration)
+            py_flake8 java_build java_test py_test integration ;;
+        all)
             py_flake8 java_build java_test py_test ;;
         *)
             echo "Invalid argument: \"$arg\"" >&2


### PR DESCRIPTION
This is initially intended to fail, but will make
use of pr5998 to make the integration tests pass.

see: https://github.com/openmicroscopy/openmicroscopy/pull/5998