### PR TITLE
Remove the generation of Ivy dependencies.html files

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -446,10 +446,6 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
         <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
         <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="client" pattern="${dist.dir}/lib/client/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
-        <mkdir dir="${dist.dir}/share/client"/>
-        <ivy:report conf="client" todir="${dist.dir}/share/client"
-            outputpattern="dependencies.html" graph="false"
-            settingsRef="ivy.toplevel"/>
     </target>
 
     <target name="copy-server" depends="init">
@@ -457,10 +453,6 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
         <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
         <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="server" pattern="${dist.dir}/lib/server/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
-        <mkdir dir="${dist.dir}/share/server"/>
-        <ivy:report conf="server" todir="${dist.dir}/share/server"
-            outputpattern="dependencies.html" graph="false"
-            settingsRef="ivy.toplevel"/>
     </target>
 
     <target name="create-workdirs" depends="init">


### PR DESCRIPTION
With the recent work on OMERO 5.5, these files currently weigh 169M out of 480M for the complete server bundle. In addition to being extremely large, their size makes them almost non-usable.

## Proposed changes
These generation of `dependencies.html` using the [Ivy report](https://ant.apache.org/ivy/history/2.4.0/use/report.html) tasks was introduced in 5a8db9c7be8ccc527b4b5ac5d501eb1e74c423a8 as part of the decoupling of Bio-Formats. For developers and especially for reviewing dependencies, having the dependency tree under some form and being able to review the version evictions still remains a useful resource. However, having it large HTML files as part of every bundle feels unnecessary.

## Testing

Without this PR, a build server (or the last 5.5.0 milestone) zip should be ~160MB or 480MB unzipped. With it included, the size should be largely reduced.

