### PR TITLE
Enable debug logs for stand-in full-text indexer.

### DIFF
--- a/etc/logback-indexing.xml
+++ b/etc/logback-indexing.xml
@@ -57,6 +57,8 @@
   <!-- Adapters are also too so is a bit verbose -->
   <logger name="ome.adapters" level="ERROR"/>
 
+  <logger name="ome.services.fulltext.FullTextIndexer2" level="DEBUG"/>
+
   <!-- THIRD PARTY //////////////////////////////////////////////////////////// -->
   <logger name="org.apache" level="WARN"/>
   <logger name="org.jgroups" level="WARN"/>

--- a/etc/logback-indexing.xml
+++ b/etc/logback-indexing.xml
@@ -57,6 +57,7 @@
   <!-- Adapters are also too so is a bit verbose -->
   <logger name="ome.adapters" level="ERROR"/>
 
+  <logger name="ome.services.fulltext.ConfiguredAnalyzer" level="DEBUG"/>
   <logger name="ome.services.fulltext.FullTextIndexer2" level="DEBUG"/>
 
   <!-- THIRD PARTY //////////////////////////////////////////////////////////// -->

--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -93,6 +93,8 @@
   <!-- Adapters are also too so is a bit verbose -->
   <logger name="ome.adapters" level="ERROR"/>
 
+  <logger name="ome.services.fulltext.ConfiguredAnalyzer" level="DEBUG"/>
+
   <!-- THIRD PARTY //////////////////////////////////////////////////////////// -->
   <logger name="org.apache" level="WARN"/>
   <logger name="org.jgroups" level="WARN"/>


### PR DESCRIPTION
Temporary PR to bump `Indexer-0.log` level for `FullTextIndexer2` up to DEBUG.