### PR TITLE
Workaround indexing of image name

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/controller/search.py
@@ -61,6 +61,10 @@ class BaseSearch(BaseController):
             fields = fields.union(("file.name", "file.path", "file.format",
                                    "file.contents"))
             fields.discard("file")      # Not supported
+        # workaround indexing bug in OMERO 5.5.0. Image Name is not indexed
+        # If no fields are specified, also search by Name
+        if len(fields) == 0 and "images" in onlyTypes and ':' not in query:
+            query += ' OR name:' + query
         fields = list(fields)
 
         if 'plates' in onlyTypes:


### PR DESCRIPTION
# What this PR does

As discussed with @jburel, this works around an indexing bug for Image Name in OMERO 5.5.
Instead of searching for ```"foo"``` we search for ```"foo OR name:foo"``` if no fields are specified and we're searching for images and the query doesn't already contain ```:```.

This applies to standard search and advanced search (IF the user doesn't enter any ```:```).

To discuss: Should we avoid modification of the query if the user is using Advanced search?
I want to avoid case where:
 - Search for "foo" under regular search -> find images named "foo"
 - Search for "foo" under advanced search -> Don't find images named "foo".

But, maybe we shouldn't modify search term if it contains ```AND``` keyword?
E.g. ```"foo AND bar"``` -> ```"foo AND bar OR name:foo AND bar"``` doesn't make sense.

# Testing this PR

1. e.g. search for ```dm2``` on eel-latest. Should find images named ```dm2```
