### PR TITLE
Enable trace logs for Hibernate Search's Lucene backend.

### DIFF
--- a/etc/logback-indexing.xml
+++ b/etc/logback-indexing.xml
@@ -72,6 +72,8 @@
   <logger name="loci" level="INFO"/><!-- Bio-Formats -->
   <logger name="ucar" level="WARN"/><!-- NetCDF -->
 
+  <logger name="org.hibernate.search.backend.impl.lucene" level="TRACE"/>
+
   <!-- DATABASE /////////////////////////////////////////////////////////////// -->
   <logger name="bitronix" level="WARN"/>
   <!-- Limit memory WARNing -->


### PR DESCRIPTION
Temporary PR to bump `Indexer-0.log` level for Hibernate's operation of Lucene up to TRACE.