### PR TITLE
web: incorrect login text can be customised

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -661,6 +661,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
          str,
          ("The Django view name used for login. Use this to provide an "
           "alternative login workflow.")],
+    "omero.web.login_incorrect_credentials_text":
+        ["LOGIN_INCORRECT_CREDENTIALS_TEXT",
+         "Connection not available, please check your user name and password.",
+         str,
+         ("The error message shown to users who enter an incorrect username "
+          "or password.")],
+
     "omero.web.user_dropdown":
         ["USER_DROPDOWN",
          "true",

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -71,7 +71,7 @@
     {% block login %}
     <form class="standard_form inlined" action="{% url 'weblogin' %}{% if url %}?{{url}}{% endif %}" method="post">{% csrf_token %}
             {% if error %}
-				<span class="error">{% trans "Error:" %} {{ error }}</span>
+				<span class="error">{% trans "Error:" %} {{ error | urlize }}</span>
 			{% endif %}
 			
 			<div id="choose_server">

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2990,8 +2990,7 @@ class LoginView(View):
                     error = ("Client version does not match server,"
                              " please contact administrator.")
                 else:
-                    error = ("Connection not available, please check your"
-                             " user name and password.")
+                    error = (settings.LOGIN_INCORRECT_CREDENTIALS_TEXT)
         return self.handle_not_logged_in(request, error, form)
 
 


### PR DESCRIPTION
If a user's OMERO.web credentials are incorrect a custom error message can be displayed. This is useful when a non-standard process is required for checking credentials.

# Testing this PR

1. `omero config set omero.web.login_incorrect_credentials_text 'Please check your user name and password. If login still fails please check your details at https://lsd.lifesci.dundee.ac.uk/'`

2. Attempt to login to a valid server with incorrect credentials.

Note this does not work when `omero.web.check_version=false`.

<img width="457" alt="Screen Shot 2019-06-06 at 14 31 56" src="https://user-images.githubusercontent.com/1644105/59036896-13b33a00-8868-11e9-9254-e81aadd1d3c8.png">
