### PR TITLE
Deploy gallery at root url

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -85,7 +85,8 @@ for app in settings.ADDITIONAL_APPS:
     except ImportError:
         pass
     else:
-        # see https://stackoverflow.com/questions/7580220/django-urls-how-to-map-root-to-app
+        # see https://stackoverflow.com
+        #                 /questions/7580220/django-urls-how-to-map-root-to-app
         if label == 'gallery':
             regex = r'^'
         else:

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -85,8 +85,13 @@ for app in settings.ADDITIONAL_APPS:
     except ImportError:
         pass
     else:
-        regex = '^(?i)%s/' % label
+        # see https://stackoverflow.com/questions/7580220/django-urls-how-to-map-root-to-app
+        if label == 'gallery':
+            regex = r'^'
+        else:
+            regex = '^(?i)%s/' % label
         urlpatterns += patterns('', (regex, include(urlmodule)),)
+
 
 urlpatterns += patterns(
     '',


### PR DESCRIPTION
# What this PR does

Give this PR a descriptive title then expand on that here.


# Testing this PR

1. The root URL ```/``` should show the gallery home page and all other gallery URLs should work without the ```/gallery/```. E.g. ```/gallery/cell/``` should be shown at ```/cell/```.
