### PR TITLE
Add punctuation to property description.

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -135,10 +135,10 @@ omero.jvmcfg.max_system_memory=48000
 # certain situations.
 Ice.IPv6=1
 
-# Glacier2Template IceSSL defaults and overrides
-# see https://doc.zeroc.com/ice/3.6/property-reference/icessl
+# Glacier2Template IceSSL defaults and overrides,
+# see https://doc.zeroc.com/ice/3.6/property-reference/icessl.
 # Any property beginning ``omero.glacier2.IceSSL.`` will be used to
-# update the corresponding IceSSL. property
+# update the corresponding IceSSL. property.
 omero.glacier2.IceSSL=
 
 # Glacier2Template SSL maximum allowed protocol (mac bug)


### PR DESCRIPTION
The paragraph under https://docs.openmicroscopy.org/omero/5.5.0-rc3/sysadmins/config.html#glacier2 is rather jumbled together because the original is probably written assuming that linebreaks ease reading.