### PR TITLE
OMERO.web client settings override server client settings

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1658,7 +1658,7 @@ present, the user will enter a console""")
         vers = popen.communicate()[1]
         _check("icegridnode version", vers)
 
-    def open_config(self, unused):
+    def open_config(self, unused=None):
         """
         Callers are responsible for closing the
         returned ConfigXml object.

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -50,6 +50,8 @@ from omero.fs import TRANSFERS
 
 from omero.gateway import KNOWN_WRAPPERS
 
+from omero.plugins.admin import AdminControl
+
 from django.utils.encoding import smart_str
 from django.conf import settings
 
@@ -238,6 +240,21 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
     ##############################################
     #   IAdmin                                  ##
+
+    def getClientSettings(self):
+        """
+        Returns all client properties matching omero.client.*
+        Local config settings override client settings sent by the server
+        """
+        configmap = super(OmeroWebGateway, self).getClientSettings()
+        localcfg = AdminControl().open_config()
+        try:
+            for key in localcfg.keys():
+                if key.startswith('omero.client.'):
+                    configmap[key] = localcfg[key]
+            return configmap
+        finally:
+            localcfg.close()
 
     def getEmailSettings(self):
         """


### PR DESCRIPTION
# What this PR does

If `omero.client.*` properties are set in OMERO.web they override the corresponding `omero.client.*` settings sent by the server.
- https://trello.com/c/UDTkNefz/616-orphaned-images-folder

# Testing this PR

1. Setup OMERO.web, connect to a different server with the default `omero.client.ui.tree.orphans.name` setting
2. Login to OMERO.web, you should see the Orphans folder is called `Orphaned images`
3. Stop OMERO.web. You may or may not need to delete the OMERO `/var` directory (not sure why)
4. `omero config set omero.client.ui.tree.orphans.name whatever`
5. Start OMERO.web
6. The Orphans folder should be called `whatever`

Note if you want to test the setting in the trello card `omero.client.ui.tree.orphans.enabled=false` you need to read the code to figure out in what situations it will hide the folder: https://github.com/openmicroscopy/openmicroscopy/blob/v5.5.0-rc3/components/tools/OmeroWeb/omeroweb/webclient/views.py#L667-L670

I was going to add a test but I couldn't figure out how.... if anyone has a suggestion let me know (or we could skip adding a test)