### PR TITLE
Make name search test less sensitive to temp file names.

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -264,9 +264,8 @@ class TestSearch(ITest):
                 ("fake", supported),
                 ("%s*" % uuid[:-1], supported),
                 (uuid, supported),
-                #
-                ("*.fake", unsupported),
-                ("%s*.fake" % uuid[:-1], unsupported)):
+                ("*.fake", supported),
+                ("%s*.fake" % uuid[:-1], supported)):
 
             m(x)
 

--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -242,7 +242,7 @@ class TestSearch(ITest):
     def testFilename(self):
         client = self.new_client()
         uuid = self.simple_uuid()
-        images = self.import_fake_file(name=uuid, client=client)
+        images = self.import_fake_file(name=uuid + ';', client=client)
         image = images[0]
         self.index(image)
         search = client.sf.createSearchService()
@@ -262,11 +262,11 @@ class TestSearch(ITest):
         for x, m in (
                 (".fake", supported),
                 ("fake", supported),
-                ("%s*" % uuid, supported),
+                ("%s*" % uuid[:-1], supported),
+                (uuid, supported),
                 #
-                (uuid, unsupported),
                 ("*.fake", unsupported),
-                ("%s*.fake" % uuid, unsupported)):
+                ("%s*.fake" % uuid[:-1], unsupported)):
 
             m(x)
 


### PR DESCRIPTION
Since build 58 stabilizes https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.test_search/TestSearch/testFilename/history/ by not making assumptions about if or what temporary file creation may append to the name prefix.

Uses a whole initial word to search for the image name; also searches for prefixes thereof.