### PR TITLE
Webclient top-bar logo can be customised

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -668,6 +668,18 @@ CUSTOM_SETTINGS_MAPPINGS = {
          ("The error message shown to users who enter an incorrect username "
           "or password.")],
 
+    "omero.web.top_logo":
+        ["TOP_LOGO",
+         "",
+         str,
+         ("Customize the webclient top bar logo. The recommended image height "
+          "is 23 pixels and it must be hosted outside of OMERO.web.")],
+    "omero.web.top_logo_link":
+        ["TOP_LOGO_LINK",
+         "",
+         str,
+         ("The target location of the webclient top logo, default unlinked.")],
+
     "omero.web.user_dropdown":
         ["USER_DROPDOWN",
          "true",

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -190,6 +190,11 @@ class render_response(omeroweb.decorators.render_response):
             links.append(l)
         context['ome']['top_links'] = links
 
+        if settings.TOP_LOGO:
+            context['ome']['logo_src'] = settings.TOP_LOGO
+        if settings.TOP_LOGO_LINK:
+            context['ome']['logo_href'] = settings.TOP_LOGO_LINK
+
         metadata_panes = settings.METADATA_PANES
         context['ome']['metadata_panes'] = metadata_panes
 

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/logo.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/logo.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{% comment %}
+<!--
+  Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+  All rights reserved.
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+{% endcomment %}
+
+<a id="logo"
+{% if ome.logo_href %}
+    href="{{ ome.logo_href }}"
+  {% endif %}
+>
+  {% if ome.logo_src %}
+    <img src="{{ ome.logo_src }}" />
+  {% else %}
+    <img src="{% static "webgateway/img/logo2.png" %}"/>
+  {% endif %}
+</a>

--- a/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/base_header.html
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/templates/webgateway/base/base_header.html
@@ -52,11 +52,13 @@
         {% block middle_header %}
         <div id="middle_header">
 
-            <a id="logo">
-                <img src="{% static "webgateway/img/logo2.png" %}"/>
-            </a>
+            <div id="middle_header_logo">
+				{% block middle_header_logo %}
+				    {% include "webclient/base/includes/logo.html" %}
+				{% endblock %}
+            </div>
 
-            
+
             <div id="middle_header_left">
 				{% block middle_header_left %}
 				    {% include "webclient/base/includes/menu.html" %}


### PR DESCRIPTION
# What this PR does
New properties to customise the top-left webclient logo after login:
- `omero.web.top_logo`: URL to externally hosted logo
- `omero.web.top_logo_link`: Hyperlink for the logo

# Testing this PR
Set a custom logo (image must be hosted outside OMERO.web) and link for when you click on the logo. Default behaviour is unchanged.
```
omero config set omero.web.top_logo_link https://idr.openmicroscopy.org
omero config set omero.web.top_logo https://idr.openmicroscopy.org/static/webgateway/img/logo2.png
```

# Related reading
- https://github.com/openmicroscopy/openmicroscopy/pull/5763