### PR TITLE
CLI ldap setdn can enable and disable LDAP for users.

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/ldap.py
+++ b/components/tools/OmeroPy/src/omero/plugins/ldap.py
@@ -58,7 +58,7 @@ class LdapControl(UserGroupControl):
         getdn = parser.add(sub, self.getdn, help="Get DN for user on stdout")
         setdn = parser.add(
             sub, self.setdn,
-            help="""Enable LDAP login for user (admins only)
+            help="""Enable or disable LDAP login for user (admins only)
 
 Once LDAP login is enabled for a user, the password set via OMERO is
 ignored, and any attempt to change it will result in an error. When


### PR DESCRIPTION
Fixes `bin/omero ldap setdn -h` so the one-line summary includes that it can work both ways for enabling/disabling LDAP. See diff.