### PR TITLE
fix login_redirect no args

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/decorators.py
@@ -51,8 +51,8 @@ def parse_url(lookup_view):
     try:
         url = reverse_with_params(
             viewname=lookup_view['viewname'],
-            args=lookup_view['args'],
-            query_string=lookup_view['query_string']
+            args=lookup_view.get('args', []),
+            query_string=lookup_view.get('query_string', None)
         )
     except KeyError:
         # assume we've been passed a url


### PR DESCRIPTION
Previously, a KeyError here would mean that reverse_with_params() didn't get called, even
if we didn't need any args or query_string

See https://github.com/ome/virtual-microscope/issues/12

With this fix, login_redirect setting should work without any ```args``` or ```query_string``` set.
E.g. to redirect to gallery:
```
$ bin/omero config set omero.web.login_redirect '{"redirect": ["webindex"], "viewname": "webgallery_index"}'
```