### PR TITLE
web login: dynamically lookup client downloads

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -732,12 +732,10 @@ CUSTOM_SETTINGS_MAPPINGS = {
          parse_boolean,
          ("Whether to link to official client downloads on the login page")],
     "omero.web.login.client_downloads_base":
-        ["CLIENT_DOWNLOAD_LATEST_BASE",
-         'https://downloads.openmicroscopy.org/latest/omero{major}.{minor}',
+        ["CLIENT_DOWNLOAD_GITHUB_REPO",
+         'ome/omero-insight',
          str,
-         ("Base URL for latest client downloads. "
-          "Template parameters ``{major}`` ``{minor}`` ``{patch}`` will be "
-          "substituted with the current OMERO.web version.")],
+         ("GitHub repository containing the Desktop client downloads")],
 
     "omero.web.apps":
         ["ADDITIONAL_APPS",

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -51,7 +51,6 @@
             if (insighttag) {
                 var insight_base = "https://github.com/" + "{{ client_download_repo }}" +
                     "/releases/download/" + insighttag + "/OMERO.insight-" + insighttag.substring(1);
-                console.log(insight_base);
                 $("#download-insight-mac").attr("href", insight_base + ".dmg");
                 $("#download-insight-win").attr("href", insight_base + ".exe");
                 $("#download-insight-linux").attr("href", insight_base + ".zip");

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/login.html
@@ -36,7 +36,34 @@
     
 	{% include "webgateway/base/includes/script_src_jquery.html" %}
 	<script src="{% static 'webclient/javascript/jquery.infieldlabel-0.1.js' %}" type="text/javascript"></script>
-	
+
+    {% if show_download_links %}
+    <script>
+        function _update_download_href(tags) {
+            var vermatch = RegExp("{{ client_download_tag_re }}");
+            var insighttag;
+            for (var i = 0; i < tags.length; i++) {
+                if (tags[i].name && tags[i].name.match(vermatch)) {
+                    insighttag = tags[i].name;
+                    break;
+                }
+            }
+            if (insighttag) {
+                var insight_base = "https://github.com/" + "{{ client_download_repo }}" +
+                    "/releases/download/" + insighttag + "/OMERO.insight-" + insighttag.substring(1);
+                console.log(insight_base);
+                $("#download-insight-mac").attr("href", insight_base + ".dmg");
+                $("#download-insight-win").attr("href", insight_base + ".exe");
+                $("#download-insight-linux").attr("href", insight_base + ".zip");
+            }
+        }
+
+        $(document).ready(function(){
+            $.get("https://api.github.com/repos/" + "{{ client_download_repo }}" + "/tags", _update_download_href);
+        });
+    </script>
+    {% endif %}
+
 {% endblock %}
 
 
@@ -141,9 +168,9 @@
 
         {% if show_download_links %}
             Download OMERO.insight for
-            <a href="{{ download_client_mac }}">Mac OS X</a>,
-            <a href="{{ download_client_win }}">Windows</a>,
-            <a href="{{ download_client_linux }}">Linux</a><br>
+            <a href="https://www.openmicroscopy.org/omero/downloads/" id="download-insight-mac">Mac OS X</a>,
+            <a href="https://www.openmicroscopy.org/omero/downloads/" id="download-insight-win">Windows</a>,
+            <a href="https://www.openmicroscopy.org/omero/downloads/" id="download-insight-linux">Linux</a><br>
         {% endif %}
 
         <img src="{% static 'webgateway/img/OME_logo_grey_110.png' %}"/>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -263,11 +263,11 @@ class WebclientLoginView(LoginView):
         if settings.SHOW_CLIENT_DOWNLOADS:
             ver = re.match('(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).*',
                            omero_version)
-            latest = settings.CLIENT_DOWNLOAD_LATEST_BASE.format(
-                **ver.groupdict())
-            context['download_client_mac'] = latest + '/insight-mac.zip'
-            context['download_client_win'] = latest + '/insight-win.zip'
-            context['download_client_linux'] = latest + '/insight-linux.zip'
+            client_download_tag_re = '^v%s\\.%s\\.[^-]+$' % (
+                ver.group('major'), ver.group('minor'))
+            context['client_download_tag_re'] = client_download_tag_re
+            context['client_download_repo'] = (
+                settings.CLIENT_DOWNLOAD_GITHUB_REPO)
 
         t = template_loader.get_template(self.template)
         c = Context(request, context)


### PR DESCRIPTION
Insight has moved to GitHub releases. The `https://downloads.openmicroscopy.org/latest/omero5.5/insight-*` download links are no longer supported so instead this looks up the required download from GitHub by matching the first two components of the version i.e. it looks for the latest tag matching `v{major}.{minor}.[^-]+` (the `[^-]+` _should_ avoid matching prereleases).

This should be failsafe- in the event of a failure the default URL is https://www.openmicroscopy.org/omero/downloads/

# Testing this PR

The download links at the bottom of the login page should download the latest 5.5 insight clients from GitHub. If there's a failure (e.g. you've blocked requests to external resources) it should link to https://www.openmicroscopy.org/omero/downloads/

