### PR TITLE
examples: no remote calls on TablesPrx after close

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -523,7 +523,8 @@ class TablesI(omero.grid.Tables, omero.util.Servant):
             p.makedirs()
 
         storage = self._storage_factory.getOrCreate(file_path, self.read_only)
-        table = TableI(self.ctx, file_obj, factory, storage, uuid=Ice.generateUUID(),
+        table = TableI(self.ctx, file_obj, factory, storage,
+                       uuid=Ice.generateUUID(),
                        call_context=current.ctx)
         self.resources.add(table)
 

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -314,10 +314,6 @@ class TestTables(ITest):
         assert table
         ofile = table.getOriginalFile()
         table.close()
-        for x in range(10):
-            # Give closer some time to complete
-            if not client.getStatefulServices():
-                break
 
         # Add the user to another group
         # and try to load the table

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -314,6 +314,10 @@ class TestTables(ITest):
         assert table
         ofile = table.getOriginalFile()
         table.close()
+        for x in range(10):
+            # Give closer some time to complete
+            if not client.getStatefulServices():
+                break
 
         # Add the user to another group
         # and try to load the table

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -230,9 +230,9 @@ def plate_well_table(itest, well_grid_factory, update_service, conn):
     data2 = StringColumn('TestColumn', '', 64, ["foobar"])
     data = [data1, data2]
     table.addData(data)
+    orig_file = table.getOriginalFile()
     table.close()
 
-    orig_file = table.getOriginalFile()
     fileAnn = FileAnnotationI()
     fileAnn.ns = rstring('openmicroscopy.org/omero/bulk_annotations')
     fileAnn.setFile(OriginalFileI(orig_file.id.val, False))

--- a/examples/Training/python/Tables.py
+++ b/examples/Training/python/Tables.py
@@ -58,12 +58,12 @@ data1 = omero.grid.LongColumn('Uid', 'test Long', ids)
 data2 = omero.grid.StringColumn('MyStringColumn', '', 64, strings)
 data = [data1, data2]
 table.addData(data)
+orig_file = table.getOriginalFile()
 table.close()           # when we are done, close.
 
 
-# Get the table as an original file
-# =================================
-orig_file = table.getOriginalFile()
+# Load the table as an original file
+# ==================================
 orig_file_id = orig_file.id.val
 # ...so you can attach this data to an object e.g. Dataset
 file_ann = omero.model.FileAnnotationI()


### PR DESCRIPTION
As part of https://github.com/ome/omero-blitz/pull/57, table.close()
is now much more definitive. No remote calls will be possible on the
instance once the wrapper has removed the servants server-side.

# Related reading

 * https://github.com/ome/omero-blitz/issues/56
