### PR TITLE
Report OpenSSL version among CLI admin diagnostics.

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1257,6 +1257,7 @@ present, the user will enter a console""")
         version(["icegridnode",  "--version"])
         iga = version(["icegridadmin", "--version"])
         version(["psql",         "--version"])
+        version(["openssl",      "version"])
 
         def get_ports(input):
             router_lines = [line for line in input.split("\n")


### PR DESCRIPTION
# What this PR does

Report the OpenSSL version of the OMERO server.

# Testing this PR

`bin/omero admin diagnostics` reports, say,

```
Commands:   java -version                  1.8.0     (/usr/bin/java)
Commands:   python -V                      2.7.13    (/tmp/omero/bin/python -- 2 others)
Commands:   icegridnode --version          3.6.3     (/usr/bin/icegridnode)
Commands:   icegridadmin --version         3.6.3     (/usr/bin/icegridadmin)
Commands:   psql --version                 9.6.13    (/usr/bin/psql)
Commands:   openssl version                1.1.0     (/usr/bin/openssl)
```
(note that last line).

# Related reading

Plenty of SSL-version-related Community issues.