### PR TITLE
Table close webgateway

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -2805,27 +2805,31 @@ def _table_query(request, fileid, conn=None, **kwargs):
     if not t:
         return dict(error="Table %s not found" % fileid)
 
-    cols = t.getHeaders()
-    rows = t.getNumberOfRows()
+    try:
+        cols = t.getHeaders()
+        rows = t.getNumberOfRows()
 
-    if query == '*':
-        hits = range(rows)
-    else:
-        match = re.match(r'^(\w+)-(\d+)', query)
-        if match:
-            query = '(%s==%s)' % (match.group(1), match.group(2))
-        try:
-            hits = t.getWhereList(query, None, 0, rows, 1)
-        except Exception:
-            return dict(error='Error executing query: %s' % query)
+        if query == '*':
+            hits = range(rows)
+        else:
+            match = re.match(r'^(\w+)-(\d+)', query)
+            if match:
+                query = '(%s==%s)' % (match.group(1), match.group(2))
+            try:
+                hits = t.getWhereList(query, None, 0, rows, 1)
+            except Exception:
+                return dict(error='Error executing query: %s' % query)
 
-    return dict(data=dict(
-        columns=[col.name for col in cols],
-        rows=[[col.values[0] for col in t.read(range(len(cols)), hit,
-                                               hit+1).columns]
-              for hit in hits],
+        return dict(data=dict(
+            columns=[col.name for col in cols],
+            rows=[[col.values[0] for col in t.read(range(len(cols)), hit,
+                                                   hit+1).columns]
+                  for hit in hits],
+            )
         )
-    )
+    finally:
+        t.close()
+
 
 table_query = login_required()(jsonp(_table_query))
 
@@ -2881,8 +2885,8 @@ def object_table_query(request, objtype, objid, conn=None, **kwargs):
             fileId = annotation['file']
             break
     if ann is None:
-        return dict(error='Could not retrieve matching bulk annotation table')
-    tableData = _table_query(request, fileId, conn, **kwargs)
+        return dict(error=tableData.get('error',
+                    'Could not retrieve matching bulk annotation table'))
     tableData['id'] = fileId
     tableData['annId'] = ann['id']
     tableData['owner'] = ann['owner']


### PR DESCRIPTION
# What this PR does

Use a try/finally block to make sure that webgateway calls ```table.close()``` after reading from it.
Also removes a duplicate call which was opening the table twice for each request.

Testing is a bit tricky:
 - Make sure tables data not broken in webclient
 - Sessions shouldn't be kept open (although that was already addressed elsewhere)

cc @joshmoore 