### PR TITLE
Revert "The remaining name search cases are now fixed."

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -264,8 +264,9 @@ class TestSearch(ITest):
                 ("fake", supported),
                 ("%s*" % uuid[:-1], supported),
                 (uuid, supported),
-                ("*.fake", supported),
-                ("%s*.fake" % uuid[:-1], supported)):
+                #
+                ("*.fake", unsupported),
+                ("%s*.fake" % uuid[:-1], unsupported)):
 
             m(x)
 


### PR DESCRIPTION
This reverts commit c6cb222e59d786797fffd47549b9278dfc8e0072. See https://github.com/openmicroscopy/openmicroscopy/pull/6056#issuecomment-504987576 for context.