### PR TITLE
Right panel performance fixes

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -133,7 +133,10 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['eventContext'] = eventContextMarshal(
             conn.getEventContext())
         context['ome']['user'] = conn.getUser
-        context['ome']['user_id'] = conn.getUserId()
+        context['ome']['getUserId'] = conn.getUserId
+        # Current active user_id (who's data are we looking at)
+        context['ome']['user_id'] = request.session.get('user_id',
+                                                        conn.getUserId())
         context['ome']['group_id'] = request.session.get('group_id', None)
         context['ome']['active_group'] = request.session.get(
             'active_group', conn.getEventContext().groupId)

--- a/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/decorators.py
@@ -133,8 +133,7 @@ class render_response(omeroweb.decorators.render_response):
         context['ome']['eventContext'] = eventContextMarshal(
             conn.getEventContext())
         context['ome']['user'] = conn.getUser
-        context['ome']['user_id'] = request.session.get('user_id',
-                                                        conn.getUserId())
+        context['ome']['user_id'] = conn.getUserId()
         context['ome']['group_id'] = request.session.get('group_id', None)
         context['ome']['active_group'] = request.session.get(
             'active_group', conn.getEventContext().groupId)

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
@@ -59,7 +59,7 @@
     </table>
 
     {% if not manager.tag %}
-    <select id="annotationFilter" title="Filter annotations by user" data-userId="{{ ome.user_id }}"
+    <select id="annotationFilter" title="Filter annotations by user" data-userId="{{ ome.getUserId }}"
             style="position:absolute; right:0; bottom:3px; width:80px">
         <option value="all">Show all</option>
         <option value="me">Show added by me</option>

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/annotations/includes/name.html
@@ -59,7 +59,7 @@
     </table>
 
     {% if not manager.tag %}
-    <select id="annotationFilter" title="Filter annotations by user" data-userId="{{ ome.user.id }}"
+    <select id="annotationFilter" title="Filter annotations by user" data-userId="{{ ome.user_id }}"
             style="position:absolute; right:0; bottom:3px; width:80px">
         <option value="all">Show all</option>
         <option value="me">Show added by me</option>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1517,9 +1517,9 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
             'shares': [c_id]}
 
         initial = {
-        'selected': selected, 'images': [],  'datasets': [],
-        'projects': [], 'screens': [], 'plates': [],
-        'acquisitions': [], 'wells': [], 'shares': shares}
+            'selected': selected, 'images': [],  'datasets': [],
+            'projects': [], 'screens': [], 'plates': [],
+            'acquisitions': [], 'wells': [], 'shares': shares}
         template = "webclient/annotations/annotations_share.html"
         manager = BaseShare(conn, c_id)
         manager.getAllUsers(c_id)

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1505,48 +1505,21 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
 
     context = dict()
 
-    # we only expect a single object, but forms can take multiple objects
-    images = (c_type == "image" and
-              list(conn.getObjects("Image", [c_id])) or
-              list())
-    datasets = (c_type == "dataset" and
-                list(conn.getObjects("Dataset", [c_id])) or list())
-    projects = (c_type == "project" and
-                list(conn.getObjects("Project", [c_id])) or list())
-    screens = (c_type == "screen" and
-               list(conn.getObjects("Screen", [c_id])) or
-               list())
-    plates = (c_type == "plate" and
-              list(conn.getObjects("Plate", [c_id])) or list())
-    acquisitions = (c_type == "acquisition" and
-                    list(conn.getObjects("PlateAcquisition", [c_id])) or
-                    list())
-    shares = ((c_type == "share" or c_type == "discussion") and
-              [conn.getShare(c_id)] or list())
-    wells = (c_type == "well" and
-             list(conn.getObjects("Well", [c_id])) or list())
-
-    # we simply set up the annotation form, passing the objects to be
-    # annotated.
-    selected = {
-        'images': c_type == "image" and [c_id] or [],
-        'datasets': c_type == "dataset" and [c_id] or [],
-        'projects': c_type == "project" and [c_id] or [],
-        'screens': c_type == "screen" and [c_id] or [],
-        'plates': c_type == "plate" and [c_id] or [],
-        'acquisitions': c_type == "acquisition" and [c_id] or [],
-        'wells': c_type == "well" and [c_id] or [],
-        'shares': ((c_type == "share" or c_type == "discussion") and [c_id] or
-                   [])}
-
-    initial = {
-        'selected': selected, 'images': images,  'datasets': datasets,
-        'projects': projects, 'screens': screens, 'plates': plates,
-        'acquisitions': acquisitions, 'wells': wells, 'shares': shares}
-
     form_comment = None
     figScripts = None
     if c_type in ("share", "discussion"):
+        shares = [conn.getShare(c_id)]
+        # we simply set up the annotation form, passing the objects to be
+        # annotated.
+        selected = {
+            'images': [], 'datasets': [], 'projects': [], 'screens': [],
+            'plates': [], 'acquisitions': [], 'wells': [],
+            'shares': [c_id]}
+
+        initial = {
+        'selected': selected, 'images': [],  'datasets': [],
+        'projects': [], 'screens': [], 'plates': [],
+        'acquisitions': [], 'wells': [], 'shares': shares}
         template = "webclient/annotations/annotations_share.html"
         manager = BaseShare(conn, c_id)
         manager.getAllUsers(c_id)

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1529,6 +1529,11 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
         try:
             manager = BaseContainer(
                 conn, **{str(c_type): long(c_id), 'index': index})
+            obj = manager._get_object()
+            # Set group - makes any subsequent queries faster
+            if obj is not None:
+                gid = obj.getDetails().group.id.val
+                conn.SERVICE_OPTS.setOmeroGroup(gid)
         except AttributeError, x:
             return handlerInternalError(request, x)
         if share_id is not None:


### PR DESCRIPTION
See https://trello.com/c/vv4mqsAi/5752-omero-omeroweb-on-demo-is-slow
This PR improves the performance of the right-hand metadata panel, particularly for Images and noticeable with large numbers of users in the current group.

Calling ```conn.getObjects()``` or ```conn.getObject()``` with group context ```-1``` is slow with large numbers of users in the group. We *could* use the current group of the webclient (```session['active_group']```) to set the group context, but it could result in 404 if user has e.g webclient open in 2 browser tabs with a different group in each etc.
Instead, this PR reduces the number of times this is called to 1, instead of 3. So it should be 3 x faster.
Also, to avoid the risk of any additional calls to ```getObject()``` being added in the future, we set the group context once we have loaded the Object and know the group.

For example, using ```{{ ome.user.id }}``` in a template was causing ```getObject("Experimenter", id)``` to be called. Setting the context improved the speed of this, although I also replaced this with ```{{ ome.user_id }}``` which removes the call entirely.

To test functionality (not broken):
 - check that the right panel still loads and displays metadata for P/D/I etc (not broken)
 - Try adding comments etc.
 - check that right panel still works for Shares, adding Comment to the Share.

To test performance (learning server with large number of users):
- Log in to the 'learning' test server from https://merge-ci.openmicroscopy.org/web/webclient/login/

I guess if we want to quantify speed improvements, we could time the right panel loading with and without this PR merged?

cc @mtbc, @pwalczysko 