### PR TITLE
Get object set group context if none

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -1580,7 +1580,7 @@ def load_metadata_details(request, c_type, c_id, conn=None, share_id=None,
     return context
 
 
-@login_required()
+@login_required(setGroupContext=True)
 @render_response()
 def load_metadata_preview(request, c_type, c_id, conn=None, share_id=None,
                           **kwargs):

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -131,7 +131,7 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
 
         super(OmeroWebGateway, self).__init__(*args, **kwargs)
         self._shareId = None
-    
+
     def getObject(self, *args, **kwargs):
         """
         We override this to handle cases where the Object is not found

--- a/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/webclient_gateway.py
@@ -144,12 +144,12 @@ class OmeroWebGateway(omero.gateway.BlitzGateway):
         if obj is None:
             self.SERVICE_OPTS.setOmeroGroup('-1')
             obj = super(OmeroWebGateway, self).getObject(*args, **kwargs)
-        if obj is not None:
             # set the group context for subsequent queries
-            group = obj.getDetails().group
-            if group is not None:
-                gid = group.id.val
-                self.SERVICE_OPTS.setOmeroGroup(gid)
+            if obj is not None:
+                group = obj.getDetails().group
+                if group is not None:
+                    gid = group.id.val
+                    self.SERVICE_OPTS.setOmeroGroup(gid)
         return obj
 
     def getShareId(self):

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -71,7 +71,8 @@ import time
 import zipfile
 import shutil
 
-from omeroweb.decorators import login_required, ConnCleaningHttpResponse
+from omeroweb.webclient.decorators import login_required
+from omeroweb.decorators import ConnCleaningHttpResponse
 from omeroweb.connector import Connector
 from omeroweb.webgateway.util import zip_archived_files, LUTS_IN_PNG
 from omeroweb.webgateway.util import get_longs, getIntOrDefault
@@ -1452,7 +1453,7 @@ def render_col_plot(request, iid, z, t, x, w=1, conn=None, **kwargs):
     return rsp
 
 
-@login_required()
+@login_required(setGroupContext=True)
 @jsonp
 def imageData_json(request, conn=None, _internal=False, **kwargs):
     """


### PR DESCRIPTION
This is a proof of concept for improving the loading speed of many OMERO.web pages, based on suggestion from @rgozim at https://trello.com/c/vv4mqsAi/5752-omero-omeroweb-on-demo-is-slow#comment-5bedae4959582c6b524d8d6e

Instead of using group context: ```-1``` by default, we use ```@login_required(setGroupContext=True)``` to improve the performance of ```conn.getObject()``` when we are in a group with many other users.

This could lead to the possibility of 404 errors if you are loading objects in a different group from the main webclient. E.g. open webclient in 2 different browser tabs, switch to a different group in tab-2, then browse the tree in tab-1.
We avoid these 404 errors by overriding the ```conn.getObject()```. If this returns None on the first attempt, we try again with groupContext ```-1```.

If we have loaded an object on the second attempt, we also set ```conn.SERVICE_OPTS.setOmeroGroup(gid)``` so that subsequent queries for objects in the same group and successful first time.

Currently in this PR I have only used ```@login_required(setGroupContext=True)``` on the right-hand Preview panel (and on the ```imgData``` JSON it loads).

To test:
 - The Preview panel should be much faster when viewing images in the current group.
 - Even when viewing images in a different group (using 2 browser tabs as above) it should still be a bit faster since we only have to do one ```group:-1``` query per request.

NB: if this approach looks good, we can add ```@login_required(setGroupContext=True)``` to other methods, testing each carefully. We don't yet handle 404 for ```conn.getObjects()``` (batch loading).

cc @mtbc @chris-allan 