### PR TITLE
Webclient performance fixes

### DIFF
--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -6111,16 +6111,20 @@ class _ExperimenterGroupWrapper (BlitzObjectWrapper):
     def _getQueryString(cls, opts=None):
         """
         Returns string for building queries, loading Experimenters for each
-        group.
+        group by default.
         Returns a tuple of (query, clauses, params).
+        Supported opts: 'load_experimenters': If True, we load experimenters
 
         :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select distinct obj from ExperimenterGroup as obj "
-                 "left outer join fetch obj.groupExperimenterMap as map "
-                 "left outer join fetch map.child e")
+        load_experimenters = True
+        if opts is not None:
+            load_experimenters = opts.get('load_experimenters', True)
+        query = "select distinct obj from ExperimenterGroup as obj"
+        if load_experimenters:
+            query += (" left outer join fetch obj.groupExperimenterMap as map"
+                      " left outer join fetch map.child e")
         return query, [], omero.sys.ParametersI()
 
     def groupSummary(self, exclude_self=False):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -5878,16 +5878,22 @@ class _ExperimenterWrapper (BlitzObjectWrapper):
     def _getQueryString(cls, opts=None):
         """
         Returns string for building queries, loading Experimenters only.
-
         Returns a tuple of (query, clauses, params).
 
+        Supported opts: 'load_experimentergroups': If True, we load groups
+
         :param opts:        Dictionary of optional parameters.
-                            NB: No options supported for this class.
         :return:            Tuple of string, list, ParametersI
         """
-        query = ("select distinct obj from Experimenter as obj "
-                 "left outer join fetch obj.groupExperimenterMap as map "
-                 "left outer join fetch map.parent g")
+        load_groups = True
+        if opts is not None:
+            load_groups = opts.get('load_experimentergroups', True)
+
+        query = "select distinct obj from Experimenter as obj"
+
+        if load_groups:
+            query += (" left outer join fetch obj.groupExperimenterMap"
+                      " as map left outer join fetch map.parent g")
         return query, [], omero.sys.ParametersI()
 
     def getRawPreferences(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2315,9 +2315,11 @@ class _BlitzGateway (object):
         """
         params = omero.sys.ParametersI()
         params.addId(group_id)
-        query = "select gem.child.id from GroupExperimenterMap gem where gem.parent.id = :id"
+        query = ("select gem.child.id from GroupExperimenterMap gem"
+                 " where gem.parent.id = :id")
         # conn.SERVICE_OPTS.setOmeroGroup(active_group)
-        result = self.getQueryService().projection(query, params, self.SERVICE_OPTS)
+        result = self.getQueryService().projection(query, params,
+                                                   self.SERVICE_OPTS)
         return [r[0].val for r in result]
 
     def getUser(self):

--- a/components/tools/OmeroPy/src/omero/gateway/__init__.py
+++ b/components/tools/OmeroPy/src/omero/gateway/__init__.py
@@ -2306,6 +2306,20 @@ class _BlitzGateway (object):
         self._userid = uid
         self._user = None
 
+    def getUserIdsForGroup(self, group_id):
+        """
+        Returns user IDs for specified Group.
+
+        :param group_id:    ID of group to query
+        :return:            List of longs
+        """
+        params = omero.sys.ParametersI()
+        params.addId(group_id)
+        query = "select gem.child.id from GroupExperimenterMap gem where gem.parent.id = :id"
+        # conn.SERVICE_OPTS.setOmeroGroup(active_group)
+        result = self.getQueryService().projection(query, params, self.SERVICE_OPTS)
+        return [r[0].val for r in result]
+
     def getUser(self):
         """
         Returns current Experimenter.

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -410,6 +410,25 @@ class TestGetObject (object):
         for grp in gps:
             assert not grp._obj.groupExperimenterMapLoaded
 
+        # getGroup
+        # load_experimenters: False - Don't load Experimenters
+        group_id = gatewaywrapper.gateway.getEventContext().groupId
+        grp = gatewaywrapper.gateway.getObject(
+            "ExperimenterGroup", group_id,
+            opts={'load_experimenters': False})
+        assert not grp._obj.groupExperimenterMapLoaded
+
+        # load_experimenters ignored if groupContext: -1
+        old_id = gatewaywrapper.gateway.SERVICE_OPTS.getOmeroGroup()
+        gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup('-1')
+        grp = gatewaywrapper.gateway.getObject(
+            "ExperimenterGroup", group_id,
+            opts={'load_experimenters': False})
+        # Experimenters ARE loaded
+        assert grp._obj.groupExperimenterMapLoaded
+        grp.copyGroupExperimenterMap()
+        gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup(old_id)
+
         # uses gateway.getObjects("ExperimenterGroup") - check this doesn't
         # throw
         colleagues = gatewaywrapper.gateway.listColleagues()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -453,8 +453,15 @@ class TestGetObject (object):
 
         findExp = gatewaywrapper.gateway.getObject(
             "Experimenter", attributes={'omeName': gatewaywrapper.USER.name})
+        # get Experimenter without Groups
         exp = gatewaywrapper.gateway.getObject(
-            "Experimenter", findExp.id)  # uses iQuery
+            "Experimenter", findExp.id,
+            opts={'load_experimentergroups': False})
+        assert not exp.groupExperimenterMapLoaded
+        # get Experimenter with Groups (default behaviour)
+        exp = gatewaywrapper.gateway.getObject(
+            "Experimenter", findExp.id)
+        assert exp.groupExperimenterMapLoaded
         assert exp.omeName == findExp.omeName
 
         # check groupExperimenterMap loaded for exp

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -397,16 +397,18 @@ class TestGetObject (object):
         #    assert e.getId() in eIds
 
         # groups
-        # groups = list( gatewaywrapper.gateway.listGroups() )
-        # now removed from blitz gateway.
-        gps = list(gatewaywrapper.gateway.getObjects("ExperimenterGroup"))
+        gps = gatewaywrapper.gateway.getObjects(
+            "ExperimenterGroup", opts={'limit': 10})
         for grp in gps:
+            assert grp._obj.groupExperimenterMapLoaded
             grp.copyGroupExperimenterMap()
-        # self.assertEqual(len(gps), len(groups))  # check unordered lists are
-        # the same length & ids
-        # gIds = [g.getId() for g in gps]
-        # for g in groups:
-        #    assert g.getId() in gIds
+
+        # Load groups 'without' experimenters
+        gps = gatewaywrapper.gateway.getObjects(
+            "ExperimenterGroup",
+            opts={'load_experimenters': False, 'limit': 10})
+        for grp in gps:
+            assert not grp._obj.groupExperimenterMapLoaded
 
         # uses gateway.getObjects("ExperimenterGroup") - check this doesn't
         # throw

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/group_user_dropdown2.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/base/includes/group_user_dropdown2.html
@@ -21,7 +21,6 @@
 {% endcomment %}
 
 
-{% if groups %}
 <script>
     $(document).ready(function(){
 
@@ -98,4 +97,3 @@
         <div id="listViewPort" class="dropdown"></div>
     </li>
 </ul>
-{% endif %}

--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/search/search.html
@@ -374,7 +374,7 @@
             </select>
 
             <!-- for each group we can choose users - only show <select> for 1 group at a time -->
-            {% for grp in groups %}
+            {% for grp in myGroups %}
             <select name="ownedBy" id="searchByGroupMember-{{ grp.id }}">
                 <option value="-1">All Members</option>
                 {% for user in grp.leaders %}}

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -443,16 +443,15 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
 
     request.session['user_id'] = user_id
 
-    myGroups = list(conn.getGroupsMemberOf())
-    myGroups.sort(key=lambda x: x.getName().lower())
-    groups = myGroups
-
     new_container_form = ContainerForm()
 
     # colleagues required for search.html page only.
     myColleagues = {}
+    myGroups = {}
     if menu == "search":
-        for g in groups:
+        myGroups = list(conn.getGroupsMemberOf())
+        myGroups.sort(key=lambda x: x.getName().lower())
+        for g in myGroups:
             g.loadLeadersAndMembers()
             for c in g.leaders + g.colleagues:
                 myColleagues[c.id] = c
@@ -465,7 +464,6 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
         'myGroups': myGroups,
         'new_container_form': new_container_form,
         'global_search_form': global_search_form}
-    context['groups'] = groups
     context['myColleagues'] = myColleagues
     context['active_group'] = conn.getObject(
         "ExperimenterGroup", long(active_group))

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -445,6 +445,11 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
 
     new_container_form = ContainerForm()
 
+    # Set group, otherwise 'load_experimenters':False is ingored
+    conn.SERVICE_OPTS.setOmeroGroup(active_group)
+    group = conn.getObject("ExperimenterGroup", long(active_group),
+                           opts={'load_experimenters': False})
+
     # colleagues required for search.html page only.
     myColleagues = {}
     myGroups = {}
@@ -465,8 +470,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
         'new_container_form': new_container_form,
         'global_search_form': global_search_form}
     context['myColleagues'] = myColleagues
-    context['active_group'] = conn.getObject(
-        "ExperimenterGroup", long(active_group), opts={'load_experimenters': False})
+    context['active_group'] = group
     context['active_user'] = conn.getObject("Experimenter", long(user_id))
     context['initially_select'] = show.initially_select
     context['initially_open'] = show.initially_open

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -450,6 +450,9 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
     group = conn.getObject("ExperimenterGroup", long(active_group),
                            opts={'load_experimenters': False})
 
+    user = conn.getObject("Experimenter", long(user_id),
+                          opts={'load_experimentergroups': False})
+
     # colleagues required for search.html page only.
     myColleagues = {}
     myGroups = {}
@@ -471,7 +474,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
         'global_search_form': global_search_form}
     context['myColleagues'] = myColleagues
     context['active_group'] = group
-    context['active_user'] = conn.getObject("Experimenter", long(user_id))
+    context['active_user'] = user
     context['initially_select'] = show.initially_select
     context['initially_open'] = show.initially_open
     context['isLeader'] = conn.isLeader()

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -466,7 +466,7 @@ def _load_template(request, menu, conn=None, url=None, **kwargs):
         'global_search_form': global_search_form}
     context['myColleagues'] = myColleagues
     context['active_group'] = conn.getObject(
-        "ExperimenterGroup", long(active_group))
+        "ExperimenterGroup", long(active_group), opts={'load_experimenters': False})
     context['active_user'] = conn.getObject("Experimenter", long(user_id))
     context['initially_select'] = show.initially_select
     context['initially_open'] = show.initially_open


### PR DESCRIPTION
Performance improvements for loading the webclient home page.

E.g. see https://trello.com/c/vv4mqsAi/5752-omero-omeroweb-on-demo-is-slow#comment-5bec2f993576763746ab1f21

We now load only the Groups and Experimenters needed for the page.
In particular, we don't load all the Experimenters in the current group (unless needed when loading the search page).

Added parameters for ```conn.getObject('ExperimenterGroup', id, opts={'load_experimenters':False})``` to avoid loading experimenters (and the same for ```getObject('Experimenter')```.

To test:
 - Groups and Experimenter functionality of webclient main page should not be broken.
     - Switch User - webclient displays their data as expected
     - Switch to All Members.
     - Switch Group etc.
     - webclient/?show=image-123 should work when image is not in current user/group
 - Should be much faster in Groups with large numbers of Experimenters.
 - Search page should still show Groups and Experimenters in form choosers.
 - Tests should be passing.

To test performance on a server with a large number of users, connect to the 'learning' server from https://merge-ci.openmicroscopy.org/web/webclient/login/ 