### PR TITLE
tables: call delete callback

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -317,16 +317,16 @@ class TableI(omero.grid.Table, omero.util.SimpleServant):
             raise
 
         try:
-            callback.loop(20, 500)
-        except LockTimeout:
+            try:
+                callback.loop(20, 500)
+            except LockTimeout:
+                raise omero.InternalException(None, None, "delete timed-out")
+
+            rsp = callback.getResponse()
+            if isinstance(rsp, omero.cmd.ERR):
+                raise omero.InternalException(None, None, str(rsp))
+        finally:
             callback.close(True)
-            raise omero.InternalException(None, None, "delete timed-out")
-
-        rsp = callback.getResponse()
-        if isinstance(rsp, omero.cmd.ERR):
-            raise omero.InternalException(None, None, str(rsp))
-
-        self.file_obj = None
 
     # TABLES METADATA API ===========================
 


### PR DESCRIPTION
In testing the table closing logic for 5.5.1, I set up a tight loop to create, delete, and close a table. At 10000 servants it failed because the callbacks were not being cleaned up. This adds a try/finally block in order to do so. Two things to note:

 1. Making use of `client.submit()` is not possible since we only have a `ServiceFactoryPrx`
 2. I don't believe the nulling of the `file_obj` was appropriate since that's part of the close logic