### PR TITLE
web: omero.web.http_response_headers to set custom headers

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/middleware/__init__.py
+++ b/components/tools/OmeroWeb/omeroweb/middleware/__init__.py
@@ -1,0 +1,5 @@
+from customheaders import CustomHeadersMiddleware
+
+__all__ = [
+    'CustomHeadersMiddleware',
+]

--- a/components/tools/OmeroWeb/omeroweb/middleware/customheaders.py
+++ b/components/tools/OmeroWeb/omeroweb/middleware/customheaders.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+# All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# https://docs.djangoproject.com/en/1.8/ref/middleware/
+
+from django.conf import settings
+
+
+class CustomHeadersMiddleware(object):
+    """
+    Django middleware to add custom headers to a response.
+
+    Headers will only be set if not already present in the response.
+    """
+    def process_response(self, request, response):
+        for header in settings.HTTP_RESPONSE_HEADERS:
+            k, v = header
+            if not response.has_header(k):
+                response[k] = v
+        return response

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -387,10 +387,12 @@ CUSTOM_SETTINGS_MAPPINGS = {
           '{"index": 3, '
           '"class": "django.contrib.sessions.middleware.SessionMiddleware"},'
           '{"index": 4, '
-          '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
+          '"class": "omeroweb.middleware.CustomHeadersMiddleware"},'
           '{"index": 5, '
-          '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
+          '"class": "django.middleware.csrf.CsrfViewMiddleware"},'
           '{"index": 6, '
+          '"class": "django.contrib.messages.middleware.MessageMiddleware"},'
+          '{"index": 7, '
           '"class": "django.middleware.clickjacking.XFrameOptionsMiddleware"}'
           ']'),
          json.loads,
@@ -855,6 +857,14 @@ CUSTOM_SETTINGS_MAPPINGS = {
          str,
          "Whether to allow OMERO.web to be loaded in a frame."
          ],
+
+    "omero.web.http_response_headers":
+        ["HTTP_RESPONSE_HEADERS",
+         "[]",
+         json.loads,
+         ("List of pairs of additional HTTP response headers e.g."
+          "[[\"X-Header-Name\", \"Value\"]]. A header will only be added if it"
+          "hasn't already been set by the application.")],
 
     "omero.web.django_additional_settings":
         ["DJANGO_ADDITIONAL_SETTINGS",


### PR DESCRIPTION
Add property to set custom headers in Django OMERO.web response

# What this PR does

This allows custom headers to be added to the HTTP response sent to the client by OMERO.web.
These header(s) will only be added if they're not already present in the response.

# Testing this PR

Set one or more custom headers, e.g.

```
omero config append omero.web.http_response_headers '["X-custom-header", "my value"]'
omero web start
```
Check the headers sent by OMERO.web, e.g. `curl -I localhost:4080`. You should see the custom headers you configured.