### PR TITLE
For omero.web.open_with's supported_objects use "images".

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -609,7 +609,7 @@ CUSTOM_SETTINGS_MAPPINGS = {
     # OPEN WITH
     "omero.web.open_with":
         ["OPEN_WITH",
-         ('[["Image viewer", "webgateway", {"supported_objects": ["image"],'
+         ('[["Image viewer", "webgateway", {"supported_objects": ["images"],'
           '"script_url": "webclient/javascript/ome.openwith_viewer.js"}]]'),
          json.loads,
          ("A list of viewers that can be used to display selected Images "


### PR DESCRIPTION
https://docs.openmicroscopy.org/omero/5.5.1/sysadmins/config.html#omero-web-open-with should maybe have a default of,
```
[[“Image viewer”,
  “webgateway”,
  {“supported_objects”: [“images”],
   ”script_url”: “webclient/javascript/ome.openwith_viewer.js”
}]]
```
or maybe the documentation is wrong?