### PR TITLE
Alternative JSON configuration system for OMERO.web

### DIFF
--- a/components/tools/OmeroPy/src/omero/config.py
+++ b/components/tools/OmeroPy/src/omero/config.py
@@ -453,22 +453,47 @@ def load_json_config_dir(configdir):
     files = (f for f in os.listdir(configdir) if
              not f.startswith('.') and
              os.path.splitext(f)[1].lower() in ('.json', '.yaml', '.yml'))
-    config = load_json_configs(os.path.join(configdir, f) for f in sorted(files))
-    return config
+    cset, cappend = load_json_configs(
+        os.path.join(configdir, f) for f in sorted(files))
+    return cset, cappend
 
 
 def load_json_configs(configfiles):
     """
-    Load a set of configuration files in the given order. Each file is a single
-    set of key-value pairs which will be merged as follows:
+    Load a set of configuration files in the given order, and return two
+    dictionaries:
+    - values to be set
+    - values to be appended
+
+    The caller should combine these two dictionaries appropriately.
+    Typically properties to be `set` will be processed first to allow existing
+    defaults to be unset if necessary, followed by processing of properties to
+    `append`.
+
+    Each file is a single JSON or YAML dictionary (set of key-value pairs).
+    A special key `_mode` can take the value `"set"` (default) or `"append"`
+    which determines whether the properties will be added to the `set` or
+    `append` config dictionary.
+
+    In `set` mode duplicate properties will overwrite existing ones, this is
+    equivalent to `omero config set` with the following rules:
     - a null value will unset the configuration key
-    - an empty list [] or dictionary {} will set the property to [] or {}
-    - a non-empty list will be appended to the existing property if set
-    - a non-empty dictionary will be merged non-recursively to the existing
-      property if set
-    - if none of the above are true the property will be set to the new value
+    - otherwise the configuration key will be set to the value
+
+    In `append` mode the value of each field must be a list or dictionary, it
+    is not possible to append a scalar.
+    - If the value is a list all values in the list will be appended to the
+      current property value
+    - If the value is a dictionary it will be merged non-recursively to the
+    all values in the list will be appended to the
+      current property value
+
+    :param configfiles [str]: List of JSON or YAML (if module is available)
+    filepaths to load
+    :return (dict, dict): Tuple of config-set and config-append properties
     """
-    config = {}
+    cset = {}
+    cappend = {}
 
     for f in configfiles:
         with open(f) as fh:
@@ -481,24 +506,48 @@ def load_json_configs(configfiles):
                 else:
                     d = json.load(fh)
             except Exception as e:
-                raise Exception('Failed to load file {}'.format(f))
+                raise Exception('Failed to load file {}: {}'.format(f, e))
+            mode = d.pop('_mode', 'set')
             for k, v in d.items():
-                if v is None:
-                    config.pop(k, None)
-                elif k not in config or v == [] or v == {}:
-                    config[k] = v
-                elif isinstance(v, list):
-                    if not isinstance(config[k], list):
-                        raise Exception(
-                            'Incompatible types for key {}: {} {}'.format(
-                                k, config[k], v))
-                    config[k].extend(v)
-                elif isinstance(v, dict):
-                    if not isinstance(config[k], dict):
-                        raise Exception(
-                            'Incompatible types for key {}: {} {}'.format(
-                                k, config[k], v))
-                    config[k].update(v)
+                if mode == 'set':
+                    _json_config_set(cset, k, v)
+                elif mode == 'append':
+                    _json_config_append(cappend, k, v)
                 else:
-                    config[k] = v
-    return config
+                    raise Exception(
+                        'Invalid configuration mode: {}'.format(mode))
+
+    return cset, cappend
+
+
+def _json_config_set(config, k, v):
+    if v is None:
+        config.pop(k, None)
+    else:
+        config[k] = v
+
+
+def _json_config_append(config, k, v):
+    if isinstance(v, list):
+        if k not in config:
+            config[k] = v
+        else:
+            try:
+                config[k].extend(v)
+            except AttributeError:
+                raise Exception(
+                    'Incompatible types for append key {}: {} {}'.format(
+                        k, config[k], v))
+    elif isinstance(v, dict):
+        if k not in config:
+            config[k] = v
+        else:
+            try:
+                config[k].update(v)
+            except AttributeError:
+                raise Exception(
+                    'Incompatible types for append key {}: {} {}'.format(
+                        k, config[k], v))
+    else:
+        raise Exception(
+            'Append requires a list or dictionary value: {}: {}'.format(k, v))

--- a/components/tools/OmeroWeb/omeroweb/api/api_settings.py
+++ b/components/tools/OmeroWeb/omeroweb/api/api_settings.py
@@ -20,8 +20,12 @@
 """Settings for the OMERO JSON api app."""
 
 import sys
-from omeroweb.settings import process_custom_settings, report_settings, \
-    str_slash
+from omeroweb.settings import (
+    int_plain,
+    process_custom_settings,
+    report_settings,
+    str_slash,
+)
 
 # load settings
 API_SETTINGS_MAPPING = {
@@ -29,12 +33,12 @@ API_SETTINGS_MAPPING = {
     "omero.web.api.limit":
         ["API_LIMIT",
          200,
-         int,
+         int_plain,
          "Default number of items returned from json api."],
     "omero.web.api.max_limit":
         ["API_MAX_LIMIT",
          500,
-         int,
+         int_plain,
          "Maximum number of items returned from json api."],
     "omero.web.api.absolute_url":
         ["API_ABSOLUTE_URL",

--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -710,13 +710,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
     "omero.web.top_logo":
         ["TOP_LOGO",
          "",
-         str,
+         str_plain,
          ("Customize the webclient top bar logo. The recommended image height "
           "is 23 pixels and it must be hosted outside of OMERO.web.")],
     "omero.web.top_logo_link":
         ["TOP_LOGO_LINK",
          "",
-         str,
+         str_plain,
          ("The target location of the webclient top logo, default unlinked.")],
 
     "omero.web.user_dropdown":


### PR DESCRIPTION
# What this PR does

This is an experimental implementation of an alternative config system discussed in https://github.com/openmicroscopy/openmicroscopy/pull/6053#issuecomment-502637833

The configuration format is described in the doc-string of `omero.config.load_json_configs`: https://github.com/openmicroscopy/openmicroscopy/compare/develop...manics:web-json-config?expand=1#diff-5deedb87cde10b4e5f8a28d83b49559aR461
This is in OmeroPy not OmeroWeb since we might want to use this elsewhere in future.

To enable the new config system, set the environment variable `OMERO_WEB_CONFIG_DIR` to the directory containing your `*.json` config files. Currently these are merged with the existing `config.xml` properties though this could be easily changed. JSON properties override config.xml ones. `.yaml`/`.yml` config files can also be used if PyYAML is installed.

The major change in `omeroweb.settings.py` is the handling the difference between JSON properties which are a typed scalars or objects, and config.xml which is always a string which is converted by OMERO.web where necessary. This means the conversion functions used by OMERO.web to convert the config.xml string value to the type required by OMERO.web have to be aware of the source.

This should be backwards compatible so existing config.xml properties will be converted as expected, and furthermore external web-apps that use mapping functions should continue to work if their properties are set using config.xml. It is not possible to use the new JSON config system in apps that haven't been updated.

# Testing this PR

```
$ cat webconfig/logging.json
{
    "omero.web.django_additional_settings": [
        [
            "LOGGING",
            {
                "handlers": {
                    "console": {
                        "formatter": "standard",
                        "class": "logging.StreamHandler",
                        "level": "INFO"
                    }
                },
                "loggers": {
                    "": {
                        "level": "DEBUG",
                        "propagate": true,
                        "handlers": [
                            "console"
                        ]
                    }
                },
                "version": 1,
                "disable_existing_loggers": false,
                "formatters": {
                    "standard": {
                        "format": "%(asctime)s %(levelname)5.5s [%(name)40.40s] (proc.%(process)5.5d) %(funcName)s():%(lineno)d %(message)s"
                    }
                }
            }
        ]
    ]
}

$ cat webconfig/tmp-append.json
{
  "_mode": "append",
  "omero.web.middleware": [
    {
      "index": 0,
      "class": "whitenoise.middleware.WhiteNoiseMiddleware"
    }
  ],
  "omero.web.server_list": [
    [
      "idr.openmicroscopy.org",
      4064,
      "idr"
    ],
    [
      "example1.openmicroscopy.org",
      4064,
      "example1"
    ],
    [
      "example2.openmicroscopy.org",
      4064,
      "example2"
    ]
  ]
}

$ cat webconfig/tmp-set.json
{
  "omero.web.api.limit": 100,
  "Xomero.web.api.max_limit": 100,
  "omero.web.debug": false
}
```
```
omero config set omero.web.... # If you want to test merging of properties

export OMERO_WEB_CONFIG_DIR=/path/to/webconfig
omero web start --foreground
```