### PR TITLE
Build Travis CI with OpenJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+---
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ sudo: required
 cache:
   directories:
   - $HOME/.m2
-  - download
 
-matrix:
-      fast_finish: true
+services:
+  - docker
 
 addons:
   apt_packages:


### PR DESCRIPTION
See https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/7,
https://travis-ci.community/t/solved-oraclejdk8-installation-failing-still-again/3428
and related threads about the persistent issues about building Travis CI with
OracleJDK8.
