### PR TITLE
PG BUG #15865 - only use single clause `alter table` statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ sudo: required
 cache:
   directories:
   - $HOME/.m2
-  - download
 
-matrix:
-      fast_finish: true
+services:
+  - docker
 
 addons:
   apt_packages:

--- a/sql/psql/OMERO5.4__0/psql-footer.sql
+++ b/sql/psql/OMERO5.4__0/psql-footer.sql
@@ -2951,20 +2951,17 @@ ALTER TABLE laser
 ALTER TABLE lightsettings
     ALTER COLUMN wavelength TYPE positive_float;
 
-ALTER TABLE logicalchannel
-    ALTER COLUMN emissionwave TYPE positive_float,
-    ALTER COLUMN excitationwave TYPE positive_float;
+ALTER TABLE logicalchannel ALTER COLUMN emissionwave TYPE positive_float;
+ALTER TABLE logicalchannel ALTER COLUMN excitationwave TYPE positive_float;
 
-ALTER TABLE pixels
-    ALTER COLUMN physicalsizex TYPE positive_float,
-    ALTER COLUMN physicalsizey TYPE positive_float,
-    ALTER COLUMN physicalsizez TYPE positive_float;
+ALTER TABLE pixels ALTER COLUMN physicalsizex TYPE positive_float;
+ALTER TABLE pixels ALTER COLUMN physicalsizey TYPE positive_float;
+ALTER TABLE pixels ALTER COLUMN physicalsizez TYPE positive_float;
 
-ALTER TABLE transmittancerange
-    ALTER COLUMN cutin TYPE positive_float,
-    ALTER COLUMN cutintolerance TYPE nonnegative_float,
-    ALTER COLUMN cutout TYPE positive_float,
-    ALTER COLUMN cutouttolerance TYPE nonnegative_float;
+ALTER TABLE transmittancerange ALTER COLUMN cutin TYPE positive_float;
+ALTER TABLE transmittancerange ALTER COLUMN cutintolerance TYPE nonnegative_float;
+ALTER TABLE transmittancerange ALTER COLUMN cutout TYPE positive_float;
+ALTER TABLE transmittancerange ALTER COLUMN cutouttolerance TYPE nonnegative_float;
 
 -- image.series should never be null
 


### PR DESCRIPTION
A bug in Postgres 9.6.14 leads to an error on the alter table clause
for logical channel since a single statement tries to alter multiple
columns. While waiting on 9.6.15, replace those statements by multiple,
single-column alterations.

see: https://github.com/ome/omero-install/issues/212