### PR TITLE
admin diagnostics: show BF (and optionally other) jar versions

### DIFF
--- a/components/tools/OmeroPy/src/omero/cli.py
+++ b/components/tools/OmeroPy/src/omero/cli.py
@@ -1042,6 +1042,7 @@ class DiagnosticsControl(BaseControl):
         diagnostics.add_argument(
             "--no-logs", action="store_true",
             help="Skip log parsing")
+        return diagnostics
 
     def _diagnostics_banner(self, control_name):
 

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1511,6 +1511,7 @@ present, the user will enter a console""")
             'Implementation-Title',
             'Implementation-Version',
             'Implementation-Date',
+            'Implementation-Build',
         )
         self.ctx.out("")
         for jar in jars:

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -103,7 +103,10 @@ class AdminControl(DiagnosticsControl,
 
     def _configure(self, parser):
         sub = parser.sub()
-        self._add_diagnostics(parser, sub)
+        parser = self._add_diagnostics(parser, sub)
+        parser.add_argument(
+            "--all-jars", action="store_true",
+            help="Show information for all jars")
         self.add_error(
             "NOT_WINDOWS", 123,
             "Not Windows")
@@ -1491,14 +1494,22 @@ present, the user will enter a console""")
             return manifest, error
 
         # Bio-Format versions
-        jars = (
-            'lib/client/formats-api.jar',
-            'lib/client/formats-bsd.jar',
-            'lib/client/formats-gpl.jar',
-            'lib/server/formats-api.jar',
-            'lib/server/formats-bsd.jar',
-            'lib/server/formats-gpl.jar',
-        )
+        if args.all_jars:
+            jars = sorted(
+                os.path.join(os.path.relpath(root, self.ctx.dir), filename)
+                for root, dirnames, filenames in os.walk(self.ctx.dir)
+                for filename in filenames
+                if filename.endswith('.jar')
+            )
+        else:
+            jars = (
+                'lib/client/formats-api.jar',
+                'lib/client/formats-bsd.jar',
+                'lib/client/formats-gpl.jar',
+                'lib/server/formats-api.jar',
+                'lib/server/formats-bsd.jar',
+                'lib/server/formats-gpl.jar',
+            )
         manifest_keys = (
             'Implementation-Title',
             'Implementation-Version',

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1503,9 +1503,6 @@ present, the user will enter a console""")
             )
         else:
             jars = (
-                'lib/client/formats-api.jar',
-                'lib/client/formats-bsd.jar',
-                'lib/client/formats-gpl.jar',
                 'lib/server/formats-api.jar',
                 'lib/server/formats-bsd.jar',
                 'lib/server/formats-gpl.jar',


### PR DESCRIPTION
# What this PR does

Displays some jar manifest information for the Bio-Formats jars.

https://github.com/IDR/deployment/pull/168 replaces the bundled BF jars with a custom version. Since development versions may be used it'd be useful to check the versions if problems occur.

# Testing this PR

```
$ bin/omero admin diagnostics

...

Jar:        lib/client/formats-api.jar     Bio-Formats API      6.1.1   7 June 2019
Jar:        lib/client/formats-bsd.jar     BSD Bio-Formats readers and writers 6.1.1    7 June 2019
Jar:        lib/client/formats-gpl.jar     Bio-Formats library  6.1.1   7 June 2019
Jar:        lib/server/formats-api.jar     Bio-Formats API      6.1.1   7 June 2019
Jar:        lib/server/formats-bsd.jar     BSD Bio-Formats readers and writers 6.1.1    7 June 2019
Jar:        lib/server/formats-gpl.jar     Bio-Formats library  6.1.1   7 June 2019
```

```
$ bin/omero admin diagnostics --all-jars
```
Recursively find and show info for all `*.jar`