### PR TITLE
omero.web.override_root_app to set custom web root app

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/settings.py
+++ b/components/tools/OmeroWeb/omeroweb/settings.py
@@ -755,6 +755,13 @@ CUSTOM_SETTINGS_MAPPINGS = {
          json.loads,
          ("Add additional Django applications. For example, see"
           " :doc:`/developers/Web/CreateApp`")],
+    "omero.web.override_root_app":
+        ["OVERRIDE_ROOT_APP",
+         '',
+         str,
+         ("Use this as the root application instead of rediredcting to the "
+          "default webclient")],
+
     "omero.web.databases":
         ["DATABASES", '{}', json.loads, None],
     "omero.web.page_size":

--- a/components/tools/OmeroWeb/omeroweb/urls.py
+++ b/components/tools/OmeroWeb/omeroweb/urls.py
@@ -85,7 +85,10 @@ for app in settings.ADDITIONAL_APPS:
     except ImportError:
         pass
     else:
-        regex = '^(?i)%s/' % label
+        if settings.OVERRIDE_ROOT_APP and label == settings.OVERRIDE_ROOT_APP:
+            regex = r'^'
+        else:
+            regex = '^(?i)%s/' % label
         urlpatterns += patterns('', (regex, include(urlmodule)),)
 
 urlpatterns += patterns(


### PR DESCRIPTION
# What this PR does

Configurable version of https://github.com/ome/openmicroscopy/pull/6046 as used in the IDR https://github.com/manics/deployment/commit/22f5c3e2f548e9a65c9abdb024272295a786b030

# Testing this PR
Setup OMERO.web with a public user. Then:
```
pip install omero-gallery
omero config set omero.web.apps '["omero_gallery"]'
omero config set omero.web.override_root_app gallery
omero web start
```
Go to OMERO.web, you should see gallery at the root (`/`) of the site.

Note this only works with add-on apps, you can't use an included app such as `webadmin`