### PR TITLE
Script gui file upload

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/include_param.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/include_param.html
@@ -90,6 +90,12 @@
 
 {% if i.min %}<span style="color: #666"> Min: {{ i.min }} </span>{% endif %}
 {% if i.max %}<span style="color: #666"> Max: {{ i.max }} </span>{% endif %}
+
+<!-- If "File Annotation", allow user to choose file to upload, to create a File-Annotation -->
+{% ifequal i.name 'File Annotation' %}
+    OR <input name='file_annotation' type='file'/>
+{% endifequal %}
+
 </td></tr>
 </table>
 </div>

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -4247,10 +4247,13 @@ def script_run(request, scriptId, conn=None, **kwargs):
     if fileupload is not None and fileupload != "":
         manager = BaseContainer(conn)
         fileAnnId = manager.createFileAnnotations(fileupload, [])
-
     for key, param in params.inputs.items():
         prototype = param.prototype
         pclass = prototype.__class__
+
+        if key == "File_Annotation" and fileAnnId is not None:
+            inputMap[key] = pclass(str(fileAnnId))
+            continue
 
         # handle bool separately, since unchecked checkbox will not be in
         # request.POST
@@ -4325,8 +4328,6 @@ def script_run(request, scriptId, conn=None, **kwargs):
                 except:
                     logger.debug("Invalid entry for '%s' : %s" % (key, value))
                     continue
-        if key == "File_Annotation" and fileAnnId is not None:
-            inputMap[key] = pclass(fileAnnId)
 
     # If we have objects specified via 'IDs' and 'DataType', try to pick
     # correct group

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -4240,6 +4240,14 @@ def script_run(request, scriptId, conn=None, **kwargs):
 
     logger.debug("Script: run with request.POST: %s" % request.POST)
 
+     # upload new file
+    fileupload = ('file_annotation' in request.FILES and
+                    request.FILES['file_annotation'] or None)
+    fileAnnId = None
+    if fileupload is not None and fileupload != "":
+        manager = BaseContainer(conn)
+        fileAnnId = manager.createFileAnnotations(fileupload, [])
+
     for key, param in params.inputs.items():
         prototype = param.prototype
         pclass = prototype.__class__
@@ -4317,6 +4325,8 @@ def script_run(request, scriptId, conn=None, **kwargs):
                 except:
                     logger.debug("Invalid entry for '%s' : %s" % (key, value))
                     continue
+        if key == "File_Annotation" and fileAnnId is not None:
+            inputMap[key] = pclass(fileAnnId)
 
     # If we have objects specified via 'IDs' and 'DataType', try to pick
     # correct group

--- a/components/tools/OmeroWeb/omeroweb/webclient/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webclient/views.py
@@ -4240,9 +4240,9 @@ def script_run(request, scriptId, conn=None, **kwargs):
 
     logger.debug("Script: run with request.POST: %s" % request.POST)
 
-     # upload new file
+    # upload new file
     fileupload = ('file_annotation' in request.FILES and
-                    request.FILES['file_annotation'] or None)
+                  request.FILES['file_annotation'] or None)
     fileAnnId = None
     if fileupload is not None and fileupload != "":
         manager = BaseContainer(conn)


### PR DESCRIPTION
See https://github.com/ome/openmicroscopy/issues/6095

Currently, some scripts that require a File use the convention of a parameter named ```File_Annotation``` to allow the user to choose a previously created ```FileAnnotation ID```.

This PR adds a File chooser input to parameter named ```File_Annotation``` which allows users to pick a local file from the Run-Script dialog in webclient. This will be used to create a File Annotation in OMERO and the ID will be passed to the ```File_Annotation``` script parameter.

To test:
 - Choose a script that has a ```File_Annotation``` parameter, such as "Populate Metadata" (https://github.com/ome/scripts/blob/develop/omero/import_scripts/Populate_Metadata.py)
 - The script dialog will allow you to choose a file:

<img width="550" alt="Screen Shot 2019-08-02 at 23 53 57" src="https://user-images.githubusercontent.com/900055/62402699-dd9ce880-b580-11e9-8830-0840fdeb29eb.png">

 - This will allow you to pick a local File to upload
 - When the script is run, a new ```FileAnnotation``` is created in OMERO (not linked to anything) and the ID is passed to the ```File_Annotation``` script parameter (so the script should work as expected)