### PR TITLE
Allow OMERO.py to connect to OMERO websockets with chained SSL certs

### DIFF
--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -223,7 +223,7 @@ class BaseClient(object):
             # OPENSSL_VERSION_INFO not available for 2.6, fall back to default
             self._optSetProp(id, prop, "HIGH:ADH")
 
-        self._optSetProp(id, "IceSSL.VerifyDepthMax", "0")
+        self._optSetProp(id, "IceSSL.VerifyDepthMax", "6")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")
 

--- a/components/tools/OmeroPy/src/omero/clients.py
+++ b/components/tools/OmeroPy/src/omero/clients.py
@@ -223,6 +223,7 @@ class BaseClient(object):
             # OPENSSL_VERSION_INFO not available for 2.6, fall back to default
             self._optSetProp(id, prop, "HIGH:ADH")
 
+        self._optSetProp(id, "IceSSL.VerifyDepthMax", "0")
         self._optSetProp(id, "IceSSL.VerifyPeer", "0")
         self._optSetProp(id, "IceSSL.Protocols", "tls1")
 


### PR DESCRIPTION
Ice defaults to only checking up to 3 certificates in a chain:
https://doc.zeroc.com/ice/3.6/property-reference/icessl#id-.IceSSL.*v3.6-IceSSL.VerifyDepthMax

Accessing an OMERO websocket behind the openmicroscopy wildcard cert fails on Linux (OS X works) unless this is increased. This PR sets it to ~unlimited~ 6.

# Testing this PR

`omero login -s wss://example.openmicroscopy.org/omero-ws` where example.openmicroscopy.org is running Nginx with the OME wildcard cert and proxies `/omero-ws` to a backend OMERO.server websocket

Without this PR it will fail:
```
InternalException: Failed to connect: exception ::Ice::SecurityException
{
    reason = outgoing connection rejected:
length of peer's certificate chain (4) exceeds maximum of 3
}
```

For example, IDR test70 has websockets enabled.