### PR TITLE
Use chosen plugin for script UI if large number of options

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/script_ui.html
+++ b/components/tools/OmeroWeb/omeroweb/webclient/templates/webclient/scripts/script_ui.html
@@ -35,6 +35,8 @@
 
 {% block link %}
 
+    <link rel="stylesheet" href="{% static "3rdparty/jquery.chosen-1.2.0/chosen.css" %}" type="text/css" media="screen"/>
+
     <style type="text/css">
         h3 {
             margin: 0px;
@@ -94,6 +96,7 @@
     {% include "webgateway/base/includes/script_src_popup.html" %}
     {% include "webgateway/base/includes/jquery-ui.html" %}
     <script type="text/javascript" src="{% static "webclient/javascript/jquery.form-3.51.js" %}"></script>
+    <script type="text/javascript" src="{% static "3rdparty/jquery.chosen-1.2.0/chosen.jquery.js" %}"></script>
     <script type="text/javascript">
 
         $(document).ready(function() {
@@ -176,6 +179,17 @@
 
             // For 'number' fields, only allow numbers input.
             $(".number").numbersOnly();
+
+            // Only use the chosen plugin if we have > 20 options
+            $("select").each(function() {
+                var limit = 2;      // UPDATE this after testing
+                var $this = $(this);
+                if ($('option', $this).length > limit) {
+                    $this.chosen({
+                        width: '300px'
+                    });
+                }
+            });
 
             // Focus first input
             $('input:visible, select:visible').first().focus();


### PR DESCRIPTION
# What this PR does

See https://forum.image.sc/t/file-browser-in-omero-script-gui/28117/16

If we have many options in a script UI field with ```defaults``` set then it becomes tricky to use.
This PR uses the chosen plugin (which we use elsewhere) to allow users to type to filter the list of options. We only use this if the number of options is large (propose to use limit of 20).

NB: The limit is currently set to 2 to allow testing (since we don't have any scripts with > 20 inputs
After testing, this can be set to e.g. 20?

To test:
 - Choose a script with a bunch of parameters with default options, e.g Batch_Image_Export.py
 - Currently, any parameters with > 2 options will use the chosen plugin, allowing you to type to select from the list
 - Others (e.g. Data_Type) will still use the regular select
