### PR TITLE
scripts: fix unpacking of download

### DIFF
--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -89,7 +89,7 @@ build_year = "${python_build_year}"
         <delete dir="../target/downloads/py/omero-py-${versions.omero-py}"/>
 
 
-        <download pkg="scripts" file="$v{versions.scripts}.tar.gz" expected="${versions.scripts-md5}"
+        <download pkg="scripts" file="v${versions.scripts}.tar.gz" expected="${versions.scripts-md5}"
                   where="../target/downloads/scripts"/>
         <untar src="../target/downloads/scripts/v${versions.scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
             <!-- Could be improved with an artifact -->

--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -89,9 +89,9 @@ build_year = "${python_build_year}"
         <delete dir="../target/downloads/py/omero-py-${versions.omero-py}"/>
 
 
-        <download pkg="scripts" file="${versions.scripts}.tar.gz" expected="${versions.scripts-md5}"
+        <download pkg="scripts" file="$v{versions.scripts}.tar.gz" expected="${versions.scripts-md5}"
                   where="../target/downloads/scripts"/>
-        <untar src="../target/downloads/scripts/${versions.scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
+        <untar src="../target/downloads/scripts/v${versions.scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
             <!-- Could be improved with an artifact -->
             <patternset>
                 <include name="scripts-${versions.scripts}/omero/**/*"/>

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -204,7 +204,7 @@ versions.omero-web-url=${versions.omero-pypi}
 versions.omero-dropbox=5.5.dev1
 versions.omero-dropbox-url=${versions.omero-pypi}
 
-versions.scripts=v5.5.1
+versions.scripts=5.5.1
 versions.scripts-url=${versions.omero-github}
 
 


### PR DESCRIPTION
The "cleanup" of the version number to include the "v"
left all files filtered by ant so that nothing was
unpacked.

https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-server/ws/OMERO.server/lib/scripts/ should show all expected scripts after the next build.

cc: @mtbc 