### PR TITLE
Enable use of decoupled omero-py

### DIFF
--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -18,7 +18,7 @@
 
     <variable name="OMEROPY_HOME"  value="lib/python/"/>
     <variable name="OMEROPY_SERV"  value="lib/python/omero/"/>
-    <variable name="PYTHONPATH"    value="PYTHONPATH=${OMEROPY_HOME}:$${PYTHONPATH}"/>
+    <variable name="PYTHONPATH"    value="PYTHONPATH=$${PYTHONPATH}:${OMEROPY_HOME}"/>
     <variable name="PYTHON"        value="python"/>
     <variable name="JAVA"          value="java"/>
     <variable name="ROUTERPORT"    value="@omero.ports.prefix@@omero.ports.ssl@"/>

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -327,7 +327,8 @@
       <parameter name="dir"/>
       <parameter name="exe" default="${PYTHON}"/>
       <server id="Processor-${index}" exe="${exe}" activation="always" pwd="${OMERO_HOME}">
-        <option>${OMEROPY_HOME}runProcessor.py</option>
+        <option>-m</option>
+        <option>runProcessor</option>
         <env>${PYTHONPATH}</env>
         <adapter name="ProcessorAdapter" endpoints="tcp">
           <object identity="Processor-${index}" type="::omero::grid::Processor"/>
@@ -349,7 +350,8 @@
       <parameter name="dir"/>
       <parameter name="exe" default="${PYTHON}"/>
       <server id="Tables-${index}" exe="${exe}" activation="always" pwd="${OMERO_HOME}">
-        <option>${OMEROPY_HOME}runTables.py</option>
+        <option>-m</option>
+        <option>runTables</option>
         <env>${PYTHONPATH}</env>
         <adapter name="TablesAdapter" endpoints="tcp">
           <object identity="Tables-${index}" type="::omero::grid::Tables"/>
@@ -369,7 +371,8 @@
     <server-template id="FileServerTemplate">
       <parameter name="exe" default="${PYTHON}"/>
       <server id="FileServer" exe="${exe}" activation="always" pwd="${OMERO_HOME}">
-        <option>${OMEROPY_HOME}fsServerFS.py</option>
+        <option>-m</option>
+        <option>fsServerFS</option>
         <env>${PYTHONPATH}</env>
         <adapter name="omerofs.FileServer" endpoints="tcp">
           <object identity="FileServer" type="::monitors::FileServer"/>
@@ -389,7 +392,8 @@
     <server-template id="MonitorServerTemplate">
       <parameter name="exe" default="${PYTHON}"/>
       <server id="MonitorServer" exe="${exe}" activation="always" pwd="${OMERO_HOME}">
-        <option>${OMEROPY_HOME}fsServerMS.py</option>
+        <option>-m</option>
+        <option>fsServerMS</option>
         <env>${PYTHONPATH}</env>
         <adapter name="omerofs.MonitorServer" endpoints="tcp">
           <object identity="MonitorServer" type="::monitors::MonitorServer"/>
@@ -409,7 +413,8 @@
     <server-template id="DropBoxTemplate">
       <parameter name="exe" default="${PYTHON}"/>
       <server id="DropBox" exe="${exe}" activation="always" pwd="${OMERO_HOME}">
-        <option>${OMEROPY_HOME}fsDropBox.py</option>
+        <option>-m</option>
+        <option>fsDropBox</option>
         <env>${PYTHONPATH}</env>
         <adapter name="omerofs.DropBox" endpoints="tcp"/>
         <properties>
@@ -429,7 +434,8 @@
     <server-template id="TestDropBoxTemplate">
       <parameter name="exe" default="${PYTHON}"/>
       <server id="TestDropBox" exe="${exe}" activation="manual" pwd="${OMERO_HOME}">
-        <option>${OMEROPY_HOME}fsDropBox.py</option>
+        <option>-m</option>
+        <option>fsDropBox</option>
         <env>${PYTHONPATH}</env>
         <adapter name="omerofs.TestDropBox" endpoints="tcp"/>
         <properties>

--- a/etc/templates/grid/windefault.xml
+++ b/etc/templates/grid/windefault.xml
@@ -27,7 +27,7 @@
 
     <variable name="OMEROPY_HOME"  value="${OMERO_HOME}\\lib\\python\\"/>
     <variable name="OMEROPY_SERV"  value="${OMERO_HOME}\\lib\\python\\omero\\"/>
-    <variable name="PYTHONPATH"    value="PYTHONPATH=${OMEROPY_HOME};%PYTHONPATH%"/>
+    <variable name="PYTHONPATH"    value="PYTHONPATH=%PYTHONPATH%;${OMEROPY_HOME}"/>
     <variable name="PYTHON"        value="python"/>
     <variable name="JAVA"          value="java"/>
     <variable name="ROUTERPORT"    value="@omero.ports.prefix@@omero.ports.ssl@"/>


### PR DESCRIPTION
fix #6103 

# What this PR does

In OMERO 5.5.1, the grid/templates.xml ran Python subprocesses via:

```
python lib/python/X.py
```

In order to also support a file on the PYTHONPATH, now use:

```
python -m X
```

# Testing this PR

1. integration tests should all pass
2. diagnostics should show Processor and Tables active