### PR TITLE
Use reverse(name) for webgateway URLs in integration tests

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -194,7 +194,7 @@ class TestCsrf(IWebTest):
         session['fromid'] = img.id.val
         session.save()
 
-        request_url = reverse('webgateway.views.copy_image_rdef_json')
+        request_url = reverse('copy_image_rdef_json')
         data = {
             'toids': img.id.val
         }

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -67,7 +67,7 @@ class TestDownload(IWebTest):
 
         plate, well, image = image_well_plate
         # download archived files
-        request_url = reverse('webgateway.views.archived_files')
+        request_url = reverse('archived_files')
         data = {
             "image": image.id.val
         }
@@ -81,7 +81,7 @@ class TestDownload(IWebTest):
         images = self.import_fake_file()
         image = images[0]
         # download archived files
-        request_url = reverse('webgateway.views.archived_files',
+        request_url = reverse('archived_files',
                               args=[image.id.val])
         get(self.django_client, request_url)
 
@@ -94,7 +94,7 @@ class TestDownload(IWebTest):
         image = images[0]
 
         # download archived files
-        request_url = reverse('webgateway.views.archived_files')
+        request_url = reverse('archived_files')
         data = {
             "image": image.id.val
         }
@@ -111,7 +111,7 @@ class TestDownload(IWebTest):
         self.link(ds, image)
 
         # download archived files
-        request_url = reverse('webgateway.views.archived_files')
+        request_url = reverse('archived_files')
         data = {
             "image": image.id.val
         }
@@ -131,7 +131,7 @@ class TestDownload(IWebTest):
         self.link(ds, image)
 
         # download archived files
-        request_url = reverse('webgateway.views.archived_files')
+        request_url = reverse('archived_files')
         data = {
             "image": image.id.val
         }
@@ -144,7 +144,7 @@ class TestDownload(IWebTest):
 
         plate, well, image = image_well_plate
         # download archived files
-        request_url = reverse('webgateway.views.archived_files')
+        request_url = reverse('archived_files')
         data = {
             "well": well.id.val
         }

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -43,7 +43,7 @@ class TestImgDetail(IWebTest):
             client=self.client, pixelType="int16", sizeX=20, sizeY=20, sizeZ=5,
             sizeT=6)
         iid = images[0].id.val
-        json_url = reverse('webgateway.views.imageData_json', args=[iid])
+        json_url = reverse('webgateway_imageData_json', args=[iid])
         data = {}
         img_data = get_json(self.django_client, json_url, data,
                             status_code=200)

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -300,7 +300,7 @@ class TestPlateGrid(object):
                     assert well_metadata['name'] == img.name.val
                     # expect default thumbnail (no size specified)
                     assert well_metadata['thumb_url'] ==\
-                        reverse('webgateway.views.render_thumbnail',
+                        reverse('webgateway_render_thumbnail',
                                 args=[img.id.val])
 
     def test_well_images(self, django_client, plate_wells, conn):
@@ -320,7 +320,7 @@ class TestPlateGrid(object):
                 assert ws_json['name'] == img.name.val
                 assert ws_json['id'] == img.id.val
                 assert ws_json['thumb_url'] ==\
-                    reverse('webgateway.views.render_thumbnail',
+                    reverse('webgateway_render_thumbnail',
                             args=[img.id.val])
                 assert ws_json['position'] == {'x': {'value': i,
                                                'unit': rf},

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -75,7 +75,7 @@ class TestRendering(IWebTest):
         assert img2_chan.getCoefficient() == 1.0
 
         # copy rendering settings from image1 via ID
-        request_url = reverse('webgateway.views.copy_image_rdef_json')
+        request_url = reverse('copy_image_rdef_json')
         data = {
             "fromid": iid1
         }
@@ -148,7 +148,7 @@ class TestRendering(IWebTest):
             '&maps=[' + exp_map1 + ',' + exp_map2 + ']'
 
         # copy rendering settings from image1 via URL
-        request_url = reverse('webgateway.views.copy_image_rdef_json')
+        request_url = reverse('copy_image_rdef_json')
         data = {
             "imageId": iid1,
             "c": old_c1,
@@ -211,7 +211,7 @@ class TestRendering(IWebTest):
 
         # request the rendering def via the method we want to test
         request_url = reverse(
-            'webgateway.views.get_image_rdefs_json', args=[iid])
+            'webgateway_get_image_rdefs_json', args=[iid])
         response = get(self.django_client, request_url)
 
         # check expected response
@@ -275,7 +275,7 @@ class TestRenderImageRegion(IWebTest):
         image_id = self.create_test_image(size_c=1, session=self.sf).id.val
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
         )
         data = {'c': '1|0:255$FF0000'}
@@ -298,7 +298,7 @@ class TestRenderImageRegion(IWebTest):
         image_id = self.create_test_image(size_c=1, session=self.sf).id.val
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
         )
         data = {'tile': 'malformed'}
@@ -321,7 +321,7 @@ class TestRenderImageRegion(IWebTest):
         image_id = self.create_test_image(size_c=1, session=self.sf).id.val
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
         )
         data = {'region': 'malformed'}
@@ -349,7 +349,7 @@ class TestRenderImageRegion(IWebTest):
         image._re.close()
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
         )
         data = {'tile': '0,0,0'}
@@ -387,7 +387,7 @@ class TestRenderImageRegion(IWebTest):
         image._re.close()
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
         )
         django_client = self.new_django_client_from_session_id(
@@ -415,7 +415,7 @@ class TestRenderImageRegion(IWebTest):
         image._re.close()
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
         )
         django_client = self.new_django_client_from_session_id(
@@ -440,7 +440,7 @@ class TestRenderImageRegion(IWebTest):
         image._re.close()
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
         )
         django_client = self.new_django_client_from_session_id(
@@ -461,7 +461,7 @@ class TestRenderImageRegion(IWebTest):
         image_id = self.import_pyramid(tmpdir, client=self.client)
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
         )
         django_client = self.new_django_client_from_session_id(
@@ -497,7 +497,7 @@ class TestRenderImageRegion(IWebTest):
         image._re.close()
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image.getId()), 'z': '0', 't': '0'}
         )
         data = {'region': '0,0,10,10'}
@@ -520,7 +520,7 @@ class TestRenderImageRegion(IWebTest):
         image_id = self.import_pyramid(tmpdir, client=self.client)
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
         )
         django_client = self.new_django_client_from_session_id(
@@ -546,7 +546,7 @@ class TestRenderImageRegion(IWebTest):
         """
         image_id = self.import_pyramid(tmpdir, client=self.client)
         request_url = reverse(
-            'webgateway.views.render_birds_eye_view',
+            'webgateway_render_birds_eye_view',
             kwargs={'iid': str(image_id), 'size': '100'}
         )
         django_client = self.new_django_client_from_session_id(
@@ -572,7 +572,7 @@ class TestRenderImageRegion(IWebTest):
         image._re.close()
 
         request_url = reverse(
-            'webgateway.views.render_image_region',
+            'webgateway_render_image_region',
             kwargs={'iid': str(image_id), 'z': '0', 't': '0'}
         )
         django_client = self.new_django_client_from_session_id(

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -49,7 +49,7 @@ class TestThumbnails(IWebTest):
         args = [iId]
         if size is not None:
             args.append(size)
-        request_url = reverse('webgateway.views.render_thumbnail', args=args)
+        request_url = reverse('webgateway_render_thumbnail', args=args)
         rsp = get(self.django_client, request_url)
 
         thumb = Image.open(StringIO(rsp.content))
@@ -70,7 +70,7 @@ class TestThumbnails(IWebTest):
         args = [iid]
         if size is not None:
             args.append(size)
-        request_url = reverse('webgateway.views.render_thumbnail', args=args)
+        request_url = reverse('webgateway_render_thumbnail', args=args)
         rsp = get(self.django_client, request_url)
         thumb = json.dumps(
             "data:image/jpeg;base64,%s" % base64.b64encode(rsp.content))
@@ -93,7 +93,7 @@ class TestThumbnails(IWebTest):
 
         expected_thumbs = {}
         for i in images:
-            request_url = reverse('webgateway.views.render_thumbnail',
+            request_url = reverse('webgateway_render_thumbnail',
                                   args=[i])
             rsp = get(self.django_client, request_url)
 
@@ -101,7 +101,7 @@ class TestThumbnails(IWebTest):
                 "data:image/jpeg;base64,%s" % base64.b64encode(rsp.content)
 
         iids = {'id': images}
-        request_url = reverse('webgateway.views.get_thumbnails_json')
+        request_url = reverse('webgateway_get_thumbnails_json')
         b64rsp = get(self.django_client, request_url, iids).content
 
         assert cmp(json.loads(b64rsp),

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -75,7 +75,7 @@ class TestThumbnails(IWebTest):
         thumb = json.dumps(
             "data:image/jpeg;base64,%s" % base64.b64encode(rsp.content))
 
-        request_url = reverse('webgateway.views.get_thumbnail_json',
+        request_url = reverse('webgateway_get_thumbnail_json',
                               args=args)
         b64rsp = get(self.django_client, request_url).content
         assert thumb == b64rsp


### PR DESCRIPTION
# What this PR does

This, along with https://github.com/ome/omero-web/pull/10/commits/b16716165c1c7dc31482e8e9f2a0f0e9d4758418 
should fix failing webgateway integration tests at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/154

I think this illustrates a breaking change in OMERO.web ```5.5.1dev``` which we first saw in the ```unit_tests``` at https://github.com/ome/omero-web/pull/10#issuecomment-527169895 and required https://github.com/ome/omero-web/pull/10/commits/2fff52d8dabfb0087493a1f2dc7068594912d1c4 to fix unit tests.

For other omero.web apps (figure, iviewer etc and 3rd-party apps), if they previously did this in views.py
```
reverse('webgateway.views.render_roi_thumbnail', args=['0'] )
```
in 5.5.1, this no-longer works with decoupled OMERO.web.
You now need to use the new 'name':
```
reverse('webgateway_render_roi_thumbnail', args=['0'] )
```
But in the Django html template, this still works with decoupled OMERO.web
```
{% url 'webgateway.views.render_roi_thumbnail' 0 %}
```

We don't use
```
reverse('webgateway.views.X')
```
in OMERO.figure or OMERO.iviewer. So they don't break with decoupled OMERO.web.
They only use
```
reverse('webgateway')
```
for the named webgateway base url, then generate other URLs via JavaScript, not python.
