### PR TITLE
Don't use wrap(id) for long IDs

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -29,7 +29,6 @@ from omero.testlib.cli import CLITest
 from omero.rtypes import rstring, rlong
 from omero.util.temp_files import create_path
 import __builtin__
-import builtins
 NSINSIGHTTAGSET = omero.constants.metadata.NSINSIGHTTAGSET
 
 
@@ -124,20 +123,20 @@ class TestTag(AbstractTagTest):
     # ========================================================================
     @pytest.mark.parametrize('name_arg', [None, '--name'])
     @pytest.mark.parametrize('desc_arg', [None, '--description'])
-    def testCreateTagA(self, name_arg, desc_arg, capfd, monkeypatch):
+    def testCreateTag(self, name_arg, desc_arg, capfd):
         tag_name = self.uuid()
         tag_desc = self.uuid()
         self.args += ["create"]
-        def mock_input(msg):
-            return tag_name
-
-        monkeypatch.setattr(builtins, "input", mock_input)
-
+        self.mox.StubOutWithMock(__builtin__, "raw_input")
         if name_arg:
             self.args += [name_arg, tag_name]
+        else:
+            name_input = 'Please enter a name for this tag: '
+            raw_input(name_input).AndReturn(tag_name)
 
         if desc_arg:
             self.args += [desc_arg, tag_desc]
+        self.mox.ReplayAll()
 
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()
@@ -152,23 +151,22 @@ class TestTag(AbstractTagTest):
 
     @pytest.mark.parametrize('name_arg', [None, '--name'])
     @pytest.mark.parametrize('desc_arg', [None, '--desc'])
-    def testCreateTagset(self, name_arg, desc_arg, capfd, monkeypatch):
+    def testCreateTagset(self, name_arg, desc_arg, capfd):
         tag_name = self.uuid()
         tag_desc = self.uuid()
         tag_ids = self.create_tags(2, tag_name)
         self.args += ["createset", "--tag"]
         self.args += ["%s" % tag_id for tag_id in tag_ids]
 
-        def mock_input(msg):
-            return tag_name
-
-        monkeypatch.setattr(builtins, "input", mock_input)
-
+        self.mox.StubOutWithMock(__builtin__, "raw_input")
         if name_arg:
             self.args += [name_arg, tag_name]
-
+        else:
+            name_input = 'Please enter a name for this tag set: '
+            raw_input(name_input).AndReturn(tag_name)
         if desc_arg:
             self.args += [desc_arg, tag_desc]
+        self.mox.ReplayAll()
 
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -29,6 +29,7 @@ from omero.testlib.cli import CLITest
 from omero.rtypes import rstring, rlong
 from omero.util.temp_files import create_path
 import __builtin__
+import builtins
 NSINSIGHTTAGSET = omero.constants.metadata.NSINSIGHTTAGSET
 
 
@@ -123,20 +124,20 @@ class TestTag(AbstractTagTest):
     # ========================================================================
     @pytest.mark.parametrize('name_arg', [None, '--name'])
     @pytest.mark.parametrize('desc_arg', [None, '--description'])
-    def testCreateTag(self, name_arg, desc_arg, capfd):
+    def testCreateTagA(self, name_arg, desc_arg, capfd, monkeypatch):
         tag_name = self.uuid()
         tag_desc = self.uuid()
         self.args += ["create"]
-        self.mox.StubOutWithMock(__builtin__, "raw_input")
+        def mock_input(msg):
+            return tag_name
+
+        monkeypatch.setattr(builtins, "input", mock_input)
+
         if name_arg:
             self.args += [name_arg, tag_name]
-        else:
-            name_input = 'Please enter a name for this tag: '
-            raw_input(name_input).AndReturn(tag_name)
 
         if desc_arg:
             self.args += [desc_arg, tag_desc]
-        self.mox.ReplayAll()
 
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()
@@ -151,22 +152,23 @@ class TestTag(AbstractTagTest):
 
     @pytest.mark.parametrize('name_arg', [None, '--name'])
     @pytest.mark.parametrize('desc_arg', [None, '--desc'])
-    def testCreateTagset(self, name_arg, desc_arg, capfd):
+    def testCreateTagset(self, name_arg, desc_arg, capfd, monkeypatch):
         tag_name = self.uuid()
         tag_desc = self.uuid()
         tag_ids = self.create_tags(2, tag_name)
         self.args += ["createset", "--tag"]
         self.args += ["%s" % tag_id for tag_id in tag_ids]
 
-        self.mox.StubOutWithMock(__builtin__, "raw_input")
+        def mock_input(msg):
+            return tag_name
+
+        monkeypatch.setattr(builtins, "input", mock_input)
+
         if name_arg:
             self.args += [name_arg, tag_name]
-        else:
-            name_input = 'Please enter a name for this tag set: '
-            raw_input(name_input).AndReturn(tag_name)
+
         if desc_arg:
             self.args += [desc_arg, tag_desc]
-        self.mox.ReplayAll()
 
         self.cli.invoke(self.args, strict=True)
         o, e = capfd.readouterr()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -19,7 +19,7 @@ import uuid
 import pytest
 
 from omero.gateway.scripts import dbhelpers
-from omero.rtypes import wrap
+from omero.rtypes import wrap, rlong
 from omero.testlib import ITest
 from omero.gateway import BlitzGateway, KNOWN_WRAPPERS
 from omero.model import DatasetI, \
@@ -704,7 +704,7 @@ class TestGetObject (object):
             "Image", imageIds, respect_order=True)
         reverseIds = [i.id for i in reverseImages]
         assert imageIds == reverseIds, "Images not ordered by ID"
-        wrappedIds = [wrap(i) for i in imageIds]
+        wrappedIds = [rlong(i) for i in imageIds]
         reverseImages = gatewaywrapper.gateway.getObjects(
             "Image", wrappedIds, respect_order=True)
         reverseIds = [i.id for i in reverseImages]

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -15,7 +15,7 @@
 """
 
 import pytest
-from cStringIO import StringIO
+from io import BytesIO
 import omero
 
 try:
@@ -40,18 +40,18 @@ class TestImage (object):
     def testThumbnail(self, author_testimg_bad, author_testimg_big,
                       gatewaywrapper):
         thumb = self.image.getThumbnail()
-        tfile = StringIO(thumb)
+        tfile = BytesIO(thumb)
         thumb = Image.open(tfile)  # Raises if invalid
         thumb.verify()  # Raises if invalid
         assert thumb.format == 'JPEG'
         assert thumb.size == (64, 64)
         thumb = self.image.getThumbnail(96)
-        tfile = StringIO(thumb)
+        tfile = BytesIO(thumb)
         thumb = Image.open(tfile)  # Raises if invalid
         thumb.verify()  # Raises if invalid
         assert thumb.size == (96, 96)
         thumb = self.image.getThumbnail((128, 96))
-        tfile = StringIO(thumb)
+        tfile = BytesIO(thumb)
         thumb = Image.open(tfile)  # Raises if invalid
         thumb.verify()  # Raises if invalid
         assert thumb.size == (128, 96)
@@ -60,7 +60,7 @@ class TestImage (object):
         # Big image (4k x 4k and up) thumb
         bigimage = author_testimg_big
         thumb = bigimage.getThumbnail()
-        tfile = StringIO(thumb)
+        tfile = BytesIO(thumb)
         thumb = Image.open(tfile)  # Raises if invalid
         thumb.verify()  # Raises if invalid
         assert thumb.format == 'JPEG'
@@ -68,7 +68,7 @@ class TestImage (object):
         # Projection
         self.image.setProjection('intmax')
         pThumb = self.image.getThumbnail()
-        ptfile = StringIO(pThumb)
+        ptfile = BytesIO(pThumb)
         pthumb = Image.open(ptfile)  # Raises if invalid
         pthumb.verify()  # Raises if invalid
         # Check that the thumbnail store is closed
@@ -81,7 +81,7 @@ class TestImage (object):
         conn = self.image._conn
         for (img_id, thumb) in conn.getThumbnailSet(image_ids=img_ids).items():
             assert img_id in img_ids
-            tfile = StringIO(thumb)
+            tfile = BytesIO(thumb)
             thumb = Image.open(tfile)  # Raises if invalid
             thumb.verify()  # Raises if invalid
             assert thumb.format == 'JPEG'
@@ -89,7 +89,7 @@ class TestImage (object):
 
         thumb = conn.getThumbnailSet(
             image_ids=[self.image.id], max_size=96)[self.image.id]
-        tfile = StringIO(thumb)
+        tfile = BytesIO(thumb)
         thumb = Image.open(tfile)  # Raises if invalid
         thumb.verify()  # Raises if invalid
         assert thumb.size == (96, 96)
@@ -103,7 +103,7 @@ class TestImage (object):
     def testRenderingModels(self):
         # default is color model
         cimg = self.image.renderJpeg(0, 0)
-        ifile = StringIO(cimg)
+        ifile = BytesIO(cimg)
         img = Image.open(ifile)
         extrema = img.getextrema()
         assert extrema[0] != extrema[1] or extrema[0] != extrema[2], \
@@ -113,7 +113,7 @@ class TestImage (object):
         assert cimg == self.image.renderJpeg(0, 0)
         # Now for greyscale
         self.image.setGreyscaleRenderingModel()
-        ifile = StringIO(self.image.renderJpeg(0, 0))
+        ifile = BytesIO(self.image.renderJpeg(0, 0))
         img = Image.open(ifile)
         extrema = img.getextrema()
         assert extrema[0] == extrema[1] and extrema[0] == extrema[2], \
@@ -128,7 +128,8 @@ class TestImage (object):
         assert cdims['c']['gridx'] == 2
         assert cdims['c']['gridy'] == 2
         # Render the view
-        ifile = StringIO(self.image.renderSplitChannel(0, 0, border=4))
+        data = self.image.renderSplitChannel(0, 0, border=4)
+        ifile = BytesIO(data)
         img = Image.open(ifile)
         assert img.size[0] == cdims['c']['width']
         assert img.size[1] == cdims['c']['height']
@@ -137,7 +138,8 @@ class TestImage (object):
         assert cdims['g']['gridy'] == 1
         # Render the view
         self.image.setGreyscaleRenderingModel()
-        ifile = StringIO(self.image.renderSplitChannel(0, 0, border=4))
+        data = self.image.renderSplitChannel(0, 0, border=4)
+        ifile = BytesIO(data)
         img = Image.open(ifile)
         assert img.size[0] == cdims['g']['width']
         assert img.size[1] == cdims['g']['height']
@@ -159,13 +161,13 @@ class TestImage (object):
         original.
         """
         # Vertical plot
-        gif = StringIO(self.image.renderColLinePlotGif(z=0, t=0, x=1))
+        gif = BytesIO(self.image.renderColLinePlotGif(z=0, t=0, x=1))
         img = Image.open(gif)
         img.verify()  # Raises if invalid
         assert img.format == 'GIF'
         assert img.size == (self.image.getSizeX(), self.image.getSizeY())
         # Horizontal plot
-        gif = StringIO(self.image.renderRowLinePlotGif(z=0, t=0, y=1))
+        gif = BytesIO(self.image.renderRowLinePlotGif(z=0, t=0, y=1))
         img = Image.open(gif)
         img.verify()  # Raises if invalid
         assert img.format == 'GIF'
@@ -180,7 +182,7 @@ class TestImage (object):
         """ Test image projections """
         for p in self.image.getProjections():
             self.image.setProjection(p)
-            ifile = StringIO(self.image.renderJpeg(0, 0))
+            ifile = BytesIO(self.image.renderJpeg(0, 0))
             img = Image.open(ifile)  # Raises if invalid
             img.verify()  # Raises if invalid
             assert img.format == 'JPEG'
@@ -384,7 +386,7 @@ class TestImage (object):
         width = 10
         height = 10
         img = self.image.renderJpegRegion(0, 0, 0, 0, width, height)
-        ifile = StringIO(img)
+        ifile = BytesIO(img)
         img_file = Image.open(ifile)  # Raises if invalid
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
@@ -395,7 +397,7 @@ class TestImage (object):
         width = 10
         height = 10
         img = self.image.renderJpegRegion(0, 0, 0, 0, width, height, level=0)
-        ifile = StringIO(img)
+        ifile = BytesIO(img)
         img_file = Image.open(ifile)  # Raises if invalid
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
@@ -410,7 +412,7 @@ class TestImage (object):
 
     def testRenderBirdsEyeView(self, gatewaywrapper):
         img = self.image.renderBirdsEyeView(None)
-        ifile = StringIO(img)
+        ifile = BytesIO(img)
         img_file = Image.open(ifile)  # Raises if invalid
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'
@@ -420,7 +422,7 @@ class TestImage (object):
     def testRenderBirdsEyeView_Size(self, gatewaywrapper):
         size = 10
         img = self.image.renderBirdsEyeView(size)
-        ifile = StringIO(img)
+        ifile = BytesIO(img)
         img_file = Image.open(ifile)  # Raises if invalid
         img_file.verify()  # Raises if invalid
         assert img_file.format == 'JPEG'

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
@@ -14,7 +14,7 @@
 
 import omero
 import omero.scripts
-from omero.rtypes import rstring, rtime, wrap
+from omero.rtypes import rstring, rtime, rlong, wrap
 from omero.gateway.scripts import dbhelpers
 import time
 import pytest
@@ -181,7 +181,7 @@ class TestScript (object):
 
         # run script
         svc = gatewaywrapper.gateway.getScriptService()
-        process = svc.runScript(scriptID, wrap({"datasetId": new_ds_Id}).val,
+        process = svc.runScript(scriptID, {"datasetId": rlong(new_ds_Id)},
                                 None, gatewaywrapper.gateway.SERVICE_OPTS)
         cb = omero.scripts.ProcessCallbackI(gatewaywrapper.gateway.c, process)
         while cb.block(500) is None:

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
@@ -14,7 +14,7 @@
 
 import omero
 import omero.scripts
-from omero.rtypes import rstring, rtime, rlong, wrap
+from omero.rtypes import rstring, rtime, rlong
 from omero.gateway.scripts import dbhelpers
 import time
 import pytest

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -24,6 +24,7 @@
 
 """
 
+from future.utils import native_str
 import pytest
 from omero.testlib import ITest, PFS
 import omero
@@ -120,7 +121,8 @@ class TestPermissions(ITest):
         rv = self.root.getPropertyMap()
         ec = self.client.sf.getAdminService().getEventContext()
         public_client = omero.client(rv)
-        public_client.getImplicitContext().put("omero.group", uuid)
+        public_client.getImplicitContext().put("omero.group",
+                                               native_str(uuid))
         sf = public_client.createSession(ec.userName, ec.userName)
         ec = sf.getAdminService().getEventContext()
         assert uuid == ec.groupName

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -432,7 +432,7 @@ client.closeSession()
         session = self.client.getSession()
         image = self.create_test_image(100, 100, 1, 1, 1, session)
         process = svc.runScript(
-            scriptID, wrap({"Data_Type": "Image", "IDs": [image.id.val]}).val,
+            scriptID, wrap({"Data_Type": "Image", "IDs": [image.id]}).val,
             None)
         wait_time, ignore = self.timeit(
             omero.scripts.wait, self.client, process)


### PR DESCRIPTION
# What this PR does

Fixes ```ClientError: Cannot handle conversion from: <type 'long'>``` in rtypes for ```TestGetObject.testOrderById()```.