### PR TITLE
python3: futurize build.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
       zlib1g-dev python-pillow python-numpy python-sphinx \
       libssl-dev libbz2-dev libmcpp-dev libdb++-dev libdb-dev \
       zeroc-ice-all-dev \
- && pip install --upgrade 'pip<10' setuptools flake8==2.4.0 pytest==2.7.3
+ && pip install --upgrade 'pip<10' setuptools flake8==2.4.0 pytest==2.7.3 future
 # TODO: unpin pip when possible
 # openjdk:8 is "stretch" or Debian 9
 RUN pip install https://github.com/ome/zeroc-ice-py-debian9/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl

--- a/build.py
+++ b/build.py
@@ -8,6 +8,7 @@
 #
 # General build scripts.
 
+from builtins import str
 import os
 import sys
 import subprocess
@@ -87,13 +88,13 @@ def handle_tools(args):
         "-py": _(["components", "tools", "OmeroPy", "build.xml"]),
         "-web": _(["components", "tools", "OmeroWeb", "build.xml"]),
     }
-    while len(args) > 0 and args[0] in mappings.keys()+["-perf"]:
+    while len(args) > 0 and args[0] in list(mappings.keys())+["-perf"]:
         if args[0] == "-perf":
             args.pop(0)
             A = ["-listener",
                  "net.sf.antcontrib.perf.AntPerformanceListener"]
             additions.extend(A)
-        elif args[0] in mappings.keys():
+        elif args[0] in list(mappings.keys()):
             F = mappings[args.pop(0)]
             A = ["-f", F]
             additions.extend(A)
@@ -139,6 +140,6 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         sys.stderr.write("\nCancelled by user\n")
         sys.exit(2)
-    except SystemExit, se:
+    except SystemExit as se:
         notification(""" Failed: %s """ % " ".join(args), 100)
         sys.exit(se.code)

--- a/components/antlib/scripts/parse_version
+++ b/components/antlib/scripts/parse_version
@@ -22,7 +22,10 @@
 """
 Helper script to simpliy version.xml
 """
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
 import os
 import re
 import sys
@@ -56,9 +59,9 @@ def choose_omero_version(omero_version):
         return "%s%s" % (omero_version, omero_build)
 
     except:
-        print "Error getting version for BUILD_NUMBER=%s" % omero_build
+        print("Error getting version for BUILD_NUMBER=%s" % omero_build)
         if err:
-            print err
+            print(err)
         sys.exit(1)
 
 
@@ -123,4 +126,4 @@ def incr_version(omero_version):
 
 
 if __name__ == "__main__":
-    print choose_omero_version(sys.argv[1]),
+    print(choose_omero_version(sys.argv[1]), end='')


### PR DESCRIPTION
Result of:

```
futurize -w -0 build.py
```

should fix:

https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-build/38/console