### PR TITLE
use mox3

### DIFF
--- a/components/tools/OmeroFS/test/drivers.py
+++ b/components/tools/OmeroFS/test/drivers.py
@@ -20,7 +20,7 @@ import omero.grid.monitors as monitors
 
 from path import path
 from omero.util import ServerContext
-from omero_ext.mox import Mox
+from mox3 import mox
 from functools import wraps
 from omero.util.temp_files import create_path
 from fsDropBoxMonitorClient import MonitorClientI
@@ -343,7 +343,7 @@ class mock_communicator(object):
 class MockServerContext(ServerContext):
 
     def __init__(self, ic, get_root):
-        self.mox = Mox()
+        self.mox = mox.Mox()
         self.communicator = ic
         self.getSession = get_root
         self.stop_event = threading.Event()

--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -29,7 +29,7 @@ from omero.plugins.sessions import SessionsControl
 from omero.rtypes import rstring
 
 from omero.testlib import ITest
-from omero_ext.mox import Mox
+from mox3 import mox
 
 
 class AbstractCLITest(ITest):
@@ -44,7 +44,7 @@ class AbstractCLITest(ITest):
         cls.cli.register("sessions", SessionsControl, "TEST")
 
     def setup_mock(self):
-        self.mox = Mox()
+        self.mox = mox.Mox()
 
     def teardown_mock(self):
         self.mox.UnsetStubs()


### PR DESCRIPTION
# What this PR does

Remove usage of Mox. This has been removed from omero-py see https://github.com/ome/omero-py/pull/46
The class is deprecated but we have not decided yet if it will be removed
