### PR TITLE
Gatewaytest chgrp

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
@@ -18,6 +18,7 @@ from omero.testlib import ITest
 from omero.cmd import State, ERR, OK
 from omero.callbacks import CmdCallbackI
 from omero.gateway import BlitzGateway
+from omero.cmd import Chgrp2
 
 PRIVATE = 'rw----'
 READONLY = 'rwr---'
@@ -84,7 +85,8 @@ class TestChgrp(ITest):
         assert conn.getObject("Image", image_id) is not None
 
         # Do the Chgrp
-        doChange(conn, "Image", [image_id], gid)
+        chgrp = Chgrp2(targetObjects={'Image': [image_id]}, groupId=gid)
+        self.do_submit(chgrp, client)
 
         # Image should no-longer be available in current group
         assert conn.getObject("Image", image_id) is None, \

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
@@ -99,8 +99,8 @@ class TestChgrp(ITest):
 
     def testDatasetChgrp(self):
         """
-        Create a new group with the User as member. Test move the Dataset/Image to
-        new group.
+        Create a new group with the User as member. Test move the
+        Dataset/Image to new group.
         """
 
         # One user in two groups
@@ -187,9 +187,9 @@ class TestChgrp(ITest):
 
     def testTwoDatasetsChgrpToProject(self):
         """
-        Create a new group with the User as member. Image has 2 Dataset Parents.
-        Test move one Dataset to new group. Image does not move. Move 2nd Dataset
-        - Image moves.
+        Create a new group with the User as member. Image has 2 Dataset
+        Parents. Test move one Dataset to new group. Image does not move.
+        Move 2nd Dataset - Image moves.
         """
         # One user in two groups
         client, exp = self.new_client_and_user()
@@ -240,7 +240,6 @@ class TestChgrp(ITest):
                  container_id=p.id.val)
 
         # Confirm that Dataset AND Image is now in new group
-        ctx = conn.getAdminService().getEventContext()
         ds = conn.getObject("Dataset", dataset2_id)
         projects = list(ds.listParents())
         assert len(projects) == 1, \
@@ -292,7 +291,7 @@ class TestChgrp(ITest):
         # Chgrp
         dsIds = [new_ds.id.val, new_ds2.id.val]
         doChange(conn, "Dataset", dsIds, gid,
-                container_id=p.id.val)
+                 container_id=p.id.val)
 
         # Check all objects in destination group
         # we can get objects from either group...
@@ -301,5 +300,6 @@ class TestChgrp(ITest):
         datasets = list(p.listChildren())
         assert len(datasets) == 2, "Project should have 2 new Datasets"
         for d in datasets:
-            assert d.details.group.id.val == gid, "Dataset should be in new group"
+            assert d.details.group.id.val == gid, \
+                "Dataset should be in new group"
             assert d.getId() in dsIds, "Checking Datasets by ID"

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
@@ -32,12 +32,12 @@ def doChange(gateway, obj_type, obj_ids, group_id, container_id=None,
     Performs the change-group action, waits on completion and checks that the
     result is not an error.
     """
-    # prx = gateway.chgrpObjects(obj_type, obj_ids, group_id, container_id)
+    prx = gateway.chgrpObjects(obj_type, obj_ids, group_id, container_id)
 
-    obj = {}
-    obj[obj_type] = obj_ids
-    chgrp = Chgrp2(targetObjects=obj, groupId=group_id)
-    prx = gateway.c.sf.submit(chgrp, {'omero.group': native_str(None)})
+    #obj = {}
+    #obj[obj_type] = obj_ids
+    #chgrp = Chgrp2(targetObjects=obj, groupId=group_id)
+    #prx = gateway.c.sf.submit(chgrp, {'omero.group': native_str(None)})
 
     if not return_complete:
         return prx

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -44,6 +44,8 @@ def build_url(client, url_name, url_kwargs):
     response = client.request()
     # http://testserver/webclient/
     webclient_url = response.url
+    # Needs hard-coding in Django 1.9
+    webclient_url = 'http://testserver/webclient/'
     url = reverse(url_name, kwargs=url_kwargs)
     url = webclient_url.replace('/webclient/', url)
     return url


### PR DESCRIPTION
# What this PR does

Several tests in ```gatewaytest/test_chgrp``` are failing on merge-ci but passing locally, E.g.
https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/189/testReport/junit/OmeroPy.test.integration.gatewaytest/test_chgrp/testImageChgrp/

This may be due to re-use of users and images in these tests. E.g. ```loginAsAuthor()```.
This PR instead uses newly created user and groups and new images.