### PR TITLE
handle empty lines

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -47,13 +47,15 @@ class TestFS(CLITest):
     def parse_ids(self, output):
         ids = []
         for line in output.split('\n')[:-1]:
-            ids.append(int(line.split(',')[1]))
+            if len(line.strip()) != 0:
+                ids.append(int(line.split(',')[1]))
         return ids
 
     def parse_repos(self, output):
         ids = []
         for line in output.split('\n')[:-1]:
-            ids.append(line.split(',')[3])
+            if len(line.strip()) != 0:
+                ids.append(line.split(',')[3])
         return ids
 
     def testRepos(self, capsys):


### PR DESCRIPTION
Fix 2 failing tests 
* https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/191/testReport/junit/OmeroPy.test.integration.clitest.test_fs/TestFS/testRepos/
* https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/191/testReport/junit/OmeroPy.test.integration.clitest.test_fs/TestFS/testSetsWithTransfer/

Check that the tests are green