### PR TITLE
django_1.9_requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,5 +74,8 @@ RUN rm -rf /opt/omero/server/OMERO.server
 COPY --chown=omero-server:omero-server --from=build /src/dist /opt/omero/server/OMERO.server
 USER root
 RUN yum install -y git
+RUN /opt/omero/server/venv/bin/pip install future
+RUN sed -i 's/#!\/usr\/bin\/env python/#!\/opt\/omero\/server\/venv\/bin\/python/' /opt/omero/server/OMERO.server/bin/omero
+RUN /opt/omero/omego/bin/pip install future
 USER omero-server
 WORKDIR /opt/omero/server/OMERO.server

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,3 +79,5 @@ RUN sed -i 's/#!\/usr\/bin\/env python/#!\/opt\/omero\/server\/venv\/bin\/python
 RUN /opt/omero/omego/bin/pip install future
 USER omero-server
 WORKDIR /opt/omero/server/OMERO.server
+ENV VIRTUAL_ENV=/opt/omero/server/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -5,8 +5,8 @@
 #
 
 zeroc-ice>3.5,<3.7
-Django>=1.8,<1.9
-django-pipeline==1.3.20
+Django>=1.9,<1.10
+django-pipeline==1.6.14
 gunicorn>=19.3
 
 omero-marshal==0.6.0

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -195,10 +195,10 @@ versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 versions.omero-github=https://github.com/ome/PACKAGE/archive
 
 # To be moved to appended
-versions.omero-py=5.5.dev2
+versions.omero-py=5.6.dev1
 versions.omero-py-url=${versions.omero-pypi}
 
-versions.omero-web=5.5.dev2
+versions.omero-web=5.6.dev2
 versions.omero-web-url=${versions.omero-pypi}
 
 versions.omero-dropbox=5.5.dev1


### PR DESCRIPTION
Update requirements-py27.txt to require Django>=1.9,<1.10

Specifies the version of Django to use for integration tests. See:

https://github.com/ome/omero-web/pull/12#issuecomment-545649552