### PR TITLE
Fix test_api_containers.py hard-coding build_url() testserver

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -214,7 +214,7 @@ class TestDelete(ITest):
             ofid = self.update.saveAndReturnObject(oFile).id.val
 
             store.setFileId(ofid)
-            binary = 'aaa\naaaa\naaaaa'
+            binary = b'aaa\naaaa\naaaaa'
             store.write(binary, 0, 0)
             of = store.save()
 

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -44,6 +44,8 @@ def build_url(client, url_name, url_kwargs):
     response = client.request()
     # http://testserver/webclient/
     webclient_url = response.url
+    # Needs hard-coding in Django 1.9
+    webclient_url = 'http://testserver/webclient/'
     url = reverse(url_name, kwargs=url_kwargs)
     url = webclient_url.replace('/webclient/', url)
     return url

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -22,7 +22,7 @@ Tests webclient login
 """
 from django.conf import settings
 from django.conf.urls import url
-from django.utils.importlib import import_module
+from importlib import import_module
 from django.test.utils import override_settings
 
 from omeroweb.webclient.views import WebclientLoginView


### PR DESCRIPTION
# What this PR does
Fix OmeroWeb ```test_api_containers.py``` tests for Django 1.9.

Failing in:
https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/197/