### PR TITLE
futurize OmeroFS

### DIFF
--- a/components/tools/OmeroFS/ez_setup.py
+++ b/components/tools/OmeroFS/ez_setup.py
@@ -11,6 +11,9 @@ This method is DEPRECATED.
 Check https://github.com/pypa/setuptools/issues/581 for more details.
 """
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import next
 import os
 import shutil
 import sys
@@ -27,7 +30,7 @@ from distutils import log
 try:
     from urllib.request import urlopen
 except ImportError:
-    from urllib2 import urlopen
+    from urllib.request import urlopen
 
 try:
     from site import USER_SITE

--- a/components/tools/OmeroFS/setup.py
+++ b/components/tools/OmeroFS/setup.py
@@ -6,6 +6,7 @@
 
 """
 
+from builtins import map
 import glob
 import sys
 import os

--- a/components/tools/OmeroFS/test/drivers.py
+++ b/components/tools/OmeroFS/test/drivers.py
@@ -9,7 +9,12 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import logging
 import threading
 import time
@@ -62,7 +67,7 @@ class AbstractEvent(object):
         By default, nothing.
         """
         self.log.info("Sleeping %s" % self.waitMillis)
-        time.sleep(self.waitMillis / 1000)
+        time.sleep(old_div(self.waitMillis, 1000))
         if not self.client:
             self.log.error("No client")
         self.doRun()
@@ -144,7 +149,7 @@ class Driver(threading.Thread):
             try:
                 event.setClient(self.client)
                 event.run()
-            except Exception, e:
+            except Exception as e:
                 self.errors.append((event, e))
                 self.log.exception("Error in Driver.run()")
 
@@ -153,7 +158,7 @@ def with_driver(func, errors=0):
     """ Decorator for running a test with a Driver """
     def handler(*args, **kwargs):
         self = args[0]
-        self.dir = create_path(folder=True) / "DropBox"
+        self.dir = old_div(create_path(folder=True), "DropBox")
         self.simulator = Simulator(self.dir)
         self.client = MockMonitor(self.dir, pre=[self.simulator], post=[])
         try:
@@ -224,7 +229,7 @@ class Replay(object):
     def fileset(self, timestamp, data):
         filesets = eval(data, {"__builtins__": None}, {})
         self.filesets = dict()
-        for k, iv in filesets.items():
+        for k, iv in list(filesets.items()):
             k = self.rewrite(k)
             ov = []
             for i in iv:
@@ -303,7 +308,7 @@ class Simulator(monitors.MonitorClient):
                     if not file.isdir():
                         raise Exception("%s is not a directory" % file)
                     self.log.info("Creating file in dir %s", file)
-                    new_file = file / str(uuid.uuid4())
+                    new_file = old_div(file, str(uuid.uuid4()))
                     new_file.write_lines(
                         ["Writing new file to modify this"
                          "directory on event: %s" % event])

--- a/components/tools/OmeroFS/test/integration/test_dbclient.py
+++ b/components/tools/OmeroFS/test/integration/test_dbclient.py
@@ -7,6 +7,7 @@
 
 """
 
+from builtins import object
 import os
 import sys
 


### PR DESCRIPTION
Output of `futurize -w -0` on all .py files under OmeroFS/. This should enable the integration tests on https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/20/testReport/junit/(root)/(empty)/OmeroFS_test_integration_test_dbclient/