### PR TITLE
futurize all remaining tests (OmeroPy)

### DIFF
--- a/components/tools/OmeroPy/test/conftest.py
+++ b/components/tools/OmeroPy/test/conftest.py
@@ -6,6 +6,8 @@
 #
 
 
+from builtins import range
+from builtins import object
 def pytest_addoption(parser):
     parser.addoption(
         '--repeat', action='store',
@@ -24,7 +26,7 @@ def pytest_generate_tests(metafunc):
         # Now we parametrize. This is what happens when we do e.g.,
         # @pytest.mark.parametrize('tmp_ct', range(count))
         # def test_foo(): pass
-        metafunc.parametrize('tmp_ct', range(count))
+        metafunc.parametrize('tmp_ct', list(range(count)))
 
 
 class Methods(object):

--- a/components/tools/OmeroPy/test/conftest.py
+++ b/components/tools/OmeroPy/test/conftest.py
@@ -8,6 +8,7 @@
 
 from builtins import range
 from builtins import object
+import pytest
 
 
 def pytest_addoption(parser):
@@ -75,10 +76,11 @@ class Methods(object):
         raise Exception(standardMsg)
 
 
-def pytest_namespace():
+def pytest_configure():
     """
     Add helper methods to the 'pytest' module
     """
-    return {
-        "assertAlmostEqual": Methods.assertAlmostEqual
-    }
+    pytest.assertAlmostEqual = Methods.assertAlmostEqual
+
+
+pytest_plugins = "omero.gateway.pytest_fixtures"

--- a/components/tools/OmeroPy/test/conftest.py
+++ b/components/tools/OmeroPy/test/conftest.py
@@ -8,6 +8,8 @@
 
 from builtins import range
 from builtins import object
+
+
 def pytest_addoption(parser):
     parser.addoption(
         '--repeat', action='store',

--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from builtins import object
 import pytest
 import warnings
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_admin.py
@@ -20,6 +20,9 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from __future__ import division
+from builtins import str
+from past.utils import old_div
 import pytest
 import os
 
@@ -51,8 +54,7 @@ class TestAdmin(RootCLITest):
         super(TestAdmin, self).setup_method(method)
         self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
         # omero needs the etc/grid directory
-        self.cli.dir = (path(__file__).dirname()
-                        / ".." / ".." / ".." / ".." / ".." / ".." / "dist")
+        self.cli.dir = (old_div(old_div(old_div(old_div(old_div(old_div(old_div(path(__file__).dirname(), ".."), ".."), ".."), ".."), ".."), ".."), "dist"))
         self.args += ["admin"]
 
     def go(self):
@@ -103,8 +105,7 @@ class TestAdminRestrictedAdmin(CLITest):
         super(TestAdminRestrictedAdmin, self).setup_method(method)
         self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
         # omero needs the etc/grid directory
-        self.cli.dir = (path(__file__).dirname()
-                        / ".." / ".." / ".." / ".." / ".." / ".." / "dist")
+        self.cli.dir = (old_div(old_div(old_div(old_div(old_div(old_div(old_div(path(__file__).dirname(), ".."), ".."), ".."), ".."), ".."), ".."), "dist"))
         self.args += ["admin"]
 
     def test_log(self):

--- a/components/tools/OmeroPy/test/integration/clitest/test_admin.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_admin.py
@@ -54,7 +54,11 @@ class TestAdmin(RootCLITest):
         super(TestAdmin, self).setup_method(method)
         self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
         # omero needs the etc/grid directory
-        self.cli.dir = (old_div(old_div(old_div(old_div(old_div(old_div(old_div(path(__file__).dirname(), ".."), ".."), ".."), ".."), ".."), ".."), "dist"))
+        self.cli.dir = (
+            old_div(old_div(old_div(old_div(
+                old_div(old_div(
+                    old_div(path(__file__).dirname(), ".."),
+                    ".."), ".."), ".."), ".."), ".."), "dist"))
         self.args += ["admin"]
 
     def go(self):
@@ -105,7 +109,11 @@ class TestAdminRestrictedAdmin(CLITest):
         super(TestAdminRestrictedAdmin, self).setup_method(method)
         self.cli.register("admin", omero.plugins.admin.AdminControl, "TEST")
         # omero needs the etc/grid directory
-        self.cli.dir = (old_div(old_div(old_div(old_div(old_div(old_div(old_div(path(__file__).dirname(), ".."), ".."), ".."), ".."), ".."), ".."), "dist"))
+        self.cli.dir = (
+            old_div(old_div(old_div(old_div(
+                old_div(old_div(
+                    old_div(path(__file__).dirname(), ".."),
+                    ".."), ".."), ".."), ".."), ".."), "dist"))
         self.args += ["admin"]
 
     def test_log(self):

--- a/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
@@ -191,7 +191,7 @@ class TestChgrp(CLITest):
     def testNonExistingGroupName(self):
         self.args += [self.uuid(), '/Image:1']
         with pytest.raises(NonZeroReturnCode):
-                self.cli.invoke(self.args, strict=True)
+            self.cli.invoke(self.args, strict=True)
 
     # These tests try to exercise the various grouping possibilities
     # when passing multiple objects on the command line. In all of these

--- a/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chgrp.py
@@ -19,6 +19,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
+from builtins import range
 import omero
 from omero.cli import NonZeroReturnCode
 from omero.plugins.chgrp import ChgrpControl

--- a/components/tools/OmeroPy/test/integration/clitest/test_chown.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_chown.py
@@ -21,6 +21,8 @@
 
 # from omero.cli import NonZeroReturnCode
 
+from builtins import str
+from builtins import range
 import omero
 from omero.plugins.chown import ChownControl
 from omero.testlib.cli import CLITest, RootCLITest

--- a/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_cleanse.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from builtins import str
 from omero.testlib.cli import CLITest
 from omero.cli import NonZeroReturnCode
 from omero.cmd import Delete2

--- a/components/tools/OmeroPy/test/integration/clitest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_delete.py
@@ -19,6 +19,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
+from builtins import range
 import omero
 from omero.plugins.delete import DeleteControl
 from omero.testlib.cli import CLITest

--- a/components/tools/OmeroPy/test/integration/clitest/test_download.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_download.py
@@ -19,6 +19,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
+from builtins import object
 import pytest
 import omero
 
@@ -31,7 +33,7 @@ from omero.model import NamedValue as NV
 from omero.util.temp_files import create_path
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -175,7 +177,7 @@ class TestDownload(CLITest):
         with open(fake.abspath(), 'w+') as f:
             bytes1 = f.read()
         pix_ids = self.import_image(f.name)
-        pixels = self.query.get("Pixels", long(pix_ids[0]))
+        pixels = self.query.get("Pixels", int(pix_ids[0]))
         tmpfile = tmpdir.join('test')
         self.args += ["Image:%s" % pixels.getImage().id.val, str(tmpfile)]
         self.cli.invoke(self.args, strict=True)
@@ -217,7 +219,7 @@ class TestDownload(CLITest):
         with open(fake.abspath(), 'w+') as f:
             bytes1 = f.read()
         pix_ids = self.import_image(f.name)
-        pixels = self.query.get("Pixels", long(pix_ids[0]))
+        pixels = self.query.get("Pixels", int(pix_ids[0]))
         tmpfile = tmpdir.join('test')
         self.set_context(client, group2.id.val)
         self.args += ["Image:%s" % pixels.getImage().id.val, str(tmpfile)]

--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -86,7 +86,7 @@ class TestFS(CLITest):
         self.cli.invoke(self.args, strict=True)
         o, e = capsys.readouterr()
         printed_ids = set(self.parse_ids(o))
-        expected_ids = set([x.id.val for x in f.values()])
+        expected_ids = set([x.id.val for x in list(f.values())])
         assert expected_ids.issubset(printed_ids)
 
         for transfer in transfers:
@@ -94,7 +94,7 @@ class TestFS(CLITest):
                             strict=True)
             o, e = capsys.readouterr()
             printed_ids = set(self.parse_ids(o))
-            expected_ids = set([x.id.val for (k, x) in f.iteritems()
+            expected_ids = set([x.id.val for (k, x) in f.items()
                                 if k == transfer])
             assert expected_ids.issubset(printed_ids)
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_group.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_group.py
@@ -18,6 +18,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
 from omero.plugins.group import GroupControl, defaultperms
 from omero.cli import NonZeroReturnCode
 from omero.testlib.cli import CLITest, RootCLITest
@@ -30,8 +31,8 @@ import pytest
 GroupNames = [str(x) for x in GroupFixtures]
 UserNames = [str(x) for x in UserFixtures]
 GroupIdNameNames = [str(x) for x in GroupIdNameFixtures]
-perms_pairs = [('--perms', v) for v in defaultperms.values()]
-perms_pairs.extend([('--type', v) for v in defaultperms.keys()])
+perms_pairs = [('--perms', v) for v in list(defaultperms.values())]
+perms_pairs.extend([('--type', v) for v in list(defaultperms.keys())])
 
 
 class TestGroup(CLITest):
@@ -201,7 +202,7 @@ class TestGroupRoot(RootCLITest):
     # ========================================================================
     @pytest.mark.parametrize(
         "idnamefixture", GroupIdNameFixtures, ids=GroupIdNameNames)
-    @pytest.mark.parametrize("from_perms", defaultperms.values())
+    @pytest.mark.parametrize("from_perms", list(defaultperms.values()))
     @pytest.mark.parametrize("perms_prefix,to_perms", perms_pairs)
     def testPerms(self, idnamefixture, from_perms, perms_prefix, to_perms):
         group = self.new_group([], from_perms)

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -24,9 +24,6 @@ from builtins import str
 from builtins import range
 from past.utils import old_div
 from builtins import object
-plugin = __import__('omero.plugins.import', globals(), locals(),
-                    ['ImportControl'], -1)
-ImportControl = plugin.ImportControl
 from omero.testlib.cli import CLITest
 import pytest
 import stat
@@ -35,6 +32,9 @@ import yaml
 import omero
 from omero.cli import NonZeroReturnCode
 from omero.rtypes import rstring
+plugin = __import__('omero.plugins.import', globals(), locals(),
+                    ['ImportControl'], -1)
+ImportControl = plugin.ImportControl
 
 
 class NamingFixture(object):
@@ -47,7 +47,10 @@ class NamingFixture(object):
         self.name_arg = name_arg
         self.description_arg = description_arg
 
+
 NF = NamingFixture
+
+
 NFS = (
     NF("Image", None, None),
     NF("Image", None, "-x"),
@@ -76,6 +79,8 @@ NFS = (
     NF("Plate", "--plate_name", "--plate_description"),
 )
 xstr = lambda s: s or ""
+
+
 NFS_names = ['%s%s%s' % (x.obj_type, xstr(x.name_arg),
              xstr(x.description_arg)) for x in NFS]
 debug_levels = ['ALL', 'TRACE',  'DEBUG', 'INFO', 'WARN', 'ERROR']
@@ -105,7 +110,10 @@ class AnnotationFixture(object):
         else:
             return '%s-%s-Official' % (self.arg_type, self.n)
 
+
 AF = AnnotationFixture
+
+
 AFS = (
     AF("Python", 1, False),
     AF("Python", 1, True),

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -18,6 +18,12 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from __future__ import division
+from __future__ import print_function
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 plugin = __import__('omero.plugins.import', globals(), locals(),
                     ['ImportControl'], -1)
 ImportControl = plugin.ImportControl
@@ -155,7 +161,7 @@ class TestImport(CLITest):
         return o, e
 
     def add_client_dir(self):
-        client_dir = self.omero_dist / "lib" / "client"
+        client_dir = old_div(old_div(self.omero_dist, "lib"), "client")
         self.args += ["--clientdir", client_dir]
 
     def check_other_output(self, out, import_type='default'):
@@ -408,7 +414,7 @@ class TestImport(CLITest):
             self.args += ['--']
         for i in range(fixture.n):
             self.args += [fixture.annotation_link_arg, '%s' % comment_ids[i]]
-        print self.args
+        print(self.args)
         # Invoke CLI import command and retrieve stdout/stderr
         o, e = self.do_import(capfd)
         obj = self.get_object(o, 'Image')

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -32,8 +32,13 @@ import yaml
 import omero
 from omero.cli import NonZeroReturnCode
 from omero.rtypes import rstring
-plugin = __import__('omero.plugins.import', globals(), locals(),
-                    ['ImportControl'], -1)
+try:
+    plugin = __import__('omero.plugins.import', globals(), locals(),
+                        ['ImportControl'], -1)
+except ValueError:
+    # Python 3
+    plugin = __import__('omero.plugins.import', globals(), locals(),
+                        ['ImportControl'], 0)
 ImportControl = plugin.ImportControl
 
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_import_bulk.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import_bulk.py
@@ -22,16 +22,16 @@ from __future__ import division
 from __future__ import print_function
 from builtins import str
 from past.utils import old_div
-plugin = __import__('omero.plugins.import', globals(), locals(),
-                    ['ImportControl'], -1)
-ImportControl = plugin.ImportControl
-
 from omero.cli import NonZeroReturnCode
 from omero.testlib.cli import CLITest
 from omero.plugins.sessions import SessionsControl
 import sys
 import re
 import subprocess
+
+plugin = __import__('omero.plugins.import', globals(), locals(),
+                    ['ImportControl'], -1)
+ImportControl = plugin.ImportControl
 
 
 class TestImportBulk(CLITest):
@@ -121,7 +121,8 @@ path: test.tsv
         script = tmpdir.join("script1.sh")
 
         self.args += ["import", "-f", "--bulk", str(yml),
-                      "--clientdir", old_div(old_div(self.omero_dist, "lib"), "client")]
+                      "--clientdir", old_div(old_div(self.omero_dist, "lib"),
+                                             "client")]
 
         bin = old_div(old_div(self.omero_dist, "bin"), "omero")
         monkeypatch.setattr(sys, "argv", [str(bin)])

--- a/components/tools/OmeroPy/test/integration/clitest/test_import_bulk.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import_bulk.py
@@ -18,6 +18,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from __future__ import division
+from __future__ import print_function
+from builtins import str
+from past.utils import old_div
 plugin = __import__('omero.plugins.import', globals(), locals(),
                     ['ImportControl'], -1)
 ImportControl = plugin.ImportControl
@@ -117,9 +121,9 @@ path: test.tsv
         script = tmpdir.join("script1.sh")
 
         self.args += ["import", "-f", "--bulk", str(yml),
-                      "--clientdir", self.omero_dist / "lib" / "client"]
+                      "--clientdir", old_div(old_div(self.omero_dist, "lib"), "client")]
 
-        bin = self.omero_dist / "bin" / "omero"
+        bin = old_div(old_div(self.omero_dist, "bin"), "omero")
         monkeypatch.setattr(sys, "argv", [str(bin)])
         out, err = self.do_import(capfd)
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_import_bulk.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import_bulk.py
@@ -29,8 +29,13 @@ import sys
 import re
 import subprocess
 
-plugin = __import__('omero.plugins.import', globals(), locals(),
-                    ['ImportControl'], -1)
+try:
+    plugin = __import__('omero.plugins.import', globals(), locals(),
+                        ['ImportControl'], -1)
+except ValueError:
+    # Python 3
+    plugin = __import__('omero.plugins.import', globals(), locals(),
+                        ['ImportControl'], 0)
 ImportControl = plugin.ImportControl
 
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -42,7 +42,7 @@ class MetadataTestBase(CLITest):
 
         conn = BlitzGateway(client_obj=self.client)
         self.imageid = unwrap(self.image.getId())
-        assert type(self.imageid) == long
+        assert type(self.imageid) == int
         wrapper = conn.getObject("Image", self.imageid)
         self.md = Metadata(wrapper)
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -228,7 +228,7 @@ class TestObj(CLITest):
         self.args = self.login_args() + [
             "obj", "get", project, "bar"]
         with pytest.raises(NonZeroReturnCode):
-                state = self.go()
+            state = self.go()
 
     def test_get_fields(self):
         name = "foo"
@@ -301,7 +301,7 @@ class TestObj(CLITest):
         self.args = self.login_args() + [
             "obj", "list-get", ann, "mapValue", "0"]
         with pytest.raises(NonZeroReturnCode):
-                state = self.go()
+            state = self.go()
         self.args = self.login_args() + [
             "obj", "map-set", ann, "mapValue", "name1", "value1"]
         self.go()
@@ -328,7 +328,7 @@ class TestObj(CLITest):
         self.args = self.login_args() + [
             "obj", "list-get", ann, "mapValue", "3"]
         with pytest.raises(NonZeroReturnCode):
-                state = self.go()
+            state = self.go()
 
         # Test for a list of strings
         updateService = self.root.getSession().getUpdateService()
@@ -344,7 +344,7 @@ class TestObj(CLITest):
         self.args = self.login_args() + [
             "obj", "list-get", "Namespace:%s" % n.id.val, "name", "0"]
         with pytest.raises(NonZeroReturnCode):
-                state = self.go()
+            state = self.go()
 
     def test_map_mods(self):
         self.args = self.login_args() + [

--- a/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
@@ -20,6 +20,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from __future__ import print_function
+from builtins import str
 from test.integration.clitest.cli import CLITest
 from omero.cli import NonZeroReturnCode
 from omero.model import PixelsI
@@ -98,7 +100,7 @@ class TestRemovePyramidsFullAdmin(CLITest):
         fakefile = tmpdir.join(name)
         fakefile.write('')
         pixels = self.import_image(filename=str(fakefile), skip="checksum")[0]
-        id = long(float(pixels))
+        id = int(float(pixels))
         # wait for the pyramid to be generated
         self.wait_for_pyramid(id)
         query_service = self.client.sf.getQueryService()

--- a/components/tools/OmeroPy/test/integration/clitest/test_script.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_script.py
@@ -9,6 +9,7 @@
 
 """
 
+from builtins import str
 from omero.testlib.cli import CLITest
 from omero.plugins.script import ScriptControl
 from omero.util.temp_files import create_path

--- a/components/tools/OmeroPy/test/integration/clitest/test_search.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_search.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from builtins import str
 import pytest
 
 from datetime import date

--- a/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_sessions.py
@@ -19,6 +19,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
 from omero.testlib.cli import CLITest
 from omero.cli import NonZeroReturnCode
 from omero.model import Experimenter
@@ -89,7 +90,7 @@ class TestSessions(CLITest):
             self.args += ["-q"]
         if timeout:
             self.args += ["--timeout", str(timeout)]
-            timetoidle = long(timeout) * 1000
+            timetoidle = int(timeout) * 1000
             timetoidle_str = "%.f min" % (float(timeout) / 60)
         self.cli.invoke(self.args, strict=True)
 

--- a/components/tools/OmeroPy/test/integration/clitest/test_tag.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_tag.py
@@ -19,6 +19,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from __future__ import print_function
+from builtins import str
+from builtins import range
 import re
 import pytest
 import omero

--- a/components/tools/OmeroPy/test/integration/clitest/test_upload.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_upload.py
@@ -19,6 +19,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
 import pytest
 
 from omero.testlib.cli import CLITest

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -19,6 +19,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from builtins import str
 from omero.cli import NonZeroReturnCode
 from omero.rtypes import rstring
 from omero.plugins.user import UserControl
@@ -346,7 +347,7 @@ class TestUserRoot(RootCLITest):
 
         # Check user has been added to the list of member/owners
         user = self.sf.getAdminService().lookupExperimenter(login)
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             assert getattr(user, key).val == kwargs[key]
 
         assert user.id.val in self.getuserids(group.id.val)

--- a/components/tools/OmeroPy/test/integration/fstest/test_rename.py
+++ b/components/tools/OmeroPy/test/integration/fstest/test_rename.py
@@ -20,6 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from builtins import str
 import pytest
 
 from omero.testlib import AbstractRepoTest

--- a/components/tools/OmeroPy/test/integration/gatewaytest/conftest.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/conftest.py
@@ -1,1 +1,0 @@
-pytest_plugins = "omero.gateway.pytest_fixtures"

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 
 from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 import time
@@ -32,6 +31,7 @@ try:
 except Exception:
     # Python 3
     long = int
+standard_library.install_aliases()
 
 
 def _testAnnotation(obj, annclass, ns, value, sameOwner=False,
@@ -81,6 +81,7 @@ def _testAnnotation(obj, annclass, ns, value, sameOwner=False,
     # Remove and check
     obj.removeAnnotations(ns)
     assert obj.getAnnotation(ns) is None
+
 
 TESTANN_NS = 'omero.gateway.test_annotation'
 
@@ -235,18 +236,18 @@ def testListAnnotations(author_testimg_generated):
     annclass.createAndLink(target=obj, ns=ns2, val=value)
     ann1 = obj.getAnnotation(ns1)
     ann2 = obj.getAnnotation(ns2)
-    l = list(obj.listAnnotations())
-    assert ann1 in l
-    assert ann2 in l
-    l = list(obj.listAnnotations(ns=ns1))
-    assert ann1 in l
-    assert ann2 not in l
-    l = list(obj.listAnnotations(ns=ns2))
-    assert ann1 not in l
-    assert ann2 in l
-    l = list(obj.listAnnotations(ns='bogusns...bogusns...'))
-    assert ann1 not in l
-    assert ann2 not in l
+    values = list(obj.listAnnotations())
+    assert ann1 in values
+    assert ann2 in values
+    values = list(obj.listAnnotations(ns=ns1))
+    assert ann1 in values
+    assert ann2 not in values
+    values = list(obj.listAnnotations(ns=ns2))
+    assert ann1 not in values
+    assert ann2 in values
+    values = list(obj.listAnnotations(ns='bogusns...bogusns...'))
+    assert ann1 not in values
+    assert ann2 not in values
     # Remove and check
     obj.removeAnnotations(ns1)
     obj.removeAnnotations(ns2)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -12,18 +12,23 @@
    - author_testimg_generated
 
 """
+from __future__ import print_function
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
 import time
 import datetime
 import os
 from tempfile import NamedTemporaryFile
-from cStringIO import StringIO
+from io import StringIO
 
 import omero.gateway
 from omero.rtypes import rstring
 from omero.gateway import FileAnnotationWrapper
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -162,7 +167,7 @@ def testBooleanAnnotation(author_testimg_generated):
 def testLongAnnotation(author_testimg_generated):
     _testAnnotation(author_testimg_generated,
                     omero.gateway.LongAnnotationWrapper,
-                    TESTANN_NS, long(1000))
+                    TESTANN_NS, int(1000))
 
 
 def testMapAnnotation(author_testimg_generated):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_chgrp.py
@@ -12,6 +12,7 @@
 
 """
 
+from builtins import range
 import omero
 from omero.rtypes import rstring
 from omero.cmd import State, ERR, OK

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_chmod.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_chmod.py
@@ -22,6 +22,7 @@ from omero.cmd import State, ERR, OK
 from omero.gateway.scripts import dbhelpers
 import uuid
 import pytest
+import logging
 
 PRIVATE = 'rw----'
 READONLY = 'rwr---'
@@ -29,7 +30,6 @@ READANN = 'rwra--'
 READWRITE = 'rwrw--'
 
 
-import logging
 logging.basicConfig(level=logging.ERROR)
 
 
@@ -382,7 +382,7 @@ class TestCustomUsers (ChmodBase):
         # Login as regular member
         gatewaywrapper.doLogin(dbhelpers.USERS['read_write_user'])
         p = gatewaywrapper.gateway.getObject("Project", pr.id.val)
-        assert None != p, "Member can access Project"
+        assert p is not None, "Member can access Project"
         assert p.canDelete() is True, \
             "Member can delete another user's Project"
         handle = gatewaywrapper.gateway.deleteObjects("Project", [pr.id.val])
@@ -390,7 +390,7 @@ class TestCustomUsers (ChmodBase):
 
         # Must reload project
         p = gatewaywrapper.gateway.getObject("Project", pr.id.val)
-        assert None == p, "Project should be Deleted"
+        assert p is None, "Project should be Deleted"
 
 
 class TestManualCreateEdit (ChmodBase):
@@ -501,7 +501,7 @@ class TestDefaultSetup (object):
         gatewaywrapper.loginAsUser()
         gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup('-1')
         i = gatewaywrapper.gateway.getObject("Image", imageId)
-        assert None == i, \
+        assert i is None, \
             "User cannot access Author's image in Read-only group"
 
         # Create new user in the same group

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_chmod.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_chmod.py
@@ -13,6 +13,8 @@
 
 """
 
+from builtins import str
+from builtins import object
 import omero
 import traceback
 from omero.rtypes import rstring

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
@@ -147,7 +147,8 @@ class TestConnectionMethods(object):
         # exps = map(lambda x: x.omeName,
         # gatewaywrapper.gateway.listExperimenters())  # removed from blitz
         # gateway
-        exps = [x.omeName for x in gatewaywrapper.gateway.getObjects("Experimenter")]
+        objects = gatewaywrapper.gateway.getObjects("Experimenter")
+        exps = [x.omeName for x in objects]
         for omeName in (gatewaywrapper.USER.name, gatewaywrapper.AUTHOR.name,
                         gatewaywrapper.ADMIN.name.decode('utf-8')):
             assert omeName in exps
@@ -197,7 +198,7 @@ class TestConnectionMethods(object):
             gatewaywrapper.USER.name, gatewaywrapper.USER.passwd)
         setprop = gatewaywrapper.gateway.c.ic.getProperties().setProperty
         list(map(lambda x: setprop(x[0], str(x[1])),
-            list(gatewaywrapper.gateway._ic_props.items())))
+             list(gatewaywrapper.gateway._ic_props.items())))
         gatewaywrapper.gateway.c.ic.getImplicitContext().put(
             omero.constants.GROUP, gatewaywrapper.gateway.group)
         # I'm not certain the following assertion is as intended.

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
@@ -11,6 +11,9 @@
 
 """
 
+from builtins import map
+from builtins import str
+from builtins import object
 import omero
 import Ice
 from omero.gateway.scripts import dbhelpers
@@ -109,25 +112,25 @@ class TestConnectionMethods(object):
         # the project created above is in new group.
         # gatewaywrapper.loginAsAdmin()
         # test passes if we remain logged in as Author
-        ids = map(lambda x: x.getId(), gatewaywrapper.gateway.listProjects())
+        ids = [x.getId() for x in gatewaywrapper.gateway.listProjects()]
         assert project_id in ids
         # test passes if we NOW log in as Admin (different group)
         gatewaywrapper.loginAsAdmin()
-        ids = map(lambda x: x.getId(), gatewaywrapper.gateway.listProjects())
+        ids = [x.getId() for x in gatewaywrapper.gateway.listProjects()]
         assert project_id not in ids
         ##
         # Test listProjects as author (sees, owns)
         gatewaywrapper.loginAsAuthor()
-        ids = map(lambda x: x.getId(), gatewaywrapper.gateway.listProjects())
+        ids = [x.getId() for x in gatewaywrapper.gateway.listProjects()]
         assert project_id in ids
-        ids = map(lambda x: x.getId(), gatewaywrapper.gateway.listProjects())
+        ids = [x.getId() for x in gatewaywrapper.gateway.listProjects()]
         assert project_id in ids
         ##
         # Test listProjects as guest (does not see, does not own)
         gatewaywrapper.doLogin(gatewaywrapper.USER)
-        ids = map(lambda x: x.getId(), gatewaywrapper.gateway.listProjects())
+        ids = [x.getId() for x in gatewaywrapper.gateway.listProjects()]
         assert project_id not in ids
-        ids = map(lambda x: x.getId(), gatewaywrapper.gateway.listProjects())
+        ids = [x.getId() for x in gatewaywrapper.gateway.listProjects()]
         assert project_id not in ids
         ##
         # Test getProject
@@ -144,8 +147,7 @@ class TestConnectionMethods(object):
         # exps = map(lambda x: x.omeName,
         # gatewaywrapper.gateway.listExperimenters())  # removed from blitz
         # gateway
-        exps = map(lambda x: x.omeName,
-                   gatewaywrapper.gateway.getObjects("Experimenter"))
+        exps = [x.omeName for x in gatewaywrapper.gateway.getObjects("Experimenter")]
         for omeName in (gatewaywrapper.USER.name, gatewaywrapper.AUTHOR.name,
                         gatewaywrapper.ADMIN.name.decode('utf-8')):
             assert omeName in exps
@@ -194,8 +196,8 @@ class TestConnectionMethods(object):
         gatewaywrapper.gateway.setIdentity(
             gatewaywrapper.USER.name, gatewaywrapper.USER.passwd)
         setprop = gatewaywrapper.gateway.c.ic.getProperties().setProperty
-        map(lambda x: setprop(x[0], str(x[1])),
-            gatewaywrapper.gateway._ic_props.items())
+        list(map(lambda x: setprop(x[0], str(x[1])),
+            list(gatewaywrapper.gateway._ic_props.items())))
         gatewaywrapper.gateway.c.ic.getImplicitContext().put(
             omero.constants.GROUP, gatewaywrapper.gateway.group)
         # I'm not certain the following assertion is as intended.

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
@@ -12,6 +12,8 @@
 
 """
 
+from builtins import str
+from builtins import object
 import omero
 from omero.rtypes import wrap, unwrap
 import time

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_fs.py
@@ -27,6 +27,9 @@
 
 """
 
+from builtins import str
+from builtins import range
+from builtins import object
 import pytest
 
 from omero.model import ImageI, PixelsI, FilesetI, FilesetEntryI, \
@@ -35,7 +38,7 @@ from omero.model import ImageI, PixelsI, FilesetI, FilesetEntryI, \
 from omero.rtypes import rstring, rlong, rint, rtime
 from uuid import uuid4
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -56,8 +59,8 @@ def create_image(image_index):
     pixels.sizeZ = rint(1)
     pixels.sizeC = rint(1)
     pixels.sizeT = rint(1)
-    pixels.dimensionOrder = DimensionOrderI(long(1), False)  # XYZCT
-    pixels.pixelsType = PixelsTypeI(long(1), False)  # bit
+    pixels.dimensionOrder = DimensionOrderI(int(1), False)  # XYZCT
+    pixels.pixelsType = PixelsTypeI(int(1), False)  # bit
     image.addPixels(pixels)
     return image
 
@@ -75,7 +78,7 @@ def images_with_original_files(request, gatewaywrapper):
             'filename_%d.ext' % original_file_index
         )
         original_file.path = rstring('/server/path/')
-        original_file.size = rlong(long(50))
+        original_file.size = rlong(int(50))
         original_files.append(original_file)
     images = list()
     for image_index in range(2):
@@ -101,7 +104,7 @@ def create_fileset():
             original_file = OriginalFileI()
             original_file.name = rstring('filename_%d.ext' % fileset_index)
             original_file.path = rstring('/server/path/')
-            original_file.size = rlong(long(50))
+            original_file.size = rlong(int(50))
             fileset_entry.originalFile = original_file
             fileset.addFilesetEntry(fileset_entry)
         fileset.addImage(image)
@@ -128,7 +131,7 @@ def fileset_with_images_and_annotations(request, gatewaywrapper):
     comment_annotation.textValue = rstring('textValue')
     long_annotation = LongAnnotationI()
     long_annotation.ns = rstring('long_annotation')
-    long_annotation.longValue = rlong(long(1))
+    long_annotation.longValue = rlong(int(1))
     fileset.linkAnnotation(comment_annotation)
     fileset.linkAnnotation(long_annotation)
     fileset = update_service.saveAndReturnObject(fileset)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -14,6 +14,9 @@
 
 """
 
+from builtins import str
+from builtins import range
+from builtins import object
 import omero
 import uuid
 import pytest
@@ -29,7 +32,7 @@ from omero.model import DatasetI, \
     WellI, \
     WellSampleI
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -112,7 +115,7 @@ class TestFindObject (object):
     def testIllegalObjTypeInt(self, gatewaywrapper):
         gatewaywrapper.loginAsAuthor()
         with pytest.raises(AttributeError):
-            gatewaywrapper.gateway.getObject(1, long(1))
+            gatewaywrapper.gateway.getObject(1, int(1))
 
     def testObjTypeUnicode(self, gatewaywrapper):
         gatewaywrapper.loginAsAuthor()
@@ -773,7 +776,7 @@ class TestLeaderAndMemberOfGroup(object):
         gatewaywrapper.doLogin(dbhelpers.USERS['group_member'])
         assert not gatewaywrapper.gateway.isLeader()
         with pytest.raises(StopIteration):
-            gatewaywrapper.gateway.getGroupsLeaderOf().next()
+            next(gatewaywrapper.gateway.getGroupsLeaderOf())
 
     def testGetGroupsMemberOf(self, gatewaywrapper):
         gatewaywrapper.doLogin(dbhelpers.USERS['group_member'])
@@ -865,7 +868,7 @@ class TestListParents(ITest):
         corresponding tests below
         """
         tested_wrappers = ['plate', 'image', 'dataset', 'experimenter', 'well']
-        for key, wrapper in KNOWN_WRAPPERS.items():
+        for key, wrapper in list(KNOWN_WRAPPERS.items()):
             if (hasattr(wrapper, 'PARENT_WRAPPER_CLASS') and
                     wrapper.PARENT_WRAPPER_CLASS is not None):
                 assert key in tested_wrappers

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_helpers.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_helpers.py
@@ -7,10 +7,11 @@
 
 """
 
+from builtins import object
 import omero
 import omero.gateway
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -41,7 +42,7 @@ class TestHelperObjects(object):
         assert isinstance(omero_type('rstring'), omero.RString)
         assert isinstance(omero_type(u'rstring'), omero.RString)
         assert isinstance(omero_type(1), omero.RInt)
-        assert isinstance(omero_type(long(1)), omero.RLong)
+        assert isinstance(omero_type(int(1)), omero.RLong)
         assert isinstance(omero_type(False), omero.RBool)
         assert isinstance(omero_type(True), omero.RBool)
         assert not isinstance(omero_type((1, 2, 'a')), omero.RType)

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -84,7 +84,8 @@ class TestImage (object):
         # ordinary and big image (4k x 4k and up)
         img_ids = [self.image.id, author_testimg_big.id]
         conn = self.image._conn
-        for (img_id, thumb) in list(conn.getThumbnailSet(image_ids=img_ids).items()):
+        thumbnails_set = conn.getThumbnailSet(image_ids=img_ids)
+        for (img_id, thumb) in list(thumbnails_set.items()):
             assert img_id in img_ids
             tfile = BytesIO(thumb)
             thumb = Image.open(tfile)  # Raises if invalid
@@ -294,11 +295,11 @@ class TestImage (object):
     def testShortname(self):
         """ Test the shortname method """
         name = self.image.name
-        l = len(self.image.name)
-        assert self.image.shortname(length=l+4, hist=5) == self.image.name
-        assert self.image.shortname(length=l-4, hist=5) == self.image.name
-        assert self.image.shortname(length=l-5, hist=5) == \
-            '...' + self.image.name[-l+5:]
+        size = len(self.image.name)
+        assert self.image.shortname(length=size+4, hist=5) == self.image.name
+        assert self.image.shortname(length=size-4, hist=5) == self.image.name
+        assert self.image.shortname(length=size-5, hist=5) == \
+            '...' + self.image.name[-size+5:]
         self.image.name = ''
         assert self.image.shortname(length=20, hist=5) == ''
         self.image.name = name

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image.py
@@ -13,7 +13,12 @@
    - author_testimg_big
 
 """
+from __future__ import print_function
 
+from builtins import zip
+from builtins import str
+from builtins import range
+from builtins import object
 import pytest
 from io import BytesIO
 import omero
@@ -79,7 +84,7 @@ class TestImage (object):
         # ordinary and big image (4k x 4k and up)
         img_ids = [self.image.id, author_testimg_big.id]
         conn = self.image._conn
-        for (img_id, thumb) in conn.getThumbnailSet(image_ids=img_ids).items():
+        for (img_id, thumb) in list(conn.getThumbnailSet(image_ids=img_ids).items()):
             assert img_id in img_ids
             tfile = BytesIO(thumb)
             thumb = Image.open(tfile)  # Raises if invalid
@@ -338,7 +343,7 @@ class TestImage (object):
         assert 'date' in m
         m = self.image.simpleMarshal(xtra={'tiled': False})
         assert 'tiled' not in m
-        parents = map(lambda x: x.simpleMarshal(), self.image.getAncestry())
+        parents = [x.simpleMarshal() for x in self.image.getAncestry()]
         m = self.image.simpleMarshal(parents=True)
         assert m['name'] == self.image.getName()
         assert m['description'] == self.image.getDescription()
@@ -354,7 +359,7 @@ class TestImage (object):
         # if we pass a bufsize we should get a generator back
         size, gen = self.image.exportOmeTiff(bufsize=16)
         assert hasattr(gen, 'next')
-        assert len(gen.next()) == 16
+        assert len(next(gen)) == 16
         del gen
         self.assert_no_leaked_exporter(gatewaywrapper.gateway.c)
         # Now try the same using a different user, admin first

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_image_wrapper.py
@@ -13,6 +13,8 @@
 
 """
 
+from builtins import range
+from builtins import object
 import pytest
 from omero.testlib import ITest
 
@@ -20,7 +22,7 @@ from omero.model import ImageI, ChannelI, LogicalChannelI, LengthI
 from omero.rtypes import rstring, rtime
 from datetime import datetime
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -55,7 +57,7 @@ def image(request, gatewaywrapper):
     image = ImageI()
     image.name = rstring('an image')
     # 2015-04-21 01:15:00
-    image.acquisitionDate = rtime(long(1429578900000))
+    image.acquisitionDate = rtime(int(1429578900000))
     image_id, = update_service.saveAndReturnIds([image])
     return gw.getObject('Image', image_id)
 
@@ -68,7 +70,7 @@ def image_no_acquisition_date(request, gatewaywrapper):
     update_service = gw.getUpdateService()
     image = ImageI()
     image.name = rstring('an image')
-    image.acquisitionDate = rtime(long(0))
+    image.acquisitionDate = rtime(int(0))
     image_id, = update_service.saveAndReturnIds([image])
     return gw.getObject('Image', image_id)
 
@@ -128,7 +130,7 @@ class TestImageWrapper(object):
 
     def testGetDate(self, gatewaywrapper, image):
         date = image.getDate()
-        assert date == datetime.fromtimestamp(long(1429578900))
+        assert date == datetime.fromtimestamp(int(1429578900))
 
     def testGetDateNoAcquisitionDate(
             self, gatewaywrapper, image_no_acquisition_date):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_missing_pyramid.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_missing_pyramid.py
@@ -9,7 +9,11 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import division
+from __future__ import print_function
 
+from builtins import object
+from past.utils import old_div
 import omero
 import pytest
 
@@ -29,7 +33,7 @@ class TestPyramid (object):
             assert False, "_prepareRE should have thrown an exception"
         except omero.ConcurrencyException as ce:
             print("Handling MissingPyramidException with backoff: %s secs"
-                  % (ce.backOff/1000))
+                  % (old_div(ce.backOff,1000)))
 
     def testPrepareRenderingEngine(self):
         """
@@ -44,7 +48,7 @@ class TestPyramid (object):
                 "_prepareRenderingEngine() should have thrown an exception"
         except omero.ConcurrencyException as ce:
             print("Handling MissingPyramidException with backoff: %s secs"
-                  % (ce.backOff/1000))
+                  % (old_div(ce.backOff,1000)))
 
     def testGetChannels(self):
         """ Missing Pyramid shouldn't stop us from getting Channel Info """

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_missing_pyramid.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_missing_pyramid.py
@@ -33,7 +33,7 @@ class TestPyramid (object):
             assert False, "_prepareRE should have thrown an exception"
         except omero.ConcurrencyException as ce:
             print("Handling MissingPyramidException with backoff: %s secs"
-                  % (old_div(ce.backOff,1000)))
+                  % (old_div(ce.backOff, 1000)))
 
     def testPrepareRenderingEngine(self):
         """
@@ -48,7 +48,7 @@ class TestPyramid (object):
                 "_prepareRenderingEngine() should have thrown an exception"
         except omero.ConcurrencyException as ce:
             print("Handling MissingPyramidException with backoff: %s secs"
-                  % (old_div(ce.backOff,1000)))
+                  % (old_div(ce.backOff, 1000)))
 
     def testGetChannels(self):
         """ Missing Pyramid shouldn't stop us from getting Channel Info """

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
@@ -12,6 +12,8 @@
 
 """
 
+from builtins import str
+from builtins import object
 import omero
 import omero.scripts
 from omero.rtypes import rstring, rtime, rlong
@@ -20,7 +22,7 @@ import time
 import pytest
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -44,9 +46,9 @@ class TestHistory (object):
     def searchHistory(self, gateway, start, end, dtype="Dataset"):
 
         tm = gateway.getTimelineService()
-        count = tm.countByPeriod([dtype], rtime(long(start)),
-                                 rtime(long(end)), None, gateway.SERVICE_OPTS)
-        data = tm.getByPeriod([dtype], rtime(long(start)), rtime(long(end)),
+        count = tm.countByPeriod([dtype], rtime(int(start)),
+                                 rtime(int(end)), None, gateway.SERVICE_OPTS)
+        data = tm.getByPeriod([dtype], rtime(int(start)), rtime(int(end)),
                               None, True, gateway.SERVICE_OPTS)
 
         logs = tm.getEventLogsByPeriod(rtime(start), rtime(end), None,

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_multi_group.py
@@ -102,9 +102,11 @@ class TestHistory (object):
         assert switched, "Failed to switch into new group"
         # Shouldn't be able to access Dataset...
         self.searchHistory(gatewaywrapper.gateway, start, end)
-        assert None == gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        value = gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        assert value is None
         gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup(str(default_groupId))
-        assert None != gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        value = gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        assert value is not None
 
         self.searchHistory(gatewaywrapper.gateway, start, end)
 
@@ -182,10 +184,12 @@ class TestScript (object):
             omero.model.ExperimenterGroupI(gid, False))
         assert switched, "Failed to switch into new group"
         # Shouldn't be able to access Dataset...
-        assert None == gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        value = gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        assert value is None
         gatewaywrapper.gateway.SERVICE_OPTS.setOmeroGroup(
             str(default_groupId))
-        assert None != gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        value = gatewaywrapper.gateway.getObject("Dataset", new_ds_Id)
+        assert value is not None
 
         # run script
         svc = gatewaywrapper.gateway.getScriptService()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_performance.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_performance.py
@@ -15,7 +15,10 @@
    - gatewaywrapper
 
 """
+from __future__ import print_function
 
+from builtins import range
+from builtins import object
 import pytest
 import omero
 import time

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_pixels.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_pixels.py
@@ -14,6 +14,9 @@
 
 """
 
+from builtins import str
+from builtins import range
+from builtins import object
 import omero
 import pytest
 
@@ -257,7 +260,7 @@ class TestPixels (object):
         theZ = 0
         theT = 0
         histogram = image.getHistogram(channels, binSize, theZ=theZ, theT=theT)
-        assert histogram.keys() == channels
+        assert list(histogram.keys()) == channels
         assert len(histogram[0]) == binSize
 
         # ...as long as we haven't left additional services open

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_plate_wrapper.py
@@ -13,13 +13,16 @@
 
 """
 
+from builtins import str
+from builtins import range
+from builtins import object
 import pytest
 
 from omero.model import PlateI, WellI, WellSampleI, ImageI
 from omero.rtypes import rstring, rint, rtime
 from uuid import uuid4
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -56,4 +59,4 @@ def plate(request, gatewaywrapper):
 class TestPlateWrapper(object):
 
     def testGetGridSize(self, gatewaywrapper, plate):
-        assert plate.getGridSize() == {'rows': long(5), 'columns': long(9)}
+        assert plate.getGridSize() == {'rows': int(5), 'columns': int(9)}

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -15,7 +15,6 @@
 """
 
 from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import object
 import pytest
@@ -23,6 +22,7 @@ import pytest
 from io import StringIO
 from PIL import Image, ImageChops
 import omero
+standard_library.install_aliases()
 
 
 class TestRDefs (object):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_rdefs.py
@@ -14,9 +14,13 @@
 
 """
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 import pytest
 
-from cStringIO import StringIO
+from io import StringIO
 from PIL import Image, ImageChops
 import omero
 
@@ -400,7 +404,7 @@ class TestRDefs (object):
         channels = self.image.getChannels()
 
         # change settings looping over all families
-        families = self.image.getFamilies().values()
+        families = list(self.image.getFamilies().values())
         for fam in families:
             i = 0
             # change and assert for new value per channel

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_search_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_search_objects.py
@@ -29,6 +29,7 @@
 """
 
 
+from builtins import object
 class TestGetObject (object):
 
     def testSearchObjects(self, gatewaywrapper):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_search_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_search_objects.py
@@ -30,6 +30,8 @@
 
 
 from builtins import object
+
+
 class TestGetObject (object):
 
     def testSearchObjects(self, gatewaywrapper):

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_services.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_services.py
@@ -13,6 +13,8 @@
 
 """
 
+from builtins import str
+from builtins import object
 import omero
 from omero.grid import StringColumn
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_ticket10618.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_ticket10618.py
@@ -25,6 +25,7 @@ sensible usages of ImageWrapper.getThumbnail()
 """
 
 
+from builtins import str
 from omero.testlib import ITest
 
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_user.py
@@ -12,6 +12,8 @@
 
 """
 
+from builtins import str
+from builtins import object
 import omero
 import pytest
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
@@ -13,6 +13,8 @@
 
 """
 
+from builtins import str
+from builtins import object
 import Ice
 import omero
 import os

--- a/components/tools/OmeroPy/test/integration/helpers.py
+++ b/components/tools/OmeroPy/test/integration/helpers.py
@@ -24,6 +24,7 @@
 
 """
 
+from builtins import range
 import omero.util.script_utils as scriptUtil
 from numpy import arange, uint8
 
@@ -53,7 +54,7 @@ def createImageWithPixels(client, name, sizes={}):
         sizeZ = "z" in sizes and sizes["z"] or 1
         sizeT = "t" in sizes and sizes["t"] or 1
         sizeC = "c" in sizes and sizes["c"] or 1
-        channelList = range(1, sizeC+1)
+        channelList = list(range(1, sizeC+1))
         id = pixelsService.createImage(
             sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType,
             name, description=None)

--- a/components/tools/OmeroPy/test/integration/helpers.py
+++ b/components/tools/OmeroPy/test/integration/helpers.py
@@ -39,23 +39,23 @@ def createTestImage(session, imageName="imageName"):
 
 
 def createImageWithPixels(client, name, sizes={}):
-        """
-        Create a new image with pixels
-        """
-        pixelsService = client.sf.getPixelsService()
-        queryService = client.sf.getQueryService()
+    """
+    Create a new image with pixels
+    """
+    pixelsService = client.sf.getPixelsService()
+    queryService = client.sf.getQueryService()
 
-        pixelsType = queryService.findByQuery(
-            "from PixelsType as p where p.value='int8'", None)
-        assert pixelsType is not None
+    pixelsType = queryService.findByQuery(
+        "from PixelsType as p where p.value='int8'", None)
+    assert pixelsType is not None
 
-        sizeX = "x" in sizes and sizes["x"] or 1
-        sizeY = "y" in sizes and sizes["y"] or 1
-        sizeZ = "z" in sizes and sizes["z"] or 1
-        sizeT = "t" in sizes and sizes["t"] or 1
-        sizeC = "c" in sizes and sizes["c"] or 1
-        channelList = list(range(1, sizeC+1))
-        id = pixelsService.createImage(
-            sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType,
-            name, description=None)
-        return id
+    sizeX = "x" in sizes and sizes["x"] or 1
+    sizeY = "y" in sizes and sizes["y"] or 1
+    sizeZ = "z" in sizes and sizes["z"] or 1
+    sizeT = "t" in sizes and sizes["t"] or 1
+    sizeC = "c" in sizes and sizes["c"] or 1
+    channelList = list(range(1, sizeC+1))
+    id = pixelsService.createImage(
+        sizeX, sizeY, sizeZ, sizeT, channelList, pixelsType,
+        name, description=None)
+    return id

--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -22,8 +22,10 @@
 """
 Integration test of metadata_mapannotation
 """
+from __future__ import print_function
 
 
+from builtins import zip
 from omero.testlib import ITest
 from omero.model import MapAnnotationI, NamedValue
 from omero.rtypes import unwrap, wrap
@@ -62,7 +64,7 @@ class TestMapAnnotationManager(ITest):
         ma3.setMapValue([NamedValue('a', '1')])
 
         mids = self.update.saveAndReturnIds([ma1, ma2, ma3])
-        print(ns1, ns3, mids)
+        print((ns1, ns3, mids))
         return ns1, ns3, mids
 
     def test_add_from_namespace_query(self):

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -24,6 +24,10 @@
    and populate_roi.py scripts.
 """
 
+from builtins import str
+from builtins import zip
+from builtins import range
+from builtins import object
 from omero.testlib import ITest
 import string
 import csv
@@ -706,7 +710,7 @@ class Dataset2Images(Fixture):
             con = mv['Concentration']
             typ = mv['Type']
             assert img[0] in ("A", "a")
-            which = long(img[1:])
+            which = int(img[1:])
             if which % 2 == 1:
                 assert con == '0'
                 assert typ == 'Control'
@@ -930,7 +934,7 @@ class TestPopulateMetadataHelper(ITest):
         rows = t.getNumberOfRows()
         fixture.assert_rows(rows)
         for hit in range(rows):
-            rowValues = [col.values[0] for col in t.read(range(len(cols)),
+            rowValues = [col.values[0] for col in t.read(list(range(len(cols))),
                                                          hit, hit+1).columns]
             assert len(rowValues) == fixture.count
             # Unsure where the lower-casing is happening
@@ -1047,8 +1051,8 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
         fixture.assert_rows(rows)
-        data = [c.values for c in t.read(range(len(cols)), 0, rows).columns]
-        rowValues = zip(*data)
+        data = [c.values for c in t.read(list(range(len(cols))), 0, rows).columns]
+        rowValues = list(zip(*data))
         assert len(rowValues) == fixture.count
         fixture.assert_row_values(rowValues)
 
@@ -1475,7 +1479,7 @@ class TestPopulateRois(ITest):
         rows = t.getNumberOfRows()
         assert rows == 1
 
-        data = t.read(range(len(cols)), 0, 1)
+        data = t.read(list(range(len(cols))), 0, 1)
         imag = data.columns[0].values[0]
         rois = self.client.sf.getRoiService()
         anns = rois.getRoiMeasurements(imag, RoiOptions())

--- a/components/tools/OmeroPy/test/integration/metadata/test_populate.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_populate.py
@@ -778,7 +778,7 @@ class GZIP(Dataset2Images):
             try:
                 try:
                     f_out = gzip.open(gzipFileName, 'wb')
-                except:
+                except Exception:
                     f_out = gzip(gzipFileName, 'wb')
                 shutil.copyfileobj(f_in, f_out)
             finally:
@@ -934,8 +934,8 @@ class TestPopulateMetadataHelper(ITest):
         rows = t.getNumberOfRows()
         fixture.assert_rows(rows)
         for hit in range(rows):
-            rowValues = [col.values[0] for col in t.read(list(range(len(cols))),
-                                                         hit, hit+1).columns]
+            rowValues = [col.values[0] for col in
+                         t.read(list(range(len(cols))), hit, hit+1).columns]
             assert len(rowValues) == fixture.count
             # Unsure where the lower-casing is happening
             if "A1" in rowValues or "a1" in rowValues:
@@ -1051,7 +1051,8 @@ class TestPopulateMetadata(TestPopulateMetadataHelper):
         cols = t.getHeaders()
         rows = t.getNumberOfRows()
         fixture.assert_rows(rows)
-        data = [c.values for c in t.read(list(range(len(cols))), 0, rows).columns]
+        data = [c.values for c in
+                t.read(list(range(len(cols))), 0, rows).columns]
         rowValues = list(zip(*data))
         assert len(rowValues) == fixture.count
         fixture.assert_row_values(rowValues)

--- a/components/tools/OmeroPy/test/integration/metadata/test_pydict_text.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_pydict_text.py
@@ -22,7 +22,9 @@
 """
 Test of the yaml/json parameters file handling
 """
+from __future__ import print_function
 
+from builtins import str
 from omero.testlib import ITest
 from omero.rtypes import unwrap
 from omero.util import pydict_text_io
@@ -75,7 +77,7 @@ class TestPydictTextIo(ITest):
         fa = self.make_file_annotation(
             name='test.%s' % format[0], binary=content, mimetype=format[1])
         fid = unwrap(fa.file.id)
-        print(fid, unwrap(fa.file.mimetype))
+        print((fid, unwrap(fa.file.mimetype)))
         retdata, rettype = pydict_text_io.get_format_originalfileid(
             fid, None, self.client.getSession())
         assert rettype == 'yaml'

--- a/components/tools/OmeroPy/test/integration/scriptsharness/definition.py
+++ b/components/tools/OmeroPy/test/integration/scriptsharness/definition.py
@@ -20,7 +20,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import sys
-import types
 
 import omero
 import omero.scripts as sc

--- a/components/tools/OmeroPy/test/integration/scriptsharness/definition.py
+++ b/components/tools/OmeroPy/test/integration/scriptsharness/definition.py
@@ -36,7 +36,7 @@ client = sc.client("script_1", """
                    sc.String("myoptional", optional=True)
                    )
 
-assert isinstance(client, types.TupleType)
+assert isinstance(client, tuple)
 
 self = sys.argv[0]
 cfg = self.replace("py", "cfg")

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
@@ -23,6 +23,7 @@
     Specifically test the parseInputs functionality
     which all scripts might want to use.
 """
+from __future__ import print_function
 
 from omero.testlib import ITest
 import omero
@@ -84,7 +85,7 @@ class TestInputs(ITest):
                 rfs.setFileId(out.val.id.val)
                 text = rfs.read(0, rfs.size())
                 if text.strip():
-                    print("===", which, "===")
+                    print(("===", which, "==="))
                     print(text)
             finally:
                 rfs.close()

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_ping.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_ping.py
@@ -25,6 +25,7 @@
 
 """
 
+from builtins import str
 from omero.testlib import ITest
 import pytest
 import os

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_rand.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_rand.py
@@ -24,6 +24,7 @@
    ServiceFactoryI.acquireProcessor().
 
 """
+from __future__ import print_function
 
 from omero.testlib import ITest
 import omero

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_script_utils.py
@@ -21,7 +21,11 @@
    Integration test which checks the various methods from script_utils
 
 """
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import pytest
 from omero.testlib import ITest
 import omero.util.script_utils as scriptUtil
@@ -70,7 +74,7 @@ class TestScriptUtils(ITest):
             min_c = c.getWindowMin()
             max_c = c.getWindowMax()
             channel_min_max.append((min_c, max_c))
-        z = image.getSizeZ() / 2
+        z = old_div(image.getSizeZ(), 2)
         t = 0
         c = 0
         try:
@@ -100,7 +104,7 @@ class TestScriptUtils(ITest):
             min_c = c.getWindowMin()
             max_c = c.getWindowMax()
             channel_min_max.append((min_c, max_c))
-        z = image.getSizeZ() / 2
+        z = old_div(image.getSizeZ(), 2)
         t = 0
         c = 0
         try:
@@ -126,7 +130,7 @@ class TestScriptUtils(ITest):
             min_c = c.getWindowMin()
             max_c = c.getWindowMax()
             channel_min_max.append((min_c, max_c))
-        z = image.getSizeZ() / 2
+        z = old_div(image.getSizeZ(), 2)
         t = 0
         c = 0
 
@@ -233,7 +237,7 @@ class TestScriptUtils(ITest):
         """Test the upload of the plane by row."""
         client = self.new_client()
         # create an image
-        channel_list = range(2)
+        channel_list = list(range(2))
         session = client.getSession()
         pixels_service = session.getPixelsService()
         query_service = session.getQueryService()
@@ -242,7 +246,7 @@ class TestScriptUtils(ITest):
             return y
 
         def f2(x, y):
-            return (x + y) / 2
+            return old_div((x + y), 2)
 
         def f3(x, y):
             return x
@@ -272,7 +276,7 @@ class TestScriptUtils(ITest):
         """Test the upload of the plane."""
         client = self.new_client()
         # create an image
-        channel_list = range(2)
+        channel_list = list(range(2))
         session = client.getSession()
         pixels_service = session.getPixelsService()
         query_service = session.getQueryService()
@@ -281,7 +285,7 @@ class TestScriptUtils(ITest):
             return y
 
         def f2(x, y):
-            return (x + y) / 2
+            return old_div((x + y), 2)
 
         def f3(x, y):
             return x

--- a/components/tools/OmeroPy/test/integration/tablestest/test_populate_metadata.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_populate_metadata.py
@@ -24,6 +24,7 @@
 
 """
 
+from builtins import range
 from omero.testlib import ITest
 import os
 
@@ -106,7 +107,7 @@ class TestPopulateMetadata(ITest):
         rows = t.getNumberOfRows()
         assert rows == rowCount * colCount
         for hit in range(rows):
-            rowValues = [col.values[0] for col in t.read(range(len(cols)),
+            rowValues = [col.values[0] for col in t.read(list(range(len(cols))),
                                                          hit, hit+1).columns]
             assert len(rowValues) == 4
             if "a1" in rowValues:

--- a/components/tools/OmeroPy/test/integration/tablestest/test_populate_metadata.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_populate_metadata.py
@@ -107,8 +107,8 @@ class TestPopulateMetadata(ITest):
         rows = t.getNumberOfRows()
         assert rows == rowCount * colCount
         for hit in range(rows):
-            rowValues = [col.values[0] for col in t.read(list(range(len(cols))),
-                                                         hit, hit+1).columns]
+            values = t.read(list(range(len(cols))), hit, hit+1).columns
+            rowValues = [col.values[0] for col in values]
             assert len(rowValues) == 4
             if "a1" in rowValues:
                 assert "Control" in rowValues

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -23,7 +23,10 @@
    Test of the Tables service
 
 """
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
 import path
 import omero
 import omero.tables
@@ -389,7 +392,7 @@ class TestTables(ITest):
         # 3 characters should work, 4 should cause an error
         scol.values = ['abc']
         table.addData([scol])
-        data = table.readCoordinates(range(table.getNumberOfRows()))
+        data = table.readCoordinates(list(range(table.getNumberOfRows())))
         assert ['abc'] == data.columns[0].values
         scol.values = ['abcd']
         with pytest.raises(omero.ValidationException):
@@ -533,7 +536,7 @@ class TestTables(ITest):
         assert [0.125, 0.0625] == testda[1]
 
         ofile = table.getOriginalFile()
-        print("testAllColumnsSameTable", "OriginalFile:", ofile.getId().val)
+        print(("testAllColumnsSameTable", "OriginalFile:", ofile.getId().val))
 
         # Now try an update
         updatel = omero.grid.LongColumn('longcol', '', [12345])

--- a/components/tools/OmeroPy/test/integration/test_admin.py
+++ b/components/tools/OmeroPy/test/integration/test_admin.py
@@ -34,8 +34,8 @@ class TestAdmin(ITest):
 
     def testGetGroup(self):
         a = self.sf.getAdminService()
-        l = a.lookupGroups()
-        g = a.getGroup(l[0].getId().val)
+        groups = a.lookupGroups()
+        g = a.getGroup(groups[0].getId().val)
         assert 0 != g.sizeOfGroupExperimenterMap()
 
     def testSetGroup(self):

--- a/components/tools/OmeroPy/test/integration/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/test_annotation.py
@@ -118,17 +118,17 @@ def saveAndLinkAnnotation(
         annotation.setDescription(rstring(description))
     annotation = updateService.saveAndReturnObject(annotation)
     if type(parent) == omero.model.DatasetI:
-        l = omero.model.DatasetAnnotationLinkI()
+        link = omero.model.DatasetAnnotationLinkI()
     elif type(parent) == omero.model.ProjectI:
-        l = omero.model.ProjectAnnotationLinkI()
+        link = omero.model.ProjectAnnotationLinkI()
     elif type(parent) == omero.model.ImageI:
-        l = omero.model.ImageAnnotationLinkI()
+        link = omero.model.ImageAnnotationLinkI()
     else:
         return
     parent = parent.__class__(parent.id.val, False)
-    l.setParent(parent)
-    l.setChild(annotation)
-    return updateService.saveAndReturnObject(l)
+    link.setParent(parent)
+    link.setChild(annotation)
+    return updateService.saveAndReturnObject(link)
 
 
 # Text Annotations

--- a/components/tools/OmeroPy/test/integration/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/test_annotation.py
@@ -95,7 +95,7 @@ class TestFigureExportScripts(ITest):
         p.map["pid"] = parent.getId()
         query = "select l from ProjectAnnotationLink as l join\
             fetch l.child as a where l.parent.id=:pid and a.ns=:ns"
-        for ns, values in annValues.items():
+        for ns, values in list(annValues.items()):
             p.map["ns"] = rstring(ns)
             # only 1 of each namespace
             link = queryService.findByQuery(query, p)

--- a/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
+++ b/components/tools/OmeroPy/test/integration/test_annotationPermissions.py
@@ -110,11 +110,11 @@ class AnnotationPermissions(ITest):
 
     def linkTagAs(self, user, project, tag):
         """ Adds a Tag. """
-        l = ProjectAnnotationLinkI()
+        link = ProjectAnnotationLinkI()
         project = project.__class__(project.id.val, False)
-        l.setParent(project)
-        l.setChild(tag)
-        l = self.updateServices[user].saveAndReturnObject(l)
+        link.setParent(project)
+        link.setChild(tag)
+        link = self.updateServices[user].saveAndReturnObject(link)
 
     def removeTagAs(self, user, project, tag):
         """ Removes (unlinks) a Tag. """

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -24,6 +24,8 @@
 
 """
 
+from builtins import str
+from builtins import range
 import omero
 import omero.gateway
 from omero.testlib import ITest

--- a/components/tools/OmeroPy/test/integration/test_chgrp.py
+++ b/components/tools/OmeroPy/test/integration/test_chgrp.py
@@ -124,9 +124,9 @@ class TestChgrp(ITest):
         # check Dataset
         query = "select link from DatasetImageLink link\
             where link.child.id=%s" % img.id.val
-        l = client.sf.getQueryService().findByQuery(query, None)
-        assert l is not None, "New DatasetImageLink on image not found"
-        assert l.details.group.id.val == first_gid,\
+        link = client.sf.getQueryService().findByQuery(query, None)
+        assert link is not None, "New DatasetImageLink on image not found"
+        assert link.details.group.id.val == first_gid,\
             "Link Created in same group as Image target"
 
     def testChgrpPDI(self):

--- a/components/tools/OmeroPy/test/integration/test_chmod.py
+++ b/components/tools/OmeroPy/test/integration/test_chmod.py
@@ -24,6 +24,7 @@
 
 """
 
+from builtins import str
 import time
 from omero.testlib import ITest
 import omero

--- a/components/tools/OmeroPy/test/integration/test_client_ctors.py
+++ b/components/tools/OmeroPy/test/integration/test_client_ctors.py
@@ -23,7 +23,9 @@
    Tests of the omero.client constructors
 
 """
+from __future__ import print_function
 
+from builtins import str
 import os
 from omero.testlib import ITest
 import omero

--- a/components/tools/OmeroPy/test/integration/test_cmdcallback.py
+++ b/components/tools/OmeroPy/test/integration/test_cmdcallback.py
@@ -23,6 +23,7 @@
 Test of the CmdCallbackI object
 """
 
+from builtins import range
 import threading
 
 from omero.testlib import ITest

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -23,7 +23,10 @@
    Integration test for delete testing
 
 """
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
 import traceback
 from omero.testlib import ITest
 import pytest
@@ -342,7 +345,7 @@ class TestDelete(ITest):
                         if not cb.block(500):  # ms.
                             # No errors possible if in progress(
                             # (since no response)
-                            print("in progress", _formatReport(handle))
+                            print(("in progress", _formatReport(handle)))
                             in_progress += 1
                         else:
                             rsp = cb.getResponse()

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 
 from builtins import str
 from builtins import range
+from future.utils import native_str
 import traceback
 from omero.testlib import ITest
 import pytest
@@ -340,7 +341,7 @@ class TestDelete(ITest):
                 try:
                     with pytest.raises(Ice.ObjectNotExistException):
                         handle = omero.cmd.HandlePrx.checkedCast(
-                            client_o.ic.stringToProxy(cbString))
+                            client_o.ic.stringToProxy(native_str(cbString)))
                         cb = omero.callbacks.CmdCallbackI(client_o, handle)
                         if not cb.block(500):  # ms.
                             # No errors possible if in progress(

--- a/components/tools/OmeroPy/test/integration/test_files.py
+++ b/components/tools/OmeroPy/test/integration/test_files.py
@@ -24,6 +24,7 @@
 
 """
 
+from builtins import str
 import pytest
 from omero.testlib import ITest
 

--- a/components/tools/OmeroPy/test/integration/test_icontainer.py
+++ b/components/tools/OmeroPy/test/integration/test_icontainer.py
@@ -24,6 +24,8 @@
 
 """
 
+from builtins import str
+from builtins import range
 from omero.testlib import ITest
 import omero
 from omero_model_CommentAnnotationI import CommentAnnotationI
@@ -103,7 +105,7 @@ class TestSplitFilesets(ITest):
         # compare result with expected...
         assert set(result.keys()) == set(
             expected.keys()),  "Result should have expected Fileset IDs"
-        for fsId, expectedDict in expected.items():
+        for fsId, expectedDict in list(expected.items()):
             assert cmpLists(
                 expectedDict[True],
                 result[fsId][True]), "True ImageIDs should match"
@@ -287,11 +289,11 @@ class TestSplitFilesets(ITest):
         # note all test case input values
 
         all_inputs = {}
-        for name in named_entities.keys():
+        for name in list(named_entities.keys()):
             all_inputs[name] = []
 
         for input, expected in test_cases:
-            for name, ids in input.items():
+            for name, ids in list(input.items()):
                 all_inputs[name] += ids
 
         # create test entities named in test case input values
@@ -384,11 +386,11 @@ class TestSplitFilesets(ITest):
 
         for named_indices, fileset_split in test_cases:
             referenced = {}
-            for name, indices in named_indices.items():
+            for name, indices in list(named_indices.items()):
                 referenced[name] = [
                     named_entities[name][index].id.val for index in indices]
             expected = {}
-            for fileset_index, image_indices in fileset_split.items():
+            for fileset_index, image_indices in list(fileset_split.items()):
                 fileset_id = filesets[fileset_index].id.val
                 expected[fileset_id] = {}
                 for included in [False, True]:

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -23,7 +23,11 @@
    Integration test focused on the omero.api.IQuery interface.
 
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
+from builtins import str
+from builtins import range
 from omero.testlib import ITest
 from omero.rtypes import rstring
 from omero.rtypes import unwrap, wrap
@@ -31,7 +35,7 @@ from omero.model import CommentAnnotationI
 from omero.model import TagAnnotationI, ImageI, ImageAnnotationLinkI
 from omero.model import PermissionsI
 from omero.sys import ParametersI
-from helpers import createImageWithPixels
+from .helpers import createImageWithPixels
 
 
 class TestQuery(ITest):
@@ -63,7 +67,7 @@ class TestQuery(ITest):
         # get group we're working on...
         ctx = self.client.sf.getAdminService().getEventContext()
         groupId = ctx.groupId
-        print('groupId', groupId)
+        print(('groupId', groupId))
 
         # Admin sets permissions to read-ann
         admin = self.root.sf.getAdminService()

--- a/components/tools/OmeroPy/test/integration/test_isession.py
+++ b/components/tools/OmeroPy/test/integration/test_isession.py
@@ -23,6 +23,7 @@
    Integration test focused on the omero.api.ISession interface.
 
 """
+from __future__ import print_function
 import os
 
 from omero.testlib import ITest

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -9,6 +9,7 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from builtins import str
 import time
 from omero.testlib import ITest
 import pytest
@@ -22,7 +23,7 @@ from test.integration.helpers import createTestImage
 import warnings
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -339,7 +340,7 @@ class TestIShare(ITest):
                "where e.id =:eid order by e.omeName")
         ms = query.findAllByQuery(sql, p)
         sid = share.createShare(("test-share-%s" % uuid),
-                                rtime(long(time.time() * 1000 + 86400)),
+                                rtime(int(time.time() * 1000 + 86400)),
                                 items, ms, [], True)
 
         # USER RETRIEVAL
@@ -465,7 +466,7 @@ class TestIShare(ITest):
 
         assert share1.getShare(sid).message.val == new_description
 
-        expiration = long(time.time() * 1000) + 86400
+        expiration = int(time.time() * 1000) + 86400
         share1.setExpiration(sid, rtime(expiration))
         self.assert_expiration(expiration, share1.getShare(sid))
 
@@ -972,7 +973,7 @@ class TestIShare(ITest):
         image_id = createTestImage(owner.sf)
 
         p = omero.sys.Parameters()
-        p.map = {"id": rlong(long(image_id))}
+        p.map = {"id": rlong(int(image_id))}
         sql = "select im from Image im join fetch im.details.owner " \
               "join fetch im.details.group where im.id=:id order by im.name"
         image = owner.sf.getQueryService().findAllByQuery(
@@ -1071,7 +1072,7 @@ class TestIShare(ITest):
         t_conn.sf.getQueryService().find("Image", image.id.val)
 
         # test expired share, if member has no access to the image
-        expiration = long(time.time() * 1000) + 500
+        expiration = int(time.time() * 1000) + 500
         o_share.setExpiration(sid, rtime(expiration))
         self.assert_expiration(expiration, o_share.getShare(sid))
         time.sleep(0.5)

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -133,22 +133,22 @@ class TestIShare(ITest):
         # test action by member
         user_conn = BlitzGateway(client_obj=client)
         # user CANNOT see image if not in share
-        assert None == user_conn.getObject("Image", image.id.val)
+        assert user_conn.getObject("Image", image.id.val) is None
         # activate share
         user_conn.SERVICE_OPTS.setOmeroShare(share_id)
-        assert False == getattr(user_conn.getObject("Image",
-                                                    image.id.val), func)()
+        assert getattr(user_conn.getObject("Image",
+                                           image.id.val), func)() is False
 
         # test action by owner
         owner_conn = BlitzGateway(client_obj=self.client)
         # owner CAN do action on the object when not in share
-        assert True == getattr(owner_conn.getObject("Image",
-                                                    image.id.val), func)()
+        assert getattr(owner_conn.getObject("Image",
+                                            image.id.val), func)() is True
         # activate share
         owner_conn.SERVICE_OPTS.setOmeroShare(share_id)
         # owner CANNOT do action on the object when in share
-        assert False == getattr(owner_conn.getObject("Image",
-                                                     image.id.val), func)()
+        assert getattr(owner_conn.getObject("Image",
+                                            image.id.val), func)() is False
 
     def test8118(self):
         uuid = self.root.sf.getAdminService().getEventContext().sessionUuid
@@ -581,8 +581,7 @@ class TestIShare(ITest):
 
         # login as user2
         share2 = client_share2.sf.getShareService()
-        l = share2.getMemberShares(False)
-        assert 1 == len(l)
+        assert 1 == len(share2.getMemberShares(False))
 
         # add comment by the member
         share2.addComment(sid, 'test comment by the member %s' % user2.id.val)

--- a/components/tools/OmeroPy/test/integration/test_itimeline.py
+++ b/components/tools/OmeroPy/test/integration/test_itimeline.py
@@ -9,6 +9,7 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from builtins import range
 import time
 import pytest
 from omero.testlib import ITest
@@ -17,7 +18,7 @@ import omero
 from omero.rtypes import rint, rlong, rstring, rtime
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -34,7 +35,7 @@ class TestITimeline(ITest):
         im_ids = dict()
         for i in range(0, 10):
             # create image
-            acquired = long(time.time() * 1000)
+            acquired = int(time.time() * 1000)
             img = self.make_image(name='test-img-%s' % uuid, date=acquired)
             im_ids[i] = [img.id.val, acquired]
 
@@ -50,8 +51,8 @@ class TestITimeline(ITest):
         p.theFilter = f
 
         M = timeline.countByPeriod
-        A = rtime(long(start))
-        B = rtime(long(end))
+        A = rtime(int(start))
+        B = rtime(int(end))
         counter = M(['Image'], A, B, p)
         assert counter['Image'] == 10
         # And with #9609
@@ -101,7 +102,7 @@ class TestITimeline(ITest):
         im_ids = dict()
         for i in range(0, 10):
             # create image
-            acquired = long(time.time() * 1000)
+            acquired = int(time.time() * 1000)
             img = self.make_image(name='test-img-%s' % client2.sf,
                                   date=acquired, client=client2)
             im_ids[i] = [img.id.val, acquired]
@@ -124,10 +125,10 @@ class TestITimeline(ITest):
             p.theFilter = f
 
             counter = timeline.countByPeriod(
-                ['Image'], rtime(long(start)), rtime(long(end)), p)
+                ['Image'], rtime(int(start)), rtime(int(end)), p)
             assert 10 == counter['Image']
             data = timeline.getByPeriod(
-                ['Image'], rtime(long(start)), rtime(long(end)), p, False)
+                ['Image'], rtime(int(start)), rtime(int(end)), p, False)
             assert 10 == len(data['Image'])
 
         assert_timeline(timeline2, start, end, ownerId, groupId)
@@ -146,8 +147,8 @@ class TestITimeline(ITest):
         ds.unload()
 
         # Here we assume that this test is not run within the last 1 second
-        start = long(time.time() * 1000 - 86400)
-        end = long(time.time() * 1000 + 86400)
+        start = int(time.time() * 1000 - 86400)
+        end = int(time.time() * 1000 + 86400)
 
         p = omero.sys.Parameters()
         p.map = {}
@@ -156,8 +157,8 @@ class TestITimeline(ITest):
         p.theFilter = f
 
         M = timeline.getEventLogsByPeriod
-        A = rtime(long(start))
-        B = rtime(long(end))
+        A = rtime(int(start))
+        B = rtime(int(end))
 
         rv = M(A, B, p)
         assert rv > 0

--- a/components/tools/OmeroPy/test/integration/test_itypes.py
+++ b/components/tools/OmeroPy/test/integration/test_itypes.py
@@ -34,7 +34,8 @@ class TestTypes(ITest):
             types.allEnumerations(str(r))
 
     def testGetEnumerationWithEntries(self):
-        list(self.root.sf.getTypesService().getEnumerationsWithEntries().items())
+        svc = self.root.sf.getTypesService()
+        list(svc.getEnumerationsWithEntries().items())
 
     def testManageEnumeration(self):
         from omero_model_ExperimentTypeI import ExperimentTypeI

--- a/components/tools/OmeroPy/test/integration/test_itypes.py
+++ b/components/tools/OmeroPy/test/integration/test_itypes.py
@@ -9,6 +9,7 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from builtins import str
 from omero.testlib import ITest
 
 from omero.rtypes import rstring
@@ -33,7 +34,7 @@ class TestTypes(ITest):
             types.allEnumerations(str(r))
 
     def testGetEnumerationWithEntries(self):
-        self.root.sf.getTypesService().getEnumerationsWithEntries().items()
+        list(self.root.sf.getTypesService().getEnumerationsWithEntries().items())
 
     def testManageEnumeration(self):
         from omero_model_ExperimentTypeI import ExperimentTypeI

--- a/components/tools/OmeroPy/test/integration/test_iupdate.py
+++ b/components/tools/OmeroPy/test/integration/test_iupdate.py
@@ -10,6 +10,7 @@
 Integration test focused on the omero.api.IUpdate interface.
 """
 
+from builtins import range
 from omero.testlib import ITest
 import omero
 import pytest

--- a/components/tools/OmeroPy/test/integration/test_mail.py
+++ b/components/tools/OmeroPy/test/integration/test_mail.py
@@ -25,6 +25,7 @@
    etc/blitz/mail-server.example
 """
 
+from builtins import str
 from omero.testlib import ITest
 import omero
 

--- a/components/tools/OmeroPy/test/integration/test_mapannotation.py
+++ b/components/tools/OmeroPy/test/integration/test_mapannotation.py
@@ -24,6 +24,7 @@ Tests for the MapAnnotation and related base types
 introduced in 5.1.
 """
 
+from builtins import range
 from omero.testlib import ITest
 import pytest
 import omero

--- a/components/tools/OmeroPy/test/integration/test_model51.py
+++ b/components/tools/OmeroPy/test/integration/test_model51.py
@@ -23,6 +23,7 @@
 Basic tests for additions/changes to the 5.1 model.
 """
 
+from builtins import str
 from omero.testlib import ITest
 import pytest
 import omero

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -460,7 +460,7 @@ class TestPermissions(ITest):
         # As root, try to load it
         root_query = self.root.sf.getQueryService()
         tag = get_tag(root_query, {})
-        assert None == tag
+        assert tag is None
 
         # Now try to load it again, with a context
         tag = get_tag(root_query, {"omero.group": "-1"})

--- a/components/tools/OmeroPy/test/integration/test_permissions.py
+++ b/components/tools/OmeroPy/test/integration/test_permissions.py
@@ -24,6 +24,8 @@
 
 """
 
+from builtins import str
+from builtins import object
 from future.utils import native_str
 import pytest
 from omero.testlib import ITest, PFS
@@ -37,7 +39,7 @@ from omero.rtypes import rbool, rstring, unwrap
 
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -820,7 +822,7 @@ class TestPermissions(ITest):
         ctx.update(params)
         store.setFileId(script.id.val, ctx)
 
-        data = store.read(0, long(script.size.val))
+        data = store.read(0, int(script.size.val))
         assert script.size.val == len(data)
         try:
             store.close()

--- a/components/tools/OmeroPy/test/integration/test_pixelsService.py
+++ b/components/tools/OmeroPy/test/integration/test_pixelsService.py
@@ -23,11 +23,12 @@
    Tests for the Pixels service.
 
 """
+from __future__ import absolute_import
 
 import omero
 import omero.gateway
 from omero.testlib import ITest
-from helpers import createImageWithPixels
+from .helpers import createImageWithPixels
 
 
 class TestPixelsService(ITest):

--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -19,7 +19,6 @@ from omero.testlib import ITest
 import pytest
 from omero.util.tiles import TileLoopIteration
 from omero.util.tiles import RPSTileLoop
-from binascii import hexlify as hex
 
 try:
     int

--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -8,7 +8,11 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import division
 
+from builtins import hex
+from builtins import range
+from past.utils import old_div
 import omero
 import threading
 from omero.testlib import ITest
@@ -18,7 +22,7 @@ from omero.util.tiles import RPSTileLoop
 from binascii import hexlify as hex
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -100,21 +104,21 @@ class TestRPS(ITest):
         try:
             # First execution should certainly fail
             try:
-                rps.setPixelsId(long(pix), True)
+                rps.setPixelsId(int(pix), True)
                 assert False, "Should throw!"
             except omero.MissingPyramidException as mpm:
-                assert long(pix) == mpm.pixelsID
+                assert int(pix) == mpm.pixelsID
 
             # Eventually, however, it should be generated
             i = 10
             success = False
             while i > 0 and not success:
                 try:
-                    rps.setPixelsId(long(pix), True)
+                    rps.setPixelsId(int(pix), True)
                     success = True
                 except omero.MissingPyramidException as mpm:
-                    assert long(pix) == mpm.pixelsID
-                    backOff = mpm.backOff / 1000
+                    assert int(pix) == mpm.pixelsID
+                    backOff = old_div(mpm.backOff, 1000)
                     event = concurrency.get_event("testRomio")
                     event.wait(backOff)  # seconds
                 i -= 1
@@ -135,21 +139,21 @@ class TestRPS(ITest):
         try:
             # First execution should certainly fail
             try:
-                rps.setPixelsId(long(pix), True, all_context)
+                rps.setPixelsId(int(pix), True, all_context)
                 assert False, "Should throw!"
             except omero.MissingPyramidException as mpm:
-                assert long(pix) == mpm.pixelsID
+                assert int(pix) == mpm.pixelsID
 
             # Eventually, however, it should be generated
             i = 10
             success = False
             while i > 0 and not success:
                 try:
-                    rps.setPixelsId(long(pix), True, all_context)
+                    rps.setPixelsId(int(pix), True, all_context)
                     success = True
                 except omero.MissingPyramidException as mpm:
-                    assert long(pix) == mpm.pixelsID
-                    backOff = mpm.backOff / 1000
+                    assert int(pix) == mpm.pixelsID
+                    backOff = old_div(mpm.backOff, 1000)
                     event = concurrency.get_event("testRomio")
                     event.wait(backOff)  # seconds
                 i -= 1
@@ -169,21 +173,21 @@ class TestRPS(ITest):
         try:
             # First execution should certainly fail
             try:
-                rps.setPixelsId(long(pix), True, all_context)
+                rps.setPixelsId(int(pix), True, all_context)
                 assert False, "Should throw!"
             except omero.MissingPyramidException as mpm:
-                assert long(pix) == mpm.pixelsID
+                assert int(pix) == mpm.pixelsID
 
             # Eventually, however, it should be generated
             i = 10
             success = False
             while i > 0 and not success:
                 try:
-                    rps.setPixelsId(long(pix), True, all_context)
+                    rps.setPixelsId(int(pix), True, all_context)
                     success = True
                 except omero.MissingPyramidException as mpm:
-                    assert long(pix) == mpm.pixelsID
-                    backOff = mpm.backOff / 1000
+                    assert int(pix) == mpm.pixelsID
+                    backOff = old_div(mpm.backOff, 1000)
                     event = concurrency.get_event("testRomio")
                     event.wait(backOff)  # seconds
                 i -= 1
@@ -202,7 +206,7 @@ class TestRPS(ITest):
                     while not event.isSet() and self.success < 10:
                         self.rps = sf.createRawPixelsStore(all_context)
                         try:
-                            self.rps.setPixelsId(long(pix), True, all_context)
+                            self.rps.setPixelsId(int(pix), True, all_context)
                             self.success += 1
                         except Exception:
                             self.failure += 1
@@ -254,7 +258,7 @@ class TestTiles(ITest):
 
         query = "from PixelsType as p where p.value='int8'"
         pixelsType = queryService.findByQuery(query, None)
-        channelList = range(sizeC)
+        channelList = list(range(sizeC))
         iId = pixelsService.createImage(
             sizeX, sizeY, sizeZ, sizeT,
             channelList, pixelsType, imageName, description)
@@ -268,7 +272,7 @@ class TestTiles(ITest):
             """
             create some fake pixel data tile (2D numpy array)
             """
-            return (x * y) / (1 + x + y)
+            return old_div((x * y), (1 + x + y))
 
         def mktile(w, h):
             tile = fromfunction(f, (w, h))

--- a/components/tools/OmeroPy/test/integration/test_reimport.py
+++ b/components/tools/OmeroPy/test/integration/test_reimport.py
@@ -20,6 +20,8 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+from builtins import str
+from builtins import range
 from omero.testlib import ITest
 
 from omero.callbacks import CmdCallbackI

--- a/components/tools/OmeroPy/test/integration/test_render.py
+++ b/components/tools/OmeroPy/test/integration/test_render.py
@@ -24,6 +24,7 @@
    rendering a 'region' of big images.
 """
 
+from builtins import range
 import omero
 import logging
 from omero.testlib import ITest
@@ -38,7 +39,7 @@ except Exception:  # pragma: nocover
         logging.error('No Pillow installed')
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -93,8 +94,8 @@ class TestRendering(ITest):
         region_def.height = height
 
         plane_def = omero.romio.PlaneDef()
-        plane_def.z = long(0)
-        plane_def.t = long(0)
+        plane_def.z = int(0)
+        plane_def.t = int(0)
 
         # First, get the full rendered plane...
         img = rendering_engine.renderCompressed(plane_def)  # compressed String

--- a/components/tools/OmeroPy/test/integration/test_reporawfilestore.py
+++ b/components/tools/OmeroPy/test/integration/test_reporawfilestore.py
@@ -14,7 +14,9 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import division
 
+from past.utils import old_div
 import pytest
 import omero
 import omero.gateway
@@ -29,7 +31,7 @@ class TestRepoRawFileStore(AbstractRepoTest):
         super(TestRepoRawFileStore, self).setup_method(method)
         tmp_dir = path(self.unique_dir)
         self.repoPrx = self.get_managed_repo()
-        self.repo_filename = tmp_dir / self.uuid() + ".txt"
+        self.repo_filename = old_div(tmp_dir, self.uuid()) + ".txt"
 
     def testCreate(self):
         rfs = self.repoPrx.file(self.repo_filename, "rw")

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -8,7 +8,14 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import division
+from __future__ import print_function
 
+from builtins import zip
+from builtins import str
+from builtins import range
+from past.utils import old_div
+from builtins import object
 import pytest
 
 import omero
@@ -105,7 +112,7 @@ class TestRepository(AbstractRepoTest):
         # Now we try to look it up with __redirect
         rfs = self.client.sf.createRawFileStore()
         rfs.setFileId(obj.id.val)
-        assert "hi" == unicode(rfs.read(0, 2), "utf-8")
+        assert "hi" == str(rfs.read(0, 2), "utf-8")
         rfs.close()
 
 
@@ -397,7 +404,7 @@ class TestRecursiveDelete(AbstractRepoTest):
         assert 1 == len(self.file_map1)
         self.dir_map = unwrap(self.mrepo.treeList(self.unique_dir))
         assert 1 == len(self.dir_map)
-        self.dir_key = self.dir_map.keys()[0]
+        self.dir_key = list(self.dir_map.keys())[0]
         self.file_map2 = self.dir_map[self.dir_key]["files"]["file.txt"]
 
     # treeList is a utility that is useful for
@@ -590,7 +597,7 @@ class TestDeletePerformance(AbstractRepoTest):
         folder = create_path(folder=True)
         for x in range(200):
             name = "%s.unknown" % x
-            (folder / name).touch()
+            (old_div(folder, name)).touch()
         paths = folder.files()
         proc = mrepo.importPaths(paths)
         hashes = self.upload_folder(proc, folder)
@@ -602,8 +609,8 @@ class TestDeletePerformance(AbstractRepoTest):
         delete = omero.cmd.Delete2()
         delete.targetObjects = {'Fileset': [fs.id.val]}
         s2 = time.time()
-        print(s2 - s1),
+        print((s2 - s1), end=' ')
         t1 = time.time()
         client.submit(delete, loops=200)
         t2 = time.time()
-        print(" ", t2-t1),
+        print((" ", t2-t1), end=' ')

--- a/components/tools/OmeroPy/test/integration/test_rois.py
+++ b/components/tools/OmeroPy/test/integration/test_rois.py
@@ -8,6 +8,8 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import print_function
+from builtins import object
 from omero.testlib import ITest
 import omero
 from omero.rtypes import rdouble, rstring, rint
@@ -268,7 +270,7 @@ class TestRois(ITest):
         """Test ROI intensity stats."""
         img = self.create_test_image(100, 100, 1, 1, 1, self.client.sf)
         pixid1 = img.getPrimaryPixels().getId().getValue()
-        print(img.id.val, pixid1)
+        print((img.id.val, pixid1))
 
         roi = omero.model.RoiI()
         roi.setImage(img)
@@ -302,7 +304,7 @@ class TestRois(ITest):
             for s in roi.copyShapes():
                 shape_ids.append(s.id.val)
 
-        print("shape_ids", shape_ids)
+        print(("shape_ids", shape_ids))
 
         stats = roi_service.getShapeStatsRestricted(shape_ids, 0, 0, [0])
         print(stats)

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -8,7 +8,12 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import division
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import os
 import time
 import pytest
@@ -24,7 +29,7 @@ from omero.rtypes import rstring, wrap, unwrap
 from omero.util.temp_files import create_path
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -157,7 +162,7 @@ class TestScripts(ITest):
             # force the server to parse the file enough to get params (checks
             # syntax etc)
             params = scriptService.getParams(id)
-            for key, param in params.inputs.items():
+            for key, param in list(params.inputs.items()):
                 assert "longParam" == key
                 assert param.prototype is not None, \
                     "Parameter prototype is 'None'"
@@ -409,13 +414,13 @@ client.closeSession()
         impl = omero.processor.usermode_processor(root_client)
         try:
             params_time, params = self.timeit(svc.getParams, scriptID)
-            assert params_time < (upload_time / 10), \
+            assert params_time < (old_div(upload_time, 10)), \
                 "upload_time(%s) <= 10 * params_time(%s)!" % \
                 (upload_time, params_time)
             assert params_time < 0.1, "params_time(%s) >= 0.01 !" % params_time
 
             run_time, process = self.timeit(
-                svc.runScript, scriptID, wrap({"a": long(5)}).val, None)
+                svc.runScript, scriptID, wrap({"a": int(5)}).val, None)
 
             def wait():
                 cb = omero.scripts.ProcessCallbackI(root_client, process)

--- a/components/tools/OmeroPy/test/integration/test_simple.py
+++ b/components/tools/OmeroPy/test/integration/test_simple.py
@@ -10,6 +10,7 @@
 
 """
 
+from builtins import str
 from omero.testlib import ITest
 
 

--- a/components/tools/OmeroPy/test/integration/test_thumbnailPerms.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbnailPerms.py
@@ -25,6 +25,7 @@
 
 """
 
+from builtins import str
 import Ice
 import pytest
 from omero.testlib import ITest

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -9,6 +9,7 @@
 
 """
 
+from builtins import range
 from omero.testlib import ITest
 import pytest
 
@@ -18,7 +19,7 @@ from omero.util.concurrency import get_event
 from omero.rtypes import rint, unwrap
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -57,7 +58,7 @@ class TestThumbs(ITest):
         """
         pix = self.missing_pyramid()
         tb = self.client.sf.createThumbnailStore()
-        tb.setPixelsId(long(pix))
+        tb.setPixelsId(int(pix))
         tb.resetDefaults()
         return tb
 
@@ -81,7 +82,7 @@ class TestThumbs(ITest):
         tb = self.client.sf.createThumbnailStore()
         try:
             tb.createThumbnailsByLongestSideSet(
-                rint(64), [long(pix1), long(pix2)])
+                rint(64), [int(pix1), int(pix2)])
         finally:
             tb.close()
 
@@ -114,7 +115,7 @@ class TestThumbs(ITest):
         # thumbnail
         tb = self.client.sf.createThumbnailStore()
         if meth == "one":
-            tb.setPixelsId(long(pix))
+            tb.setPixelsId(int(pix))
             tb.resetDefaults()
             assert not tb.thumbnailExists(i64, i64)
             assert tb.isInProgress()
@@ -126,8 +127,8 @@ class TestThumbs(ITest):
             assert not tb.thumbnailExists(i64, i64)
             assert tb.isInProgress()
         elif meth == "set":
-            before = tb.getThumbnailSet(i64, i64, [long(pix)])
-            before = before[long(pix)]
+            before = tb.getThumbnailSet(i64, i64, [int(pix)])
+            before = before[int(pix)]
         assert get().version.val == -1
 
         # Now we wait until the pyramid has been created
@@ -137,7 +138,7 @@ class TestThumbs(ITest):
         rps = self.client.sf.createRawPixelsStore()
         for x in range(secs):
             try:
-                rps.setPixelsId(long(pix), True)
+                rps.setPixelsId(int(pix), True)
                 event = None
                 break
             except MissingPyramidException:
@@ -150,17 +151,17 @@ class TestThumbs(ITest):
             # the pyramid is generated.
             tb.close()
             tb = self.client.sf.createThumbnailStore()
-            if not tb.setPixelsId(long(pix)):
+            if not tb.setPixelsId(int(pix)):
                 tb.resetDefaults()
                 tb.close()
                 tb = self.client.sf.createThumbnailStore()
-                assert tb.setPixelsId(long(pix))
+                assert tb.setPixelsId(int(pix))
             after = tb.getThumbnail(i64, i64)
             assert before != after
             assert tb.thumbnailExists(i64, i64)
             assert not tb.isInProgress()
         elif meth == "set":
-            tb.getThumbnailSet(i64, i64, [long(pix)])
+            tb.getThumbnailSet(i64, i64, [int(pix)])
         assert get().version.val >= 0
 
 
@@ -173,7 +174,7 @@ def assign(f, method, *args):
                 name += "x%s" % unwrap(i2)
         except Exception:
             name += "x%s" % unwrap(i)
-    f.func_name = name
+    f.__name__ = name
     setattr(TestThumbs, name, f)
 
 
@@ -194,11 +195,11 @@ def make_test_set(method, x, y, *args):
         pix2 = self.missing_pyramid()
         tb = self.client.sf.createThumbnailStore()
         copy = list(args)
-        copy.append([long(pix1), long(pix2)])
+        copy.append([int(pix1), int(pix2)])
         copy = tuple(copy)
         try:
             buf_map = getattr(tb, method)(*copy)
-            for id, buf in buf_map.items():
+            for id, buf in list(buf_map.items()):
                 self.assertTb(buf, x, y)
         finally:
             tb.close()

--- a/components/tools/OmeroPy/test/integration/test_tickets1000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets1000.py
@@ -8,6 +8,7 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import print_function
 
 from omero.testlib import ITest
 import pytest
@@ -72,7 +73,7 @@ class TestTicket1000(ITest):
         search.byHqlQuery(
             "select o from OriginalFile o where o.name = 'stderr'", params)
         if search.hasNext():
-            ofile = search.next()
+            ofile = next(search)
             tmpfile = self.tmpfile()
             self.client.download(ofile, tmpfile)
         else:

--- a/components/tools/OmeroPy/test/integration/test_tickets2000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets2000.py
@@ -9,6 +9,8 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from builtins import str
+from builtins import range
 import time
 from omero.testlib import ITest
 import pytest
@@ -20,7 +22,7 @@ from omero_model_ExperimenterI import ExperimenterI
 from omero_model_ExperimenterGroupI import ExperimenterGroupI
 
 try:
-    long
+    int
 except Exception:
     # Python 3
     long = int
@@ -108,7 +110,7 @@ class TestTickets2000(ITest):
 
         # test:
         hier = pojos.findContainerHierarchies(
-            "Project", [long(im2.id.val)], None)
+            "Project", [int(im2.id.val)], None)
 
         assert 3 == len(hier), \
             "len of hier != 3: %s" % [type(x) for x in hier]
@@ -160,7 +162,7 @@ class TestTickets2000(ITest):
 
         # test:
         hier = c2_pojos.findContainerHierarchies(
-            "Project", [long(im2.id.val)], None)
+            "Project", [int(im2.id.val)], None)
 
         assert 2 == len(hier), "size of hier != 2: %s" % \
             [type(x) for x in hier]

--- a/components/tools/OmeroPy/test/integration/test_tickets3000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets3000.py
@@ -8,6 +8,8 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from builtins import str
+from builtins import range
 import omero
 from omero.testlib import ITest
 import pytest

--- a/components/tools/OmeroPy/test/integration/test_tickets4000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets4000.py
@@ -55,7 +55,7 @@ class TestTickets4000(ITest):
         proxies['admin'] = client.sf.getAdminService()
 
         # changing group
-        for k in proxies.keys():
+        for k in list(proxies.keys()):
             try:
                 proxies[k].close()
             except AttributeError:
@@ -109,7 +109,7 @@ class TestTickets4000(ITest):
         proxies['admin'] = sf.getAdminService()
 
         # changing group
-        for k in proxies.keys():
+        for k in list(proxies.keys()):
             prx = proxies[k]
             if isinstance(prx, omero.api.StatefulServiceInterfacePrx):
                 prx.close()
@@ -123,7 +123,7 @@ class TestTickets4000(ITest):
             sf.setSecurityContext(
                 omero.model.ExperimenterGroupI(grp.id.val, False))
 
-        for k in copy.keys():
+        for k in list(copy.keys()):
             prx = copy[k]
             if isinstance(prx, omero.api.StatefulServiceInterfacePrx):
                 prx.close()

--- a/components/tools/OmeroPy/test/integration/test_tickets6000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets6000.py
@@ -9,6 +9,7 @@
 """
 Integration tests for tickets between 5000 and 5999
 """
+from __future__ import print_function
 
 import pytest
 from omero.testlib import ITest

--- a/components/tools/OmeroPy/test/integration/test_util.py
+++ b/components/tools/OmeroPy/test/integration/test_util.py
@@ -24,6 +24,7 @@
 Test of various things under omero.util
 """
 
+from builtins import object
 from omero.util.upgrade_check import UpgradeCheck
 
 


### PR DESCRIPTION
Like https://github.com/ome/openmicroscopy/pull/6120, but the futurize output for all tests under OmeroPy/ which are not already modified on snoopy's merge-ci branch.