### PR TITLE
futurize all remaining tests (OmeroWeb)

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_annotate.py
+++ b/components/tools/OmeroWeb/test/integration/test_annotate.py
@@ -21,6 +21,7 @@
 Tests adding & removing annotations
 """
 
+from builtins import str
 import omero
 import omero.clients
 from time import sleep

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -524,11 +524,11 @@ class TestContainers(IWebTest):
         minMaxIndex = [0, 0]
         links = []
         for idx in range(minMaxIndex[0], minMaxIndex[1]+1):
-            l = build_url(client, 'api_plate_wellsampleindex_wells',
-                          {'api_version': version,
-                           'plate_id': plate_json['@id'],
-                           'index': idx})
-            links.append(l)
+            link = build_url(client, 'api_plate_wellsampleindex_wells',
+                             {'api_version': version,
+                              'plate_id': plate_json['@id'],
+                              'index': idx})
+            links.append(link)
         extra = [{'url:wellsampleindex_wells': links,
                   'omero:wellsampleIndex': minMaxIndex}]
         assert_objects(conn, [plate_json], plates[0:1], dtype='Plate',

--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -18,7 +18,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Tests querying & editing Containers with webgateway json api."""
+from __future__ import print_function
 
+from builtins import zip
+from builtins import str
+from builtins import range
 from omeroweb.testlib import IWebTest, get_json, \
     post_json, put_json, delete_json
 from django.core.urlresolvers import reverse
@@ -75,7 +79,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     pids = []
     for p in omero_ids_objects:
         try:
-            pids.append(long(p))
+            pids.append(int(p))
         except TypeError:
             pids.append(p.id.val)
     conn.SERVICE_OPTS.setOmeroGroup(group)
@@ -83,11 +87,11 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     objs = [p._obj for p in objs]
     expected = marshal_objects(objs)
     assert len(json_objects) == len(expected)
-    for i, o1, o2 in zip(range(len(expected)), json_objects, expected):
+    for i, o1, o2 in zip(list(range(len(expected))), json_objects, expected):
         if extra is not None and i < len(extra):
             o2.update(extra[i])
         # remove any urls from json, if not in both objects
-        for key in o1.keys():
+        for key in list(o1.keys()):
             if key.startswith('url:') and key not in o2:
                 del(o1[key])
         # add urls to any 'Image' in expected 'Wells' dict
@@ -571,7 +575,7 @@ class TestContainers(IWebTest):
         assert well_json['url:plates'] == well_plates_url
 
         # Get parent plate (Plates list, filtered by Well)
-        print 'well_plates_url', well_plates_url
+        print('well_plates_url', well_plates_url)
         rsp = get_json(client, well_plates_url)
         plates_json = rsp['data']
         # check for link to Screen

--- a/components/tools/OmeroWeb/test/integration/test_api_errors.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_errors.py
@@ -19,6 +19,7 @@
 
 """Tests querying & editing Projects with webgateway json api."""
 
+from builtins import str
 from omeroweb.testlib import IWebTest, post_json, put_json, get_json
 from django.core.urlresolvers import reverse
 from omeroweb.api import api_settings

--- a/components/tools/OmeroWeb/test/integration/test_api_images.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_images.py
@@ -19,6 +19,8 @@
 
 """Tests querying Images with web json api."""
 
+from builtins import zip
+from builtins import range
 from omeroweb.testlib import IWebTest, get_json
 from django.core.urlresolvers import reverse
 from omeroweb.api import api_settings
@@ -49,7 +51,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     pids = []
     for p in omero_ids_objects:
         try:
-            pids.append(long(p))
+            pids.append(int(p))
         except TypeError:
             pids.append(p.id.val)
     conn.SERVICE_OPTS.setOmeroGroup(group)
@@ -57,14 +59,14 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     objs = [p._obj for p in objs]
     expected = marshal_objects(objs)
     assert len(json_objects) == len(expected)
-    for i, o1, o2 in zip(range(len(expected)), json_objects, expected):
+    for i, o1, o2 in zip(list(range(len(expected))), json_objects, expected):
         if extra is not None and i < len(extra):
             o2.update(extra[i])
         # dumping to json and loading (same as test data) means that
         # unicode has been handled in same way, e.g. Pixel size symbols.
         o2 = json.loads(json.dumps(o2))
         # remove any urls from json (tested elsewhere)
-        for key in o1.keys():
+        for key in list(o1.keys()):
             if key.startswith('url:'):
                 del(o1[key])
         assert o1 == o2

--- a/components/tools/OmeroWeb/test/integration/test_api_projects.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_projects.py
@@ -21,6 +21,10 @@
 Tests querying & editing Projects with webgateway json api
 """
 
+from past.builtins import cmp
+from builtins import zip
+from builtins import str
+from builtins import range
 from omeroweb.testlib import IWebTest, get_json, \
     post_json, put_json, delete_json
 from django.core.urlresolvers import reverse
@@ -165,7 +169,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     pids = []
     for p in omero_ids_objects:
         try:
-            pids.append(long(p))
+            pids.append(int(p))
         except TypeError:
             pids.append(p.id.val)
     if len(pids) == 0:
@@ -178,7 +182,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     assert len(json_objects) == len(expected)
     for o1, o2 in zip(json_objects, expected):
         # remove any urls from json
-        for key in o1.keys():
+        for key in list(o1.keys()):
             if key.startswith('url:'):
                 del(o1[key])
         assert o1 == o2
@@ -461,8 +465,8 @@ class TestProjects(IWebTest):
             owner = details['owner']
             group = details['group']
             # owner and group have @id only
-            assert owner.keys() == ['@id']
-            assert group.keys() == ['@id']
+            assert list(owner.keys()) == ['@id']
+            assert list(group.keys()) == ['@id']
         # check normaliszed owners and groups are same as before
         rsp_owners = {}
         for o in rsp['experimenters']:

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -19,6 +19,9 @@
 
 """Tests querying Wells with web json api."""
 
+from past.builtins import cmp
+from builtins import zip
+from builtins import range
 from omeroweb.testlib import IWebTest, get_json
 from django.core.urlresolvers import reverse
 from omeroweb.api import api_settings
@@ -54,7 +57,7 @@ def cmp_column_row(x, y):
 
 def remove_urls(marshalled, keys=[]):
     """Traverse a dict (Well) removing 'url:' values."""
-    for key, val in marshalled.items():
+    for key, val in list(marshalled.items()):
         if key.startswith('url:') and key not in keys:
             del(marshalled[key])
         # We only traverse paths where we know urls are
@@ -79,7 +82,7 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     pids = []
     for p in omero_ids_objects:
         try:
-            pids.append(long(p))
+            pids.append(int(p))
         except TypeError:
             pids.append(p.id.val)
     conn.SERVICE_OPTS.setOmeroGroup(group)
@@ -87,11 +90,11 @@ def assert_objects(conn, json_objects, omero_ids_objects, dtype="Project",
     objs = [p._obj for p in objs]
     expected = marshal_objects(objs)
     assert len(json_objects) == len(expected)
-    for i, o1, o2 in zip(range(len(expected)), json_objects, expected):
+    for i, o1, o2 in zip(list(range(len(expected))), json_objects, expected):
         dont_remove = []
         if extra is not None and i < len(extra):
             o2.update(extra[i])
-            dont_remove = extra[i].keys()
+            dont_remove = list(extra[i].keys())
         # We dump to json and re-load (same as test data). This means that
         # unicode has been handled in same way, e.g. Pixel size symbols.
         o2 = json.loads(json.dumps(o2))
@@ -124,8 +127,8 @@ class TestWells(IWebTest):
             plate_acq.name = rstring('plateacquisition_%s' % p)
             plate_acq.description = rstring('plateacquisition_description')
             plate_acq.maximumFieldCount = rint(3)
-            plate_acq.startTime = rtime(1L)
-            plate_acq.endTime = rtime(2L)
+            plate_acq.startTime = rtime(1)
+            plate_acq.endTime = rtime(2)
             plate_acq.plate = PlateI(plate.id.val, False)
             plate_acq = updateService.saveAndReturnObject(plate_acq)
             plate_acqs.append(plate_acq)

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -261,11 +261,11 @@ class TestWells(IWebTest):
         plate = conn.getObject('Plate', plate_id)
         idx = plate.getNumberOfFields()
         for i in range(idx[0], idx[1]+1):
-            l = build_url(client, 'api_plate_wellsampleindex_wells',
-                          {'api_version': version,
-                           'plate_id': plate_id,
-                           'index': i})
-            index_links.append(l)
+            link = build_url(client, 'api_plate_wellsampleindex_wells',
+                             {'api_version': version,
+                              'plate_id': plate_id,
+                              'index': i})
+            index_links.append(link)
         # ...and compare plate json:
         assert_objects(conn, [plate_json], [multi_acquisition_plate],
                        dtype='Plate',
@@ -286,12 +286,12 @@ class TestWells(IWebTest):
         for p, plate_acq in enumerate(pas):
             index_links = []
             for i in range(p * 3, (p + 1) * 3):
-                l = build_url(client,
-                              'api_plateacquisition_wellsampleindex_wells',
-                              {'api_version': version,
-                               'plateacquisition_id': plate_acq.id,
-                               'index': i})
-                index_links.append(l)
+                link = build_url(client,
+                                 'api_plateacquisition_wellsampleindex_wells',
+                                 {'api_version': version,
+                                  'plateacquisition_id': plate_acq.id,
+                                  'index': i})
+                index_links.append(link)
             extra.append({'url:wellsampleindex_wells': index_links,
                           'omero:wellsampleIndex': [p * 3, (p + 1) * 3 - 1]})
         # ...and compare

--- a/components/tools/OmeroWeb/test/integration/test_chgrp.py
+++ b/components/tools/OmeroWeb/test/integration/test_chgrp.py
@@ -20,7 +20,9 @@
 """
 Tests chgrp functionality of views.py
 """
+from __future__ import print_function
 
+from builtins import str
 from omero.model import ProjectI, DatasetI, TagAnnotationI
 from omero.rtypes import rstring
 from omero.gateway import BlitzGateway
@@ -213,10 +215,10 @@ class TestChgrp(IWebTest):
             data = get_json(django_client, activities_url)
 
         # individual activities/jobs are returned as dicts within json data
-        for k, o in data.items():
+        for k, o in list(data.items()):
             if hasattr(o, 'values'):    # a dict
                 if 'report' in o:
-                    print o['report']
+                    print(o['report'])
                 assert o['status'] == 'finished'
                 assert o['job_name'] == 'Change group'
                 assert o['to_group_id'] == self.group2.id.val
@@ -278,10 +280,10 @@ class TestChgrp(IWebTest):
             data = get_json(django_client, activities_url)
 
         # individual activities/jobs are returned as dicts within json data
-        for k, o in data.items():
+        for k, o in list(data.items()):
             if hasattr(o, 'values'):    # a dict
                 if 'report' in o:
-                    print o['report']
+                    print(o['report'])
                 assert o['status'] == 'finished'
                 assert o['job_name'] == 'Change group'
                 assert o['to_group_id'] == self.group2.id.val

--- a/components/tools/OmeroWeb/test/integration/test_config.py
+++ b/components/tools/OmeroWeb/test/integration/test_config.py
@@ -49,9 +49,9 @@ def flattenProperties(d):
     """
 
     def items():
-        for key, value in d.items():
+        for key, value in list(d.items()):
             if isinstance(value, dict):
-                for subkey, subvalue in flattenProperties(value).items():
+                for subkey, subvalue in list(flattenProperties(value).items()):
                     yield key + "." + subkey, subvalue
             else:
                 yield key, value
@@ -90,10 +90,8 @@ class TestConfig(ITest):
         login_required(default_view).load_server_settings(self.conn, self.r)
         s = {"omero": {"client": self.r.session.get('server_settings', {})}}
         # compare keys in default and config loaded by decorator
-        a = filter(lambda x: x not in (
-            set(default.keys())),
-            set(flattenProperties(s).keys())
-            )
+        a = [x for x in set(flattenProperties(s).keys()) if x not in (
+            set(default.keys()))]
         assert a == ['omero.client.email']
 
     def testDefaultConfigConversion(self):

--- a/components/tools/OmeroWeb/test/integration/test_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_containers.py
@@ -20,7 +20,10 @@
 """
 Tests creation, linking, editing & deletion of containers
 """
+from __future__ import print_function
 
+from builtins import str
+from builtins import range
 import omero
 import omero.clients
 from omero.rtypes import rtime
@@ -43,7 +46,7 @@ class TestContainers(IWebTest):
         Returns a new foundational Image with Channel objects attached for
         view method testing.
         """
-        print dir(self)
+        print(dir(self))
 
         pixels = self.create_pixels(client=self.client)
         for the_c in range(pixels.getSizeC().val):
@@ -138,7 +141,7 @@ class TestContainers(IWebTest):
         did = json.loads(response.content).get("id")
 
         img = self.make_image()
-        print img
+        print(img)
 
         # Link image to Dataset
         request_url = reverse("api_links")

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -22,6 +22,7 @@ Simple integration tests to ensure that the CSRF middleware is enabled and
 working correctly.
 """
 
+from builtins import range
 import omero
 import omero.clients
 from omero.rtypes import rstring

--- a/components/tools/OmeroWeb/test/integration/test_history.py
+++ b/components/tools/OmeroWeb/test/integration/test_history.py
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """Tests display of data in History page."""
+from __future__ import print_function
 
 from omeroweb.testlib import IWebTest
 from omeroweb.testlib import get, post
@@ -59,7 +60,7 @@ class TestHistory(IWebTest):
         """Test loading of calendar, specifying this month."""
         now = datetime.now()
         calendar_url = reverse("load_calendar", args=[now.year, now.month])
-        print 'calendar_url', calendar_url
+        print('calendar_url', calendar_url)
         response = get(self.django_client, calendar_url)
         # Calendar is initially empty (no 'Dataset' icon)
         assert "folder_image16.png" not in response.content

--- a/components/tools/OmeroWeb/test/integration/test_links.py
+++ b/components/tools/OmeroWeb/test/integration/test_links.py
@@ -21,6 +21,8 @@
 Tests creation and deletion of links between e.g. Projects & Datasets etc.
 """
 
+from builtins import str
+from builtins import range
 import omero
 
 from omero.rtypes import rstring

--- a/components/tools/OmeroWeb/test/integration/test_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_login.py
@@ -20,6 +20,7 @@
 """
 Tests webclient login
 """
+from builtins import str
 from django.conf import settings
 from django.conf.urls import url
 from django.utils.importlib import import_module

--- a/components/tools/OmeroWeb/test/integration/test_plategrid.py
+++ b/components/tools/OmeroWeb/test/integration/test_plategrid.py
@@ -8,7 +8,14 @@
 """
    Integration tests for the "plategrid" module.
 """
+from __future__ import division
+from __future__ import print_function
 
+from builtins import map
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import pytest
 from omeroweb.testlib import IWebTest
 
@@ -130,7 +137,7 @@ def full_plate_wells(itest, update_service):
     Returns a full OMERO Plate, linked Wells, linked WellSamples, and linked
     Images populated by an L{omeroweb.testlib.IWebTest} instance.
     """
-    lett = map(chr, range(ord('A'), ord('Z')+1))
+    lett = list(map(chr, list(range(ord('A'), ord('Z')+1))))
     plate = PlateI()
     plate.name = rstring(itest.uuid())
     for row in range(8):
@@ -162,7 +169,7 @@ def plate_wells_with_acq_date(itest, well_grid_factory, update_service):
     plate.addWell(well)
     plate = update_service.saveAndReturnObject(plate)
     return {'plate': plate,
-            'acq_date': int(acq_date / 1000)}
+            'acq_date': int(old_div(acq_date, 1000))}
 
 
 @pytest.fixture()
@@ -182,7 +189,7 @@ def plate_wells_with_no_acq_date(itest, well_grid_factory, update_service,
     image = plate.copyWells()[0].copyWellSamples()[0].image
     creation_date = image.details.creationEvent.time
     return {'plate': plate,
-            'creation_date': creation_date.val / 1000}
+            'creation_date': old_div(creation_date.val, 1000)}
 
 
 @pytest.fixture()
@@ -224,7 +231,7 @@ def plate_well_table(itest, well_grid_factory, update_service, conn):
     table.initialize(columns)
 
     wellIds = [w.id.val for w in plate.copyWells()]
-    print "WellIds", wellIds
+    print("WellIds", wellIds)
 
     data1 = WellColumn('Well', '', wellIds)
     data2 = StringColumn('TestColumn', '', 64, ["foobar"])
@@ -362,7 +369,7 @@ class TestPlateGrid(object):
         Check that all wells are assigned correctly even if the entire plate of
         wells is full
         """
-        lett = map(chr, range(ord('A'), ord('Z')+1))
+        lett = list(map(chr, list(range(ord('A'), ord('Z')+1))))
         plate_grid = PlateGrid(conn, full_plate_wells.id.val, 0)
         metadata = plate_grid.metadata
         for row in range(8):
@@ -422,7 +429,7 @@ class TestScreenPlateTables(object):
         response = django_client.get(request_url,
                                      data={'query': 'Well-%s' % wellId})
         rspJson = json.loads(response.content)
-        print rspJson
+        print(rspJson)
         assert rspJson['data'] == {
             'rows': [[wellId, 'foobar']],
             'columns': ['Well', 'TestColumn']}

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -21,6 +21,9 @@
 Tests copying and pasting of rendering settings in webclient
 """
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 import json
 
 import omero
@@ -31,7 +34,7 @@ from omeroweb.testlib import post, get
 
 from django.core.urlresolvers import reverse
 
-from cStringIO import StringIO
+from io import StringIO
 try:
     from PIL import Image
 except ImportError:

--- a/components/tools/OmeroWeb/test/integration/test_rendering.py
+++ b/components/tools/OmeroWeb/test/integration/test_rendering.py
@@ -22,10 +22,9 @@ Tests copying and pasting of rendering settings in webclient
 """
 
 from future import standard_library
-standard_library.install_aliases()
+
 from builtins import str
 import json
-
 import omero
 import omero.clients
 
@@ -39,6 +38,7 @@ try:
     from PIL import Image
 except ImportError:
     import Image
+standard_library.install_aliases()
 
 
 class TestRendering(IWebTest):

--- a/components/tools/OmeroWeb/test/integration/test_scripts.py
+++ b/components/tools/OmeroWeb/test/integration/test_scripts.py
@@ -19,6 +19,7 @@
 
 """Test OMERO.scripts usage in the webclient."""
 
+from builtins import str
 from omeroweb.testlib import IWebTest
 from omeroweb.testlib import get, post, get_json
 import time
@@ -128,7 +129,7 @@ if __name__ == '__main__':
             data = get_json(self.django_client, activities_url)
 
         # individual activities/jobs are returned as dicts within json data
-        for k, o in data.items():
+        for k, o in list(data.items()):
             # find dict of results from the script job
             if job_id in k:
                 assert o['status'] == 'finished'

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1361,7 +1361,8 @@ class TestShow(IWebTest):
             [{'type': 'experimenter', 'id': project.details.owner.id.val},
              {'type': 'project', 'id': project.id.val},
              {'type': 'dataset', 'childIndex': imgIndex,
-              'id': dataset.id.val, 'childPage': (old_div(imgIndex,page_size)) + 1,
+              'id': dataset.id.val,
+              'childPage': (old_div(imgIndex, page_size)) + 1,
               'childCount': len(iids)},
              {'type': 'image', 'id': iid}]]
         assert paths == expected
@@ -1382,7 +1383,7 @@ class TestShow(IWebTest):
             [{'type': 'experimenter', 'id': ownerId},
              {'type': 'orphaned', 'id': ownerId,
               'childIndex': imgIndex,
-              'childPage': (old_div(imgIndex,page_size)) + 1,
+              'childPage': (old_div(imgIndex, page_size)) + 1,
               'childCount': len(iids)},
              {'type': 'image', 'id': iid}]]
         assert paths == expected

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -8,7 +8,13 @@
    Use is subject to license terms supplied in LICENSE.txt
 
 """
+from __future__ import division
+from __future__ import print_function
 
+from past.builtins import cmp
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import omero
 import omero.clients
 import pytest
@@ -144,7 +150,7 @@ class TestShow(IWebTest):
         project.linkDataset(dataset)
         project = self.update.saveAndReturnObject(project)
 
-        print "Fixture project_dataset_image_roi image", image.id.val
+        print("Fixture project_dataset_image_roi image", image.id.val)
         roi = RoiI()
         roi.image = ImageI(image.id.val, False)
         roi = self.update.saveAndReturnObject(roi)
@@ -1355,7 +1361,7 @@ class TestShow(IWebTest):
             [{'type': 'experimenter', 'id': project.details.owner.id.val},
              {'type': 'project', 'id': project.id.val},
              {'type': 'dataset', 'childIndex': imgIndex,
-              'id': dataset.id.val, 'childPage': (imgIndex/page_size) + 1,
+              'id': dataset.id.val, 'childPage': (old_div(imgIndex,page_size)) + 1,
               'childCount': len(iids)},
              {'type': 'image', 'id': iid}]]
         assert paths == expected
@@ -1376,7 +1382,7 @@ class TestShow(IWebTest):
             [{'type': 'experimenter', 'id': ownerId},
              {'type': 'orphaned', 'id': ownerId,
               'childIndex': imgIndex,
-              'childPage': (imgIndex/page_size) + 1,
+              'childPage': (old_div(imgIndex,page_size)) + 1,
               'childCount': len(iids)},
              {'type': 'image', 'id': iid}]]
         assert paths == expected
@@ -2051,7 +2057,7 @@ class TestShow(IWebTest):
              {'type': 'plate', 'id': plate.id.val},
              {'type': 'acquisition', 'id': plate_acquisition1.id.val}]]
 
-        print paths
+        print(paths)
 
         for e in expected:
             try:
@@ -2101,7 +2107,7 @@ class TestShow(IWebTest):
              {'type': 'plate', 'id': plate.id.val},
              {'type': 'acquisition', 'id': plate_acquisition2.id.val}]]
 
-        print paths
+        print(paths)
 
         for e in expected:
             try:

--- a/components/tools/OmeroWeb/test/integration/test_tags.py
+++ b/components/tools/OmeroWeb/test/integration/test_tags.py
@@ -21,6 +21,8 @@
 Tests creation, linking, editing and deletion of Tags
 """
 
+from builtins import str
+from builtins import range
 import omero
 import omero.clients
 from omero.rtypes import rstring

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -19,12 +19,16 @@
 
 """Tests rendering of thumbnails."""
 
+from past.builtins import cmp
+from future import standard_library
+standard_library.install_aliases()
+from builtins import range
 import base64
 import json
 from omeroweb.testlib import IWebTest
 from omeroweb.testlib import get
 
-from cStringIO import StringIO
+from io import StringIO
 import pytest
 from django.core.urlresolvers import reverse
 try:

--- a/components/tools/OmeroWeb/test/integration/test_thumbnails.py
+++ b/components/tools/OmeroWeb/test/integration/test_thumbnails.py
@@ -21,7 +21,6 @@
 
 from past.builtins import cmp
 from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 import base64
 import json
@@ -33,8 +32,9 @@ import pytest
 from django.core.urlresolvers import reverse
 try:
     from PIL import Image
-except:
+except Exception:
     import Image
+standard_library.install_aliases()
 
 
 class TestThumbnails(IWebTest):

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -20,7 +20,11 @@
 """
 Simple integration tests for the "tree" module.
 """
+from __future__ import division
 
+from past.builtins import cmp
+from builtins import str
+from past.utils import old_div
 import pytest
 from omero.testlib import ITest
 
@@ -1910,7 +1914,7 @@ class TestTree(ITest):
             i.setAcquisitionDate(rtime(utcAcq))
         images = conn.getUpdateService().saveAndReturnArray(images)
         # All images created at same time
-        utcCreate = datetime.fromtimestamp(utcCreate/1000).isoformat() + 'Z'
+        utcCreate = datetime.fromtimestamp(old_div(utcCreate,1000)).isoformat() + 'Z'
         extraValues = {'acqDate': acqDate,
                        'date': utcCreate}
         expected = expected_images(userA, images,
@@ -2154,7 +2158,7 @@ class TestTree(ITest):
         '''
         conn = get_connection(userA)
         expected = {
-            'id': -2L,
+            'id': -2,
             'childCount': 0
         }
         marshaled = marshal_orphaned(conn=conn,

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -1798,7 +1798,7 @@ class TestTree(ITest):
         # Thumbnail creation is optional, see testlib.ITest.create_test_image
         try:
             extraValues = {'thumbVersion': thumb['version']}
-        except:
+        except Exception:
             extraValues = None
         expected = expected_images(
             userA, [image], extraValues=extraValues)
@@ -1914,7 +1914,8 @@ class TestTree(ITest):
             i.setAcquisitionDate(rtime(utcAcq))
         images = conn.getUpdateService().saveAndReturnArray(images)
         # All images created at same time
-        utcCreate = datetime.fromtimestamp(old_div(utcCreate,1000)).isoformat() + 'Z'
+        utcCreate = datetime.fromtimestamp(
+            old_div(utcCreate, 1000)).isoformat() + 'Z'
         extraValues = {'acqDate': acqDate,
                        'date': utcCreate}
         expected = expected_images(userA, images,

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -171,7 +171,7 @@ def annotate_project(ann, project, user):
 
 
 def expected_date(time):
-    d = datetime.fromtimestamp(old_div(time,1000))
+    d = datetime.fromtimestamp(old_div(time, 1000))
     return d.isoformat() + 'Z'
 
 

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -20,7 +20,13 @@
 """
 Integration tests for annotations methods in the "tree" module.
 """
+from __future__ import division
+from __future__ import print_function
 
+from past.builtins import cmp
+from builtins import zip
+from builtins import str
+from past.utils import old_div
 import pytest
 from omero.testlib import ITest
 from datetime import datetime
@@ -155,7 +161,7 @@ def annotate_project(ann, project, user):
     by userA and userB
     """
     ctx = {'omero.group': str(project.details.group.id.val)}
-    print "annotate_project", ctx
+    print("annotate_project", ctx)
     link = ProjectAnnotationLinkI()
     link.parent = ProjectI(project.id.val, False)
     link.child = ann
@@ -165,7 +171,7 @@ def annotate_project(ann, project, user):
 
 
 def expected_date(time):
-    d = datetime.fromtimestamp(time/1000)
+    d = datetime.fromtimestamp(old_div(time,1000))
     return d.isoformat() + 'Z'
 
 
@@ -248,7 +254,7 @@ def expected_annotations(user, links):
         annotations.append(marshalled)
 
     # remove duplicates
-    experimenters = [expected_experimenter(e) for e in exps.values()]
+    experimenters = [expected_experimenter(e) for e in list(exps.values())]
     experimenters.sort(key=lambda x: x['id'])
 
     return annotations, experimenters
@@ -273,7 +279,7 @@ class TestTreeAnnotations(ITest):
     def groupA(self):
         """Returns a new read-annotate group."""
         a = self.new_group(perms='rwra--')
-        print "GroupA", a.id.val
+        print("GroupA", a.id.val)
         return a
 
     # Create a read-only group
@@ -281,7 +287,7 @@ class TestTreeAnnotations(ITest):
     def groupB(self):
         """Returns a new read-only group."""
         b = self.new_group(perms='rwr---')
-        print "Group B", b.id.val
+        print("Group B", b.id.val)
         return b
 
     # Create users in groups
@@ -290,7 +296,7 @@ class TestTreeAnnotations(ITest):
         """Returns a new user in the groupB (default) also add to groupA"""
         c, user = self.new_client_and_user(group=groupB)
         self.add_groups(user, [groupA])
-        print "USER A", user.id.val, 'groupA', groupA.id.val
+        print("USER A", user.id.val, 'groupA', groupA.id.val)
         c.getSession().getAdminService().getEventContext()
         return c, user
 
@@ -298,7 +304,7 @@ class TestTreeAnnotations(ITest):
     def userB(self, groupA):
         """Returns another new user in the read-only group."""
         c, userb = self.new_client_and_user(group=groupA)
-        print "USER B", userb.id.val, 'groupA', groupA.id.val
+        print("USER B", userb.id.val, 'groupA', groupA.id.val)
         return c, userb
 
     def test_single_tag(self, userA, project_userA, tags_userA_userB):

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -20,6 +20,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from builtins import zip
 import pytest
 from omeroweb.testlib import IWebTest
 from omeroweb.testlib import post, get


### PR DESCRIPTION
Like https://github.com/ome/openmicroscopy/pull/6120, but the futurize output for all tests under OmeroWeb/ which are not already modified on snoopy's merge-ci branch.