### PR TITLE
fix test_repository.testSimpleDelete with b'bytes'

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -455,7 +455,7 @@ class TestDeleteLog(AbstractRepoTest):
         # Assert contents of file
         rfs = mrepo.fileById(ofile.id.val)
         try:
-            assert "hi" == rfs.read(0, 2)
+            assert b"hi" == rfs.read(0, 2)
         finally:
             rfs.close()
 
@@ -469,7 +469,7 @@ class TestDeleteLog(AbstractRepoTest):
         # But should just be an empty file.
         rfs = mrepo.file(filename, "rw")
         try:
-            assert "\x00\x00" == rfs.read(0, 2)
+            assert b"\x00\x00" == rfs.read(0, 2)
         finally:
             rfs.close()
 


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/27/testReport/OmeroPy.test.integration.test_repository/TestDeleteLog/testSimpleDelete/ along with https://github.com/ome/omero-py/pull/76