### PR TITLE
Fix print syntax in scriptstest test_ping

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_ping.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_ping.py
@@ -66,7 +66,7 @@ print("Session", client.getSession())
 #
 import sys
 from pprint import pprint
-print "PATH:"
+print("PATH:")
 pprint(sys.path)
 
 print("CONFIG")
@@ -95,7 +95,7 @@ for key in keys:
 #
 print("This was my environment:")
 for k,v in os.environ.items():
-    print "%s => %s" %(k,v)
+    print("%s => %s" %(k,v))
 
 sys.stderr.write("Oh, and this is stderr.");
 


### PR DESCRIPTION
# What this PR does
Fix https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/28/testReport/OmeroPy.test.integration.scriptstest.test_ping/TestPing/testProcessorExpires/