### PR TITLE
test_ping

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_ping.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_ping.py
@@ -66,7 +66,7 @@ print("Session", client.getSession())
 #
 import sys
 from pprint import pprint
-print "PATH:"
+print("PATH:")
 pprint(sys.path)
 
 print("CONFIG")


### PR DESCRIPTION
Add bracket

This should fix tests like 
https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/28/testReport/junit/OmeroPy.test.integration.scriptstest.test_ping/TestPing/testProcessorStop/