### PR TITLE
test-annotation

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -359,7 +359,7 @@ def testFileAnnotationSpeed(author_testimg_generated, gatewaywrapper):
     """ Tests speed of loading file annotations. See PR: 4176 """
     try:
         f = NamedTemporaryFile()
-        f.write(("testFileAnnotationSpeed text").encode("utf-8"))
+        f.write(b"testFileAnnotationSpeed text")
         ns = TESTANN_NS
         image = author_testimg_generated
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -262,6 +262,7 @@ def testFileAnnotation(author_testimg_generated, gatewaywrapper):
     fileText = "Test text for writing to file for upload"
     f.write(fileText)
     f.close()
+
     ns = TESTANN_NS
     image = author_testimg_generated
 
@@ -314,7 +315,8 @@ def testFileAnnotation(author_testimg_generated, gatewaywrapper):
     annId = ann.getId()
     assert ann.OMERO_TYPE == omero.model.FileAnnotationI
     for t in ann.getFileInChunks():
-        assert str(t) == fileText   # we get whole text in one chunk
+        # see https://github.com/ome/omero-py/pull/69
+        assert t == fileText.encode("utf-8")   # we get whole text in one chunk
 
     # delete what we created
     assert gateway.getObject("Annotation", annId) is not None

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -357,7 +357,7 @@ def testFileAnnotationSpeed(author_testimg_generated, gatewaywrapper):
     """ Tests speed of loading file annotations. See PR: 4176 """
     try:
         f = NamedTemporaryFile()
-        f.write("testFileAnnotationSpeed text")
+        f.write(("testFileAnnotationSpeed text").encode("utf-8"))
         ns = TESTANN_NS
         image = author_testimg_generated
 

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -327,8 +327,9 @@ def testFileAnnotationNoName(author_testimg_generated, gatewaywrapper):
     """Test conn.createOriginalFileFromFileObj() and getFileName()"""
     file_text = "test"
     file_size = len(file_text)
-    f = StringIO()
-    f.write(file_text)
+    f = NamedTemporaryFile()
+    f.write(file_text.encode("utf-8"))
+
     file_name = "testFileAnnotationNoName"
     conn = gatewaywrapper.gateway
     update_service = conn.getUpdateService()

--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_annotation.py
@@ -21,7 +21,6 @@ import time
 import datetime
 import os
 from tempfile import NamedTemporaryFile
-from io import StringIO
 
 import omero.gateway
 from omero.rtypes import rstring


### PR DESCRIPTION
Encode String
This should fix
* https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.gatewaytest/test_annotation/testFileAnnotationSpeed/
* https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.gatewaytest/test_annotation/testFileAnnotation/
* https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.gatewaytest/test_annotation/testFileAnnotationNoName/

The test should be green for py2 and 3