### PR TITLE
Use b'binary' fixes test_tickets3000.py test2396

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_tickets3000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets3000.py
@@ -25,7 +25,7 @@ class TestTickets3000(ITest):
         img = self.make_image(name='test2396-img-%s' % self.uuid())
 
         format = "txt"
-        binary = "12345678910"
+        binary = b"12345678910"
         oFile = omero.model.OriginalFileI()
         oFile.setName(rstring(str("txt-name")))
         oFile.setPath(rstring(str("txt-name")))


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.test_tickets3000/TestTickets3000/test2396/