### PR TITLE
list(keys) to fix test_search test3721Ordering

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -90,7 +90,7 @@ class TestSearch(ITest):
             proj = self.update.saveAndReturnObject(proj)
             proj_by_ns[ns] = proj
             self.index(proj)
-        all_ns = proj_by_ns.keys()
+        all_ns = list(proj_by_ns.keys())
 
         search = self.client.sf.createSearchService()
         search.onlyType("Project")


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.test_search/TestSearch/test3721Ordering/