### PR TITLE
gatewaytest: connection

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_connection.py
@@ -150,7 +150,7 @@ class TestConnectionMethods(object):
         objects = gatewaywrapper.gateway.getObjects("Experimenter")
         exps = [x.omeName for x in objects]
         for omeName in (gatewaywrapper.USER.name, gatewaywrapper.AUTHOR.name,
-                        gatewaywrapper.ADMIN.name.decode('utf-8')):
+                        gatewaywrapper.ADMIN.name):
             assert omeName in exps
             assert len(list(gatewaywrapper.gateway.getObjects(
                 "Experimenter", attributes={'omeName': omeName}))) > 0


### PR DESCRIPTION
remove decode

This should fix 
* https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.gatewaytest.test_connection/TestConnectionMethods/testTopLevelObjects/
Test should pass in py2 and py3
