### PR TITLE
Unpin pytest<3

### DIFF
--- a/components/tools/OmeroFS/setup.py
+++ b/components/tools/OmeroFS/setup.py
@@ -35,4 +35,4 @@ setup(name="OmeroFS",
       package_dir={"": "target"},
       packages=[''],
       cmdclass={'test': PyTest},
-      tests_require=['pytest<3'])
+      tests_require=['pytest'])

--- a/components/tools/OmeroFS/setup.py
+++ b/components/tools/OmeroFS/setup.py
@@ -35,4 +35,4 @@ setup(name="OmeroFS",
       package_dir={"": "target"},
       packages=[''],
       cmdclass={'test': PyTest},
-      tests_require=['pytest'])
+      tests_require=['pytest', 'pytest-xdist'])

--- a/components/tools/OmeroPy/setup.py
+++ b/components/tools/OmeroPy/setup.py
@@ -69,4 +69,4 @@ setup(
         'omero.gateway': ['pilfonts/*'],
         'omero.gateway.scripts': ['imgs/*']},
     cmdclass={'test': PyTest},
-    tests_require=['pytest'])
+    tests_require=['pytest', 'pytest-xdist'])

--- a/components/tools/OmeroPy/setup.py
+++ b/components/tools/OmeroPy/setup.py
@@ -69,4 +69,4 @@ setup(
         'omero.gateway': ['pilfonts/*'],
         'omero.gateway.scripts': ['imgs/*']},
     cmdclass={'test': PyTest},
-    tests_require=['pytest<3'])
+    tests_require=['pytest'])

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -51,5 +51,5 @@ OmeroWeb is the container of the web clients for OMERO."
       packages=[''],
       test_suite='test.suite',
       cmdclass={'test': PyTest},
-      tests_require=['pytest'],
+      tests_require=['pytest', 'pytest-xdist'],
       )

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -51,5 +51,5 @@ OmeroWeb is the container of the web clients for OMERO."
       packages=[''],
       test_suite='test.suite',
       cmdclass={'test': PyTest},
-      tests_require=['pytest<3'],
+      tests_require=['pytest'],
       )

--- a/components/tools/OmeroWeb/test/conftest.py
+++ b/components/tools/OmeroWeb/test/conftest.py
@@ -1,0 +1,20 @@
+import os
+
+
+def workdir(worker):
+    home = os.path.expanduser("~")
+    job = os.environ.get("JOB_NAME", "unknown_job")
+    path = [home, "omero", "pytest", job, worker]
+    return os.sep.join(path)
+
+
+def pytest_configure(config):
+    if not hasattr(config, 'slaveinput'):
+        workerid = 'main'
+        os.environ["OMERO_USERDIR"] = workdir(workerid)
+
+
+def pytest_configure_node(node):
+    if hasattr(node, 'slaveinput'):
+        workerid = node.slaveinput["workerid"]
+        os.environ["OMERO_USERDIR"] = workdir(workerid)


### PR DESCRIPTION
Pytest dropped support for Python 2 syntax leading us
to pin the version. Since the syntax has been updated,
this can now be unpinned.