### PR TITLE
metadata test

### DIFF
--- a/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
+++ b/components/tools/OmeroPy/test/integration/metadata/test_metadata_mapannotations.py
@@ -99,7 +99,7 @@ class TestMapAnnotationManager(ITest):
         mgr.add_from_namespace_query(self.sf, ns1, pks)
         with pytest.raises(Exception) as exc_info:
             mgr.add_from_namespace_query(self.sf, ns1, pks)
-        assert exc_info.value.message.startswith(
+        assert str(exc_info.value).startswith(
             'Duplicate MapAnnotation primary key')
 
     def test_update_existing_mapann(self):


### PR DESCRIPTION
remove usage of message
This should fix
https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.metadata.test_metadata_mapannotations/TestMapAnnotationManager/test_add_from_namespace_query_duplicate/

Test should be green for py2 and 3