### PR TITLE
gatewaytest: test helper

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_helpers.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_helpers.py
@@ -11,7 +11,7 @@ from builtins import object
 import omero
 import omero.gateway
 try:
-    int
+    long
 except Exception:
     # Python 3
     long = int
@@ -38,11 +38,16 @@ class TestHelperObjects(object):
         assert c1.getCss() == 'rgba(50,100,200,1.000)'
 
     def testOmeroType(self):
+        import sys
         omero_type = omero.gateway.omero_type
         assert isinstance(omero_type('rstring'), omero.RString)
         assert isinstance(omero_type(u'rstring'), omero.RString)
         assert isinstance(omero_type(1), omero.RInt)
-        assert isinstance(omero_type(int(1)), omero.RLong)
+        if sys.version_info[0] < 3:
+            assert isinstance(omero_type(long(1)), omero.RLong)
+        else:
+            assert isinstance(omero_type(long(1)), omero.RInt)
+        assert isinstance(omero_type(int(1)), omero.RInt)
         assert isinstance(omero_type(False), omero.RBool)
         assert isinstance(omero_type(True), omero.RBool)
         assert not isinstance(omero_type((1, 2, 'a')), omero.RType)


### PR DESCRIPTION
handle py2 and py3
``omero_type`` is not really helping anymore for long/int case

Adjust the tests to check both cases py2 and py3 
This should fix
*  https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.gatewaytest.test_helpers/TestHelperObjects/testOmeroType/