### PR TITLE
fix scriptstest.test_inputs

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_inputs.py
@@ -37,6 +37,7 @@ SENDFILE = """
 # Setup to run as an integration test
 import os
 import sys
+from past.builtins import long
 
 import omero.scripts as s
 import omero.util.script_utils as su


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/29/testReport/OmeroPy.test.integration.scriptstest.test_inputs/TestInputs/testInputs/