### PR TITLE
test service

### DIFF
--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -24,7 +24,7 @@
 
 """
 from __future__ import print_function
-
+from future.utils import native_str
 from builtins import str
 from builtins import range
 import path
@@ -309,7 +309,7 @@ class TestTables(ITest):
 
         # Create a user in one group and a table.
         group1 = self.new_group()
-        gid1 = str(group1.id.val)
+        gid1 = native_str(group1.id.val)
         client = self.new_client(group1)
         admin = client.sf.getAdminService()
         sr = client.sf.sharedResources()


### PR DESCRIPTION
Use native_string
Fix https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/217/testReport/OmeroPy.test.integration.tablestest.test_service/TestTables/testCallContext/

This should pass on py2 and py3