### PR TITLE
cli test-metadata

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -29,6 +29,7 @@ from omero.plugins.metadata import Metadata, MetadataControl
 from omero.rtypes import rdouble, unwrap
 from omero.testlib.cli import CLITest
 from omero.model.enums import UnitsLength
+from past.builtins import long
 
 
 class MetadataTestBase(CLITest):
@@ -42,7 +43,7 @@ class MetadataTestBase(CLITest):
 
         conn = BlitzGateway(client_obj=self.client)
         self.imageid = unwrap(self.image.getId())
-        assert type(self.imageid) == int
+        assert type(self.imageid) == long
         wrapper = conn.getObject("Image", self.imageid)
         self.md = Metadata(wrapper)
 


### PR DESCRIPTION
Use long instead of int

This should fix tests like https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/217/testReport/OmeroPy.test.integration.clitest.test_metadata/TestMetadata/test_get_identifiers/
Tests should remain green on both py2 and py3