### PR TITLE
Test tree annotation py2py3

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -39,11 +39,6 @@ from omero.rtypes import rstring, rlong
 from omeroweb.webclient.tree import marshal_annotations
 
 
-def cmp_id(x, y):
-    """Identifier comparator."""
-    return cmp(unwrap(x.id), unwrap(y.id))
-
-
 def unwrap(x):
     """Handle case where there is no value because attribute is None"""
     if x is not None:

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -154,7 +154,6 @@ def rating_userA(request, userA, groupA):
     return rating
 
 
-@pytest.fixture(scope='function')
 def annotate_project(ann, project, user):
     """
     Returns userA's Tag linked to userB's Project

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -121,7 +121,7 @@ def tags_userA_userB(request, userA, userB, groupA):
             tag.description = rstring('tag description')
         tag = get_update_service(user).saveAndReturnObject(tag, ctx)
         tags.append(tag)
-    tags.sort(cmp_id)
+    tags.sort(key=lambda x: unwrap(x.id))
     return tags
 
 
@@ -137,7 +137,7 @@ def comments_userA(request, userA, groupA):
         comment.textValue = rstring(text)
         comments.append(comment)
     comments = get_update_service(userA).saveAndReturnArray(comments, ctx)
-    comments.sort(cmp_id)
+    comments.sort(key=lambda x: unwrap(x.id))
     return comments
 
 

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -23,7 +23,6 @@ Integration tests for annotations methods in the "tree" module.
 from __future__ import division
 from __future__ import print_function
 
-from past.builtins import cmp
 from builtins import zip
 from future.utils import native_str
 from past.utils import old_div


### PR DESCRIPTION
Fixes both https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/31/testReport/junit/OmeroWeb.test.integration.test_tree_annotations/TestTreeAnnotations/ and  https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/217/testReport/junit/OmeroWeb.test.integration.test_tree_annotations/TestTreeAnnotations/test_filter_by_namespace/


772d8cb matches the uncapping of `pytest` proposed in #6143. The following two commits use `list.sort(key=key)` for Python2/3 compatiblity.

--depends-on https://github.com/ome/omero-web/pull/35
