### PR TITLE
Use key instead of cmp to sort in test_api_containers

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_api_containers.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_containers.py
@@ -28,7 +28,7 @@ from omeroweb.testlib import IWebTest, get_json, \
 from django.core.urlresolvers import reverse
 from omeroweb.api import api_settings
 import pytest
-from test_api_projects import cmp_name_insensitive, get_update_service, \
+from test_api_projects import lower_or_none, get_update_service, \
     get_connection, marshal_objects
 from omero.gateway import BlitzGateway
 from omero.model import DatasetI, \
@@ -39,7 +39,7 @@ from omero.model import DatasetI, \
     TagAnnotationI, \
     WellI, \
     WellSampleI
-from omero.rtypes import rstring, rint
+from omero.rtypes import rstring, rint, unwrap
 from omero_marshal import OME_SCHEMA_URL
 
 
@@ -159,7 +159,7 @@ class TestContainers(IWebTest):
 
         # Add well to first plate
         plates = screen.linkedPlateList()
-        plates.sort(cmp_name_insensitive)
+        plates.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         plate_id = plates[0].id.val
         well = WellI()
         well.column = rint(0)
@@ -183,7 +183,7 @@ class TestContainers(IWebTest):
             screen.name = rstring('Screen%s' % i)
             screens.append(screen)
         screens = get_update_service(user1).saveAndReturnArray(screens)
-        screens.sort(cmp_name_insensitive)
+        screens.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         return screens
 
     @pytest.mark.parametrize("dtype", ['Plate', 'Image', 'Well',
@@ -340,7 +340,7 @@ class TestContainers(IWebTest):
                                'offset': 0}
 
         # Filter Datasets by Project or Plates by Screen
-        children.sort(cmp_name_insensitive)
+        children.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         payload = {ptype: parent.id.val,
                    'childCount': str(child_count).lower()}
         rsp = get_json(django_client, request_url, payload)
@@ -506,7 +506,7 @@ class TestContainers(IWebTest):
         # List plates
         plates_url = screens_json[0]['url:plates']
         plates = screen.linkedPlateList()
-        plates.sort(cmp_name_insensitive)
+        plates.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         rsp = get_json(client, plates_url)
         plates_json = rsp['data']
         extra = []
@@ -555,7 +555,7 @@ class TestContainers(IWebTest):
         version = api_settings.API_VERSIONS[-1]
         screen, plate = screen_plates
         plates = screen.linkedPlateList()
-        plates.sort(cmp_name_insensitive)
+        plates.sort(key=lambda x: lower_or_none(unwrap(x.name)))
 
         # Listing wells - all have link to parents
         wells_url = reverse('api_wells', kwargs={'api_version': version})
@@ -627,7 +627,7 @@ class TestContainers(IWebTest):
         # List datasets
         datasets_url = projects_json[0]['url:datasets']
         datasets = project.linkedDatasetList()
-        datasets.sort(cmp_name_insensitive)
+        datasets.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         rsp = get_json(client, datasets_url)
         datasets_json = rsp['data']
         extra = []
@@ -650,7 +650,7 @@ class TestContainers(IWebTest):
         # List images (from last Dataset)
         images_url = datasets_json[-1]['url:images']
         images = datasets[-1].linkedImageList()
-        images.sort(cmp_name_insensitive)
+        images.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         rsp = get_json(client, images_url)
         images_json = rsp['data']
         extra = []
@@ -677,7 +677,7 @@ class TestContainers(IWebTest):
         # Get image...
         project, dataset = project_datasets
         datasets = project.linkedDatasetList()
-        datasets.sort(cmp_name_insensitive)
+        datasets.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         # ...from last dataset
         images = datasets[-1].linkedImageList()
         dataset_id = datasets[-1].id.val

--- a/components/tools/OmeroWeb/test/integration/test_api_images.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_images.py
@@ -25,10 +25,10 @@ from omeroweb.testlib import IWebTest, get_json
 from django.core.urlresolvers import reverse
 from omeroweb.api import api_settings
 import pytest
-from test_api_projects import cmp_name_insensitive, get_update_service, \
+from test_api_projects import lower_or_none, get_update_service, \
     get_connection, marshal_objects
 from omero.model import DatasetI, ImageI
-from omero.rtypes import rstring
+from omero.rtypes import rstring, unwrap
 import json
 
 
@@ -136,7 +136,7 @@ class TestImages(IWebTest):
                                'offset': 0}
 
         # Filter Images by Dataset
-        images.sort(cmp_name_insensitive)
+        images.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         payload = {'dataset': dataset.id.val}
         rsp = get_json(django_client, images_url, payload)
         # Manual check that Pixels & Type are loaded but Channels are not

--- a/components/tools/OmeroWeb/test/integration/test_api_projects.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_projects.py
@@ -51,12 +51,6 @@ def lower_or_none(x):
     return None
 
 
-def cmp_name_insensitive(x, y):
-    """Case-insensitive name comparator."""
-    return cmp(lower_or_none(unwrap(x.name)),
-               lower_or_none(unwrap(y.name)))
-
-
 def get_connection(user, group_id=None):
     """
     Get a BlitzGateway connection for the given user's client
@@ -100,7 +94,7 @@ def projects_user1_group1(request, names1, user1,
         to_save.append(project)
     projects = get_update_service(user1).saveAndReturnArray(to_save)
     projects.extend(project_hierarchy_user1_group1[:2])
-    projects.sort(cmp_name_insensitive)
+    projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
     return projects
 
 
@@ -117,7 +111,7 @@ def projects_user2_group1(request, names2, user2):
         to_save.append(project)
     projects = get_update_service(user2).saveAndReturnArray(
         to_save)
-    projects.sort(cmp_name_insensitive)
+    projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
     return projects
 
 
@@ -135,7 +129,7 @@ def projects_user1_group2(request, names3, user1, group2):
     conn = get_connection(user1, group2.id.val)
     projects = conn.getUpdateService().saveAndReturnArray(to_save,
                                                           conn.SERVICE_OPTS)
-    projects.sort(cmp_name_insensitive)
+    projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
     return projects
 
 
@@ -146,7 +140,7 @@ def projects_user1(request, projects_user1_group1,
     Returns OMERO Projects for user1 in both group1 and group2
     """
     projects = projects_user1_group1 + projects_user1_group2
-    projects.sort(cmp_name_insensitive)
+    projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
     return projects
 
 
@@ -257,13 +251,13 @@ class TestProjects(IWebTest):
 
         to_save = [project1, project2]
         projects = get_update_service(user1).saveAndReturnArray(to_save)
-        projects.sort(cmp_name_insensitive)
+        projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
 
         datasets = projects[0].linkedDatasetList()
-        datasets.sort(cmp_name_insensitive)
+        datasets.sort(key=lambda x: lower_or_none(unwrap(x.name)))
 
         images = datasets[0].linkedImageList()
-        images.sort(cmp_name_insensitive)
+        images.sort(key=lambda x: lower_or_none(unwrap(x.name)))
 
         return projects + datasets + images
 
@@ -372,7 +366,7 @@ class TestProjects(IWebTest):
         and filtering by owner.
         """
         projects = projects_user1_group1 + projects_user2_group1
-        projects.sort(cmp_name_insensitive)
+        projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         conn = get_connection(user1)
         user_name = conn.getUser().getName()
         django_client = self.new_django_client(user_name, user_name)
@@ -401,7 +395,7 @@ class TestProjects(IWebTest):
         Test pagination of projects
         """
         projects = projects_user1_group1 + projects_user2_group1
-        projects.sort(cmp_name_insensitive)
+        projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         conn = get_connection(user1)
         user_name = conn.getUser().getName()
         django_client = self.new_django_client(user_name, user_name)
@@ -433,7 +427,7 @@ class TestProjects(IWebTest):
         Tests normalize and childCount params of projects
         """
         projects = projects_user1_group1 + projects_user2_group1
-        projects.sort(cmp_name_insensitive)
+        projects.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         conn = get_connection(user1)
         user_name = conn.getUser().getName()
         django_client = self.new_django_client(user_name, user_name)

--- a/components/tools/OmeroWeb/test/integration/test_api_projects.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_projects.py
@@ -21,7 +21,6 @@
 Tests querying & editing Projects with webgateway json api
 """
 
-from past.builtins import cmp
 from builtins import zip
 from builtins import str
 from builtins import range

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -19,7 +19,6 @@
 
 """Tests querying Wells with web json api."""
 
-from past.builtins import cmp
 from builtins import zip
 from builtins import range
 from omeroweb.testlib import IWebTest, get_json

--- a/components/tools/OmeroWeb/test/integration/test_api_wells.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_wells.py
@@ -26,7 +26,7 @@ from omeroweb.testlib import IWebTest, get_json
 from django.core.urlresolvers import reverse
 from omeroweb.api import api_settings
 import pytest
-from test_api_projects import cmp_name_insensitive, \
+from test_api_projects import lower_or_none, \
     get_connection, \
     get_update_service, \
     marshal_objects
@@ -47,12 +47,9 @@ def get_query_service(user):
     return user[0].getSession().getQueryService()
 
 
-def cmp_column_row(x, y):
+def column_row_key(x):
     """Sort wells by row, then column."""
-    sort_by_column = cmp(unwrap(x.column), unwrap(y.column))
-    if sort_by_column == 0:
-        return cmp(unwrap(x.row), unwrap(y.row))
-    return sort_by_column
+    return (x.column.val * 1000) + (x.row.val)
 
 
 def remove_urls(marshalled, keys=[]):
@@ -213,7 +210,7 @@ class TestWells(IWebTest):
             # Use Blitz Plates for listing Wells etc.
             plate_wrapper = conn.getObject('Plate', plate.id.val)
             wells = [w._obj for w in plate_wrapper.listChildren()]
-            wells.sort(cmp_column_row)
+            wells.sort(key=lambda x: column_row_key(x))
             payload = {'plate': plate.id.val}
             rsp = get_json(django_client, wells_url, payload)
             # Manual check that Images are loaded but Pixels are not
@@ -280,7 +277,7 @@ class TestWells(IWebTest):
 
         # Construct data & urls we expect...
         pas = list(plate.listPlateAcquisitions())
-        pas.sort(cmp_name_insensitive)
+        pas.sort(key=lambda x: lower_or_none(unwrap(x.name)))
         paq_ids = [p.id for p in pas]
         extra = []
         for p, plate_acq in enumerate(pas):
@@ -308,7 +305,7 @@ class TestWells(IWebTest):
 
         small_plate = conn.getObject('Plate', small_plate.id.val)
         wells = [w._obj for w in small_plate.listChildren()]
-        wells.sort(cmp_column_row)
+        wells.sort(key=lambda x: column_row_key(x))
 
         # plate has 2 wells. First has WellSamples, other doesn't
         for well, has_image in zip(wells, [True, False]):


### PR DESCRIPTION
Fixes https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_api_containers/TestContainers/test_datasets_plates_Dataset_True_/

Using same approach as in https://github.com/ome/openmicroscopy/pull/6152/
cc @sbesson 