### PR TITLE
test: api_error

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_api_errors.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_errors.py
@@ -19,7 +19,7 @@
 
 """Tests querying & editing Projects with webgateway json api."""
 
-from builtins import str
+from future.utils import native_str
 from omeroweb.testlib import IWebTest, post_json, put_json, get_json
 from django.core.urlresolvers import reverse
 from omeroweb.api import api_settings
@@ -125,13 +125,13 @@ class TestErrors(IWebTest):
         # Create project in group_A (default group)
         payload = {'Name': 'test_security_violation',
                    '@type': OME_SCHEMA_URL + '#Project'}
-        save_url_grp_A = save_url + '?group=' + str(group_A_id)
+        save_url_grp_A = save_url + '?group=' + native_str(group_A_id)
         rsp = post_json(django_client, save_url_grp_A, payload,
                         status_code=201)
         pr_json = rsp['data']
         projectId = pr_json['@id']
         # Try to save again into group B
-        save_url_grp_B = save_url + '?group=' + str(group_B_id)
+        save_url_grp_B = save_url + '?group=' + native_str(group_B_id)
         rsp = put_json(django_client, save_url_grp_B, pr_json, status_code=403)
         assert 'message' in rsp
         msg = "Cannot read ome.model.containers.Project:Id_%s" % projectId
@@ -147,7 +147,7 @@ class TestErrors(IWebTest):
         django_client = self.new_django_client(userName, userName)
         version = api_settings.API_VERSIONS[-1]
         save_url = reverse('api_save', kwargs={'api_version': version})
-        save_url += '?group=' + str(group)
+        save_url += '?group=' + native_str(group)
 
         # Create Tag
         tag = TagAnnotationI()

--- a/components/tools/OmeroWeb/test/integration/test_api_projects.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_projects.py
@@ -21,9 +21,9 @@
 Tests querying & editing Projects with webgateway json api
 """
 
+from future.utils import native_str
 from past.builtins import cmp
 from builtins import zip
-from builtins import str
 from builtins import range
 from omeroweb.testlib import IWebTest, get_json, \
     post_json, put_json, delete_json
@@ -575,7 +575,7 @@ class TestProjects(IWebTest):
         assert project_json['Description'] == 'Test update'  # No change
 
         # 2) Put from scratch (will delete empty fields, E.g. Description)
-        save_url += '?group=' + str(group)
+        save_url += '?group=' + native_str(group)
         payload = {'Name': 'updated name',
                    '@id': project.id.val}
         # Test error message if we don't pass @type:

--- a/components/tools/OmeroWeb/test/integration/test_api_projects.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_projects.py
@@ -23,7 +23,6 @@ Tests querying & editing Projects with webgateway json api
 
 
 from future.utils import native_str
-from past.builtins import cmp
 
 from builtins import zip
 from builtins import range


### PR DESCRIPTION
use native_str

Fix tests like

* https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/219/testReport/junit/OmeroWeb.test.integration.test_api_errors/TestErrors/test_security_violation/
* https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/219/testReport/junit/OmeroWeb.test.integration.test_api_projects/TestProjects/test_project_update/
* https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_api_projects/TestProjects/test_project_delete/
