### PR TITLE
test_rawpixelsstore: rjust string to 40 chars

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -43,7 +43,8 @@ class TestRPS(ITest):
                 sha1 = format(int.from_bytes(md, 'big'), 'x')
             except:
                 # python 2
-                sha1 = hex(int(md.encode('hex'), 16))[2:].rjust(40, "0")
+                sha1 = hex(int(md.encode('hex'), 16))[2:]
+            sha1 = sha1.rjust(40, "0")
             assert sha1 == pix.sha1.val
         finally:
             rps.close()

--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -43,7 +43,7 @@ class TestRPS(ITest):
                 sha1 = format(int.from_bytes(md, 'big'), 'x')
             except:
                 # python 2
-                sha1 = hex(int(md.encode('hex'), 16))[2:]
+                sha1 = hex(int(md.encode('hex'), 16))[2:].rjust(40, "0")
             assert sha1 == pix.sha1.val
         finally:
             rps.close()


### PR DESCRIPTION
Apparently when the method being used can produce shorter
strings when the left most digits are 0. rjust'ing them
corrects for this.

Fixes:
 - https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/219/testReport/junit/OmeroPy.test.integration.test_rawpixelsstore/TestRPS/testTicket4737WithClose/
 - https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/219/testReport/junit/OmeroPy.test.integration.test_rawpixelsstore/TestRPS/testTicket4737WithSave/
 - https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/219/testReport/junit/OmeroPy.test.integration.test_rawpixelsstore/TestRPS/testTicket4737WithForEachTile/