### PR TITLE
web: test_api_login

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -24,6 +24,7 @@ Tests logging in with webgateway json api
 import pytest
 from omeroweb.testlib import IWebTest, get_json, _response, post
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.middleware import csrf
 from omeroweb.api import api_settings
 from django.test import Client
 from omero_marshal import OME_SCHEMA_URL
@@ -160,9 +161,10 @@ class TestLogin(IWebTest):
         # Need a CSRF token
         token_rsp = get_json(django_client, token_url)
         token = token_rsp['data']
+
         # Can also get this from our session cookies
         csrf_token = django_client.cookies['csrftoken'].value
-        assert token == csrf_token
+        assert csrf._compare_salted_tokens(token, csrf_token) is True
         # Now we have all info we need for login.
         # Set the header, so we don't need to do this for every POST/PUT/DELETE
         # OR we could add it to each POST as 'csrfmiddlewaretoken'


### PR DESCRIPTION
Fix comparison of tokens
Tokens will be different if attribute is not set.
Better to compare the value using the ``_compare_salted_tokens`` method

https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_api_login/TestLogin/test_login_example/

cc @will-moore 
