### PR TITLE
web: test_api_projects

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_api_projects.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_projects.py
@@ -21,8 +21,8 @@
 Tests querying & editing Projects with webgateway json api
 """
 
+from future.utils import native_str
 from builtins import zip
-from builtins import str
 from builtins import range
 from omeroweb.testlib import IWebTest, get_json, \
     post_json, put_json, delete_json
@@ -568,7 +568,7 @@ class TestProjects(IWebTest):
         assert project_json['Description'] == 'Test update'  # No change
 
         # 2) Put from scratch (will delete empty fields, E.g. Description)
-        save_url += '?group=' + str(group)
+        save_url += '?group=' + native_str(group)
         payload = {'Name': 'updated name',
                    '@id': project.id.val}
         # Test error message if we don't pass @type:


### PR DESCRIPTION
 use native_str

This should fix:

* https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_api_projects/TestProjects/test_project_delete/
* https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroWeb.test.integration.test_api_projects/TestProjects/test_project_update/
