### PR TITLE
Bump omero-py, omero-web and omero-marshal versions

### DIFF
--- a/components/tools/OmeroWeb/requirements-py27.txt
+++ b/components/tools/OmeroWeb/requirements-py27.txt
@@ -9,5 +9,5 @@ Django>=1.11,<2.0
 django-pipeline==1.6.14
 gunicorn>=19.3
 
-omero-marshal==0.6.0
+omero-marshal==0.6.3
 django-redis>=4.4,<4.9

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -195,10 +195,10 @@ versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 versions.omero-github=https://github.com/ome/PACKAGE/archive
 
 # To be moved to appended
-versions.omero-py=5.6.dev1
+versions.omero-py=5.6.dev2
 versions.omero-py-url=${versions.omero-pypi}
 
-versions.omero-web=5.6.dev2
+versions.omero-web=5.6.dev3
 versions.omero-web-url=${versions.omero-pypi}
 
 versions.omero-dropbox=5.5.dev1


### PR DESCRIPTION
These should include the latest changes for Py3 compatibility
