### PR TITLE
Add testDeleteObjectDirect()

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_delete.py
@@ -143,3 +143,21 @@ class TestDelete (object):
 
         assert qs.find('OriginalFile', oid) is None
         assert qs.find('FileAnnotation', faid) is None
+
+    def testDeleteObjectDirect(self, gatewaywrapper):
+        """ tests conn.deleteObjectDirect(obj) """
+
+        gatewaywrapper.loginAsAuthor()
+        conn = gatewaywrapper.gateway
+        us = conn.getUpdateService()
+        project = omero.model.ProjectI()
+        project.setName(wrap('project'))
+        project = us.saveAndReturnObject(project)
+        pid = unwrap(project.getId())
+
+        project_wrapper = conn.getObject("Project", pid)
+        assert project_wrapper is not None
+
+        conn.deleteObjectDirect(project_wrapper._obj)
+
+        assert conn.getObject("Project", pid) is None


### PR DESCRIPTION
I found when trying to run "Dataset_to_Plate.py" script that the deprecated ```conn.deleteObjectDirect(l._obj)``` is failing with

```
Traceback (most recent call last):
  File "./script", line 354, in <module>
    run_script()
  File "./script", line 343, in run_script
    new_obj, message = datasets_to_plates(conn, script_params)
  File "./script", line 225, in datasets_to_plates
    dataset_id, screen)
  File "./script", line 127, in dataset_to_plate
    col, row, remove_from)
  File "./script", line 70, in add_images_to_plate
    conn.deleteObjectDirect(l._obj)
  File "/home/omero/workspace/OMERO-server/OMERO.server/lib/python/omero/gateway/__init__.py", line 4335, in deleteObjectDirect
    self.c.submit(delete, self.SERVICE_OPTS)
  File "/home/omero/workspace/OMERO-server/OMERO.server/lib/python/omero/clients.py", line 983, in submit
    closehandle=True)
  File "/home/omero/workspace/OMERO-server/OMERO.server/lib/python/omero/clients.py", line 1002, in waitOnCmd
    callback.loop(loops, ms)  # Throw LockTimeout
  File "/home/omero/workspace/OMERO-server/OMERO.server/lib/python/omero/callbacks.py", line 248, in loop
    while count < loops:
TypeError: '<' not supported between instances of 'int' and 'ServiceOptsDict'
```
We don't have a test for this method so I've created a test which fails in the same way.