### PR TITLE
Test download as png

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG BUILD_IMAGE=openjdk:8
 # RUN_IMAGE for end-use. This value can also be
 # set at build time with --build-arg RUN_IMAGE=...
 ARG COMPONENT=server
-ARG RUN_IMAGE=openmicroscopy/omero-${COMPONENT}:latest
+ARG RUN_IMAGE=openmicroscopy/omero-${COMPONENT}:5.6
 
 
 FROM ${BUILD_IMAGE} as build
@@ -74,10 +74,9 @@ RUN rm -rf /opt/omero/server/OMERO.server
 COPY --chown=omero-server:omero-server --from=build /src/dist /opt/omero/server/OMERO.server
 USER root
 RUN yum install -y git
-RUN /opt/omero/server/venv/bin/pip install future
-RUN sed -i 's/#!\/usr\/bin\/env python/#!\/opt\/omero\/server\/venv\/bin\/python/' /opt/omero/server/OMERO.server/bin/omero
-RUN /opt/omero/omego/bin/pip install future
+RUN /opt/omero/server/venv3/bin/pip install future
+RUN sed -i 's/#!\/usr\/bin\/env python/#!\/opt\/omero\/server\/venv3\/bin\/python/' /opt/omero/server/OMERO.server/bin/omero
 USER omero-server
 WORKDIR /opt/omero/server/OMERO.server
-ENV VIRTUAL_ENV=/opt/omero/server/venv
+ENV VIRTUAL_ENV=/opt/omero/server/venv3
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -192,7 +192,6 @@ class TestDownloadAsPng(IWebTest):
         img = Image.open(BytesIO(rsp.content))
         assert img.size == (width, height)
 
-
     def test_download_images_as_zip(self, format='png'):
         """Test we can download a zip with multiple images."""
         name = "test_download_zip"

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -193,7 +193,6 @@ class TestDownloadAsPng(IWebTest):
         img = Image.open(BytesIO(rsp.content))
         assert img.size == (width, height)
 
-
     @pytest.mark.parametrize("format", ['jpeg', 'png', 'tif'])
     def test_download_images_as_zip(self, format):
         """Test we can download a zip with multiple images."""

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -171,7 +171,7 @@ class TestDownload(IWebTest):
 
 class TestDownloadAs(IWebTest):
     """
-    Tests to check download of Image(s) as PNG.
+    Tests to check download of Image(s) in multiple formats.
     """
 
     @pytest.mark.parametrize("format", ['jpeg', 'png', 'tif'])

--- a/components/tools/OmeroWeb/test/integration/test_download.py
+++ b/components/tools/OmeroWeb/test/integration/test_download.py
@@ -169,7 +169,7 @@ class TestDownload(IWebTest):
         get(self.django_client, request_url)
 
 
-class TestDownloadAsPng(IWebTest):
+class TestDownloadAs(IWebTest):
     """
     Tests to check download of Image(s) as PNG.
     """


### PR DESCRIPTION
Adds a test to download as PNG (fixed in https://github.com/ome/omero-web/pull/70).

close https://github.com/ome/omero-web/issues/72

Test passing now at https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/72/testReport/OmeroWeb.test.integration.test_download/TestDownloadAsPng/ with fix in https://github.com/ome/omero-web/pull/76