### PR TITLE
Allow to specify prefix for scripts archive

### DIFF
--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -89,9 +89,9 @@ build_year = "${python_build_year}"
         <delete dir="../target/downloads/py/omero-py-${versions.omero-py}"/>
 
 
-        <download pkg="scripts" file="v${versions.scripts}.tar.gz" expected="${versions.scripts-md5}"
+        <download pkg="scripts" file="${versions.scripts-prefix}${versions.scripts}.tar.gz" expected="${versions.scripts-md5}"
                   where="../target/downloads/scripts"/>
-        <untar src="../target/downloads/scripts/v${versions.scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
+        <untar src="../target/downloads/scripts/${versions.scripts-prefix}${versions.scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
             <!-- Could be improved with an artifact -->
             <patternset>
                 <include name="scripts-${versions.scripts}/omero/**/*"/>

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -205,6 +205,7 @@ versions.omero-dropbox=5.5.dev1
 versions.omero-dropbox-url=${versions.omero-pypi}
 
 versions.scripts=5.6.0-m1
+versions.scripts-prefix=v
 versions.scripts-url=${versions.omero-github}
 
 


### PR DESCRIPTION
This is a prerequisite to be able to consume script integration branches from GitHub.

Unlike the other Python dependencies, the OMERO scripts are currently unpacked from GitHub source archives under `lib`. In order to consume archives from integration branches using a custom `versions.omero-github` location, it is also necessary to override the `v` prefix used for release tags.

Alongside https://github.com/ome/devspace/pull/157m this feature should be primarily be tested in the context of the merge devspaces, consuming the https://github.com/snoopycrimecop/scripts/tree/py3_ci and/or https://github.com/snoopycrimecop/scripts/tree/merge_ci integration branches and deploying servers including open script PRs.
