### PR TITLE
Deprecated plugins test

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_metadata.py
@@ -28,7 +28,7 @@ from omero.constants.namespaces import NSBULKANNOTATIONS, NSMEASUREMENT
 from omero.gateway import BlitzGateway
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    from omero.plugins.metadata import Metadata, MetadataControl
+    from omero.plugins._metadata_deprecated import Metadata, MetadataControl
 from omero.rtypes import rdouble, unwrap
 from omero.testlib.cli import CLITest
 from omero.model.enums import UnitsLength

--- a/components/tools/OmeroPy/test/integration/clitest/test_upload.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_upload.py
@@ -28,7 +28,7 @@ from omero.cli import NonZeroReturnCode
 from omero.plugins.obj import ObjControl
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    from omero.plugins.upload import UploadControl
+    from omero.plugins._upload_deprecated import UploadControl
 from omero.util.temp_files import create_path
 
 


### PR DESCRIPTION
Companion PR to https://github.com/ome/omero-py/pull/124

The renaming of the `metadata` and `import` plugins in the `omero-py` repository prevents the import and the execution of all OMERO.py tests - see https://py3-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/64/testReport/(root)/(empty)/OmeroPy_test_integration_clitest_test_metadata/

This should fix the import to match the renaming done in #124. As the decoupled plugins have now been upgraded to be Python 3 and are tested via omero-test-infra, an alternative would be to remove these tests.