### PR TITLE
Bump pypi versions

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -195,13 +195,13 @@ versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 versions.omero-github=https://github.com/ome/PACKAGE/archive
 
 # To be moved to appended
-versions.omero-py=5.6.dev3
+versions.omero-py=5.6.dev5
 versions.omero-py-url=${versions.omero-pypi}
 
-versions.omero-web=5.6.dev3
+versions.omero-web=5.6.dev5
 versions.omero-web-url=${versions.omero-pypi}
 
-versions.omero-dropbox=5.5.dev1
+versions.omero-dropbox=5.5.dev2
 versions.omero-dropbox-url=${versions.omero-pypi}
 
 versions.scripts=5.6.0-m1

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -201,7 +201,7 @@ versions.omero-py-url=${versions.omero-pypi}
 versions.omero-web=5.6.dev5
 versions.omero-web-url=${versions.omero-pypi}
 
-versions.omero-dropbox=5.5.dev2
+versions.omero-dropbox=5.6.dev2
 versions.omero-dropbox-url=${versions.omero-pypi}
 
 versions.scripts=5.6.0-m1
@@ -216,4 +216,3 @@ versions.scripts-url=${versions.omero-github}
 versions.omero-blitz=5.5.3
 versions.omero-common-test=5.5.2
 versions.omero-gateway=5.5.3
-


### PR DESCRIPTION
Latest version of the Python dependencies for release as 5.6.0-m2