### PR TITLE
Update testAllColumnsSameTable to test Unicode with StringColumn

### DIFF
--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -476,7 +476,7 @@ class TestTables(ITest):
         lcol = columns.LongColumnI('longcol', 'long col')
         lcol.values = [-1, -2]
 
-        scol = columns.StringColumnI('stringcol', 'string col', 4)
+        scol = columns.StringColumnI('stringcol', 'string col', 46)
         scol.values = ["მიკროსკოპის პონი", "de"]
 
         mask = self.createMaskCol()

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -477,7 +477,7 @@ class TestTables(ITest):
         lcol.values = [-1, -2]
 
         scol = columns.StringColumnI('stringcol', 'string col', 4)
-        scol.values = ["αbc", "de"]
+        scol.values = ["მიკროსკოპის პონი", "de"]
 
         mask = self.createMaskCol()
 
@@ -523,7 +523,7 @@ class TestTables(ITest):
         assert -2 == testl[1]
 
         tests = data.columns[8].values
-        assert "αbc" == tests[0]
+        assert "მიკროსკოპის პონი" == tests[0]
         assert "de" == tests[1]
 
         testm = data.columns[9]

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -476,8 +476,8 @@ class TestTables(ITest):
         lcol = columns.LongColumnI('longcol', 'long col')
         lcol.values = [-1, -2]
 
-        scol = columns.StringColumnI('stringcol', 'string col', 3)
-        scol.values = ["abc", "de"]
+        scol = columns.StringColumnI('stringcol', 'string col', 4)
+        scol.values = ["αbc", "de"]
 
         mask = self.createMaskCol()
 
@@ -523,7 +523,7 @@ class TestTables(ITest):
         assert -2 == testl[1]
 
         tests = data.columns[8].values
-        assert "abc" == tests[0]
+        assert "αbc" == tests[0]
         assert "de" == tests[1]
 
         testm = data.columns[9]


### PR DESCRIPTION
While working on the support for  CSV files with Unicode in `omero-metadata`, I encountered an issue with the OMERO 5.6 server on Python 3.
This PR updates the default StringColumn integration test to test strings with unicode characters in it. It should initially pass on Python 2 but fail on Python 3.