### PR TITLE
Consume omero-scripts source distributions

### DIFF
--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -91,14 +91,10 @@ build_year = "${python_build_year}"
 
         <download pkg="omero-scripts" file="omero-scripts-${versions.omero-scripts}.tar.gz" expected="${versions.omero-scripts-md5}"
                   where="../target/downloads/scripts"/>
-        <untar src="../target/downloads/scripts/omero-scripts-${versions.omero-scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
-            <!-- Could be improved with an artifact -->
-            <patternset>
-                <include name="omero-scripts-${versions.scripts}/omero/**/*"/>
-                <include name="omero-scripts-${versions.scripts}/README*"/>
-            </patternset>
-            <globmapper from="omero-scripts-${versions.scripts}/*" to="./*" />
-        </untar>
+        <untar src="../target/downloads/scripts/omero-scripts-${versions.omero-scripts}.tar.gz" dest="../target/downloads/scripts" compression="gzip"/>
+        <copy todir="../target/lib/scripts">
+            <fileset dir="../target/downloads/scripts/omero-scripts-${versions.omero-scripts}" includes="omero/**/*,README*"/>
+        </copy>
 
 
         <download pkg="omero-web" file="omero-web-${versions.omero-web}.tar.gz" expected="${versions.omero-web-md5}"

--- a/components/tools/python.xml
+++ b/components/tools/python.xml
@@ -89,15 +89,15 @@ build_year = "${python_build_year}"
         <delete dir="../target/downloads/py/omero-py-${versions.omero-py}"/>
 
 
-        <download pkg="scripts" file="${versions.scripts-prefix}${versions.scripts}.tar.gz" expected="${versions.scripts-md5}"
+        <download pkg="omero-scripts" file="omero-scripts-${versions.omero-scripts}.tar.gz" expected="${versions.omero-scripts-md5}"
                   where="../target/downloads/scripts"/>
-        <untar src="../target/downloads/scripts/${versions.scripts-prefix}${versions.scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
+        <untar src="../target/downloads/scripts/omero-scripts-${versions.omero-scripts}.tar.gz" dest="../target/lib/scripts" compression="gzip">
             <!-- Could be improved with an artifact -->
             <patternset>
-                <include name="scripts-${versions.scripts}/omero/**/*"/>
-                <include name="scripts-${versions.scripts}/README*"/>
+                <include name="omero-scripts-${versions.scripts}/omero/**/*"/>
+                <include name="omero-scripts-${versions.scripts}/README*"/>
             </patternset>
-            <globmapper from="scripts-${versions.scripts}/*" to="./*" />
+            <globmapper from="omero-scripts-${versions.scripts}/*" to="./*" />
         </untar>
 
 

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -192,7 +192,6 @@ versions.testng=6.8
 versions.velocity=1.4
 
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
-versions.omero-github=https://github.com/ome/PACKAGE/archive
 
 # To be moved to appended
 versions.omero-py=5.6.dev6
@@ -204,9 +203,8 @@ versions.omero-web-url=${versions.omero-pypi}
 versions.omero-dropbox=5.6.dev3
 versions.omero-dropbox-url=${versions.omero-pypi}
 
-versions.scripts=5.6.0-m1
-versions.scripts-prefix=v
-versions.scripts-url=${versions.omero-github}
+versions.omero-scripts=5.6.dev1
+versions.omero-scripts-url=${versions.omero-pypi}
 
 
 ###


### PR DESCRIPTION
This updates the Python downloading logic to consume source distributions of the `omero-scripts` component from PyPI like `omero-py`, `omero-web` rather downloading the GitHub archive previously.
