### PR TITLE
Bump python deps for 5.6.0-m4

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -194,10 +194,10 @@ versions.velocity=1.4
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 
 # To be moved to appended
-versions.omero-py=5.6.dev6
+versions.omero-py=5.6.dev8
 versions.omero-py-url=${versions.omero-pypi}
 
-versions.omero-web=5.6.dev6
+versions.omero-web=5.6.dev7
 versions.omero-web-url=${versions.omero-pypi}
 
 versions.omero-dropbox=5.6.dev3


### PR DESCRIPTION
Bump to the latest releases of omero-py and omero-web. Travis status should suffice.