### PR TITLE
Bump omero-py to 5.6.dev9

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -194,7 +194,7 @@ versions.velocity=1.4
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
 
 # To be moved to appended
-versions.omero-py=5.6.dev8
+versions.omero-py=5.6.dev9
 versions.omero-py-url=${versions.omero-pypi}
 
 versions.omero-web=5.6.dev7


### PR DESCRIPTION
See https://github.com/ome/omero-py/blob/v5.6.dev9/CHANGELOG.md

This should contain the fix required for #6189 