### PR TITLE
Clean up pypi version properties

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -192,20 +192,7 @@ versions.testng=6.8
 versions.velocity=1.4
 
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE
-
-# To be moved to appended
-versions.omero-py=5.6.dev9
-versions.omero-py-url=${versions.omero-pypi}
-
-versions.omero-web=5.6.dev7
-versions.omero-web-url=${versions.omero-pypi}
-
-versions.omero-dropbox=5.6.dev3
-versions.omero-dropbox-url=${versions.omero-pypi}
-
-versions.omero-scripts=5.6.dev1
 versions.omero-scripts-url=${versions.omero-pypi}
-
 
 ###
 ### Appended Values
@@ -215,3 +202,4 @@ versions.omero-scripts-url=${versions.omero-pypi}
 versions.omero-blitz=5.5.5
 versions.omero-common-test=5.5.3
 versions.omero-gateway=5.6.2
+versions.omero-scripts=5.6.0


### PR DESCRIPTION
The omero-py, web, and dropbox versions are no longer used
in this repository. The scripts version *is* used and should
have been bumped to 5.6.0.