### PR TITLE
Fix DJANGO_SETTINGS_MODULE not defined

### DIFF
--- a/components/tools/OmeroPy/test/conftest.py
+++ b/components/tools/OmeroPy/test/conftest.py
@@ -95,4 +95,15 @@ def pytest_configure(config):
         os.environ["OMERO_USERDIR"] = workdir(workerid)
 
 
+try:
+    import xdist  # noqa
+
+    def pytest_configure_node(node):
+        if hasattr(node, 'slaveinput'):
+            workerid = node.slaveinput["workerid"]
+            os.environ["OMERO_USERDIR"] = workdir(workerid)
+except ImportError:
+    pass
+
+
 pytest_plugins = "omero.gateway.pytest_fixtures"

--- a/components/tools/OmeroPy/test/conftest.py
+++ b/components/tools/OmeroPy/test/conftest.py
@@ -95,10 +95,4 @@ def pytest_configure(config):
         os.environ["OMERO_USERDIR"] = workdir(workerid)
 
 
-def pytest_configure_node(node):
-    if hasattr(node, 'slaveinput'):
-        workerid = node.slaveinput["workerid"]
-        os.environ["OMERO_USERDIR"] = workdir(workerid)
-
-
 pytest_plugins = "omero.gateway.pytest_fixtures"

--- a/components/tools/OmeroWeb/setup.py
+++ b/components/tools/OmeroWeb/setup.py
@@ -13,13 +13,6 @@ import os
 from setuptools import setup
 from omero_version import omero_version as ov
 
-if "test" in sys.argv:
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "omeroweb.settings")
-
-    import django
-    if django.VERSION > (1, 7):
-        django.setup()
-
 
 setup(name="OmeroWeb",
       version=ov,
@@ -33,5 +26,5 @@ OmeroWeb is the container of the web clients for OMERO."
       download_url="https://github.com/openmicroscopy/openmicroscopy/",
       packages=[''],
       test_suite='test.suite',
-      tests_require=['pytest', 'pytest-xdist'],
+      tests_require=['pytest', 'pytest-xdist', 'pytest-django'],
       )

--- a/components/tools/OmeroWeb/test/conftest.py
+++ b/components/tools/OmeroWeb/test/conftest.py
@@ -12,3 +12,14 @@ def pytest_configure(config):
     if not hasattr(config, 'slaveinput'):
         workerid = 'main'
         os.environ["OMERO_USERDIR"] = workdir(workerid)
+
+
+try:
+    import xdist  # noqa
+
+    def pytest_configure_node(node):
+        if hasattr(node, 'slaveinput'):
+            workerid = node.slaveinput["workerid"]
+            os.environ["OMERO_USERDIR"] = workdir(workerid)
+except ImportError:
+    pass

--- a/components/tools/OmeroWeb/test/conftest.py
+++ b/components/tools/OmeroWeb/test/conftest.py
@@ -12,9 +12,3 @@ def pytest_configure(config):
     if not hasattr(config, 'slaveinput'):
         workerid = 'main'
         os.environ["OMERO_USERDIR"] = workdir(workerid)
-
-
-def pytest_configure_node(node):
-    if hasattr(node, 'slaveinput'):
-        workerid = node.slaveinput["workerid"]
-        os.environ["OMERO_USERDIR"] = workdir(workerid)

--- a/components/tools/pytest.ini
+++ b/components/tools/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+# pip install pytest-django
+DJANGO_SETTINGS_MODULE = omeroweb.settings
 markers =
     broken: mark the test as broken, i.e. it may be intermittent or failing without a fully understood cause
     fs_suite: group together FS tests


### PR DESCRIPTION
# What this PR does

Uses pytest-django to fix test setup failures with "You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings" at https://latest-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/247/testReport/(root)/

See https://pytest-django.readthedocs.io/en/latest/

Tests run locally with:

```
cd components/tools/OmeroWeb
pytest test/integration/test_login.py
```

Also removes code used for  ```./setup.py test -t test/integration/test_login.py``` which we no-longer support.

Also removes ```def pytest_configure_node(node):``` from ```conftest.py``` in OmeroPy and OmeroWeb, to avoid the need for ```pip install pytest-xdist```. Was otherwise failing with 
```
INTERNALERROR> pluggy.manager.PluginValidationError: unknown hook 'pytest_configure_node' in plugin <module 'test.conftest' from '/Users/wmoore/Desktop/OMERO/openmicroscopy/components/tools/OmeroPy/test/conftest.py'>
```