### PR TITLE
Don't assume `*.fake` is unsupported

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_search.py
+++ b/components/tools/OmeroPy/test/integration/test_search.py
@@ -265,7 +265,6 @@ class TestSearch(ITest):
                 ("%s*" % uuid[:-1], supported),
                 (uuid, supported),
                 #
-                ("*.fake", unsupported),
                 ("%s*.fake" % uuid[:-1], unsupported)):
 
             m(x)


### PR DESCRIPTION
Sometimes a search for `*.fake` _does_ pass.
Likely the difference is due to the number of
existing contents of the FullText index. If
there are too many, then the leading wildcard
fails. The negative test is unneeded and leads
to flaky results.
