### PR TITLE
remove deprecated method

### DIFF
--- a/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayTest.java
@@ -109,7 +109,7 @@ public class GatewayTest {
         String port = client.getProperty("omero.port");
         
         LoginCredentials c = new LoginCredentials();
-        c.getServer().setHostname(host);
+        c.getServer().setHost(host);
         c.getServer().setPort(Integer.parseInt(port));
         c.getUser().setUsername("root");
         c.getUser().setPassword(pass);

--- a/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/GatewayUsageTest.java
@@ -61,7 +61,7 @@ public class GatewayUsageTest extends AbstractServerTest
         omero.client client =  new omero.client();
         String port = client.getProperty("omero.port");
         LoginCredentials c = new LoginCredentials();
-        c.getServer().setHostname(client.getProperty("omero.host"));
+        c.getServer().setHost(client.getProperty("omero.host"));
         c.getServer().setPort(Integer.parseInt(port));
         c.getUser().setUsername("root");
         c.getUser().setPassword(client.getProperty("omero.rootpass"));


### PR DESCRIPTION
# What this PR does

use ``setHost`` instead of ``setHostname``

cc @dominikl 

