### PR TITLE
Import deprecate method

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import ome.formats.OMEROMetadataStoreClient;
 import ome.formats.importer.IObservable;
@@ -287,6 +289,7 @@ public class AbstractServerTest extends AbstractTest {
         if (newScalingFactor > scalingFactor) {
             scalingFactor = newScalingFactor;
         }
+
     }
 
     /**
@@ -1438,9 +1441,15 @@ public class AbstractServerTest extends AbstractTest {
         ic.setUserSpecifiedName(format);
         ic.setTarget(target);
         // ic = library.uploadFilesToRepository(ic);
-        List<Pixels> pixels = library.importImage(ic, 0, 0, 1);
-        Assert.assertNotNull(pixels);
-        Assert.assertTrue(CollectionUtils.isNotEmpty(pixels));
+        ExecutorService threadPool = Executors.newSingleThreadExecutor();
+        List<Pixels> pixels;
+        try {
+            pixels = library.importImage(ic, threadPool, 0);
+            Assert.assertNotNull(pixels);
+            Assert.assertTrue(CollectionUtils.isNotEmpty(pixels));
+        } finally {
+            threadPool.shutdownNow();
+        }
         return pixels;
     }
 

--- a/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
@@ -157,10 +157,13 @@ public class ImportLibraryTest extends AbstractServerTest {
         // FIXME: Using importImage here to keep the tests working
         // but this is not the method under test (which has been removed)
         Assert.assertTrue(library.importCandidates(config, candidates));
-        // omero.grid.Import data = library.uploadFilesToRepository(ic);
-        // List<Pixels> pixels = repo.importMetadata(data);
-        // assertNotNull(pixels);
-        // assertEquals(pixels.size(), 1);
+        ImportContainer ic = candidates.getContainers().get(0);
+        String[] paths = new String[1];
+        paths[0] = f.getAbsolutePath();
+        final omero.grid.ImportProcessPrx proc = library.createImport(ic);
+        List<String> data = library.uploadFilesToRepository(paths, proc);
+        Assert.assertNotNull(data);
+        Assert.assertEquals(data.size(), 1);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
@@ -100,10 +100,8 @@ public class ImportLibraryTest extends AbstractServerTest {
         ImportConfig config = new ImportConfig();
         ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
                 config));
-        ImportContainer ic = getCandidates(f).getContainers().get(0);
-        List<Pixels> pixels = library.importImage(ic, 0, 0, 1);
-        Assert.assertNotNull(pixels);
-        Assert.assertEquals(1, pixels.size());
+        ImportCandidates candidates = getCandidates(f);
+        Assert.assertTrue(library.importCandidates(config, candidates));
     }
 
     /**
@@ -154,13 +152,11 @@ public class ImportLibraryTest extends AbstractServerTest {
         ImportConfig config = new ImportConfig();
         ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
                 config));
-        ImportContainer ic = getCandidates(f).getContainers().get(0);
 
+        ImportCandidates candidates = getCandidates(f);
         // FIXME: Using importImage here to keep the tests working
         // but this is not the method under test (which has been removed)
-        List<Pixels> pixels = library.importImage(ic, 0, 0, 1);
-        Assert.assertNotNull(pixels);
-        Assert.assertEquals(1, pixels.size());
+        Assert.assertTrue(library.importCandidates(config, candidates));
         // omero.grid.Import data = library.uploadFilesToRepository(ic);
         // List<Pixels> pixels = repo.importMetadata(data);
         // assertNotNull(pixels);

--- a/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
@@ -24,6 +24,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import loci.formats.in.FakeReader;
 
@@ -191,9 +193,14 @@ public class ImportLibraryTest extends AbstractServerTest {
                 config));
         ImportContainer ic = getCandidates(f).getContainers().get(0);
         ic = new ImportContainer(f, null, null, null, ic.getUsedFiles(), null);
-        List<Pixels> pixels = library.importImage(ic, 0, 0, 1);
-        Assert.assertNotNull(pixels);
-        Assert.assertEquals(1, pixels.size());
+        ExecutorService threadPool = Executors.newSingleThreadExecutor();
+        try {
+            List<Pixels> pixels = library.importImage(ic, threadPool, 0);
+            Assert.assertNotNull(pixels);
+            Assert.assertEquals(1, pixels.size());
+        } finally {
+            threadPool.shutdownNow();
+        }
     }
 
     /**


### PR DESCRIPTION
# What this PR does

Remove the usage of the deprecate method

Check that the tests remain green
