### PR TITLE
Unit test cleanup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -204,6 +204,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     </target>
 
     <target name="test-unit" description="Run all unit tests" depends="init">
+        <echo message="This task is deprecated"/>
         <launchSuite suite="test"/>
     </target>
 

--- a/components/tools/OmeroFS/build.xml
+++ b/components/tools/OmeroFS/build.xml
@@ -37,6 +37,7 @@
     <target name="tools-dist" depends="tools-build" description="Copied artifacts to tools/target" unless="env.NOPYTHON"/>
 
     <target name="test">
+        <echo message="This task is deprecated"/>
     </target>
 
     <target name="tools-clean" depends="python-clean">

--- a/components/tools/OmeroFS/build.xml
+++ b/components/tools/OmeroFS/build.xml
@@ -28,8 +28,6 @@
     <import file="../common.xml"/>
     <import file="../python.xml"/>
 
-    <target name="test" depends="python-test" unless="env.NOPYTHON"/>
-
     <target name="integration" depends="python-integration" unless="env.NOPYTHON"/>
 
     <target name="tools-init" unless="env.NOPYTHON"/>
@@ -37,6 +35,9 @@
     <target name="tools-build" depends="tools-init" description="Creates all artifacts for tools/target" unless="env.NOPYTHON"/>
 
     <target name="tools-dist" depends="tools-build" description="Copied artifacts to tools/target" unless="env.NOPYTHON"/>
+
+    <target name="test">
+    </target>
 
     <target name="tools-clean" depends="python-clean">
         <delete dir="${copy.dir}"/>

--- a/components/tools/OmeroJava/build.xml
+++ b/components/tools/OmeroJava/build.xml
@@ -73,6 +73,7 @@
     </target>
 
     <target name="test">
+    <echo message="This task is deprecated"/>
     </target>
     <target name="tools-build" depends="tools-init,install"
         description="Creates all artifacts for tools/target"/>

--- a/components/tools/OmeroPy/build.xml
+++ b/components/tools/OmeroPy/build.xml
@@ -30,8 +30,6 @@
     <!-- after python.xml for the overriding of test-* tasks -->
     <import file="${import.dir}/lifecycle.xml"/>
 
-    <target name="test" depends="python-test" unless="env.NOPYTHON"/>
-
     <target name="integration" depends="python-integration" unless="env.NOPYTHON"/>
 
     <target name="tools-init" depends="retrieve" unless="env.NOPYTHON"/>
@@ -39,9 +37,10 @@
     <!-- Copied prefs.class for testing the prefs plugin. -->
     <target name="tools-build" depends="tools-init" description="Uses setup.py to build artifacts" unless="env.NOPYTHON"/>
 
-    <target name="tools-test" depends="tools-build,python-test" description="Runs test target of setup.py" unless="env.NOPYTHON"/>
-
     <target name="tools-dist" depends="tools-build" description="Copies files into tools/target" unless="env.NOPYTHON">
+    </target>
+
+    <target name="test">
     </target>
 
    <target name="tools-clean" depends="python-clean">

--- a/components/tools/OmeroPy/build.xml
+++ b/components/tools/OmeroPy/build.xml
@@ -41,6 +41,7 @@
     </target>
 
     <target name="test">
+        <echo message="This task is deprecated"/>
     </target>
 
    <target name="tools-clean" depends="python-clean">

--- a/components/tools/OmeroWeb/build.xml
+++ b/components/tools/OmeroWeb/build.xml
@@ -29,7 +29,7 @@
     <import file="${up-two}/common.xml"/>
     <import file="${up-two}/python.xml"/>
 
-    <target name="test" depends="python-test" unless="env.NOPYTHON"/>
+    <target name="test"/>
 
     <target name="integration" depends="python-integration" unless="env.NOPYTHON"/>
 

--- a/components/tools/OmeroWeb/build.xml
+++ b/components/tools/OmeroWeb/build.xml
@@ -29,7 +29,9 @@
     <import file="${up-two}/common.xml"/>
     <import file="${up-two}/python.xml"/>
 
-    <target name="test"/>
+    <target name="test">
+    <echo message="This task is deprecated"/>
+    </target>
 
     <target name="integration" depends="python-integration" unless="env.NOPYTHON"/>
 


### PR DESCRIPTION
# What this PR does

Following the decoupling, unit tests are no longer present under ``components/<component>``
* I have added ``no op`` for the test target in case someone still run
``./build.py -f components/<component>/build.xml test``

* I have added a message indicating that the task ``test/test-unit`` is deprecated
* Remove setup.py since we cannot run the test that way. See https://github.com/ome/ome-documentation/pull/2099


Doc PR: https://github.com/ome/ome-documentation/pull/2102

# Testing this PR
* Check that the integration tests remain green
* Check that you can run without error
    - ``./build.py test-unit``
    - ``./build.py -f components/<component>/build.xml test`` where for ``OmeroFs``, ``OmeroPy``, ``OmeroJava``


