### PR TITLE
Bump TestNG version to match other components of OMERO.

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -188,7 +188,7 @@ versions.janino=2.5.10
 
 versions.reportng=1.1.1
 
-versions.testng=6.8
+versions.testng=6.14.2
 versions.velocity=1.4
 
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE


### PR DESCRIPTION
Seems odd to be using a different version of TestNG than most of its components. Can make testing with IDEs a bit of a pain.