### PR TITLE
RawDataFacilityTest testGetPixelValues

### DIFF
--- a/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
+++ b/components/tools/OmeroJava/test/integration/gateway/RawDataFacilityTest.java
@@ -21,6 +21,7 @@
 package integration.gateway;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -89,9 +90,8 @@ public class RawDataFacilityTest extends GatewayTest {
             expPixelData[x][y] = (double) Byte.toUnsignedInt(plane
                     .getRawValue(y * 100 + x));
         }
-
-        Assert.assertEquals(pixelData, expPixelData);
-        Assert.assertEquals(plane.getPixelValues(), expPixelData);
+        Assert.assertTrue(Arrays.deepEquals(pixelData, expPixelData));
+        Assert.assertTrue(Arrays.deepEquals(plane.getPixelValues(), expPixelData));
     }
     
     @Test


### PR DESCRIPTION
# What this PR does

Use deepEquals to compare the arrays

This fixes https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/317/

The failure was due to a change in testNG version
see https://github.com/ome/openmicroscopy/pull/6219
# Testing this PR
Check that the integration test is green

Locally in the ``OmeroJava`` component, run:
```
gradle test --tests "integration.gateway.RawDataFacilityTest.testGetPixelValues"
```