### PR TITLE
Import as

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerImportTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerImportTest.java
@@ -26,10 +26,14 @@ import java.util.List;
 import loci.formats.in.FakeReader;
 
 import ome.formats.OMEROMetadataStoreClient;
+import ome.formats.importer.ImportCandidates;
 import ome.formats.importer.ImportConfig;
 import ome.formats.importer.ImportContainer;
+import ome.formats.importer.ImportEvent;
 import ome.formats.importer.ImportLibrary;
 import ome.formats.importer.ImportLibrary.ImportCallback;
+import ome.formats.importer.IObservable;
+import ome.formats.importer.IObserver;
 import ome.formats.importer.OMEROWrapper;
 import ome.formats.importer.util.ProportionalTimeEstimatorImpl;
 import ome.formats.importer.util.TimeEstimator;
@@ -111,5 +115,46 @@ public class AbstractServerImportTest extends AbstractServerTest {
         cb.loop(60 * 60, 1000); // Wait 1 hr per step.
         Assert.assertNotNull(cb.getImportResponse());
         return req.location;
+    }
+
+    /**
+     * Returns the import candidates corresponding to the specified file.
+     *
+     * @param f
+     *            The file to handle.
+     * @return See above.
+     */
+    protected ImportCandidates getCandidates(File f)
+        throws Exception
+    {
+        ImportConfig config = new ImportConfig();
+        OMEROWrapper reader = new OMEROWrapper(config);
+        String[] paths = new String[1];
+        paths[0] = f.getAbsolutePath();
+        IObserver o = new IObserver() {
+            public void update(IObservable importLibrary, ImportEvent event) {
+
+            }
+        };
+        return new ImportCandidates(reader, paths, o);
+    }
+
+    /**
+     * Import the image with the specified file name
+     *
+     * @param name The name of the file
+     */
+    protected boolean importImageFile(String name)
+        throws Throwable
+    {
+        File f = File.createTempFile(name + ModelMockFactory.FORMATS[0], "."
+                + ModelMockFactory.FORMATS[0]);
+        mmFactory.createImageFile(f, ModelMockFactory.FORMATS[0]);
+        f.deleteOnExit();
+        ImportConfig config = new ImportConfig();
+        ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
+                config));
+        ImportCandidates candidates = getCandidates(f);
+        return library.importCandidates(config, candidates);
     }
 }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2528,4 +2528,45 @@ public class AbstractServerTest extends AbstractTest {
         }
         return newUser;
     }
+
+    /**
+     * Returns the import candidates corresponding to the specified file.
+     *
+     * @param f
+     *            The file to handle.
+     * @return See above.
+     */
+    protected ImportCandidates getCandidates(File f)
+        throws Exception
+    {
+        ImportConfig config = new ImportConfig();
+        OMEROWrapper reader = new OMEROWrapper(config);
+        String[] paths = new String[1];
+        paths[0] = f.getAbsolutePath();
+        IObserver o = new IObserver() {
+            public void update(IObservable importLibrary, ImportEvent event) {
+
+            }
+        };
+        return new ImportCandidates(reader, paths, o);
+    }
+
+    /**
+     * Import the image with the specified file name
+     *
+     * @param name The name of the file
+     */
+    protected boolean importImageFile(String name)
+        throws Throwable
+    {
+        File f = File.createTempFile(name + ModelMockFactory.FORMATS[0], "."
+                + ModelMockFactory.FORMATS[0]);
+        mmFactory.createImageFile(f, ModelMockFactory.FORMATS[0]);
+        f.deleteOnExit();
+        ImportConfig config = new ImportConfig();
+        ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
+                config));
+        ImportCandidates candidates = getCandidates(f);
+        return library.importCandidates(config, candidates);
+    }
 }

--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -2529,44 +2529,4 @@ public class AbstractServerTest extends AbstractTest {
         return newUser;
     }
 
-    /**
-     * Returns the import candidates corresponding to the specified file.
-     *
-     * @param f
-     *            The file to handle.
-     * @return See above.
-     */
-    protected ImportCandidates getCandidates(File f)
-        throws Exception
-    {
-        ImportConfig config = new ImportConfig();
-        OMEROWrapper reader = new OMEROWrapper(config);
-        String[] paths = new String[1];
-        paths[0] = f.getAbsolutePath();
-        IObserver o = new IObserver() {
-            public void update(IObservable importLibrary, ImportEvent event) {
-
-            }
-        };
-        return new ImportCandidates(reader, paths, o);
-    }
-
-    /**
-     * Import the image with the specified file name
-     *
-     * @param name The name of the file
-     */
-    protected boolean importImageFile(String name)
-        throws Throwable
-    {
-        File f = File.createTempFile(name + ModelMockFactory.FORMATS[0], "."
-                + ModelMockFactory.FORMATS[0]);
-        mmFactory.createImageFile(f, ModelMockFactory.FORMATS[0]);
-        f.deleteOnExit();
-        ImportConfig config = new ImportConfig();
-        ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
-                config));
-        ImportCandidates candidates = getCandidates(f);
-        return library.importCandidates(config, candidates);
-    }
 }

--- a/components/tools/OmeroJava/test/integration/ImportAsTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportAsTest.java
@@ -1,0 +1,85 @@
+/*
+ *------------------------------------------------------------------------------
+ *  Copyright (C) 2020 University of Dundee. All rights reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *------------------------------------------------------------------------------
+ */
+package integration;
+
+import java.util.Collections;
+
+
+import omero.SecurityViolation;
+import omero.api.ISessionPrx;
+import omero.model.ExperimenterGroup;
+import omero.model.ExperimenterGroupI;
+import omero.model.Session;
+import omero.sys.EventContext;
+import omero.sys.Principal;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests import as another user
+ *
+ * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp; <a
+ *         href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
+ * @since 5.6.1
+ */
+@Test(groups = { "import", "integration"})
+public class ImportAsTest extends AbstractServerTest {
+
+
+    @DataProvider(name = "role")
+    public Object[][] dataProviderMethod() {
+        return new Object[][] { { "owner" }, { "admin" } };
+    }
+
+    @Test(dataProvider = "role")
+    public void testImportAs(String role) throws Throwable {
+        EventContext sudoer;
+        if (role.equals("owner")) {
+           sudoer = newUserAndGroup("rwr---", true);
+        } else {
+           sudoer = newUserAndGroup("rwr---");
+           ExperimenterGroup systemGroup = new ExperimenterGroupI(roles.systemGroupId, false);
+           addUsers(systemGroup, Collections.singletonList(sudoer.userId), false);
+        }
+        final EventContext scientist = addUser(sudoer, false, false);
+
+        /* The sudoer takes on the scientist's identity. */
+        loginUser(sudoer);
+        final Principal principal = new Principal();
+        principal.name = scientist.userName;
+        principal.group = iAdmin.getEventContext().groupName;
+        principal.eventType = "User";
+        final ISessionPrx iSession = factory.getSessionService();
+        final Session session = iSession.createSessionWithTimeout(principal, 50000);
+        final omero.client client = newOmeroClient();
+        client.joinSession(session.getUuid().getValue());
+        init(client);
+        // Now we create an importer for that user
+        boolean value = importImageFile("testImportAsGroupOwner");
+        if (role.equals("owner")) {
+            Assert.assertFalse(value); // This should be true
+        } else {
+            Assert.assertTrue(value);
+        }
+    }
+
+}

--- a/components/tools/OmeroJava/test/integration/ImportAsTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportAsTest.java
@@ -45,7 +45,7 @@ public class ImportAsTest extends AbstractServerImportTest {
         return new Object[][] { { "rwr---" }, { "rwra--" }, {"rwrw--"} };
     }
 
-    @Test(dataProvider = "permission", groups = "broken")
+    @Test(dataProvider = "permission")
     public void testImportAsGroupOwner(String permission) throws Throwable {
         final EventContext sudoer = newUserAndGroup(permission, true);
         final EventContext scientist = addUser(sudoer, false, false);

--- a/components/tools/OmeroJava/test/integration/ImportAsTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportAsTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
  * @since 5.6.1
  */
 @Test(groups = { "import", "integration"})
-public class ImportAsTest extends AbstractServerTest {
+public class ImportAsTest extends AbstractServerImportTest {
 
 
     @DataProvider(name = "permission")

--- a/components/tools/OmeroJava/test/integration/ImportAsTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportAsTest.java
@@ -19,13 +19,9 @@
  */
 package integration;
 
-import java.util.Collections;
-
 
 import omero.SecurityViolation;
 import omero.api.ISessionPrx;
-import omero.model.ExperimenterGroup;
-import omero.model.ExperimenterGroupI;
 import omero.model.Session;
 import omero.sys.EventContext;
 import omero.sys.Principal;
@@ -45,21 +41,14 @@ import org.testng.annotations.Test;
 public class ImportAsTest extends AbstractServerTest {
 
 
-    @DataProvider(name = "role")
+    @DataProvider(name = "permission")
     public Object[][] dataProviderMethod() {
-        return new Object[][] { { "owner" }, { "admin" } };
+        return new Object[][] { { "rwr---" }, { "rwra--" }, {"rwrw--"} };
     }
 
-    @Test(dataProvider = "role")
-    public void testImportAs(String role) throws Throwable {
-        EventContext sudoer;
-        if (role.equals("owner")) {
-           sudoer = newUserAndGroup("rwr---", true);
-        } else {
-           sudoer = newUserAndGroup("rwr---");
-           ExperimenterGroup systemGroup = new ExperimenterGroupI(roles.systemGroupId, false);
-           addUsers(systemGroup, Collections.singletonList(sudoer.userId), false);
-        }
+    @Test(dataProvider = "permission", groups = "broken")
+    public void testImportAsGroupOwner(String permission) throws Throwable {
+        final EventContext sudoer = newUserAndGroup(permission, true);
         final EventContext scientist = addUser(sudoer, false, false);
 
         /* The sudoer takes on the scientist's identity. */
@@ -75,11 +64,7 @@ public class ImportAsTest extends AbstractServerTest {
         init(client);
         // Now we create an importer for that user
         boolean value = importImageFile("testImportAsGroupOwner");
-        if (role.equals("owner")) {
-            Assert.assertFalse(value); // This should be true
-        } else {
-            Assert.assertTrue(value);
-        }
+        Assert.assertTrue(value);
     }
 
 }

--- a/components/tools/OmeroJava/test/integration/ImportAsTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportAsTest.java
@@ -20,7 +20,6 @@
 package integration;
 
 
-import omero.SecurityViolation;
 import omero.api.ISessionPrx;
 import omero.model.Session;
 import omero.sys.EventContext;

--- a/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
@@ -73,7 +73,7 @@ import com.google.common.collect.ImmutableMap;
  * @since 5.0.0
  */
 @Test(groups = { "import", "integration", "fs" })
-public class ImportLibraryTest extends AbstractServerTest {
+public class ImportLibraryTest extends AbstractServerImportTest {
 
     /**
      * Tests the <code>ImportImage</code> method using an import container

--- a/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
+++ b/components/tools/OmeroJava/test/integration/ImportLibraryTest.java
@@ -29,12 +29,9 @@ import java.util.concurrent.Executors;
 
 import loci.formats.in.FakeReader;
 
-import ome.formats.importer.IObservable;
-import ome.formats.importer.IObserver;
 import ome.formats.importer.ImportCandidates;
 import ome.formats.importer.ImportConfig;
 import ome.formats.importer.ImportContainer;
-import ome.formats.importer.ImportEvent;
 import ome.formats.importer.ImportLibrary;
 import ome.formats.importer.OMEROWrapper;
 import ome.services.blitz.repo.path.ClientFilePathTransformer;
@@ -95,15 +92,7 @@ public class ImportLibraryTest extends AbstractServerTest {
             throws Throwable {
         // create a new group and user
         login(permissions, userRole);
-        File f = File.createTempFile(name + ModelMockFactory.FORMATS[0], "."
-                + ModelMockFactory.FORMATS[0]);
-        mmFactory.createImageFile(f, ModelMockFactory.FORMATS[0]);
-        f.deleteOnExit();
-        ImportConfig config = new ImportConfig();
-        ImportLibrary library = new ImportLibrary(createImporter(), new OMEROWrapper(
-                config));
-        ImportCandidates candidates = getCandidates(f);
-        Assert.assertTrue(library.importCandidates(config, candidates));
+        Assert.assertTrue(importImageFile(name));
     }
 
     /**
@@ -222,26 +211,6 @@ public class ImportLibraryTest extends AbstractServerTest {
     @Override
     @AfterClass
     public void tearDown() throws Exception {
-    }
-
-    /**
-     * Returns the import candidates corresponding to the specified file.
-     *
-     * @param f
-     *            The file to handle.
-     * @return See above.
-     */
-    private ImportCandidates getCandidates(File f) throws Exception {
-        ImportConfig config = new ImportConfig();
-        OMEROWrapper reader = new OMEROWrapper(config);
-        String[] paths = new String[1];
-        paths[0] = f.getAbsolutePath();
-        IObserver o = new IObserver() {
-            public void update(IObservable importLibrary, ImportEvent event) {
-
-            }
-        };
-        return new ImportCandidates(reader, paths, o);
     }
 
     /**


### PR DESCRIPTION
# What this PR does

Add a test to import as group owner
Currently the test is green but it should not
Since we are using data provider, I test the admin and group owner case
I did not add the test to the already complicated classes like ``LightAdminPrivilegesTest``

in the ``OmeroJava`` component: 
run ``gradle test --tests "integration.ImportAsTest. testImportAsGroupOwner"``

cc @pwalczysko @mtbc 
