### PR TITLE
Add test for paths_to_object ROI

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1412,6 +1412,25 @@ class TestShow(IWebTest):
 
         assert paths == expected
 
+    def test_roi(self, project_dataset_image_roi):
+        """Test path to ROI."""
+        project, roi = project_dataset_image_roi
+        dataset, = project.linkedDatasetList()
+        image, = dataset.linkedImageList()
+
+        paths = paths_to_object(self.conn, None, None, None, None, None,
+                                None, None, None, None, None, roi.id.val)
+
+        expected = [
+            [{'type': 'experimenter', 'id': project.details.owner.id.val},
+             {'type': 'project', 'id': project.id.val},
+             {'type': 'dataset', 'id': dataset.id.val, 'childCount': 1},
+             {'type': 'image', 'id': image.id.val},
+             {'type': 'roi', 'id': roi.id.val}]]
+
+        assert paths == expected
+
+
     def test_image_orphan(self, image):
         """
         Test image path for orphaned Image

--- a/components/tools/OmeroWeb/test/integration/test_show.py
+++ b/components/tools/OmeroWeb/test/integration/test_show.py
@@ -1430,7 +1430,6 @@ class TestShow(IWebTest):
 
         assert paths == expected
 
-
     def test_image_orphan(self, image):
         """
         Test image path for orphaned Image


### PR DESCRIPTION
# What this PR does

Add a test for https://github.com/ome/omero-web/pull/159

Test has been passing at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/408/testReport/OmeroWeb.test.integration.test_show/TestShow/test_roi/