### PR TITLE
Test the reset password functionality

### DIFF
--- a/components/tools/OmeroJava/test/integration/AbstractServerTest.java
+++ b/components/tools/OmeroJava/test/integration/AbstractServerTest.java
@@ -897,14 +897,14 @@ public class AbstractServerTest extends AbstractTest {
     /**
      * Logs in the user.
      *
-     * @param ownerName
+     * @param omeName
      *            The OME name of the user.
      * @throws Exception
      *             Thrown if an error occurred.
      */
-    protected void loginUser(String ownerName) throws Exception {
+    protected void loginUser(String omeName) throws Exception {
         omero.client client = newOmeroClient();
-        client.createSession(ownerName, ownerName);
+        client.createSession(omeName, omeName);
         init(client);
     }
 

--- a/components/tools/OmeroJava/test/integration/ResetPasswordTest.java
+++ b/components/tools/OmeroJava/test/integration/ResetPasswordTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package integration;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import omero.cmd.ResetPasswordRequest;
+import omero.cmd.ResetPasswordResponse;
+import omero.cmd.Response;
+import omero.model.Experimenter;
+import omero.sys.EventContext;
+
+import Glacier2.PermissionDeniedException;
+
+/**
+ * Test the reset password function.
+ * @author m.t.b.carroll@dundee.ac.uk
+ * @since 5.6.2
+ */
+public class ResetPasswordTest extends AbstractServerTest {
+
+    /**
+     * Test that resetting a password with a correct e-mail reports success and does affect further logins.
+     * @throws Exception unexpected
+     */
+    @Test
+    public void testPasswordResetEmailGood() throws Exception {
+        final EventContext ec = iAdmin.getEventContext();
+
+        /* Set up a user with e-mail. */
+        final String email = "nobody@example.org";
+        final Experimenter user = iAdmin.getExperimenter(ec.userId);
+        user.setEmail(omero.rtypes.rstring(email));
+        iAdmin.updateSelf(user);
+
+        /* Login should succeed. */
+        loginUser(ec);
+
+        /* As guest reset the user's password. */
+        loginUser(roles.guestName);
+        final ResetPasswordRequest req = new ResetPasswordRequest();
+        req.omename = ec.userName;
+        req.email = email;
+        final Response rsp = doChange(req);
+        Assert.assertTrue(rsp instanceof ResetPasswordResponse);
+
+        try {
+            /* Login should fail. */
+            loginUser(ec);
+            Assert.fail("password should have been changed");
+        } catch (PermissionDeniedException pde) {
+            /* expected */
+        }
+    }
+
+    /**
+     * Test that resetting a password with an incorrect e-mail reports failure and does not affect further logins.
+     * @param hasEmail if the target user should have an e-mail address
+     * @param useEmail if the reset request should use an e-mail address
+     * @throws Exception unexpected
+     */
+    @Test(dataProvider = "test cases using two Boolean arguments")
+    public void testPasswordResetEmailBad(boolean hasEmail, boolean useEmail) throws Exception {
+        final EventContext ec = iAdmin.getEventContext();
+
+        /* Set up a user with e-mail or not. */
+        final String email = "correct@example.org";
+        final Experimenter user = iAdmin.getExperimenter(ec.userId);
+        user.setEmail(hasEmail ? omero.rtypes.rstring(email) : null);
+        iAdmin.updateSelf(user);
+
+        /* Login should succeed. */
+        loginUser(ec);
+
+        /* As guest reset the user's password. */
+        loginUser(roles.guestName);
+        final ResetPasswordRequest req = new ResetPasswordRequest();
+        req.omename = ec.userName;
+        req.email = useEmail ? "wrong@example.org" : null;
+        Assert.assertNotEquals(req.email, email);
+        doChange(client, factory, req, false);  // fails
+
+        /* Login should succeed. */
+        loginUser(ec);
+    }
+}


### PR DESCRIPTION
# What this PR does

Adds integration testing for [ResetPasswordRequest](https://docs.openmicroscopy.org/omero-blitz/5.5.6/slice2html/omero/cmd/ResetPasswordRequest.html).

# Testing this PR

Tests should pass against OMERO 5.6.0.
Tests should pass against OMERO 5.6.1 except for `testPasswordResetEmailGood` which can be seen failing on [OMERO-test-integration](https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testngreports/integration/ResetPasswordTest/). *Update:* With https://github.com/ome/omero-blitz/pull/85 they should all pass.

# Related reading

https://forum.image.sc/t/35701
https://www.openmicroscopy.org/security/advisories/2019-SV3/