### PR TITLE
xdist: fix import to disable pytest_configure_node

### DIFF
--- a/components/tools/OmeroPy/test/conftest.py
+++ b/components/tools/OmeroPy/test/conftest.py
@@ -96,7 +96,7 @@ def pytest_configure(config):
 
 
 try:
-    import xdist  # noqa
+    import xdist.plugin  # noqa
 
     def pytest_configure_node(node):
         if hasattr(node, 'slaveinput'):

--- a/components/tools/OmeroWeb/test/conftest.py
+++ b/components/tools/OmeroWeb/test/conftest.py
@@ -15,7 +15,7 @@ def pytest_configure(config):
 
 
 try:
-    import xdist  # noqa
+    import xdist.plugin  # noqa
 
     def pytest_configure_node(node):
         if hasattr(node, 'slaveinput'):


### PR DESCRIPTION
`import xdist` apparently still passes even after
`pip uninstall pytest-xdist` but that's not the
case (currently) for `import xdist.plugin`.