### PR TITLE
scripts: make test stricter

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_cli.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_cli.py
@@ -63,14 +63,16 @@ import omero.cli as cli
 c = cli.CLI()
 c.loadplugins()
 c._client = client.createClient(secure = True)  # TODO: setter?
-c.invoke(["login"], strict=True)
+c.onecmd(["login"])
+c.assertRC()
 
 #
 # Try an import
 #
 with open("a.fake", "a"):
     pass
-c.invoke(["import", "a.fake"], strict=True)
+c.onecmd(["import", "a.fake"])
+c.assertRC()
 """
 
 

--- a/components/tools/OmeroPy/test/integration/scriptstest/test_cli.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_cli.py
@@ -63,14 +63,14 @@ import omero.cli as cli
 c = cli.CLI()
 c.loadplugins()
 c._client = client.createClient(secure = True)  # TODO: setter?
-c.invoke(["login"])
+c.invoke(["login"], strict=True)
 
 #
 # Try an import
 #
 with open("a.fake", "a"):
     pass
-c.invoke(["import", "a.fake"])
+c.invoke(["import", "a.fake"], strict=True)
 """
 
 


### PR DESCRIPTION
After the tests were merged but *before* the implementation was
merged, the lastest-ci run of the tests still passed. With this
change merged, latest-ci should go red (though perhaps that isn't
necessary.

see: https://github.com/ome/omero-py/pull/186#issuecomment-608287585