### PR TITLE
Fix new flake8 fails: ambiguous variable name 'l'

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_get_objects.py
@@ -253,9 +253,9 @@ class TestFindObject (object):
             assert t.OMERO_TYPE == tag.OMERO_TYPE
         assert tagId in [t.getId() for t in tags]
         longs = list(gatewaywrapper.gateway.getObjects("LongAnnotation"))
-        for l in longs:
-            assert l.OMERO_TYPE == longAnn.OMERO_TYPE
-        assert longId in [l.getId() for l in longs]
+        for lng in longs:
+            assert lng.OMERO_TYPE == longAnn.OMERO_TYPE
+        assert longId in [lng.getId() for lng in longs]
         bools = list(gatewaywrapper.gateway.getObjects("BooleanAnnotation"))
         for b in bools:
             assert b.OMERO_TYPE == boolAnn.OMERO_TYPE

--- a/components/tools/OmeroPy/test/integration/test_delete.py
+++ b/components/tools/OmeroPy/test/integration/test_delete.py
@@ -252,8 +252,8 @@ class TestDelete(ITest):
 
         # Remove comment from first image
         linkIds = []
-        for l in images[0].copyAnnotationLinks():
-            linkIds.append(l.id.val)
+        for link in images[0].copyAnnotationLinks():
+            linkIds.append(link.id.val)
         command = Delete2(targetObjects={"ImageAnnotationLink": linkIds})
         handle = self.client.sf.submit(command)
         self.wait_on_cmd(self.client, handle)

--- a/components/tools/OmeroPy/test/integration/test_iquery.py
+++ b/components/tools/OmeroPy/test/integration/test_iquery.py
@@ -110,10 +110,10 @@ class TestQuery(ITest):
 
         # Root also links user's tag to images
         rootLinks = []
-        for l in links:
+        for lnk in links:
             link = ImageAnnotationLinkI()
-            link.parent = ImageI(l.parent.id, False)
-            link.child = TagAnnotationI(l.child.id, False)
+            link.parent = ImageI(lnk.parent.id, False)
+            link.child = TagAnnotationI(lnk.child.id, False)
             rootLinks.append(link)
         rootUpdate.saveAndReturnArray(rootLinks, {'omero.group':
                                                   native_str(groupId)})

--- a/components/tools/OmeroPy/test/integration/test_tickets2000.py
+++ b/components/tools/OmeroPy/test/integration/test_tickets2000.py
@@ -397,8 +397,8 @@ class TestTickets2000(ITest):
         p = self.new_project(name="ticket1183")
         p.linkAnnotation(omero.model.CommentAnnotationI())
         p = self.update.saveAndReturnObject(p)
-        for l in p.copyAnnotationLinks():
-            l.child.unload()
+        for link in p.copyAnnotationLinks():
+            link.child.unload()
         p.description = rstring("desc")
         p = self.update.saveAndReturnObject(p)
         p = self.update.saveAndReturnObject(p)

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -203,7 +203,8 @@ class TestExperimenters(IWebTest):
             assert enabled == expected, p_name
 
         # Shouldn't be able to create a Full Admin
-        admin_option = [l for l in form_lines if 'value="administrator"' in l]
+        admin_option = [line for line in form_lines
+                        if 'value="administrator"' in line]
         assert 'disabled' in admin_option[0]
 
     def test_restricted_admin_create_edit_user(self):

--- a/sql/misc/enums.py
+++ b/sql/misc/enums.py
@@ -75,8 +75,8 @@ def compare(conn1, conn2, table):
             print(" ** ADDED ** ")
         elif l2_deleted:
             print(" ** DELETED ** ")
-        for l in output:
-            print(l)
+        for line in output:
+            print(line)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# What this PR does

Fixes new flake8 errors.
This commit was originally needed in https://github.com/ome/openmicroscopy/pull/6235 but is also needed in https://github.com/ome/openmicroscopy/pull/6224 so best to merge on it's own.