### PR TITLE
Re-introduce jul and jcl redirection (fix #6049)

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -11,6 +11,8 @@
   <dependencies>
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
     <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
+    <dependency org="org.slf4j" name="jul-to-slf4j" rev="1.7.30"/>
+    <dependency org="org.slf4j" name="jcl-over-slf4j" rev="1.7.30"/>
     <!-- runtime dependencies from dsl/ivy.xml -->
     <dependency org="janino" name="janino" rev="${versions.janino}"/>
   </dependencies>


### PR DESCRIPTION
The decoupling work dropped a few SLF4j libraries which
automatically redirect java.utils.logging and Java Commons
Logging to the active SLF4J implementation (i.e. logback).
This led to unintentional output in var/log/master.err
which has now been removed.