### PR TITLE
Add integration test covering bulk import with log flags

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -1356,7 +1356,7 @@ path: test.tsv
                       "--file", "log.out", "--err", "log.err"]
         self.cli.invoke(self.args, strict=True)
 
-        with open("%s/log.out" % logdir, "r") as l:
-            out = "\n".join(l.readlines())
-            o = self.get_objects(out, 'Image')
-            assert len(o) == 2, "Found %s images" % len(o)
+        with open("%s/log.out" % logdir, "r") as logfile:
+            out = "\n".join(logfile.readlines())
+            objects = self.get_objects(out, 'Image')
+            assert len(objects) == 2, "Found %s images" % len(objects)

--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -1338,3 +1338,25 @@ path: test.tsv
         images = self.get_objects(out, 'Image')
         imagenames = set([image.name.val for image in images])
         assert filenames == imagenames
+
+    def testBulkImportLogs(self, tmpdir):
+        """Test out/err logs of bulk import command"""
+
+        tmpdir.join("test1.fake").write('')
+        tmpdir.join("test2.fake").write('')
+
+        tmpdir.join("filelist.tsv").write("test1.fake\ntest2.fake")
+
+        yml = tmpdir.join("bulk.yml")
+        yml.write("---\npath: filelist.tsv")
+
+        logdir = str(tmpdir.mkdir("logs"))
+
+        self.args += ["--bulk", str(yml), "--logprefix", logdir,
+                      "--file", "log.out", "--err", "log.err"]
+        self.cli.invoke(self.args, strict=True)
+
+        with open("%s/log.out" % logdir, "r") as l:
+            out = "\n".join(l.readlines())
+            o = self.get_objects(out, 'Image')
+            assert len(o) == 2, "Found %s images" % len(o)


### PR DESCRIPTION
This PR adds an integration test covering the scenario reported in https://github.com/ome/omero-py/issues/40

The test should be failing with `omero-py 5.7.0` or earlier but passing with the changes introduced in https://github.com/ome/omero-py/pull/223