### PR TITLE
Include logback-cli.xml in OMERO.java.zip

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -301,6 +301,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     <target name="release-clients" description="Zip the Java zip">
         <zip destfile="${omero.home}/target/OMERO.java-${omero.version}.zip">
             <zipfileset dir="${dist.dir}/lib/client"    prefix="OMERO.java-${omero.version}/libs" includes="**/*.jar"/>
+            <zipfileset dir="${dist.dir}/etc" prefix="OMERO.java-${omero.version}/libs" includes="logback-cli.xml"/>
         </zip>
 
     </target>


### PR DESCRIPTION
# What this PR does

Includes `etc/logback-cli.xml` in OMERO.java, alongside the jars.

This is required by https://github.com/ome/omero-py/pull/162#issuecomment-653032880 which was released in OMERO.py 5.8.0

# Testing this PR

1. If you haven't previously run `omero import` without `OMERODIR` then do so, this should download OMERO.java into your OMERO user cache directory
2. Find your OMERO user cache directory: `` OMEROUSERCACHEDIR=`python -c 'import omero.clients; print(omero.util.get_omero_user_cache_dir())'` ``
3. Find your current OMERO client jars: `` echo $OMEROUSERCACHEDIR/jars/`cat $OMEROUSERCACHEDIR/jars/OMERO.java.txt`/libs ``. 
4. Replace the contents of the directory in step (3) with the contents of the `libs` directory from the OMERO.java.zip built with this PR.
5. Run `omero import`, the logging should be the same as with `OMERODIR=/path/to/OMERO.server`.

# Related reading

- https://github.com/ome/omero-py/pull/162#issuecomment-653032880