### PR TITLE
Only assert_objects if len(exp_ids) > 0

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_api_experimenters_groups.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_experimenters_groups.py
@@ -138,18 +138,21 @@ class TestExperimenters(IWebTest):
 
         assert_objects(conn, groups_json, groups, dtype="ExperimenterGroup")
 
-        # Check we can follow link to Experimenters for first Group
-        expimenters_url = groups_json[0]["url:experimenters"]
-        rsp = get_json(django_client, expimenters_url)
-        exps_json = rsp['data']
-        exp_ids = [e['@id'] for e in exps_json]
+        # Check experimenters_url for all groups above
+        for group_json in groups_json:
+            # Check we can follow link to Experimenters for first Group
+            expimenters_url = group_json["url:experimenters"]
+            rsp = get_json(django_client, expimenters_url)
+            exps_json = rsp['data']
+            exp_ids = [e['@id'] for e in exps_json]
 
-        # Check if eids are same for group (won't be ordered)
-        grp = conn.getObject("ExperimenterGroup", groups_json[0]['@id'])
-        eids = [link.child.id.val for link in grp.copyGroupExperimenterMap()]
-        assert set(eids) == set(exp_ids)
+            # Check if eids are same for group (won't be ordered)
+            grp = conn.getObject("ExperimenterGroup", group_json['@id'])
+            eids = [link.child.id.val for link in grp.copyGroupExperimenterMap()]
+            assert set(eids) == set(exp_ids)
 
-        assert_objects(conn, exps_json, exp_ids, dtype="Experimenter")
+            if len(exp_ids) > 0:
+                assert_objects(conn, exps_json, exp_ids, dtype="Experimenter")
 
     def test_filter_groups(self, user1):
         """

--- a/components/tools/OmeroWeb/test/integration/test_api_experimenters_groups.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_experimenters_groups.py
@@ -148,7 +148,8 @@ class TestExperimenters(IWebTest):
 
             # Check if eids are same for group (won't be ordered)
             grp = conn.getObject("ExperimenterGroup", group_json['@id'])
-            eids = [link.child.id.val for link in grp.copyGroupExperimenterMap()]
+            eids = [link.child.id.val
+                    for link in grp.copyGroupExperimenterMap()]
             assert set(eids) == set(exp_ids)
 
             if len(exp_ids) > 0:


### PR DESCRIPTION
# What this PR does

Fix test failure at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/543/testReport/junit/OmeroWeb.test.integration.test_api_experimenters_groups/TestExperimenters/test_groups_experimenters/

This failure can happen if the Group for which we check experimenters, has 0 experimenters.
Now we only `assert_objects()` if we have more than zero experimenters.
But to be sure that we call `assert_objects()`, we check all the groups that were previously loaded (up to 10) instead of just checking the first group.