### PR TITLE
Documentation for https://github.com/ome/omero-py/pull/272

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -156,7 +156,9 @@ omero.glacier2.IceSSL.Protocols=tls1
 # set this to ``master:Blitz-0,Tables-0``.
 # Also use this to distribute OMERO services across multiple nodes,
 # for example:
-# ``master:Blitz-0,Tables-0 worker1:Processor-0``
+# ``master:Blitz-0,Tables-0 worker1:Processor-0``.
+# See
+# https://docs.openmicroscopy.org/omero/latest/sysadmins/grid.html#deployment-examples
 omero.server.nodedescriptors=
 
 #############################################

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -150,6 +150,15 @@ omero.glacier2.IceSSL.VerifyPeer=0
 # Glacier2Template SSL allowed protocols
 omero.glacier2.IceSSL.Protocols=tls1
 
+# Override the default set of OMERO servers.
+# For example, to run OMERO.server with Blitz and Tables only
+# (i.e. disable Processor, DropBox, Indexer, PixelData)
+# set this to ``master:Blitz-0,Tables-0``.
+# Also use this to distribute OMERO services across multiple nodes,
+# for example:
+# ``master:Blitz-0,Tables-0 worker1:Processor-0``
+omero.glacier2.IceSSL.Protocols=
+
 #############################################
 ## Darwin (OS X) specific defaults for templated configuration files only.
 ## ``_xxx.yyy.darwin`` properties will override xxx.yyy properties in this

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -157,7 +157,7 @@ omero.glacier2.IceSSL.Protocols=tls1
 # Also use this to distribute OMERO services across multiple nodes,
 # for example:
 # ``master:Blitz-0,Tables-0 worker1:Processor-0``
-omero.glacier2.IceSSL.Protocols=
+omero.server.nodedescriptors=
 
 #############################################
 ## Darwin (OS X) specific defaults for templated configuration files only.

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -150,7 +150,7 @@ omero.glacier2.IceSSL.VerifyPeer=0
 # Glacier2Template SSL allowed protocols
 omero.glacier2.IceSSL.Protocols=tls1
 
-# Override the default set of OMERO servers.
+# Override the default set of OMERO services.
 # For example, to run OMERO.server with Blitz and Tables only
 # (i.e. disable Processor, DropBox, Indexer, PixelData)
 # set this to ``master:Blitz-0,Tables-0``.


### PR DESCRIPTION
# What this PR does

https://github.com/ome/omero-py/pull/272 adds a new property `omero.server.nodedescriptors`. This adds some docs that should end up on https://docs.openmicroscopy.org/omero/5/sysadmins/config.html.


# Testing this PR

See the examples linked from https://github.com/ome/omero-py/pull/272
