### PR TITLE
Test for newlines in `omero obj`

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -390,3 +390,14 @@ class TestObj(CLITest):
         type, id = ann.split(":")
         ann3 = self.client.sf.getQueryService().get(type, int(id))
         assert ann3.ns is None
+
+    def test_newines(self):
+        desc = "A\nB"
+        self.args = self.login_args() + [
+            "obj", "new", "Dataset", "name=test", "description="+desc]
+        state = self.go()
+        ds = state.get_row(0)
+
+        type, id = ds.split(":")
+        ds2 = self.client.sf.getQueryService().get(type, int(id))
+        assert ds2.description.val == desc

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -391,7 +391,7 @@ class TestObj(CLITest):
         ann3 = self.client.sf.getQueryService().get(type, int(id))
         assert ann3.ns is None
 
-    def test_newines(self):
+    def test_newlines(self):
         desc = "A\nB"
         self.args = self.login_args() + [
             "obj", "new", "Dataset", "name=test", "description="+desc]


### PR DESCRIPTION
see: https://github.com/ome/omero-py/pull/279

Without this PR, no attempt to pass a newline to the `obj` command will succeed. e.g.:

```
omero obj update Dataset:123 description=$'A\nB'
```
or
```
omero obj update Dataset:123 description="A

B"
```
will stop at the A.

With this PR, both usages (and likely others) will correctly pass a newline to the server.