### PR TITLE
Test edit user settings

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -37,8 +37,8 @@ def get_all_privileges(client):
 
 class TestUserSettings(IWebTest):
 
-    def validate_settings_page(self, django_client, ome_name, first_name, last_name,
-                               default_group_id, admin=False):
+    def validate_settings_page(self, django_client, ome_name, first_name,
+                               last_name, default_group_id, admin=False):
         request_url = reverse("wamyaccount", args=['edit'])
         rsp = get(django_client, request_url)
         html = rsp.content.decode("utf-8")
@@ -60,11 +60,12 @@ class TestUserSettings(IWebTest):
         first_name = exp.firstName.val
         last_name = exp.lastName.val
         django_client = self.new_django_client(ome_name, ome_name)
-        self.validate_settings_page(django_client, ome_name, first_name, last_name, gid)
+        self.validate_settings_page(django_client, ome_name, first_name,
+                                    last_name, gid)
         # admin
         gid = self.root.sf.getAdminService().getEventContext().groupId
-        self.validate_settings_page(self.django_root_client, "root", "root", "root",
-                                    gid, admin=True)
+        self.validate_settings_page(self.django_root_client, "root", "root",
+                                    "root", gid, admin=True)
 
     def test_edit_settings(self):
         request_url = reverse("wamyaccount", args=['save'])
@@ -72,7 +73,6 @@ class TestUserSettings(IWebTest):
         ome_name = exp.omeName.val
         first = "Ben"
         last = "Nevis"
-        email = "ben@openmicroscopy.org"
         # Add user to a 2nd group
         groupid = self.new_group(experimenters=[exp]).id.val
         django_client = self.new_django_client(ome_name, ome_name)
@@ -88,7 +88,8 @@ class TestUserSettings(IWebTest):
         rsp = post(django_client, request_url, data, status_code=302)
         assert rsp.get('Location').endswith(reverse("wamyaccount"))
         # Check fields and default group have been saved
-        self.validate_settings_page(django_client, ome_name, first, last, groupid)
+        self.validate_settings_page(django_client, ome_name, first, last,
+                                    groupid)
 
 
 class TestExperimenters(IWebTest):

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -37,24 +37,33 @@ def get_all_privileges(client):
 
 class TestUserSettings(IWebTest):
 
-    def test_user_settings_page(self):
-        request_url = reverse("wamyaccount", args=['edit'])
+    def validate_settings_page(self, html, ome_name, first_name, last_name,
+                               admin=False):
+
         admin_link = ("""<a href="/webadmin/" title="Web-Admin:"""
                       """ Edit users and groups">Admin</a>""")
+        assert "Username:" in html
+        assert (admin_link in html) == admin
+        assert ("name=\"omename\" value=\"%s\"" % ome_name) in html
+        assert ("name=\"first_name\" value=\"%s\"" % first_name) in html
+        assert ("name=\"last_name\" value=\"%s\"" % last_name) in html
+
+    def test_user_settings_page(self):
+        request_url = reverse("wamyaccount", args=['edit'])
         # regular user
         exp = self.new_user()
         ome_name = exp.omeName.val
+        first_name = exp.firstName.val
+        last_name = exp.lastName.val
         django_client = self.new_django_client(ome_name, ome_name)
         rsp = get(django_client, request_url)
         page_html = rsp.content.decode("utf-8")
-        assert "Username:" in page_html
-        assert admin_link not in page_html
+        self.validate_settings_page(page_html, ome_name, first_name, last_name)
         # admin
         rsp = get(self.django_root_client, request_url)
         page_html = rsp.content.decode("utf-8")
-        assert "Username:" in page_html
-        # Admin should see link at top of webclient:
-        assert admin_link in page_html
+        self.validate_settings_page(page_html, "root", "root", "root",
+                                    admin=True)
 
 
 class TestExperimenters(IWebTest):


### PR DESCRIPTION
# What this PR does

As a follow-up to #6269 (which tested that the User Settings page loaded and checked a little of it's html),
this PR adds to that test to check more user settings on the page, and tests submitting the form to edit user settings.