### PR TITLE
Test deltephoto instead of crop

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -337,15 +337,9 @@ class TestCsrf(IWebTest):
         finally:
             temp.close()
 
-        # Crop avatar
-        request_url = reverse('wamanageavatar', args=[user_id, "crop"])
-        data = {
-            'x1': 50,
-            'x2': 150,
-            'y1': 50,
-            'y2': 150
-        }
-        csrf_response(self.django_client, request_url, 'post', data,
+        # Delete avatar - check we get a redirect
+        request_url = reverse('wamanageavatar', args=[user_id, "deletephoto"])
+        csrf_response(self.django_client, request_url, 'post',
                       status_code=302, test_csrf_required=False)
 
     def test_create_group(self):


### PR DESCRIPTION
# What this PR does

Fix tests for https://github.com/ome/omero-web/pull/274

 - Don't test crop photo (removed)
 - Instead, test delete photo (fixed)