### PR TITLE
Test avatar user id

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -304,7 +304,7 @@ class TestCsrf(IWebTest):
             img_data = temp.read()
             temp.seek(0)
 
-            request_url = reverse('wamanageavatar', args=["upload"])
+            request_url = reverse('wamanageavatar', kwargs={"action": "upload"})
             data = {
                 'filename': 'avatar.png',
                 "photo": temp
@@ -320,7 +320,7 @@ class TestCsrf(IWebTest):
         assert rsp.content == img_data
 
         # Delete photo
-        request_url = reverse('wamanageavatar', args=["deletephoto"])
+        request_url = reverse('wamanageavatar', kwargs={"action": "deletephoto"})
         csrf_response(self.django_client, request_url, 'post', {},
                       status_code=302, test_csrf_required=False)
         # Should get placeholder photo again

--- a/components/tools/OmeroWeb/test/integration/test_csrf.py
+++ b/components/tools/OmeroWeb/test/integration/test_csrf.py
@@ -304,7 +304,8 @@ class TestCsrf(IWebTest):
             img_data = temp.read()
             temp.seek(0)
 
-            request_url = reverse('wamanageavatar', kwargs={"action": "upload"})
+            request_url = reverse('wamanageavatar',
+                                  kwargs={"action": "upload"})
             data = {
                 'filename': 'avatar.png',
                 "photo": temp
@@ -320,7 +321,8 @@ class TestCsrf(IWebTest):
         assert rsp.content == img_data
 
         # Delete photo
-        request_url = reverse('wamanageavatar', kwargs={"action": "deletephoto"})
+        request_url = reverse('wamanageavatar',
+                              kwargs={"action": "deletephoto"})
         csrf_response(self.django_client, request_url, 'post', {},
                       status_code=302, test_csrf_required=False)
         # Should get placeholder photo again

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -62,6 +62,10 @@ class TestUserSettings(IWebTest):
         django_client = self.new_django_client(ome_name, ome_name)
         self.validate_settings_page(django_client, ome_name, first_name,
                                     last_name, gid)
+        # check when experimenter -1. See https://github.com/ome/omero-web/pull/285
+        rsp = get(django_client, reverse("userdata"), {'experimenter': '-1'})
+        self.validate_settings_page(django_client, ome_name, first_name,
+                                    last_name, gid)
         # admin
         gid = self.root.sf.getAdminService().getEventContext().groupId
         self.validate_settings_page(self.django_root_client, "root", "root",

--- a/components/tools/OmeroWeb/test/integration/test_webadmin.py
+++ b/components/tools/OmeroWeb/test/integration/test_webadmin.py
@@ -62,8 +62,8 @@ class TestUserSettings(IWebTest):
         django_client = self.new_django_client(ome_name, ome_name)
         self.validate_settings_page(django_client, ome_name, first_name,
                                     last_name, gid)
-        # check when experimenter -1. See https://github.com/ome/omero-web/pull/285
-        rsp = get(django_client, reverse("userdata"), {'experimenter': '-1'})
+        # check experimenter -1. See https://github.com/ome/omero-web/pull/285
+        get(django_client, reverse("userdata"), {'experimenter': '-1'})
         self.validate_settings_page(django_client, ome_name, first_name,
                                     last_name, gid)
         # admin


### PR DESCRIPTION
# What this PR does

Updates and adds to tests corresponding https://github.com/ome/omero-web/pull/285

 - Updates `manageavatar` URLs to not use `user_id`
 - Checks that photo upload and delete have the expected result

Should fix test failing at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/763/testReport/junit/OmeroWeb.test.integration.test_csrf/TestCsrf/test_avatar/