### PR TITLE
Don't hard-code acquisition Date. Format according to time zone

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -23,7 +23,6 @@ Simple integration tests for the "tree" module.
 from __future__ import division
 
 from builtins import str
-from past.utils import old_div
 import pytest
 from omero.testlib import ITest
 
@@ -1849,17 +1848,16 @@ class TestTree(ITest):
         dataset = project_hierarchy_userA_groupA[2]
         images = project_hierarchy_userA_groupA[4:6]
         utcAcq = 1444129810716
-        acqDate = '2015-10-06T12:10:10Z'
         for i in images:
             # get Creation date and set Acquisition Date.
             utcCreate = i.details.creationEvent._time.val
             i.setAcquisitionDate(rtime(utcAcq))
         images = conn.getUpdateService().saveAndReturnArray(images)
         # All images created at same time
-        utcCreate = datetime.fromtimestamp(
-            old_div(utcCreate, 1000)).isoformat() + 'Z'
+        creDate = datetime.fromtimestamp(utcCreate//1000).isoformat() + 'Z'
+        acqDate = datetime.fromtimestamp(utcAcq//1000).isoformat() + 'Z'
         extraValues = {'acqDate': acqDate,
-                       'date': utcCreate}
+                       'date': creDate}
         expected = expected_images(userA, images,
                                    extraValues=extraValues)
         marshaled = marshal_images(conn=conn,

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -39,6 +39,8 @@ from omeroweb.webclient.tree import marshal_experimenter, \
     marshal_screens, marshal_plate_acquisitions, marshal_orphaned, \
     marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
 
+from test_tree_annotations import expected_date
+
 from datetime import datetime
 
 
@@ -191,8 +193,8 @@ def expected_plate_acquisitions(user, plate_acquisitions):
         if acq.name is not None:
             acq_name = acq.name.val
         elif acq.startTime is not None and acq.endTime is not None:
-            start_time = datetime.utcfromtimestamp(acq.startTime.val / 1000.0)
-            end_time = datetime.utcfromtimestamp(acq.endTime.val / 1000.0)
+            start_time = expected_date(acq.startTime.val)
+            end_time = expected_date(acq.endTime.val)
             acq_name = '%s - %s' % (start_time, end_time)
         else:
             acq_name = 'Run %d' % acq.id.val
@@ -1854,8 +1856,8 @@ class TestTree(ITest):
             i.setAcquisitionDate(rtime(utcAcq))
         images = conn.getUpdateService().saveAndReturnArray(images)
         # All images created at same time
-        creDate = datetime.fromtimestamp(utcCreate//1000).isoformat() + 'Z'
-        acqDate = datetime.fromtimestamp(utcAcq//1000).isoformat() + 'Z'
+        creDate = expected_date(utcCreate)
+        acqDate = expected_date(utcAcq)
         extraValues = {'acqDate': acqDate,
                        'date': creDate}
         expected = expected_images(userA, images,

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -192,7 +192,8 @@ def expected_plate_acquisitions(user, plate_acquisitions):
         if acq.name is not None:
             acq_name = acq.name.val
         elif acq.startTime is not None and acq.endTime is not None:
-            start_time = datetime.utcfromtimestamp(unwrap(acq.startTime) / 1000.0)
+            start_time = datetime.utcfromtimestamp(
+                unwrap(acq.startTime) / 1000.0)
             end_time = datetime.utcfromtimestamp(unwrap(acq.endTime) / 1000.0)
             acq_name = '%s - %s' % (start_time, end_time)
         else:

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -41,8 +41,6 @@ from omeroweb.webclient.tree import marshal_experimenter, \
 
 from test_tree_annotations import expected_date
 
-from datetime import datetime
-
 
 def unwrap(x):
     """Handle case where there is no value because attribute is None"""

--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -39,6 +39,7 @@ from omeroweb.webclient.tree import marshal_experimenter, \
     marshal_screens, marshal_plate_acquisitions, marshal_orphaned, \
     marshal_tags, marshal_tagged, marshal_shares, marshal_discussions
 
+from datetime import datetime
 from test_tree_annotations import expected_date
 
 
@@ -191,8 +192,8 @@ def expected_plate_acquisitions(user, plate_acquisitions):
         if acq.name is not None:
             acq_name = acq.name.val
         elif acq.startTime is not None and acq.endTime is not None:
-            start_time = expected_date(acq.startTime.val)
-            end_time = expected_date(acq.endTime.val)
+            start_time = datetime.utcfromtimestamp(unwrap(acq.startTime) / 1000.0)
+            end_time = datetime.utcfromtimestamp(unwrap(acq.endTime) / 1000.0)
             acq_name = '%s - %s' % (start_time, end_time)
         else:
             acq_name = 'Run %d' % acq.id.val

--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -27,6 +27,7 @@ from builtins import zip
 from future.utils import native_str
 from past.utils import old_div
 import pytest
+import pytz
 from omero.testlib import ITest
 from datetime import datetime
 
@@ -165,7 +166,10 @@ def annotate_project(ann, project, user):
 
 def expected_date(time):
     d = datetime.fromtimestamp(old_div(time, 1000))
-    return d.isoformat() + 'Z'
+    # Add time-zone awareness. Use default TIME_ZONE setting
+    tz = pytz.timezone("Europe/London")
+    d = tz.localize(d)
+    return d.isoformat()
 
 
 def expected_experimenter(experimenter):


### PR DESCRIPTION
See https://github.com/ome/omero-web/pull/303#issuecomment-876528153

This fixes a failing test https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/822/testReport/OmeroWeb.test.integration.test_tree/TestTree/test_marshal_images_dataset_date/
which fails because a datetime from value `1444129810716` was hard-coded as expected value `'2015-10-06T12:10:10Z'`
but this is dependent on the Django `TIME_ZONE` setting (which is changed in https://github.com/ome/omero-web/pull/303).

The `TIME_ZONE` setting change in that PR may or may not be desirable, but this test should probably not be testing that setting.
We now consistently format the creationDate and acquisitionDate in the same way.