### PR TITLE
Fix polygon ROI points string format

### DIFF
--- a/examples/Training/python/ROIs.py
+++ b/examples/Training/python/ROIs.py
@@ -195,8 +195,9 @@ polygon.theT = rint(t)
 polygon.fillColor = rint(rgba_to_int(255, 0, 255, 50))
 polygon.strokeColor = rint(rgba_to_int(255, 255, 0))
 polygon.strokeWidth = omero.model.LengthI(10, UnitsLength.PIXEL)
-points = "10,20, 50,150, 200,200, 250,75"
+points = "10,20 50,150 200,200 250,75"
 polygon.points = rstring(points)
+polygon.textValue = rstring("test-Polygon")
 create_roi(image, [polygon])
 
 # Retrieve ROIs linked to an Image


### PR DESCRIPTION
# What this PR does

The current point string format (`"X1,Y1, X2,Y2, X3,Y3"`) in [python training example](https://github.com/ome/openmicroscopy/blob/develop/examples/Training/python/ROIs.py) is causing an error in PathViewer and resulting in a "locked" state in the annotation tools. Changing the point string format to `"X1,Y1 X2,Y2 X3,Y3"` fixed the issue.


# Related reading

- See [Polygon/@Points](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Polygon_Points) section in OME Schemas
