### PR TITLE
Fix pyaml load

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_import.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_import.py
@@ -969,7 +969,7 @@ class TestImport(CLITest):
 
         self.args += [str(fakefile)]
         o, e = self.do_import(capfd)
-        yo = yaml.load(o)
+        yo = yaml.load(o, Loader=yaml.FullLoader)
         # Check the contents of "yo",
         # and the existence of the newly created fileset and image
         self.assert_object("Fileset", int(yo[0]['Fileset']))


### PR DESCRIPTION
Fix an issue with PyYAML, equivalent to https://github.com/ome/scc/pull/274 .
Should fix the [merge-build error](https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_import/TestImport/testImportOutputYaml/) 
