### PR TITLE
Omero table csv writer test fix

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_table.py
+++ b/components/tools/OmeroWeb/test/integration/test_table.py
@@ -59,7 +59,7 @@ class TestOmeroTables(IWebTest):
             [1, 'test', 0.5, 135345.0, 2],
             [2, 'string', 1.0, 345345.121, 4],
             [3, 'column', 0.75, 356575.012, 6],
-            [4, 'data', 0.12345, 13579.0, 8],
+            [4, 'data,comma', 0.12345, 13579.0, 8],
             [5, 'five', 0.01, 500.05, 10]
         ]
         return (col_types, col_names, rows)
@@ -141,8 +141,10 @@ class TestOmeroTables(IWebTest):
         csv_data = "".join(chunks)
         cols_csv = ','.join(col_names)
         rows.append([''])       # add empty row (as found in exported csv)
+        def wrap_commas(value):
+            return str(value) if "," not in str(value) else '"%s"' % value
         rows_csv = '\r\n'.join([','.join(
-            [str(td) for td in row]) for row in rows])
+            [wrap_commas(td) for td in row]) for row in rows])
         assert csv_data == '%s\r\n%s' % (cols_csv, rows_csv)
 
     def test_table_pagination(self, omero_table_file, django_client,

--- a/components/tools/OmeroWeb/test/integration/test_table.py
+++ b/components/tools/OmeroWeb/test/integration/test_table.py
@@ -140,9 +140,10 @@ class TestOmeroTables(IWebTest):
         chunks = [c.decode("utf-8") for c in rsp.streaming_content]
         csv_data = "".join(chunks)
         cols_csv = ','.join(col_names)
-        rows_csv = '\n'.join([','.join(
+        rows.append([''])       # add empty row (as found in exported csv)
+        rows_csv = '\r\n'.join([','.join(
             [str(td) for td in row]) for row in rows])
-        assert csv_data == '%s\n%s' % (cols_csv, rows_csv)
+        assert csv_data == '%s\r\n%s' % (cols_csv, rows_csv)
 
     def test_table_pagination(self, omero_table_file, django_client,
                               table_data):


### PR DESCRIPTION
# What this PR does

See PR: https://github.com/ome/omero-web/pull/342

Fixes test failure at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/977/testReport/OmeroWeb.test.integration.test_table/TestOmeroTables/test_table_html/

Also updates the test to handle `,` in CSV values (as fixed by PR above).

EDIT:
Test fixed: https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/978/testReport/junit/OmeroWeb.test.integration.test_table/TestOmeroTables/test_table_html/