### PR TITLE
Use the copy

### DIFF
--- a/components/tools/build.xml
+++ b/components/tools/build.xml
@@ -36,8 +36,18 @@
 			side code for use with OMERO.
 		</echo>
 		<mkdir dir="target/lib/server"/>
-		<download pkg="omero-scripts" file="omero-scripts-${versions.omero-scripts}.tar.gz" expected="${versions.omero-scripts-md5}"
+		<!-- Look for file above src -->
+		<property name="filegz" value="../../../omero-scripts-${versions.omero-scripts}.tar.gz" />
+		<if>
+			<available file="${filegz}"/>
+            <then>
+               <copy file="${filegz}" todir="target/downloads/scripts"/>
+            </then>
+			<else>
+		        <download pkg="omero-scripts" file="omero-scripts-${versions.omero-scripts}.tar.gz" expected="${versions.omero-scripts-md5}"
 			where="target/downloads/scripts"/>
+		    </else>
+		</if>
 		<untar src="target/downloads/scripts/omero-scripts-${versions.omero-scripts}.tar.gz" dest="target/downloads/scripts" compression="gzip"/>
 		<copy todir="target/lib/scripts">
 			<fileset dir="target/downloads/scripts/omero-scripts-${versions.omero-scripts}" includes="omero/**/*,README*"/>


### PR DESCRIPTION
Copy the file if found locally above src

Background:

During the daily build process, an entry is added to ``etc/omero.properties``  indicating where to download the artifacts from, e.g. https://merge-ci.openmicroscopy.org/jenkins//job/OMERO-python-superbuild-build/lastSuccessfulBuild/artifact/PACKAGE/dist/
This only works when using DNS.

In the case of the temporary devspace (no DNS the url is set to for example https://github.com/snoopycrimecop/openmicroscopy/blob/snoopycrimecop_ci/etc/omero.properties#L211 but the url points to nothing real ("real" is something like idr1-slot3.o.org:PORT/jenkins/...)

To support the non DNS case, artifacts are copied using the "CopyArtifacts" option in the jenkins job and moved to the directory where ``src`` is (location can be modified if there is a more suitable place)
The proposed change first looks if the artifact is available locally before using the ``versions.omero-pypi`` property.
