### PR TITLE
remove usage of LooseVersion

### DIFF
--- a/components/antlib/scripts/parse_version
+++ b/components/antlib/scripts/parse_version
@@ -95,8 +95,8 @@ def incr_version(omero_version):
     """
     try:
         # First we try to use distutils
-        from distutils.version import LooseVersion
-        version = LooseVersion(omero_version).version
+        from packaging.version import Version
+        version = Version(omero_version).version
         # Find the last index which is an int
         for idx in range(len(version)-1, 0, -1):
             val = version[idx]


### PR DESCRIPTION
When build is done using Python 3.8
The ``omero-version`` is not set correctly and it is then not possible to run for example ``./build.py clean``

i hit this problem again when doing the following:
* Create a local conda environment with Python 3.8. I wanted to use omero-py
* Activate the environment
* Try to run ``./build clean``
* Error: ``omero_version = "parse_version:99: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead. ``