### PR TITLE
Remove zarr reader

### DIFF
--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -9,7 +9,7 @@
 #
 # 2. Adjust the cron schedule as necessary
 
-name: OMERO
+name: OMERO Plugin
 on:
   push:
   pull_request:
@@ -31,30 +31,6 @@ jobs:
           repository: ome/omero-test-infra
           path: .omero
           ref: ${{ secrets.OMERO_TEST_INFRA_REF }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Install slice2java
-        run: |
-          sudo apt-get install -y libmcpp-dev
-          wget -q https://github.com/ome/zeroc-ice-ubuntu2004/releases/download/0.2.0/ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
-          tar xf ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
-          mv ice-3.6.5-0.2.0 ice-3.6.5
-          mv ice-3.6.5 /opt
-          rm ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
-          echo "${{ env.ICE_HOME }}/bin" >> $GITHUB_PATH
-      - name: Build
-        run: ./build.py
       - name: Set up log level
         run: |
           echo 'ivy.retrieve.log=default' >> etc/local.properties

--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       STAGE: srv # app, cli, lib, scripts, srv
-      ICE_HOME: /opt/ice-3.6.5 # location where Ice is installed
     steps:
       - uses: actions/checkout@v2
       - name: Checkout omero-test-infra

--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Set up log level
         run: |
           echo 'ivy.retrieve.log=default' >> etc/local.properties
-#      - name: Build and run OMERO tests
-#        run: .omero/docker $STAGE
+      - name: Build and run OMERO tests
+        run: .omero/docker $STAGE

--- a/.github/workflows/omero_plugin.yml
+++ b/.github/workflows/omero_plugin.yml
@@ -19,9 +19,10 @@ on:
 jobs:
   test:
     name: Run integration tests against OMERO
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       STAGE: srv # app, cli, lib, scripts, srv
+      ICE_HOME: /opt/ice-3.6.5 # location where Ice is installed
     steps:
       - uses: actions/checkout@v2
       - name: Checkout omero-test-infra
@@ -30,6 +31,30 @@ jobs:
           repository: ome/omero-test-infra
           path: .omero
           ref: ${{ secrets.OMERO_TEST_INFRA_REF }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install slice2java
+        run: |
+          sudo apt-get install -y libmcpp-dev
+          wget -q https://github.com/ome/zeroc-ice-ubuntu2004/releases/download/0.2.0/ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+          tar xf ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+          mv ice-3.6.5-0.2.0 ice-3.6.5
+          mv ice-3.6.5 /opt
+          rm ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+          echo "${{ env.ICE_HOME }}/bin" >> $GITHUB_PATH
+      - name: Build
+        run: ./build.py
       - name: Set up log level
         run: |
           echo 'ivy.retrieve.log=default' >> etc/local.properties

--- a/.github/workflows/source_build.yml
+++ b/.github/workflows/source_build.yml
@@ -1,0 +1,37 @@
+name: "Source Build"
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  buil:
+    name: Build OMERO from source
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Install slice2java
+        run: |
+          sudo apt-get install -y libmcpp-dev
+          wget -q https://github.com/ome/zeroc-ice-ubuntu2004/releases/download/0.2.0/ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+          tar xf ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+          mv ice-3.6.5-0.2.0 ice-3.6.5
+          mv ice-3.6.5 /opt
+          rm ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
+          echo "/opt/ice-3.6.5/bin" >> $GITHUB_PATH
+      - name: Build
+        run: ./build.py

--- a/components/tools/OmeroJava/build.gradle
+++ b/components/tools/OmeroJava/build.gradle
@@ -16,8 +16,8 @@ ext {
 }
 
 repositories {
-    jcenter()
     mavenLocal()
+    mavenCentral()
 }
 
 java {

--- a/components/tools/OmeroPy/test/integration/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_db.py
@@ -10,7 +10,7 @@
 """
 
 from future import standard_library
-standard_library.install_aliases()  # noqa
+
 from builtins import str
 from builtins import object
 import pytest
@@ -23,6 +23,8 @@ from mox3 import mox
 import getpass
 import builtins
 import re
+standard_library.install_aliases()  # noqa
+
 
 OMERODIR = False
 if 'OMERODIR' in os.environ:

--- a/components/tools/OmeroPy/test/integration/tablestest/test_tables.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_tables.py
@@ -28,15 +28,9 @@ import omero.grid
 from omero.testlib import ITest
 
 from omero import columns
-from omero.rtypes import (
-    RFloatI,
-    RLongI,
-    RStringI,
-    rfloat,
-    rint,
-    rlong,
-    rstring,
-)
+
+from omero.rtypes import RFloatI, RLongI, RStringI
+from omero.rtypes import rfloat, rint, rlong, rstring
 
 
 class TableIntegrityBase(ITest):
@@ -54,6 +48,7 @@ class TableIntegrityBase(ITest):
         return mask
 
     def checkMaskCol(self, test):
+
         def arr(x):
             import numpy
             import tables
@@ -199,7 +194,7 @@ class TestTableIntegrity(TableIntegrityBase):
     def testAllColumnsAndMetadata(self):
         """
         Check the integrity of an created OMERO table created within this test.
-        This test mainly checks if the created table is as expected by checking 
+        This test mainly checks if the created table is as expected by checking
         column types and values.
         """
 

--- a/components/tools/OmeroWeb/test/integration/test_table.py
+++ b/components/tools/OmeroWeb/test/integration/test_table.py
@@ -141,6 +141,7 @@ class TestOmeroTables(IWebTest):
         csv_data = "".join(chunks)
         cols_csv = ','.join(col_names)
         rows.append([''])       # add empty row (as found in exported csv)
+
         def wrap_commas(value):
             return str(value) if "," not in str(value) else '"%s"' % value
         rows_csv = '\r\n'.join([','.join(

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -208,9 +208,9 @@ versions.omero-scripts-url=${versions.omero-pypi}
 ###
 
 ## Internal dependencies
-versions.omero-blitz=5.5.8
-versions.omero-common-test=5.5.7
-versions.omero-gateway=5.6.5
+versions.omero-blitz=5.5.9
+versions.omero-common-test=5.5.8
+versions.omero-gateway=5.6.8
 versions.omero-scripts=5.6.1
 versions.OMEZarrReader=0.1.0
 ## Global overrides, if empty ignored

--- a/ivy.xml
+++ b/ivy.xml
@@ -18,6 +18,6 @@
     <!-- Useful for globally overriding the Bio-Formats version, empty version is ignored by default -->
     <dependency org="ome" name="formats-gpl" rev="${versions.bioformats}"/>
     <!-- Extensions for bundling into the release -->
-    <dependency org="ome" name="OMEZarrReader" rev="${versions.OMEZarrReader}"/>
+    <!--<dependency org="ome" name="OMEZarrReader" rev="${versions.OMEZarrReader}"/>-->
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
Discussed with @sbesson and @dgault.
This PR 
* reactivate the build via GHA
* bump omero dependencies version to pass the build
* remove the ZarrReader for now due to https://github.com/ome/openmicroscopy/pull/6312#issuecomment-1103083040

The reader will be turned back on post release

Make sure the GHA builds are green