### PR TITLE
OMERO.server 5.6.5 components

### DIFF
--- a/.github/workflows/source_build.yml
+++ b/.github/workflows/source_build.yml
@@ -18,3 +18,5 @@ jobs:
           flake8 .
       - name: Build
         run: ./build.py
+      - name: Rebuild
+        run: ./build.py clean && ./build.py

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -212,6 +212,6 @@ versions.omero-blitz=5.5.12
 versions.omero-common-test=5.5.10
 versions.omero-gateway=5.6.10
 versions.omero-scripts=5.6.2
-versions.OMEZarrReader=0.2.0
+versions.OMEZarrReader=0.3.0
 ## Global overrides, if empty ignored
 versions.bioformats=

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -211,7 +211,7 @@ versions.omero-scripts-url=${versions.omero-pypi}
 versions.omero-blitz=5.5.12
 versions.omero-common-test=5.5.10
 versions.omero-gateway=5.6.10
-versions.omero-scripts=5.6.2
+versions.omero-scripts=5.7.0
 versions.OMEZarrReader=0.3.0
 ## Global overrides, if empty ignored
 versions.bioformats=

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -208,9 +208,9 @@ versions.omero-scripts-url=${versions.omero-pypi}
 ###
 
 ## Internal dependencies
-versions.omero-blitz=5.5.10
-versions.omero-common-test=5.5.9
-versions.omero-gateway=5.6.9
+versions.omero-blitz=5.5.12
+versions.omero-common-test=5.5.10
+versions.omero-gateway=5.6.10
 versions.omero-scripts=5.6.2
 versions.OMEZarrReader=0.2.0
 ## Global overrides, if empty ignored

--- a/history.rst
+++ b/history.rst
@@ -23,6 +23,7 @@ Improvements include:
 
 -  a new server configuration allowing to control the pyramidal requirement for floating-point images
 -  an upgrade of Bio-Formats to version 6.10.0
+-  the inclusion of the experimental OMEZarrReader version 0.2.0 for reading OME-NGFF data
 
 **Note:** This upgrade will invalidate the Bio-Formats Memoizer cache. Please
 see the upgrade guide for further information.

--- a/history.rst
+++ b/history.rst
@@ -5,6 +5,35 @@
 OMERO version history
 =====================
 
+5.6.5 (June 2022)
+------------------
+
+This release includes the following upgrade of the OMERO.server Java components:
+
+- omero-gateway-java 5.6.10
+- omero-blitz 5.5.12
+- omero-server 5.6.4
+- omero-renderer 5.5.12
+- omero-romio 5.5.12
+- omero-common 5.5.12
+- omero-model 5.5.12
+
+
+Improvements include:
+
+-  a new server configuration allowing to control the pyramidal requirement for floating-point images
+-  an upgrade of Bio-Formats to version 6.10.0
+-  the inclusion of the experimental OMEZarrReader version 0.2.0 for reading OME-NGFF data
+
+**Note:** This upgrade will invalidate the Bio-Formats Memoizer cache. Please
+see the upgrade guide for further information.
+
+This version of the OMERO.server has been tested with:
+
+- OMERO.py 5.11.2
+- OMERO.web 5.14.1
+- OMERO.dropbox 5.6.2
+
 5.6.4 (April 2022)
 ------------------
 

--- a/history.rst
+++ b/history.rst
@@ -13,10 +13,10 @@ This release includes the following upgrade of the OMERO.server Java components:
 - omero-gateway-java 5.6.10
 - omero-blitz 5.5.12
 - omero-server 5.6.4
-- omero-renderer 5.5.12
-- omero-romio 5.5.12
-- omero-common 5.5.12
-- omero-model 5.5.12
+- omero-renderer 5.5.10
+- omero-romio 5.7.0
+- omero-common 5.5.10
+- omero-model 5.6.7
 
 
 Improvements include:

--- a/history.rst
+++ b/history.rst
@@ -18,6 +18,7 @@ This release includes the following upgrade of the OMERO.server Java components:
 - omero-common 5.5.10
 - omero-model 5.6.7
 
+as well as the upgrade of omero-scripts to version 5.7.0.
 
 Improvements include:
 

--- a/history.rst
+++ b/history.rst
@@ -23,7 +23,6 @@ Improvements include:
 
 -  a new server configuration allowing to control the pyramidal requirement for floating-point images
 -  an upgrade of Bio-Formats to version 6.10.0
--  the inclusion of the experimental OMEZarrReader version 0.2.0 for reading OME-NGFF data
 
 **Note:** This upgrade will invalidate the Bio-Formats Memoizer cache. Please
 see the upgrade guide for further information.

--- a/history.rst
+++ b/history.rst
@@ -23,7 +23,7 @@ Improvements include:
 
 -  a new server configuration allowing to control the pyramidal requirement for floating-point images
 -  an upgrade of Bio-Formats to version 6.10.0
--  the inclusion of the experimental OMEZarrReader version 0.2.0 for reading OME-NGFF data
+-  the inclusion of the OMEZarrReader version 0.3.0 for reading OME-NGFF data
 
 **Note:** This upgrade will invalidate the Bio-Formats Memoizer cache. Please
 see the upgrade guide for further information.


### PR DESCRIPTION
- Bumps the OMERO.server Java components to the latest released versions
- add changelog entry including more information about the changes