### PR TITLE
rebuild

### DIFF
--- a/.github/workflows/source_build.yml
+++ b/.github/workflows/source_build.yml
@@ -18,3 +18,5 @@ jobs:
           flake8 .
       - name: Build
         run: ./build.py
+      - name: Rebuild
+        run: ./build.py clean && ./build.py

--- a/.github/workflows/source_build.yml
+++ b/.github/workflows/source_build.yml
@@ -12,13 +12,28 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ome/action-ice@v1
+      - name: Checkout repositories
+        run: |
+          cd ..
+          WORKSPACE=$(pwd)
+          echo "space="${WORKSPACE} >> $GITHUB_ENV
+          git clone -b dependency-updates https://github.com/jburel/ZarrReader
+      - name: Build ZarrReader
+        run: |
+          cd $space/ZarrReader
+          mvn install
       - name: Install and run flake8
         run: |
+          cd $space/openmicroscopy
           pip install flake8
           flake8 .
       - name: Build
-        run: ./build.py
+        run: |
+          cd $space/openmicroscopy
+          ./build.py
       - name: Check .m2
         run: ls -alR ${HOME}/.m2
       - name: Rebuild
-        run: ./build.py clean && ./build.py
+        run: |
+          cd $space/openmicroscopy
+          ./build.py clean && ./build.py

--- a/.github/workflows/source_build.yml
+++ b/.github/workflows/source_build.yml
@@ -18,5 +18,7 @@ jobs:
           flake8 .
       - name: Build
         run: ./build.py
+      - name: Check .m2
+        run: ls -alR ${HOME}/.m2
       - name: Rebuild
         run: ./build.py clean && ./build.py

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -212,6 +212,6 @@ versions.omero-blitz=5.5.10
 versions.omero-common-test=5.5.9
 versions.omero-gateway=5.6.9
 versions.omero-scripts=5.6.2
-versions.OMEZarrReader=0.2.0
+versions.OMEZarrReader=0.2.1-SNAPSHOT
 ## Global overrides, if empty ignored
 versions.bioformats=


### PR DESCRIPTION
# What this PR does

This PR highlights the failure introduced by the ZARR reader.

Running ``./build.py`` will work in the ``.m2`` folder is empty.
If it is not it will fail with 
```
::::::::::::::::::::::::::::::::::::::::::::::
		::              FAILED DOWNLOADS            ::
		:: ^ see resolution messages for details  ^ ::
		::::::::::::::::::::::::::::::::::::::::::::::
		:: io.netty#netty-transport-native-epoll;4.1.46.Final!netty-transport-native-epoll.jar
```
This PR introduced a ``rebuild`` step to highlight the issue
A failure is expected.

cc @sbesson