### PR TITLE
Doc warning

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -134,7 +134,7 @@ omero.jvmcfg.max_system_memory=48000
 Ice.IPv6=1
 
 # Glacier2Template IceSSL defaults and overrides,
-# see https://doc.zeroc.com/ice/3.6/property-reference/icessl.
+# see :zerocdoc:`icessl <ice/3.6/property-reference/icessl>`.
 # Any property beginning ``omero.glacier2.IceSSL.`` will be used to
 # update the corresponding IceSSL. property.
 omero.glacier2.IceSSL=

--- a/history.rst
+++ b/history.rst
@@ -575,7 +575,7 @@ Developer updates include:
 -  added support for PyTables version 3.4+
 -  deprecated Path Object in OMERO Model
 -  updated the documentation for server installation on Mac OS to no longer
-   use the homebrew formulae from https://github.com/ome/homebrew-alt (these
+   use the homebrew formulae from :omero_subs_github_repo_root:`homebrew-alt <homebrew-alt>` (these
    are not working and will not be fixed)
 
 Further changes to the Python BlitzGateway are described in

--- a/history.rst
+++ b/history.rst
@@ -127,19 +127,19 @@ This release focuses on dropping support for Java 7, Python 2.6 and Ice 3.5,
 adding support for Java 11 and PostgreSQL 10, and on decoupling the Java components to new,
 separate repositories, each with a new `Gradle <https://gradle.org>`_ build system:
 
-- https://github.com/ome/omero-dsl-plugin
-- https://github.com/ome/omero-model
-- https://github.com/ome/omero-common
-- https://github.com/ome/omero-romio
-- https://github.com/ome/omero-renderer
-- https://github.com/ome/omero-server
-- https://github.com/ome/omero-blitz
-- https://github.com/ome/omero-gateway-java
-- https://github.com/ome/omero-blitz-plugin
-- https://github.com/ome/omero-insight
-- https://github.com/ome/omero-matlab
-- https://github.com/ome/omero-javapackager-plugin
-- https://github.com/ome/omero-api-plugin
+- :omero_subs_github_repo_root:`omero-dsl-plugin <omero-dsl-plugin>`
+- :omero_subs_github_repo_root:`omero-model <omero-model>`
+- :omero_subs_github_repo_root:`omero-common <omero-common>`
+- :omero_subs_github_repo_root:`omero-romio <omero-romio>`
+- :omero_subs_github_repo_root:`omero-renderer <omero-renderer>`
+- :omero_subs_github_repo_root:`omero-server <omero-server>`
+- :omero_subs_github_repo_root:`omero-blitz <omero-blitz>`
+- :omero_subs_github_repo_root:`omero-gateway-java <omero-gateway-java>`
+- :omero_subs_github_repo_root:`omero-blitz-plugin <omero-blitz-plugin>`
+- :omero_subs_github_repo_root:`omero-insight <omero-insight>`
+- :omero_subs_github_repo_root:`omero-matlab <omero-matlab>`
+- :omero_subs_github_repo_root:`omero-javapackager-plugin <omero-javapackager-plugin>`
+- :omero_subs_github_repo_root:`omero-api-plugin <omero-api-plugin>`
 
 This has the goal of enabling more fine-grained releases.
 


### PR DESCRIPTION
Fix warning that show up when building the doc with newer version of sphinx.
i.e.
```
/Users/jmarie/Documents/git-repo/omero-documentation/omero/users/history.rst:604: WARNING: hardcoded link 'https://github.com/ome/homebrew-alt' could be replaced by an extlink (try using ':omero_subs_github_repo_root:`homebrew-alt`' instead)
```