### PR TITLE
Add integration test for omero fs importtime

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_fs.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_fs.py
@@ -127,6 +127,30 @@ class TestFS(CLITest):
         out, err = capsys.readouterr()
         assert err.endswith("SecurityViolation: Admins only!\n")
 
+    @pytest.mark.parametrize("hcs", [True, False])
+    @pytest.mark.parametrize("skip", ["all", "minmax", "thumbnails"])
+    def testImportTime(self, hcs, skip, capfd):
+
+        kwargs = {}
+        if hcs:
+            kwargs["plateCols"] = 2
+            kwargs["plateRows"] = 2
+            kwargs["fields"] = 2
+            kwargs["images_count"] = 8
+        images = self.import_fake_file(skip=skip, **kwargs)
+        fileset = self.get_fileset(images)
+
+        self.args += ["importtime", "Fileset:%s" % fileset.getId().val]
+        self.cli.invoke(self.args, strict=True)
+        o, e = capfd.readouterr()
+
+        assert "upload time" in o
+        assert "metadata time" in o
+        assert "pixels time" in o
+        if skip not in ["all", "thumbnails"]:
+            assert "rdefs time" in o
+            assert "thumbnail time" in o
+
 
 class TestFsRoot(RootCLITest):
 


### PR DESCRIPTION
# What this PR does

Related to the work on https://github.com/ome/omero-py/pull/335

This PR adds a new integration test that:
- check that all expected phases of import are returned by the `omero fs importtime` both for HCS/non-HCS data
- test various combinations of import flags skipping some import steps (`all`, `thumbnails`, `minmax`)

# Testing this PR

New tests should be executed by the nightly CI builds and all be successful.
Note this PR depends on https://github.com/ome/omero-py/pull/335 as it captures the expectation that `pixels time` should always be reported.