### PR TITLE
bump TestNG to 7.5.0

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -197,7 +197,7 @@ versions.janino=2.5.10
 
 versions.reportng=1.1.1
 
-versions.testng=7.5.0
+versions.testng=7.5
 versions.velocity=1.4
 
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -197,7 +197,7 @@ versions.janino=2.5.10
 
 versions.reportng=1.1.1
 
-versions.testng=6.14.2
+versions.testng=7.5.0
 versions.velocity=1.4
 
 versions.omero-pypi=https://pypi.io/packages/source/o/PACKAGE


### PR DESCRIPTION
Bump testNG version to match the upgrade in the Java repo stack
