### PR TITLE
Remove no-op services.jar from being generated by the build system

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -350,14 +350,14 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
 
     <target name="copy-client" depends="init">
         <mkdir dir="${dist.dir}/lib/client"/>
-        <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
+        <!-- sync="true" deletes any other files like extensions.jar which may be under lib -->
         <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="client" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="client" pattern="${dist.dir}/lib/client/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
     </target>
 
     <target name="copy-server" depends="init">
         <mkdir dir="${dist.dir}/lib/server"/>
-        <!-- sync="true" deletes any other files like services.jar or extensions.jar which may be under lib -->
+        <!-- sync="true" deletes any other files like extensions.jar which may be under lib -->
         <ivy:resolve file="ivy.xml" type="jar,egg,bundle,zip" conf="server" settingsRef="ivy.toplevel" log="quiet"/>
         <ivy:retrieve conf="server" pattern="${dist.dir}/lib/server/[artifact].[ext]" sync="false" log="quiet" settingsRef="ivy.toplevel"/>
     </target>

--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -348,7 +348,7 @@ omero.version=${omero.version}
             pathsep=" " dirsep="/">
             <flattenmapper/>
         </pathconvert>
-                <property name="mf.classpath.and.jars" value="../../etc ${mf.classpath} services.jar extensions.jar"/>
+                <property name="mf.classpath.and.jars" value="../../etc ${mf.classpath} extensions.jar"/>
         <jar destfile="${target.dir}/${ivy.module}.jar" update="true">
             <manifest>
                 <attribute name="Class-Path" value="${mf.classpath.and.jars}"/>

--- a/components/tools/build.xml
+++ b/components/tools/build.xml
@@ -36,7 +36,6 @@
 			side code for use with OMERO.
 		</echo>
 		<mkdir dir="target/lib/server"/>
-		<jar update="true" destfile="target/lib/server/services.jar" basedir="${tools.classes}" includes="**/*"/>
 		<download pkg="omero-scripts" file="omero-scripts-${versions.omero-scripts}.tar.gz" expected="${versions.omero-scripts-md5}"
 			where="target/downloads/scripts"/>
 		<untar src="target/downloads/scripts/omero-scripts-${versions.omero-scripts}.tar.gz" dest="target/downloads/scripts" compression="gzip"/>


### PR DESCRIPTION
From an historical lookup, this JAR was used up to the OMERO 4.4.x series to ship some importer code. Since OMERO 5.x, this is a shallow JAR only containing a manifest and a readme.

Primarily driven by the review of the server dependencies and licenses as I could not figure out what this dependency was related to. The removal should have no functional impact since the JAR contains no code and there are other mechanisms described in the [documentation](https://omero.readthedocs.io/en/stable/developers/Server/ExtendingOmero.html) to extend the OMERO.server with new services.