### PR TITLE
logback.xml/logback-indexing.xml: add default scanPeriod of 1 minute

### DIFF
--- a/etc/logback-indexing.xml
+++ b/etc/logback-indexing.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration scan="true" debug="false">
+<configuration scan="true" debug="false" scanPeriod="1 minute">
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 

--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration scan="true" debug="false">
+<configuration scan="true" debug="false" scanPeriod="1 minute">
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${omero.logfile}</file>


### PR DESCRIPTION
## Context

The configuration files used by the server components are expected to be automatically reloaded as per the scan="true" property - see https://logback.qos.ch/manual/configuration.html#autoScan. However, this behavior is currently affects by a regression introduced in logback 1.1.7 and only corrected in logback 1.3.x - see https://jira.qos.ch/browse/LOGBACK-1194
At least until we are ready to switch the codebase to logback 1.3.x, this should restore the ability to dynamically adjust the log levels of a running server

## Testing

Without this PR, update logback.xml of a running OMERO.server e.g. by adjusting a log level to `DEBUG` and watch the logs. Nothing should happen and only a server restart will allow to take the new level into account.
With this PR included, the configuration change should be automatically reloaded within 1 minute and reflected in the logs

## Related reading

https://github.com/ome/omero-blitz/pull/137 bears some relationship as it proposes to bump the logback version shipped within the server to the 1.3.x series which should contain the fix for the original regression. Independently, we might still want to define an explicit default for the `scanPeriod` in these configuration files