### PR TITLE
Map contributors to use canonical real names and email addresses #482

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,13 +12,13 @@ Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@05709c45-44f0-0310-885b-81a
 Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
 Andrea Falconi <andrea.falconi@gmail.com> <afalconi@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Andrea Falconi <andrea.falconi@gmail.com> <(no author)@6f2cb1de-eb0d-0410-b157-e593188b5901>
-Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> Andrew J Patterson <ajpatterson@lifesci.dundee.ac.uk>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <andrew@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <andrew@05709c45-44f0-0310-885b-81a1db45b4a6>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <ajpatterson@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <ajpatterson@05709c45-44f0-0310-885b-81a1db45b4a6>
-Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> bwzloranger <bwzloranger@lifesci.dundee.ac.uk>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brian.loranger@lifesci.dundee.ac.uk>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <bwzloranger@05709c45-44f0-0310-885b-81a1db45b4a6>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brain@05709c45-44f0-0310-885b-81a1db45b4a6>
@@ -33,15 +33,15 @@ Chris Allan <callan@glencoesoftware.com> <cxallan@f08c0cc7-402c-0410-8265-edbaff
 Chris Allan <callan@glencoesoftware.com> <callan@05709c45-44f0-0310-885b-81a1db45b4a6>
 Chris Allan <callan@glencoesoftware.com> <callan@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Chris Allan <callan@glencoesoftware.com> <callan@f08c0cc7-402c-0410-8265-edbaffadc9ce>
-Carlos Neves <carlos@glencoesoftware.com>
+Carlos Neves <carlos@glencoesoftware.com> cneves <carlos@glencoesoftware.com>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-81a1db45b4a6>
 Curtis Rueden <ctrueden@wisc.edu> <ctrueden@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 David Whitehurst <david@glencoesoftware.com> <david@05709c45-44f0-0310-885b-81a1db45b4a6>
-Dominik Lindner <d.lindner@dundee.ac.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk> dominikl <d.lindner@dundee.ac.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
-Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> dzmacdonald <dzmacdonald@lifesci.dundee.ac.uk>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <dzmacdonald@05709c45-44f0-0310-885b-81a1db45b4a6>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@05709c45-44f0-0310-885b-81a1db45b4a6>
@@ -49,12 +49,13 @@ Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@f08c0cc7-402c-0410-8
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.local>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.dyn.lifesci.dundee.ac.uk>
 Douglas Creager <douglas.creager@comlab.ox.ac.uk> <dcreager@6f2cb1de-eb0d-0410-b157-e593188b5901>
-Douglas Russell <douglas.russell@bioch.ox.ac.uk>
+Douglas Russell <douglas.russell@bioch.ox.ac.uk> dpwrussell <douglas.russell@bioch.ox.ac.uk>
 Douglas Russell <douglas.russell@bioch.ox.ac.uk> <douglas_russell@hms.harvard.edu>
 Emil Rozbicki <emil@glencoesoftware.com> <emilroz@gmail.com>
 Harry Hochheiser <harryh@pitt.edu> <hsh@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
-Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> jburel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> jean-marie burel <j.burel@dundee.ac.uk>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@05709c45-44f0-0310-885b-81a1db45b4a6>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@f08c0cc7-402c-0410-8265-edbaffadc9ce>
@@ -69,11 +70,12 @@ Josh Moore <josh@openmicroscopy.org> <josh@05709c45-44f0-0310-885b-81a1db45b4a6>
 Josh Moore <josh@openmicroscopy.org> <jmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
 Josh Moore <josh@openmicroscopy.org> <jmoore@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Josh Moore <josh@openmicroscopy.org> <jmoore@6f2cb1de-eb0d-0410-b157-e593188b5901>
-Joshua Ballanco <jballanc@glencoesoftware.com>
+Joshua Ballanco <jballanc@glencoesoftware.com> Josh Ballanco <jballanc@glencoesoftware.com>
 Joshua Ballanco <jballanc@glencoesoftware.com> <jballanc@gmail.com>
-Kenny Gillen <k.h.gillen@dundee.ac.uk>
-Kouichi Nakamura <kouichi.c.nakamura@gmail.com>
-Liza Unson <lunson@glencoesoftware.com>
+Kenny Gillen <k.h.gillen@dundee.ac.uk> Kenneth Gillen <k.h.gillen@dundee.ac.uk>
+Kouichi Nakamura <kouichi.c.nakamura@gmail.com> Kouichi C. Nakamura <kouichi.c.nakamura@gmail.com>
+Kouichi Nakamura <kouichi.c.nakamura@gmail.com> KOUICHI NAKAMURA <kouichi.c.nakamura@gmail.com>
+Liza Unson <lunson@glencoesoftware.com> Liza <lunson@glencoesoftware.com>
 Luca Lianas <luca.lianas@crs4.it> <lianas@crs4.it>
 Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
 Mark Carroll <m.t.b.carroll@dundee.ac.uk> <mtbc@ls28101>
@@ -85,8 +87,8 @@ Melissa Linkert <melissa@glencoesoftware.com> <melissa@05709c45-44f0-0310-885b-8
 Nikolaus Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch>
 Nikolaus Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
 Paula Forbes <pforbes@computing.dundee.ac.uk> <uimage@6f2cb1de-eb0d-0410-b157-e593188b5901>
-Paul van Schayck <polleke@gmail.com>
-Petr Walczysko <p.walczysko@dundee.ac.uk>
+Paul van Schayck <polleke@gmail.com> pvc-local <polleke@gmail.com>
+Petr Walczysko <p.walczysko@dundee.ac.uk> pwalczysko <p.walczysko@dundee.ac.uk>
 Riad Gozim <r.gozim@dundee.ac.uk> <rgozim@users.noreply.github.com>
 Riad Gozim <r.gozim@dundee.ac.uk> <rgozim1@gmail.com>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
@@ -94,13 +96,13 @@ Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@dundee.ac.uk>
 Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@codelibre.net>
 Scott Littlewood <sylittlewood@dundee.ac.uk> <scottlittlewood@gmail.com>
 Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
-Sébastien Simard <ssimard@pasteur.fr>
+Sébastien Simard <ssimard@pasteur.fr> ssimard <ssimard@pasteur.fr>
 Simon Li <spli@dundee.ac.uk> <orpheus+devel@gmail.com>
 Simone Leo <s.z.leo@dundee.ac.uk> <simleo@crs4.it>
 Simon Wells <szwells@dundee.ac.uk> <siwells@gmail.com>
 Stefan Frank <s.frank@dkfz-heidelberg.de> <sfrank@05709c45-44f0-0310-885b-81a1db45b4a6>
 Tom Macura <tm289@cam.ac.uk> <tmacur1@6f2cb1de-eb0d-0410-b157-e593188b5901>
-Will Moore <w.moore@dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> William Moore <w.moore@dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <wmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
 Will Moore <w.moore@dundee.ac.uk> <wmoore@6f2cb1de-eb0d-0410-b157-e593188b5901>

--- a/.mailmap
+++ b/.mailmap
@@ -71,7 +71,7 @@ Josh Moore <josh@openmicroscopy.org> <jmoore@f08c0cc7-402c-0410-8265-edbaffadc9c
 Josh Moore <josh@openmicroscopy.org> <jmoore@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Joshua Ballanco <jballanc@glencoesoftware.com>
 Joshua Ballanco <jballanc@glencoesoftware.com> <jballanc@gmail.com>
-Kenneth Gillen <k.h.gillen@dundee.ac.uk>
+Kenny Gillen <k.h.gillen@dundee.ac.uk>
 Kouichi Nakamura <kouichi.c.nakamura@gmail.com>
 Liza Unson <lunson@glencoesoftware.com>
 Luca Lianas <luca.lianas@crs4.it> <lianas@crs4.it>
@@ -82,8 +82,8 @@ Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
 Melissa Linkert <melissa@glencoesoftware.com> <mlinkert-x@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa@05709c45-44f0-0310-885b-81a1db45b4a6>
-Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch>
-Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
+Nikolaus Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch>
+Nikolaus Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
 Paula Forbes <pforbes@computing.dundee.ac.uk> <uimage@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Paul van Schayck <polleke@gmail.com>
 Petr Walczysko <p.walczysko@dundee.ac.uk>

--- a/.mailmap
+++ b/.mailmap
@@ -58,9 +58,9 @@ Jean-Marie Burel <j.burel@dundee.ac.uk>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@05709c45-44f0-0310-885b-81a1db45b4a6>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@users.noreply.github.com>
 Jeff Mellen <jeffm@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Jesse Corrington <jesse@glencoesoftware.com> <jesse.corrington@gmail.com>
-Josh Moore <josh@openmicroscopy.org> <jburel@users.noreply.github.com>
 Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
 Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
 Josh Moore <josh@openmicroscopy.org> <josh@example.com>

--- a/.mailmap
+++ b/.mailmap
@@ -23,6 +23,7 @@ Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brian.loranger@lifesci.dundee
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <bwzloranger@05709c45-44f0-0310-885b-81a1db45b4a6>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brain@05709c45-44f0-0310-885b-81a1db45b4a6>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <TheBrain@05709c45-44f0-0310-885b-81a1db45b4a6>
+Carlos Neves <carlos@glencoesoftware.com> cneves <carlos@glencoesoftware.com>
 Carlos Neves <carlos@glencoesoftware.com> <cneves-x@05709c45-44f0-0310-885b-81a1db45b4a6>
 Carlos Neves <carlos@glencoesoftware.com> <carlos@05709c45-44f0-0310-885b-81a1db45b4a6>
 Carlos Neves <carlos@glencoesoftware.com> <staff@glencoesoftware.com>
@@ -33,7 +34,6 @@ Chris Allan <callan@glencoesoftware.com> <cxallan@f08c0cc7-402c-0410-8265-edbaff
 Chris Allan <callan@glencoesoftware.com> <callan@05709c45-44f0-0310-885b-81a1db45b4a6>
 Chris Allan <callan@glencoesoftware.com> <callan@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Chris Allan <callan@glencoesoftware.com> <callan@f08c0cc7-402c-0410-8265-edbaffadc9ce>
-Carlos Neves <carlos@glencoesoftware.com> cneves <carlos@glencoesoftware.com>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-81a1db45b4a6>
@@ -84,7 +84,7 @@ Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
 Melissa Linkert <melissa@glencoesoftware.com> <mlinkert-x@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Melissa Linkert <melissa@glencoesoftware.com> <melissa@05709c45-44f0-0310-885b-81a1db45b4a6>
-Nikolaus Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch>
+Nikolaus Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> Niko Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch>
 Nikolaus Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
 Paula Forbes <pforbes@computing.dundee.ac.uk> <uimage@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Paul van Schayck <polleke@gmail.com> pvc-local <polleke@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,97 @@
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@entrypoint.tech>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <aleksandrat@lifesci.dundee.ac.uk>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <atarkowska@lifesci.dundee.ac.uk>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <A.Tarkowska@dundee.ac.uk>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <aleksandra-tarkowska@users.noreply.github.com>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <atarkowska@05709c45-44f0-0310-885b-81a1db45b4a6>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <Aleksandra Tarkowska@05709c45-44f0-0310-885b-81a1db45b4a6>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <Aleksandra Tarkowska@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@05709c45-44f0-0310-885b-81a1db45b4a6>
+Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
+Andrea Falconi <andrea.falconi@gmail.com> <afalconi@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <andrew@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <andrew@05709c45-44f0-0310-885b-81a1db45b4a6>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <ajpatterson@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <ajpatterson@05709c45-44f0-0310-885b-81a1db45b4a6>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brian.loranger@lifesci.dundee.ac.uk>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <bwzloranger@05709c45-44f0-0310-885b-81a1db45b4a6>
+Carlos Neves <carlos@glencoesoftware.com> <cneves-x@05709c45-44f0-0310-885b-81a1db45b4a6>
+Carlos Neves <carlos@glencoesoftware.com> <carlos@05709c45-44f0-0310-885b-81a1db45b4a6>
+Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
+Chris Allan <callan@glencoesoftware.com> <cxallan@05709c45-44f0-0310-885b-81a1db45b4a6>
+Chris Allan <callan@glencoesoftware.com> <cxallan@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Chris Allan <callan@glencoesoftware.com> <cxallan@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Chris Allan <callan@glencoesoftware.com> <callan@05709c45-44f0-0310-885b-81a1db45b4a6>
+Chris Allan <callan@glencoesoftware.com> <callan@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Chris Allan <callan@glencoesoftware.com> <callan@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Carlos Neves <carlos@glencoesoftware.com>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
+Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-81a1db45b4a6>
+Curtis Rueden <ctrueden@wisc.edu> <ctrueden@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Dominik Lindner <d.lindner@dundee.ac.uk>
+Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <dzmacdonald@05709c45-44f0-0310-885b-81a1db45b4a6>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@05709c45-44f0-0310-885b-81a1db45b4a6>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.local>
+Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.dyn.lifesci.dundee.ac.uk>
+Douglas Russell <douglas.russell@bioch.ox.ac.uk>
+Douglas Russell <douglas.russell@bioch.ox.ac.uk> <douglas_russell@hms.harvard.edu>
+Emil Rozbicki <emil@glencoesoftware.com> <emilroz@gmail.com>
+Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
+Jean-Marie Burel <j.burel@dundee.ac.uk>
+Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@05709c45-44f0-0310-885b-81a1db45b4a6>
+Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Jesse Corrington <jesse@glencoesoftware.com> <jesse.corrington@gmail.com>
+Josh Moore <josh@openmicroscopy.org> <jburel@users.noreply.github.com>
+Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
+Josh Moore <josh@openmicroscopy.org> <josh@glencoesoftware.com>
+Josh Moore <josh@openmicroscopy.org> <josh@example.com>
+Josh Moore <josh@openmicroscopy.org> <josh.moore@gmx.de>
+Josh Moore <josh@openmicroscopy.org> <josh@05709c45-44f0-0310-885b-81a1db45b4a6>
+Josh Moore <josh@openmicroscopy.org> <jmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
+Josh Moore <josh@openmicroscopy.org> <jmoore@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Josh Moore <josh@openmicroscopy.org> <jmoore@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Joshua Ballanco <jballanc@glencoesoftware.com>
+Joshua Ballanco <jballanc@glencoesoftware.com> <jballanc@gmail.com>
+Kenneth Gillen <k.h.gillen@dundee.ac.uk>
+Kouichi Nakamura <kouichi.c.nakamura@gmail.com>
+Liza Unson <lunson@glencoesoftware.com>
+Luca Lianas <luca.lianas@crs4.it> <lianas@crs4.it>
+Mark Carroll <m.t.b.carroll@dundee.ac.uk> <M.T.B.Carroll@Dundee.ac.uk>
+Mark Carroll <m.t.b.carroll@dundee.ac.uk> <mtbc@ls28101>
+Muhanad Zahra <muhanad@glencoesoftware.com> <Muhanad.Zahra@outlook.com>
+Melissa Linkert <melissa@glencoesoftware.com> <melissa.linkert@gmail.com>
+Melissa Linkert <melissa@glencoesoftware.com> <mlinkert-x@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Melissa Linkert <melissa@glencoesoftware.com> <melissa@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Melissa Linkert <melissa@glencoesoftware.com> <melissa@05709c45-44f0-0310-885b-81a1db45b4a6>
+Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch>
+Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
+Paul van Schayck <polleke@gmail.com>
+Petr Walczysko <p.walczysko@dundee.ac.uk>
+Riad Gozim <r.gozim@dundee.ac.uk> <rgozim@users.noreply.github.com>
+Riad Gozim <r.gozim@dundee.ac.uk> <rgozim1@gmail.com>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@debian.org>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@dundee.ac.uk>
+Roger Leigh <r.leigh@dundee.ac.uk> <rleigh@codelibre.net>
+Scott Littlewood <sylittlewood@dundee.ac.uk> <scottlittlewood@gmail.com>
+Sébastien Besson <sbesson@glencoesoftware.com> <seb.besson@gmail.com>
+Sébastien Simard <ssimard@pasteur.fr>
+Simon Li <spli@dundee.ac.uk> <orpheus+devel@gmail.com>
+Simone Leo <s.z.leo@dundee.ac.uk> <simleo@crs4.it>
+Simon Wells <szwells@dundee.ac.uk> <siwells@gmail.com>
+Will Moore <w.moore@dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>
+Will Moore <w.moore@dundee.ac.uk> <wmoore@05709c45-44f0-0310-885b-81a1db45b4a6>
+Will Moore <w.moore@dundee.ac.uk> <wmoore@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Will Moore <w.moore@dundee.ac.uk> <will@05709c45-44f0-0310-885b-81a1db45b4a6>
+Will Moore <w.moore@dundee.ac.uk> <will@6f2cb1de-eb0d-0410-b157-e593188b5901>

--- a/.mailmap
+++ b/.mailmap
@@ -11,6 +11,7 @@ Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@f08c0cc7-402c-0410-8265-edb
 Aleksandra Tarkowska <a.tarkowska@dundee.ac.uk> <ola@05709c45-44f0-0310-885b-81a1db45b4a6>
 Andreas Knab <andreas@glencoesoftware.com> <knabar@gmail.com>
 Andrea Falconi <andrea.falconi@gmail.com> <afalconi@6f2cb1de-eb0d-0410-b157-e593188b5901>
+Andrea Falconi <andrea.falconi@gmail.com> <(no author)@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <workonly@qidane.com>
 Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <andrew@f08c0cc7-402c-0410-8265-edbaffadc9ce>
@@ -20,8 +21,11 @@ Andrew Patterson <ajpatterson@lifesci.dundee.ac.uk> <ajpatterson@05709c45-44f0-0
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brian.loranger@lifesci.dundee.ac.uk>
 Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <bwzloranger@05709c45-44f0-0310-885b-81a1db45b4a6>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <brain@05709c45-44f0-0310-885b-81a1db45b4a6>
+Brian Loranger <bwzloranger@lifesci.dundee.ac.uk> <TheBrain@05709c45-44f0-0310-885b-81a1db45b4a6>
 Carlos Neves <carlos@glencoesoftware.com> <cneves-x@05709c45-44f0-0310-885b-81a1db45b4a6>
 Carlos Neves <carlos@glencoesoftware.com> <carlos@05709c45-44f0-0310-885b-81a1db45b4a6>
+Carlos Neves <carlos@glencoesoftware.com> <staff@glencoesoftware.com>
 Chris Allan <callan@glencoesoftware.com> <callan@blackcat.ca>
 Chris Allan <callan@glencoesoftware.com> <cxallan@05709c45-44f0-0310-885b-81a1db45b4a6>
 Chris Allan <callan@glencoesoftware.com> <cxallan@6f2cb1de-eb0d-0410-b157-e593188b5901>
@@ -34,6 +38,7 @@ Colin Blackburn <c.blackburn@dundee.ac.uk> <C.Blackburn@dundee.ac.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <colin@ximenes.org.uk>
 Colin Blackburn <c.blackburn@dundee.ac.uk> <cblackburn@05709c45-44f0-0310-885b-81a1db45b4a6>
 Curtis Rueden <ctrueden@wisc.edu> <ctrueden@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+David Whitehurst <david@glencoesoftware.com> <david@05709c45-44f0-0310-885b-81a1db45b4a6>
 Dominik Lindner <d.lindner@dundee.ac.uk>
 Dominik Lindner <d.lindner@dundee.ac.uk> <dominikl@users.noreply.github.com>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk>
@@ -43,14 +48,17 @@ Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@05709c45-44f0-0310-8
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@f08c0cc7-402c-0410-8265-edbaffadc9ce>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.local>
 Donald MacDonald <dzmacdonald@lifesci.dundee.ac.uk> <donald@Grumpy.dyn.lifesci.dundee.ac.uk>
+Douglas Creager <douglas.creager@comlab.ox.ac.uk> <dcreager@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Douglas Russell <douglas.russell@bioch.ox.ac.uk>
 Douglas Russell <douglas.russell@bioch.ox.ac.uk> <douglas_russell@hms.harvard.edu>
 Emil Rozbicki <emil@glencoesoftware.com> <emilroz@gmail.com>
+Harry Hochheiser <harryh@pitt.edu> <hsh@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Helen Flynn <h.flynn@dundee.ac.uk> <omehelen@gmail.com>
 Jean-Marie Burel <j.burel@dundee.ac.uk>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@05709c45-44f0-0310-885b-81a1db45b4a6>
 Jean-Marie Burel <j.burel@dundee.ac.uk> <jburel@f08c0cc7-402c-0410-8265-edbaffadc9ce>
+Jeff Mellen <jeffm@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Jesse Corrington <jesse@glencoesoftware.com> <jesse.corrington@gmail.com>
 Josh Moore <josh@openmicroscopy.org> <jburel@users.noreply.github.com>
 Josh Moore <josh@openmicroscopy.org> <j.a.moore@dundee.ac.uk>
@@ -76,6 +84,7 @@ Melissa Linkert <melissa@glencoesoftware.com> <melissa@f08c0cc7-402c-0410-8265-e
 Melissa Linkert <melissa@glencoesoftware.com> <melissa@05709c45-44f0-0310-885b-81a1db45b4a6>
 Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch>
 Nikolas Ehrenfeuchter <nikolaus.ehrenfeuchter@unibas.ch> <mail@he1ix.org>
+Paula Forbes <pforbes@computing.dundee.ac.uk> <uimage@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Paul van Schayck <polleke@gmail.com>
 Petr Walczysko <p.walczysko@dundee.ac.uk>
 Riad Gozim <r.gozim@dundee.ac.uk> <rgozim@users.noreply.github.com>
@@ -89,6 +98,8 @@ Sébastien Simard <ssimard@pasteur.fr>
 Simon Li <spli@dundee.ac.uk> <orpheus+devel@gmail.com>
 Simone Leo <s.z.leo@dundee.ac.uk> <simleo@crs4.it>
 Simon Wells <szwells@dundee.ac.uk> <siwells@gmail.com>
+Stefan Frank <s.frank@dkfz-heidelberg.de> <sfrank@05709c45-44f0-0310-885b-81a1db45b4a6>
+Tom Macura <tm289@cam.ac.uk> <tmacur1@6f2cb1de-eb0d-0410-b157-e593188b5901>
 Will Moore <w.moore@dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <will@lifesci.dundee.ac.uk>
 Will Moore <w.moore@dundee.ac.uk> <wmoore@05709c45-44f0-0310-885b-81a1db45b4a6>


### PR DESCRIPTION
# What this PR does

Since 2003, this codebase has substantially grown thanks to the input of several tens of contributors. Over two decades, commits from the same author are associated with multiple variants of the author line. In order to effectively review and audit contributions, it is necessary to normalize these variants.

The following rules are used for the construction of the .mailmap file:

- for all contributors who were also employees of the University of Dundee of Glencoe Software, the @dundee.ac.uk or @glencoesoftware.com email address is used as the canonical email address
- for all contributors with an executed CLA, the email address sent via the CLA is used as the canonical address
- for all contributors, the name used in https://www.openmicroscopy.org/teams/ or https://www.openmicroscopy.org/contributors/ is used as the canonical real name.

The .mailmap is constructed according to the official [documentation](https://git-scm.com/docs/gitmailmap) using one of the two forms:
```
Proper Name <proper@email.xx> <commit@email.xx>
```

for mapping different email addresses and
```
Proper Name <proper@email.xx> Commit Name <commit@email.xx>
```

for mapping different real names.

# Testing this PR

The unique list of commit authors can be generated and reviewing using `git shortlog -se`

All lines of the mailmap should be reviewed to make sure the email addresses and the mapping are valid. There are still a few historical users who I could not map so the knowledge of early day OME contributors will be very appreciated. The configuration can then easily be re-used for all the projects which were extracted (`omero-model`, `omero-common`....)

