### PR TITLE
Histogram tests: fix tests and cover more pixel types

### DIFF
--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -103,6 +103,9 @@ public class ModelMockFactory {
     /** The 32-bit floating-point Type. */
     public static final String FLOAT = omero.model.enums.PixelsTypefloat.value;
 
+    /** The 64-bit floating-point Type. */
+    public static final String DOUBLE = omero.model.enums.PixelsTypedouble.value;
+
     /** The bit pixels Type. */
     public static final String BIT =  omero.model.enums.PixelsTypebit.value;
 

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -100,6 +100,9 @@ public class ModelMockFactory {
     /** The unsigned int 8 pixels Type. */
     public static final String UINT8 = omero.model.enums.PixelsTypeuint8.value;
     
+    /** The 32-bit floating-point Type. */
+    public static final String FLOAT = omero.model.enums.PixelsTypefloat.value;
+
     /** The bit pixels Type. */
     public static final String BIT =  omero.model.enums.PixelsTypebit.value;
 

--- a/components/tools/OmeroJava/test/integration/ModelMockFactory.java
+++ b/components/tools/OmeroJava/test/integration/ModelMockFactory.java
@@ -88,6 +88,12 @@ public class ModelMockFactory {
     /** The dimension order for the pixels type. */
     public static final String XYZCT = omero.model.enums.DimensionOrderXYZCT.value;
 
+    /** The signed int 8 pixels Type. */
+    public static final String INT8 = omero.model.enums.PixelsTypeint8.value;
+
+    /** The signed int 16 pixels Type. */
+    public static final String INT16 = omero.model.enums.PixelsTypeint16.value;
+
     /** The unsigned int 16 pixels Type. */
     public static final String UINT16 = omero.model.enums.PixelsTypeuint16.value;
 

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -422,10 +422,6 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         // Only set data for the first z/t plane, where...
         // channel 0 contains 10px with value 63 and 10px 127
         // all other pixels have value 0
-        //
-        // -> expected values are:
-        // bin[0] = 80, bin[127] = 10 and bin[255] = 10, all other bins = 0;
-
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
             for (int i = 0; i < byteSize; i++) {
@@ -443,6 +439,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         int[] channels = new int[] { 0 };
 
+        // Test the histogram for the entire plane
+        // Expected values for both channels are:
+        // bin[0] = 80, bin[126] = 10 and bin[255] = 10, all other bins = 0;
         PlaneDef plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0,
                 0, z, t, null, -1);
         Map<Integer, int[]> data = svc.getHistogram(channels, binCount,
@@ -455,14 +454,12 @@ public class RawPixelsStoreTest extends AbstractServerTest {
             Entry<Integer, int[]> e = it.next();
             int[] counts = e.getValue();
             Assert.assertEquals(counts.length, binCount);
-            for (int bin = 0; bin < binCount; bin++) {
-                int exp = 0;
-                if (bin == 0)
-                    exp = 80;
-                else if (bin == 126 || bin == 255)
-                    exp = 10;
-                Assert.assertEquals(counts[bin], exp);
-            }
+
+            int[] expectedCounts = new int[binCount];
+            expectedCounts[0] = 80;
+            expectedCounts[126] = 10;
+            expectedCounts[255] = 10;
+            Assert.assertEquals(counts, expectedCounts);
 
             int ch = e.getKey();
             if (ch == 0 || ch == 1)
@@ -503,12 +500,8 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         final int t = 0;
 
         // Only set data for the first z/t plane, where...
-        // channel 0 contains 10px with value 0 and 10px 63
-        // all other pixels have value -128
-        //
-        // -> expected values are:
-        // bin[0] = 80, bin[171] = 10 and bin[255] = 10, all other bins = 0;
-
+        // channel 0 contains 10px with value -128 and 10px 63
+        // all other pixels have value 0
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
             for (int i = 0; i < byteSize; i++) {
@@ -526,6 +519,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         int[] channels = new int[] { 0 };
 
+        // Test the histogram for the entire plane
+        // Expected values for both channels are:
+        // bin[0] = 10, bin[171] = 80 and bin[255] = 10, all other bins = 0;
         PlaneDef plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0,
                 0, z, t, null, -1);
         Map<Integer, int[]> data = svc.getHistogram(channels, binCount,
@@ -538,14 +534,12 @@ public class RawPixelsStoreTest extends AbstractServerTest {
             Entry<Integer, int[]> e = it.next();
             int[] counts = e.getValue();
             Assert.assertEquals(counts.length, binCount);
-            for (int bin = 0; bin < binCount; bin++) {
-                int exp = 0;
-                if (bin == 171)
-                    exp = 80;
-                else if (bin == 0 || bin == 255)
-                    exp = 10;
-                Assert.assertEquals(counts[bin], exp);
-            }
+
+            int[] expectedCounts = new int[binCount];
+            expectedCounts[0] = 10;
+            expectedCounts[171] = 80;
+            expectedCounts[255] = 10;
+            Assert.assertEquals(counts, expectedCounts);
 
             int ch = e.getKey();
             if (ch == 0 || ch == 1)
@@ -589,10 +583,6 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         // channel 0 contains 10px with value 12800 and 10px 25600
         // channel 1 contains 10px with value 25600 and 10px 51200
         // all other pixels have value 0
-        //
-        // -> expected values for both channels are:
-        // bin[0] = 80, bin[127] = 10 and bin[255] = 10, all other bins = 0;
-
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
             for (int i = 0; i < byteSize; i += 2) {
@@ -619,6 +609,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         int[] channels = new int[] { 0, 1 };
 
+        // Test the histogram for the entire plane
+        // Expected values for both channels are:
+        // bin[0] = 80, bin[128] = 10 and bin[255] = 10, all other bins = 0;
         PlaneDef plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0,
                 0, z, t, null, -1);
         Map<Integer, int[]> data = svc.getHistogram(channels, binCount,
@@ -631,14 +624,12 @@ public class RawPixelsStoreTest extends AbstractServerTest {
             Entry<Integer, int[]> e = it.next();
             int[] counts = e.getValue();
             Assert.assertEquals(counts.length, binCount);
-            for (int bin = 0; bin < binCount; bin++) {
-                int exp = 0;
-                if (bin == 0)
-                    exp = 80;
-                else if (bin == 128 || bin == 255)
-                    exp = 10;
-                Assert.assertEquals(counts[bin], exp);
-            }
+
+            int[] expectedCounts = new int[binCount];
+            expectedCounts[0] = 80;
+            expectedCounts[128] = 10;
+            expectedCounts[255] = 10;
+            Assert.assertEquals(counts, expectedCounts);
 
             int ch = e.getKey();
             if (ch == 0 || ch == 1)
@@ -647,10 +638,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         Assert.assertTrue(data.isEmpty());
 
-        // Test a 5x5px region, first channel only;
-        // First row of pixels is 12800, second row = 25600, others = 0;
-        // -> expected bin[0] = 15, bin[127] = 5 and bin[255] = 5, all other
-        // bins = 0;
+        // Test the histogram for a 5x5px region, first channel only;
+        // Expected values
+        // bin[0] = 15, bin[127] = 5 and bin[255] = 5, all other bins = 0;
         RegionDef region = new RegionDef(0, 0, 5, 5);
         plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0, z, t,
                 region, -1);
@@ -662,14 +652,11 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         int[] counts = data.values().iterator().next();
         Assert.assertEquals(counts.length, binCount);
 
-        for (int bin = 0; bin < binCount; bin++) {
-            int exp = 0;
-            if (bin == 0)
-                exp = 15;
-            else if (bin == 128 || bin == 255)
-                exp = 5;
-            Assert.assertEquals(counts[bin], exp);
-        }
+        int[] expectedCounts = new int[binCount];
+        expectedCounts[0] = 15;
+        expectedCounts[128] = 5;
+        expectedCounts[255] = 5;
+        Assert.assertEquals(counts, expectedCounts);
     }
 
     /**
@@ -706,10 +693,6 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         // channel 0 contains 10px with value -12800 and 10px 25600
         // channel 1 contains 10px with value -25600 and 10px 51200
         // all other pixels have value 0
-        //
-        // -> expected values for both channels are:
-        // bin[0] = 80, bin[127] = 10 and bin[255] = 10, all other bins = 0;
-
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
             for (int i = 0; i < byteSize; i += 2) {
@@ -736,6 +719,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         int[] channels = new int[] { 0, 1 };
 
+        // Test the histogram for the entire plane
+        // Expected values for both channels are:
+        // bin[0] = 10, bin[85] = 80 and bin[255] = 10, all other bins = 0;
         PlaneDef plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0,
                 0, z, t, null, -1);
         Map<Integer, int[]> data = svc.getHistogram(channels, binCount,
@@ -748,14 +734,12 @@ public class RawPixelsStoreTest extends AbstractServerTest {
             Entry<Integer, int[]> e = it.next();
             int[] counts = e.getValue();
             Assert.assertEquals(counts.length, binCount);
-            for (int bin = 0; bin < binCount; bin++) {
-                int exp = 0;
-                if (bin == 85)
-                    exp = 80;
-                else if (bin == 0 || bin == 255)
-                    exp = 10;
-                Assert.assertEquals(counts[bin], exp);
-            }
+
+            int[] expectedCounts = new int[binCount];
+            expectedCounts[0] = 10;
+            expectedCounts[85] = 80;
+            expectedCounts[255] = 10;
+            Assert.assertEquals(counts, expectedCounts);
 
             int ch = e.getKey();
             if (ch == 0 || ch == 1)
@@ -764,9 +748,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         Assert.assertTrue(data.isEmpty());
 
-        // Test a 5x5px region, first channel only;
-        // -> expected bin[0] = 5, bin[85] = 15 and bin[255] = 5, all other
-        // bins = 0;
+        // Test the histogram for a 5x5px region, first channel only;
+        // Expected values are:
+        // bin[0] = 5, bin[85] = 15 and bin[255] = 5, all other bins = 0;
         RegionDef region = new RegionDef(0, 0, 5, 5);
         plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0, z, t,
                 region, -1);
@@ -778,14 +762,11 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         int[] counts = data.values().iterator().next();
         Assert.assertEquals(counts.length, binCount);
 
-        for (int bin = 0; bin < binCount; bin++) {
-            int exp = 0;
-            if (bin == 85)
-                exp = 15;
-            else if (bin == 0 || bin == 255)
-                exp = 5;
-            Assert.assertEquals(counts[bin], exp);
-        }
+        int[] expectedCounts = new int[binCount];
+        expectedCounts[0] = 5;
+        expectedCounts[85] = 15;
+        expectedCounts[255] = 5;
+        Assert.assertEquals(counts, expectedCounts);
     }
 
     /**
@@ -796,8 +777,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
      */
     @Test
     public void testGetHistogramFLOAT() throws Exception {
-        // Create an UINT16 image with 2 channels
-        // Possible px values: [0-65535]
+        // Create an FLOAT image with 2 channels
         final int nChannels = 2;
         localSetUp(nChannels, 10, 10, ModelMockFactory.FLOAT);
 
@@ -822,10 +802,6 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         // channel 0 contains 10px with value -0.1 and 10px with value 0.1
         // channel 1 contains 10px with value -0.8 and 10px with value 0.8
         // all other pixels have value 0
-        //
-        // -> expected values for both channels are:
-        // bin[0] = 10, bin[128] = 80 and bin[255] = 10, all other bins = 0;
-
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
             for (int i = 0; i < byteSize; i += 4) {
@@ -854,6 +830,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         int[] channels = new int[] { 0, 1 };
 
+        // Test the histogram for the entire plane
+        // Expected values for both channels are:
+        // bin[0] = 10, bin[128] = 80 and bin[255] = 10, all other bins = 0;
         PlaneDef plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0,
                 0, z, t, null, -1);
         Map<Integer, int[]> data = svc.getHistogram(channels, binCount,
@@ -866,14 +845,12 @@ public class RawPixelsStoreTest extends AbstractServerTest {
             Entry<Integer, int[]> e = it.next();
             int[] counts = e.getValue();
             Assert.assertEquals(counts.length, binCount);
-            for (int bin = 0; bin < binCount; bin++) {
-                int exp = 0;
-                if (bin == 128)
-                    exp = 80;
-                else if (bin == 0 || bin == 255)
-                    exp = 10;
-                Assert.assertEquals(counts[bin], exp);
-            }
+
+            int[] expectedCounts = new int[binCount];
+            expectedCounts[0] = 10;
+            expectedCounts[128] = 80;
+            expectedCounts[255] = 10;
+            Assert.assertEquals(counts, expectedCounts);
 
             int ch = e.getKey();
             if (ch == 0 || ch == 1)
@@ -882,9 +859,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         Assert.assertTrue(data.isEmpty());
 
-        // Test a 5x5px region, first channel only;
-        // -> expected bin[0] = 5, bin[128] = 15 and bin[255] = 5, all other
-        // bins = 0;
+        // Test the histogram for a 5x5px region, first channel only;
+        // Expected values are:
+        // bin[0] = 5, bin[128] = 15 and bin[255] = 5, all other bins = 0;
         RegionDef region = new RegionDef(0, 0, 5, 5);
         plane = new PlaneDef(omeis.providers.re.data.PlaneDef.XY, 0, 0, z, t,
                 region, -1);
@@ -896,14 +873,11 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         int[] counts = data.values().iterator().next();
         Assert.assertEquals(counts.length, binCount);
 
-        for (int bin = 0; bin < binCount; bin++) {
-            int exp = 0;
-            if (bin == 128)
-                exp = 15;
-            else if (bin == 0 || bin == 255)
-                exp = 5;
-            Assert.assertEquals(counts[bin], exp);
-        }
+        int[] expectedCounts = new int[binCount];
+        expectedCounts[0] = 5;
+        expectedCounts[128] = 15;
+        expectedCounts[255] = 5;
+        Assert.assertEquals(counts, expectedCounts);
     }
 
     /**

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -600,9 +600,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
                         pxValue = 51200;
                 }
 
-                byte[] pxBytes = intTo2ByteArray(pxValue);
-                buf[i] = pxBytes[0];
-                buf[i + 1] = pxBytes[1];
+                byte[] pxBytes = ByteBuffer.allocate(4).putInt(pxValue).array();
+                buf[i] = pxBytes[2];
+                buf[i + 1] = pxBytes[3];
             }
             svc.setPlane(buf, z, ch, t);
         }
@@ -710,9 +710,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
                         pxValue = 12800;
                 }
 
-                byte[] pxBytes = intTo2ByteArray(pxValue);
-                buf[i] = pxBytes[0];
-                buf[i + 1] = pxBytes[1];
+                byte[] pxBytes = ByteBuffer.allocate(4).putInt(pxValue).array();
+                buf[i] = pxBytes[2];
+                buf[i + 1] = pxBytes[3];
             }
             svc.setPlane(buf, z, ch, t);
         }
@@ -880,17 +880,6 @@ public class RawPixelsStoreTest extends AbstractServerTest {
         Assert.assertEquals(counts, expectedCounts);
     }
 
-    /**
-     * Convert an integer into a two byte array
-     * 
-     * @param value
-     *            the integer value
-     * @return See above.
-     */
-    private byte[] intTo2ByteArray(int value) {
-        return new byte[] { (byte) (value >>> 8), (byte) value };
-    }
-    
     /**
      * Tests to set a region that is bigger than the entire file
      *

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -691,7 +691,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         // Only set data for the first z/t plane, where...
         // channel 0 contains 10px with value -12800 and 10px 25600
-        // channel 1 contains 10px with value -25600 and 10px 51200
+        // channel 1 contains 10px with value -6400 and 10px 12800
         // all other pixels have value 0
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -800,7 +800,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         // Only set data for the first z/t plane, where...
         // channel 0 contains 10px with value -0.1 and 10px with value 0.1
-        // channel 1 contains 10px with value -0.8 and 10px with value 0.8
+        // channel 1 contains 10px with value -100.0 and 10px with value 100.0
         // all other pixels have value 0
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
@@ -814,9 +814,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
                         pxValue = (float) .1;
                 } else if (ch == 1) {
                     if (pxCount < 10)
-                        pxValue = (float) -.8;
+                        pxValue = (float) -100.0;
                     else if (pxCount < 20)
-                        pxValue = (float) .8;
+                        pxValue = (float) 100.0;
                 }
 
                 byte[] pxBytes = ByteBuffer.allocate(4).putFloat(pxValue).array();
@@ -911,7 +911,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
 
         // Only set data for the first z/t plane, where...
         // channel 0 contains 10px with value -0.1 and 10px with value 0.1
-        // channel 1 contains 10px with value -0.8 and 10px with value 0.8
+        // channel 1 contains 10px with value -100.0 and 10px with value 100.0
         // all other pixels have value 0
         for (int ch = 0; ch < nChannels; ch++) {
             byte[] buf = new byte[byteSize];
@@ -925,9 +925,9 @@ public class RawPixelsStoreTest extends AbstractServerTest {
                         pxValue = .1;
                 } else if (ch == 1) {
                     if (pxCount < 10)
-                        pxValue = -.8;
+                        pxValue = -100.0;
                     else if (pxCount < 20)
-                        pxValue = .8;
+                        pxValue = 100.0;
                 }
 
                 byte[] pxBytes = ByteBuffer.allocate(8).putDouble(pxValue).array();

--- a/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
+++ b/components/tools/OmeroJava/test/integration/RawPixelsStoreTest.java
@@ -458,7 +458,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
                 int exp = 0;
                 if (bin == 0)
                     exp = 80;
-                else if (bin == 127 || bin == 255)
+                else if (bin == 126 || bin == 255)
                     exp = 10;
                 Assert.assertEquals(counts[bin], exp);
             }
@@ -551,7 +551,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
                 int exp = 0;
                 if (bin == 0)
                     exp = 80;
-                else if (bin == 127 || bin == 255)
+                else if (bin == 128 || bin == 255)
                     exp = 10;
                 Assert.assertEquals(counts[bin], exp);
             }
@@ -582,7 +582,7 @@ public class RawPixelsStoreTest extends AbstractServerTest {
             int exp = 0;
             if (bin == 0)
                 exp = 15;
-            else if (bin == 127 || bin == 255)
+            else if (bin == 128 || bin == 255)
                 exp = 5;
             Assert.assertEquals(counts[bin], exp);
         }


### PR DESCRIPTION
Companion PR to https://github.com/ome/omero-server/pull/164 which fixes the bin assignment in the `getHistorgram` API. The bug fix exposes the fact that the underlying integration tests were incorrect

This PR fixes the assertions for the existing tests (uint8 and uint16) and expands the coverage to also test signed pixel types as well as 32 and 64 bit pixel types.

As ground truth, the Python snippet below returns the expected non-zero bin counts for all scenarios

```python
import numpy

def get_histogram(a, c):
    data = numpy.histogram(
        a[:,:,c],
        bins=256,
        range=[a[:,:,c].min(), a[:,:,c].max()])[0]
    print(f"Channel: {c}")
    for i in numpy.nditer(numpy.nonzero(data)):
        print(f" {i}: {data[i]}")
    
print("Pixel type: uint8")
a = numpy.zeros((10, 10, 1), dtype=numpy.uint8)
a[0, :, 0] = 63
a[1, :, 0] = 127
get_histogram(a, 0)

print("Pixel type: int8")
a = numpy.zeros((10, 10, 1), dtype=numpy.int8)
a[0, :, 0] = -128
a[1, :, 0] = 63
get_histogram(a, 0)

print("Pixel type: uint16")
a = numpy.zeros((10, 10, 2), dtype=numpy.uint16)
a[0, :, 0] = 12800
a[1, :, 0] = 25600
a[0, :, 1] = 25600
a[1, :, 1] = 51200
get_histogram(a, 0)
get_histogram(a, 1)

print("Pixel type: int16")
a = numpy.zeros((10, 10, 2), dtype=numpy.int16)
a[0, :, 0] = -12800
a[1, :, 0] = 25600
a[0, :, 1] = -6400
a[1, :, 1] = 12800
get_histogram(a, 0)
get_histogram(a, 1)


print("Pixel type: float")
a = numpy.zeros((10, 10, 2), dtype=numpy.float32)
a[0, :, 0] = -.1
a[1, :, 0] = .1
a[0, :, 1] = -100.0
a[1, :, 1] = 100.0
get_histogram(a, 0)
get_histogram(a, 1)

print("Pixel type: double")
a = numpy.zeros((10, 10, 2), dtype=numpy.float64)
a[0, :, 0] = -.1
a[1, :, 0] = .1
a[0, :, 1] = -100.0
a[1, :, 1] = 100.0
get_histogram(a, 0)
get_histogram(a, 1)
````