### PR TITLE
Remove all usages of mox3 in OMERO.py/OMERO.dropbox integration tests

### DIFF
--- a/components/tools/OmeroFS/test/drivers.py
+++ b/components/tools/OmeroFS/test/drivers.py
@@ -29,7 +29,6 @@ except ImportError:
     # Python 2
     from path import path
 from omero.util import ServerContext
-from mox3 import mox
 from functools import wraps
 from omero.util.temp_files import create_path
 from fsDropBoxMonitorClient import MonitorClientI
@@ -352,14 +351,9 @@ class mock_communicator(object):
 class MockServerContext(ServerContext):
 
     def __init__(self, ic, get_root):
-        self.mox = mox.Mox()
         self.communicator = ic
         self.getSession = get_root
         self.stop_event = threading.Event()
-
-    def newSession(self, *args):
-        sess = self.mox.CreateMock(omero.api.ServiceFactoryPrx.__class__)
-        return sess
 
 
 class MockMonitor(MonitorClientI):
@@ -381,9 +375,10 @@ class MockMonitor(MonitorClientI):
             post = []
         self.root = None
         ic = mock_communicator()
+        self.ctx = MockServerContext(ic, self.get_root)
         MonitorClientI.__init__(
             self, dir, ic, getUsedFiles=self.used_files,
-            ctx=MockServerContext(ic, self.get_root), worker_wait=0.1)
+            ctx=self.ctx, worker_wait=0.1)
         self.log = logging.getLogger("MockMonitor")
         self.events = []
         self.files = {}

--- a/components/tools/OmeroFS/test/drivers.py
+++ b/components/tools/OmeroFS/test/drivers.py
@@ -20,7 +20,6 @@ import threading
 import time
 import uuid
 
-import omero.all
 import omero.grid.monitors as monitors
 
 try:

--- a/components/tools/OmeroPy/setup.py
+++ b/components/tools/OmeroPy/setup.py
@@ -59,4 +59,4 @@ setup(
     package_data={
         'omero.gateway': ['pilfonts/*'],
         'omero.gateway.scripts': ['imgs/*']},
-    tests_require=['pytest', 'pytest-xdist', 'mox3'])
+    tests_require=['pytest', 'pytest-xdist', 'pytest-mock'])

--- a/components/tools/OmeroPy/test/integration/clitest/cli.py
+++ b/components/tools/OmeroPy/test/integration/clitest/cli.py
@@ -30,7 +30,6 @@ from omero.plugins.sessions import SessionsControl
 from omero.rtypes import rstring
 
 from omero.testlib import ITest
-from mox3 import mox
 
 
 class AbstractCLITest(ITest):
@@ -43,13 +42,6 @@ class AbstractCLITest(ITest):
         super(AbstractCLITest, cls).setup_class()
         cls.cli = CLI()
         cls.cli.register("sessions", SessionsControl, "TEST")
-
-    def setup_mock(self):
-        self.mox = mox.Mox()
-
-    def teardown_mock(self):
-        self.mox.UnsetStubs()
-        self.mox.VerifyAll()
 
 
 class CLITest(AbstractCLITest):

--- a/components/tools/OmeroPy/test/integration/clitest/test_db.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_db.py
@@ -19,8 +19,6 @@ from omero.plugins.db import DatabaseControl
 from omero.util.temp_files import create_path
 from omero.cli import NonZeroReturnCode
 from omero.cli import CLI
-import getpass
-import builtins
 import re
 standard_library.install_aliases()  # noqa
 
@@ -103,13 +101,17 @@ class TestDatabase(object):
         if not password:
             if user_id != '' and user_id != '0':
                 expected_calls = [
-                    mocker.call(f'Please enter password for OMERO user {user_id}: '),
-                    mocker.call(f'Please re-enter password for OMERO user {user_id}: ')
+                    mocker.call(
+                        f'Please enter password for OMERO user {user_id}: '),
+                    mocker.call(
+                        f'Please re-enter password for OMERO user {user_id}: ')
                 ]
             else:
                 expected_calls = [
-                    mocker.call('Please enter password for OMERO root user: '),
-                    mocker.call('Please re-enter password for OMERO root user: ')
+                    mocker.call(
+                        'Please enter password for OMERO root user: '),
+                    mocker.call(
+                        'Please re-enter password for OMERO root user: ')
                 ]
             mock_get_pass.assert_has_calls(expected_calls)
 
@@ -180,7 +182,6 @@ class TestDatabase(object):
         assert 'Using %s for patch' % (arg_values[1]) in err
         assert 'Using password from commandline' in err
         assert 'Invalid Database version/patch' in err
-
 
     def password_output(self, user_id, no_salt):
         update_msg = "UPDATE password SET hash = \'%s\'" \

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -36,10 +36,6 @@ class TestObj(CLITest):
         super(TestObj, self).setup_method(method)
         self.cli.register("obj", ObjControl, "TEST")
         self.args += ["obj"]
-        self.setup_mock()
-
-    def teardown_method(self, method):
-        self.teardown_mock()
 
     def go(self):
         self.cli.invoke(self.args, strict=True)

--- a/components/tools/OmeroPy/test/integration/clitest/test_search.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_search.py
@@ -66,7 +66,6 @@ class TestSearch(CLITest):
         super(TestSearch, self).setup_method(method)
         self.cli.register("search", SearchControl, "TEST")
         self.args += ["search"]
-        self.setup_mock()
 
     def go(self):
         self.cli.invoke(self.args, strict=True)

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -184,7 +184,7 @@ class TestUser(CLITest):
     # Password subcommand
     # ========================================================================
     @pytest.mark.parametrize("is_unicode", [True, False])
-    def testPassword(self, is_unicode):
+    def testPassword(self, is_unicode, mocker):
         self.args += ["password"]
         login = self.ctx.userName
         if is_unicode:
@@ -192,19 +192,21 @@ class TestUser(CLITest):
         else:
             password = self.uuid()
 
-        self.setup_mock()
-        self.mox.StubOutWithMock(getpass, 'getpass')
-        i1 = 'Please enter password for your user (%s): ' % login
-        i2 = 'Please enter password to be set: '
-        i3 = 'Please re-enter password to be set: '
-        getpass.getpass(i1).AndReturn(login)
-        getpass.getpass(i2).AndReturn(password)
-        getpass.getpass(i3).AndReturn(password)
-        self.mox.ReplayAll()
+        mock_get_pass = mocker.patch('getpass.getpass')
+        mock_get_pass.side_effect = [
+                login,
+                password,
+                password
+        ]
 
         try:
             self.cli.invoke(self.args, strict=True)
-            self.teardown_mock()
+            expected_calls = [
+                mocker.call(f'Please enter password for your user ({login}): '),
+                mocker.call('Please enter password to be set: '),
+                mocker.call('Please re-enter password to be set: ')
+            ]
+            mock_get_pass.assert_has_calls(expected_calls)
 
             # Check session creation using new password
             self.new_client(user=login, password=password)
@@ -389,7 +391,7 @@ class TestUserRoot(RootCLITest):
 
     @pytest.mark.parametrize("password_prefix", password_prefixes)
     @pytest.mark.parametrize("is_unicode", [True, False])
-    def testAddPassword(self, password_prefix, is_unicode):
+    def testAddPassword(self, password_prefix, is_unicode, mocker):
         group = self.new_group()
         login = self.uuid()
         firstname = self.uuid()
@@ -404,17 +406,16 @@ class TestUserRoot(RootCLITest):
         if password_prefix:
             self.args += [password_prefix, "%s" % password]
         else:
-            self.setup_mock()
-            self.mox.StubOutWithMock(getpass, 'getpass')
-            i1 = 'Please enter password for your new user (%s): ' % login
-            i2 = 'Please re-enter password for your new user (%s): ' % login
-            getpass.getpass(i1).AndReturn(password)
-            getpass.getpass(i2).AndReturn(password)
-            self.mox.ReplayAll()
+            mock_get_pass = mocker.patch('getpass.getpass')
+            mock_get_pass.return_value = password
 
         self.cli.invoke(self.args, strict=True)
         if not password_prefix:
-            self.teardown_mock()
+            expected_calls = [
+                mocker.call(f'Please enter password for your new user ({login}): '),
+                mocker.call(f'Please re-enter password for your new user ({login}): '),
+            ]
+            mock_get_pass.assert_has_calls(expected_calls)
 
         # Check user has been added to the list of member/owners
         user = self.root.sf.getAdminService().lookupExperimenter(login)
@@ -447,7 +448,7 @@ class TestUserRoot(RootCLITest):
     # Password subcommand
     # ========================================================================
     @pytest.mark.parametrize("is_unicode", [True, False])
-    def testPassword(self, is_unicode):
+    def testPassword(self, is_unicode, mocker):
         user = self.new_user()
         login = user.omeName.val
         self.args += ["password", "%s" % login]
@@ -456,18 +457,20 @@ class TestUserRoot(RootCLITest):
         else:
             password = self.uuid()
 
-        self.setup_mock()
-        self.mox.StubOutWithMock(getpass, 'getpass')
-        i1 = 'Please enter password for your user (root): '
-        i2 = 'Please enter password to be set: '
-        i3 = 'Please re-enter password to be set: '
-        getpass.getpass(i1).AndReturn(self.root.getProperty("omero.rootpass"))
-        getpass.getpass(i2).AndReturn(password)
-        getpass.getpass(i3).AndReturn(password)
-        self.mox.ReplayAll()
+        mock_get_pass = mocker.patch('getpass.getpass')
+        mock_get_pass.side_effect = [
+                self.root.getProperty("omero.rootpass"),
+                password,
+                password
+        ]
 
         self.cli.invoke(self.args, strict=True)
-        self.teardown_mock()
+        expected_calls = [
+            mocker.call('Please enter password for your user (root): '),
+            mocker.call('Please enter password to be set: '),
+            mocker.call('Please re-enter password to be set: ')
+        ]
+        mock_get_pass.assert_has_calls(expected_calls)
 
         # Check session creation using new password
         self.new_client(user=login, password=password)

--- a/components/tools/OmeroPy/test/integration/clitest/test_user.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_user.py
@@ -29,7 +29,6 @@ from omero.testlib.cli import UserIdNameFixtures
 from omero.testlib.cli import GroupFixtures
 from omero.testlib.cli import UserFixtures
 from Glacier2 import PermissionDeniedException
-import getpass
 import pytest
 
 GroupNames = [str(x) for x in GroupFixtures]
@@ -202,7 +201,8 @@ class TestUser(CLITest):
         try:
             self.cli.invoke(self.args, strict=True)
             expected_calls = [
-                mocker.call(f'Please enter password for your user ({login}): '),
+                mocker.call(
+                    f'Please enter password for your user ({login}): '),
                 mocker.call('Please enter password to be set: '),
                 mocker.call('Please re-enter password to be set: ')
             ]
@@ -412,8 +412,10 @@ class TestUserRoot(RootCLITest):
         self.cli.invoke(self.args, strict=True)
         if not password_prefix:
             expected_calls = [
-                mocker.call(f'Please enter password for your new user ({login}): '),
-                mocker.call(f'Please re-enter password for your new user ({login}): '),
+                mocker.call(
+                    f'Please enter password for your new user ({login}): '),
+                mocker.call(
+                    f'Please re-enter password for your new user ({login}): '),
             ]
             mock_get_pass.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
Due to compatibility issues with Python 3.11, these are replaced by pytest-mock which wraps the standard library mock infrastructure.

See also https://github.com/ome/omero-py/pull/385 and https://github.com/ome/omero-dropbox/pull/22 which contain similar changes to the unit tests

Initially opening as a draft as I think the `test_requires` changes are ignored by the current logic of the Jenkins OMERO integration jobs - see https://github.com/ome/devspace/blob/master/home/jobs/OMERO-test-integration/config.xml#L26