### PR TITLE
Update tests for revised webclient annotations json

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree_annotations.py
@@ -238,6 +238,7 @@ def expected_annotations(user, links):
             'owner': {
                 'id': ann.details.owner.id.val
             },
+            'name': unwrap(ann.name),
             'ns': unwrap(ann.ns),
             'description': unwrap(ann.description),
             'id': ann.id.val,


### PR DESCRIPTION
This PR should update the omero-web tests for changes made in ome/omero-web#530

With that PR the webclient annotations json would now return the `name` parameter alongside the existing `ns` and `description` fields. I've updated the "expected" results accordingly.