### PR TITLE
Scripts update

### DIFF
--- a/components/tools/build.xml
+++ b/components/tools/build.xml
@@ -37,20 +37,20 @@
 		</echo>
 		<mkdir dir="target/lib/server"/>
 		<!-- Look for file above src -->
-		<property name="filegz" value="../../../omero-scripts-${versions.omero-scripts}.tar.gz" />
+		<property name="filegz" value="../../../omero_scripts-${versions.omero-scripts}.tar.gz" />
 		<if>
 			<available file="${filegz}"/>
             <then>
                <copy file="${filegz}" todir="target/downloads/scripts"/>
             </then>
 			<else>
-		        <download pkg="omero-scripts" file="omero-scripts-${versions.omero-scripts}.tar.gz" expected="${versions.omero-scripts-md5}"
+		        <download pkg="omero-scripts" file="omero_scripts-${versions.omero-scripts}.tar.gz" expected="${versions.omero-scripts-md5}"
 			where="target/downloads/scripts"/>
 		    </else>
 		</if>
-		<untar src="target/downloads/scripts/omero-scripts-${versions.omero-scripts}.tar.gz" dest="target/downloads/scripts" compression="gzip"/>
+		<untar src="target/downloads/scripts/omero_scripts-${versions.omero-scripts}.tar.gz" dest="target/downloads/scripts" compression="gzip"/>
 		<copy todir="target/lib/scripts">
-			<fileset dir="target/downloads/scripts/omero-scripts-${versions.omero-scripts}" includes="omero/**/*,README*"/>
+			<fileset dir="target/downloads/scripts/omero_scripts-${versions.omero-scripts}" includes="omero/**/*,README*"/>
 		</copy>
 		<copy todir="${dist.dir}">
 			<fileset dir="target" includes="*.war,var/**/*,etc/**/*,lib/**/*,include/**/*" followsymlinks="false">

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -211,7 +211,7 @@ versions.omero-scripts-url=${versions.omero-pypi}
 versions.omero-blitz=5.7.2
 versions.omero-common-test=5.6.4
 versions.omero-gateway=5.9.0
-versions.omero-scripts=5.7.3
+versions.omero-scripts=5.8.2
 versions.OMEZarrReader=0.3.1
 ## Global overrides, if empty ignored
 versions.bioformats=


### PR DESCRIPTION
Due to a recent change in setuptools cf.  https://setuptools.pypa.io/en/latest/history.html#v69-3-0, 
The name of the ``tar.gz`` is now ``omero_scripts`` instead of `omero-scripts``
The change of name only happens when ``python -m build`` is used (This is currently the command used in the CI) but not when ``python setup.py sdist`` is used.