### PR TITLE
Use cookie to get csrf token in JSON API Login.py

### DIFF
--- a/examples/Training/python/Json_Api/Login.py
+++ b/examples/Training/python/Json_Api/Login.py
@@ -35,9 +35,12 @@ projects_url = urls['url:projects']
 save_url = urls['url:save']
 schema_url = urls['url:schema']
 
-# To login we need to get CSRF token
+# To login we need to get CSRF token from cookie
 token_url = urls['url:token']
-token = session.get(token_url).json()['data']
+# we need to trigger the creation of csrf token with this URL
+session.get(token_url)
+# but the token we want is accessed as a cookie
+token = session.cookies.get_dict().get("csrftoken")
 print('CSRF token', token)
 # We add this to our session header
 # Needed for all POST, PUT, DELETE requests


### PR DESCRIPTION
# What this PR does

Fixing this example as part of question at https://forum.image.sc/t/testing-omero-json-api-with-curl-token-login/97400

# Testing this PR

1. Run `python Login.py` with the correct credentials (edit the constants in the file or use `Parse_OMERO_Properties`)

2. Should be able to login to the specified server and should list Projects etc. 
