### PR TITLE
Add documentation for the omero.logging properties

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -147,7 +147,7 @@ omero.logging.logsize=5000000
 omero.logging.lognum=9
 
 ## (For documentation only)
-# Specifies the threshold for the server log files. Logging messages
+# Specifies the threshold for the Python servers log files. Logging messages
 # which are less severe than this value will be ignored. For a list of
 # available values, see https://docs.python.org/3/library/logging.html#levels.
 omero.logging.level=20

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -132,16 +132,16 @@ omero.logging.directory=var/log/
 # interval. If true, log files will be rolled over at midnight.
 # Otherwise, log files will be rolled over at a predetermined size,
 # see omero.logging.logsize for more information.
-omero.logging.timedlog=False
+omero.logging.timedlog=false
 
 ## (For documentation only)
-# If omero.logging.timedlog is False or unset, specifies the
+# If omero.logging.timedlog is false or unset, specifies the
 # maximum size of the server log files in bytes above which a
 # new log file should be created.
 omero.logging.logsize=5000000
 
 ## (For documentation only)
-# If omero.logging.timedlog is False or unset, specifies the
+# If omero.logging.timedlog is false or unset, specifies the
 # number of old server log files that should be kept. Old log
 # files will be saved by appending the extensions '.1', '.2' etc.
 omero.logging.lognum=9

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -51,8 +51,8 @@ omero.ports.registry=4061
 ## JVM configuration
 ##
 ## Note: changes to the omero.jvmcfg properties
-## will *not* be reflected in the compiled server
-## since they are defined in a Python file.
+## will *not* be reflected in OMERO.server
+## since they are defined in OMERO.py.
 #############################################
 ## (For documentation only)
 # Memory strategy which will be used by default.
@@ -114,6 +114,43 @@ omero.jvmcfg.min_system_memory=3414
 # that they will use for calculating JVM settings (MB).
 omero.jvmcfg.max_system_memory=48000
 
+
+#############################################
+## Logging properties
+##
+## Note: changes to the default omero.logging values in
+## this file will *not* be reflected in OMERO.server
+## since they are defined in OMERO.py
+#############################################
+
+## (For documentation only)
+# Relative server directory where the log files should be stored.
+omero.logging.directory=var/log/
+
+## (For documentation only)
+# Whether the server log files should be rotated at a certain time
+# interval. If true, log files will be rolled over at midnight.
+# Otherwise, log files will be rolled over at a predetermined size,
+# see omero.logging.logsize for more information.
+omero.logging.timedlog=False
+
+## (For documentation only)
+# If omero.logging.timedlog is False or unset, specifies the
+# maximum size of the server log files in bytes above which a
+# new log file should be created.
+omero.logging.logsize=5000000
+
+## (For documentation only)
+# If omero.logging.timedlog is False or unset, specifies the
+# number of old server log files that should be kept. Old log
+# files will be saved by appending the extensions '.1', '.2' etc.
+omero.logging.lognum=9
+
+## (For documentation only)
+# Specifies the threshold for the server log files. Logging messages
+# which are less severe than this value will be ignored. For a list of
+# available values, see https://docs.python.org/3/library/logging.html#levels.
+omero.logging.level=20
 
 #############################################
 ## Ice overrides


### PR DESCRIPTION
Initial step towards fixing #6225 

All these properties are defined in OMERO.py so changing the default value in this file has no effect but allows for the configuration to be included in the reference documentation
