### PR TITLE
Update IceGrid templates to make the OMERO.tables module configurable

### DIFF
--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -168,7 +168,9 @@ omero.server.nodedescriptors=
 #############################################
 _omero.glacier2.IceSSL.Ciphers.darwin=(AES)
 
-
+## (For documentation only)
+# Name of the Python module to use when starting the Tables service
+omero.tables.module=runTables
 
 #############################################
 ## Server product name for release artifacts

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -21,6 +21,7 @@
     <variable name="ROUTERPORT"    value="@omero.ports.prefix@@omero.ports.ssl@"/>
     <variable name="INSECUREROUTER" value="OMERO.Glacier2/router:tcp -p @omero.ports.prefix@@omero.ports.tcp@ -h @omero.host@"/>
     <variable name="SEP"           value=":"/>
+    <variable name="TABLES_MODULE" value="@omero.tables.module@"/>
 
     <properties id="Profile">
       <!--

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -350,7 +350,7 @@
       <parameter name="exe" default="${PYTHON}"/>
       <server id="Tables-${index}" exe="${exe}" activation="always" pwd="${OMERO_HOME}">
         <option>-m</option>
-        <option>runTables</option>
+        <option>${TABLES_MODULE}</option>
         <adapter name="TablesAdapter" endpoints="tcp">
           <object identity="Tables-${index}" type="::omero::grid::Tables"/>
         </adapter>


### PR DESCRIPTION
Add a new top-level TABLES_MODULE variable used by the Tables template to start the new server.
Functionally, this will need to be tested alongside a corresponding OMERO.py with the logic to replace @omero.tables.module@ by either the value of the omero.tables.module configuration or the default runTables value.

Together with https://github.com/ome/omero-py/pull/419, the following scenarios should be tested

- the default behavior should be unchanged i.e. starting the server either via `omero admin start` or the systemd service file should rewrite the IceGrid templates using the default `runTables` value and start the `Tables` service
- setting `omero config set omero.tables.module runTables` in the OMERO configuration and restarting the server should have an identical behavior
- setting `omero config set omero.tables.module notexistingTables` in the OMERO configuration and restarting the server should not start the `Tables` service and `master.err` should contain a line similar to `/opt/omero/OMERO.venv/bin/python: No module named notexistingTables`