### PR TITLE
Supplement TestTables.testColumnSpaceNames with advanced queries

### DIFF
--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -702,14 +702,32 @@ class TestTables(ITest):
         table.addData(cols)
 
         assert [1, 2, 3] == table.getWhereList(
-            "x>1",  {'x': rstring("Long column")}, 0, 4, 0)
+            "x>1", {'x': rstring("Long column")}, 0, 4, 0)
+        assert [1, 2, 3] == table.getWhereList(
+            "x>value",
+            {
+                'x': rstring("Long column"),
+                'value': rint(1)
+            },
+            0, 4, 0)
         assert [1] == table.getWhereList(
             "x=='bar'", {'x': rstring("String column")}, 0, 4, 0)
         assert [0, 2] == table.getWhereList(
             "x=='foo'", {'x': rstring("String column")}, 0, 4, 0)
         assert [1, 2] == table.getWhereList(
             "(x>1)&(y!='spam')",
-            {'x': rstring("Long column"), 'y': rstring("String column")},
+            {
+                'x': rstring("Long column"),
+                'y': rstring("String column")
+            },
+            0, 4, 0)
+        assert [1, 2] == table.getWhereList(
+            "(x>a)&(y!='spam')",
+            {
+                'x': rstring("Long column"),
+                'y': rstring("String column"),
+                'a': rint(1)
+            },
             0, 4, 0)
         table.delete()
         table.close()


### PR DESCRIPTION
Variable mapping passed to getWhereList can be used both for the column names and the values. The current test logic was focusing on the checking the replacement of column names with spaces. This commit adds a few additional advanced scenarios where the integer value used for the condition is also mapped using the supplied dictionary

Testing-wise, the test should keep passing using the current PyTables OMERO.tables implementation, there are no associated functional changes.