### PR TITLE
Bump jul-to-slf4j and jcl-over-slf4j to version 2.0.16

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -11,8 +11,8 @@
   <dependencies>
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
     <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
-    <dependency org="org.slf4j" name="jul-to-slf4j" rev="1.7.30"/>
-    <dependency org="org.slf4j" name="jcl-over-slf4j" rev="1.7.30"/>
+    <dependency org="org.slf4j" name="jul-to-slf4j" rev="2.0.16"/>
+    <dependency org="org.slf4j" name="jcl-over-slf4j" rev="2.0.16"/>
     <!-- runtime dependencies from dsl/ivy.xml -->
     <dependency org="janino" name="janino" rev="${versions.janino}"/>
     <!-- Useful for globally overriding the Bio-Formats version, empty version is ignored by default -->


### PR DESCRIPTION
Motivated primarily by the regression in #6405 and https://github.com/ome/openmicroscopy/issues/6405#issuecomment-2283339623, this bumps the version of `jul-to-slf4j` and `jcl-over-slf4j` to the latest release of the 2.0.x series, currently 2.0.16. These should be compatible with the version of `slf4j-api` which is now shipped in OMERO.server.

As an additional feature, the latest version of `jul-to-slf4j` now depends on `reload4j` (rather than `log4j`) for testing purposes. This does not resolve the dependency problems raised in #6405 but it further reduces the chances of `log4j.jar` unexpectedly creeping into the binaries.

Testing should confirm that logging statements using either JCL (Apache Commons Logging, formerly Jakarta Commons Logging) or JUL (java.util.logging) as still handled via `slf4` and ultimately `logback`.

Unfortunately the biggest usage of these logging frameworks will be in third-party dependencies since the majority of the OMERO code base has been converted to using `slf4j` and `logback` over a decade ago - https://github.com/ome/openmicroscopy/pull/1006.

Within OMERO, there are still a few classes making internal use of  either JCL or JUL:
- the JVM checks in [ome.service.util.JvmSettingsCheck](https://github.com/ome/omero-server/blob/8eb311d45642163b79463c38c4b06884a637923d/src/main/java/ome/services/util/JvmSettingsCheck.java#L79) are using JCL -L85. These should be easy to test as they are logged in `Blitz-0.log` at the server startup
- `ome.util.Utils` uses JUL in its [closeQuietly](https://github.com/ome/omero-model/blob/7e89fbd253f75213d1c3c0dc9fb202ecf3296b6c/src/main/java/ome/util/Utils.java#L158-L168) API, `Utils.closeQuietly` is used in a few components to close input streams however the logging message will only appear if `close()` throws an exception so I can't think of a good scenario off-hand
- [omero.util.Resources](https://github.com/ome/omero-blitz/blob/bf9a738b0417973de01be3b2f7ccf45ee2eacd19/src/main/java/omero/util/Resources.java) uses JUL internally when adding/removing/cleaning managed entries. Here again most logging statement are at the FINEST (aka TRACE) level and only unexpected behaviors are logged at a WARNING level. This class is used in `omero.client` and the import code base primarily when calling keepAlive - https://github.com/search?q=org%3Aome+omero.util.Resources+language%3AJava&type=code&l=Java

As a follow-up all the classes above could probably be updated to use the `slf4j` API and get rid of JCL and JUL at least in the OME codebase. I'll hold on opening these until this has been tested as it could make the testing more complicated.