### PR TITLE
Ivy: resolve netcdf-java-platform artifact using unidata-resolver

### DIFF
--- a/etc/ivysettings.xml
+++ b/etc/ivysettings.xml
@@ -146,6 +146,7 @@
     <module organisation="edu.ucar" name="cdm" resolver="unidata-resolver"/>
     <module organisation="edu.ucar" name="httpservices" resolver="unidata-resolver"/>
     <module organisation="edu.ucar" name="cdm-core" resolver="unidata-resolver"/>
+    <module organisation="edu.ucar" name="netcdf-java-platform" resolver="unidata-resolver"/>
     <module organisation="omero" name="omejava" resolver="omero-resolver" />
     <module organisation="omero" name="*-test" resolver="test-resolver" matcher="glob"/>
     <module organisation="org.springframework" resolver="maven-resolver"/>


### PR DESCRIPTION
Bio-Formats 8.0.0 bumps the dependency of the cdm-core dependency to 5.6.0. As the parent POM has been renamed to netcdf-java-platform, this commit maps this artifact to the unidata-resolver so that it can be retrieved during the copy-server operation.

Related to https://github.com/ome/omero-model/pull/105 (now superseded by https://github.com/ome/omero-model/pull/106)