### PR TITLE
Drop omero.version from zip name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           tag_name="${GITHUB_REF##*/}"
           tag_name=$(grep -o '[0-9].*' <<< $tag_name)
-          tag_value="${tag_name}-ice36"
+          tag_value="${tag_name}"
           echo "omero.version=$tag_value" >> etc/local.properties
       - name: Build and package
         run: ./build.py build-dev release-all release-src

--- a/build.xml
+++ b/build.xml
@@ -241,8 +241,8 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
         depends="release-clients,release-zip">
    </target>
 
-    <target name="release-zip" description="Zip the dist directory into ${product.name}-${omero.version}.zip">
-        <zip destfile="${omero.home}/target/${product.name}-${omero.version}.zip">
+    <target name="release-zip" description="Zip the dist directory into ${product.name}.zip">
+        <zip destfile="${omero.home}/target/${product.name}.zip">
             <zipfileset dir="${dist.dir}" prefix="${product.name}-${omero.version}"/>
         </zip>
     </target>
@@ -269,19 +269,19 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
 
     </target>
 
-    <target name="release-src" description="Package the git source tree into openmicroscopy-${omero.version}.zip"
+    <target name="release-src" description="Package the git source tree into openmicroscopy.zip"
             depends="release-src-embed,release-src-git"/>
 
     <target name="release-clients" description="Zip the Java zip">
-        <zip destfile="${omero.home}/target/OMERO.java-${omero.version}.zip">
+        <zip destfile="${omero.home}/target/OMERO.java.zip">
             <zipfileset dir="${dist.dir}/lib/client"    prefix="OMERO.java-${omero.version}/libs" includes="**/*.jar"/>
             <zipfileset dir="${dist.dir}/etc" prefix="OMERO.java-${omero.version}/libs" includes="logback-cli.xml"/>
         </zip>
 
     </target>
 
-    <target name="release-tar" description="Tar the dist directory into ${product-name}-${omero.version}.tar.bz2">
-        <tar destfile="${product.name}-${omero.version}.tar.bz2" compression="bzip2">
+    <target name="release-tar" description="Tar the dist directory into ${product-name}.tar.bz2">
+        <tar destfile="${product.name}.tar.bz2" compression="bzip2">
             <zipfileset dir="${dist.dir}" prefix="${product.name}-${omero.version}"/>
         </tar>
     </target>
@@ -303,7 +303,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     </target>
 
     <target name="release-training" description="Produces a zip with the examples/Training files">
-        <zip destfile="${omero.home}/target/OMERO.training-${omero.version}.zip">
+        <zip destfile="${omero.home}/target/OMERO.training.zip">
             <zipfileset dir="${omero.home}/examples/Training" prefix="OMERO.training-${omero.version}" includes="**" excludes="markup.py"/>
             <zipfileset dir="${omero.home}" prefix="OMERO.training-${omero.version}" includes="LICENSE.txt"/>
         </zip>

--- a/components/antlib/scripts/source-archive.py
+++ b/components/antlib/scripts/source-archive.py
@@ -61,7 +61,8 @@ if __name__ == "__main__":
     vcs_date = sys.argv[6]
     vcs_date_unix = sys.argv[7]
     target = os.path.abspath(sys.argv[8])
-    release = "%s-%s" % (release, version)
+    if release != "openmicroscopy":
+        release = "%s-%s" % (release, version)
 
     if not os.path.isdir('.git'):
         raise Exception('Releasing is only possible from a git repository')


### PR DESCRIPTION
This PR removes the version from the zip name to simplify installation when downloading from GH
See https://github.com/ome/omero-install/pull/292 for background