### PR TITLE
Remove JUL over SLF4J and JCL over SLF4J as OMERO server dependencies

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -11,8 +11,6 @@
   <dependencies>
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
     <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
-    <dependency org="org.slf4j" name="jul-to-slf4j" rev="2.0.16"/>
-    <dependency org="org.slf4j" name="jcl-over-slf4j" rev="2.0.16"/>
     <!-- runtime dependencies from dsl/ivy.xml -->
     <dependency org="janino" name="janino" rev="${versions.janino}"/>
     <!-- Useful for globally overriding the Bio-Formats version, empty version is ignored by default -->

--- a/lib/licenses/README
+++ b/lib/licenses/README
@@ -470,13 +470,6 @@
   License:      Apache License, Version 2.0
   License File: apache-v2.0.txt
 
-  
-  Artifacts:    jcl-over-slf4j-*.jar
-  Project:      JCL 1.1.1 implemented over SLF4J.
-  Web Site:     http://www.slf4j.org
-  License:      MIT License
-  License File: slf4j.txt
-
 
   Artifacts:    jcommander-*.jar
   Project:      A Java framework to parse command line options with annotations.
@@ -589,13 +582,6 @@
   Web Site:     http://java.sun.com/products/jts
   License:      Sun License
   License File:
-
-
-  Artifacts:    jul-to-slf4j-*.jar
-  Project:      JUL to SLF4J bridge.
-  Web Site:     http://www.slf4j.org
-  License:      MIT License
-  License File: slf4j.txt
 
 
   Artifacts:    junit-*.jar


### PR DESCRIPTION
Fixes #6416 

Depends on https://github.com/ome/omero-model/pull/108, https://github.com/ome/omero-server/pull/185 and https://github.com/ome/omero-blitz/pull/155 being integrated in order to unify all OMERO.server components to use the SLF4J API.