### PR TITLE
OMERO.web: improve the CSRF tests coverage

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -96,12 +96,7 @@ class TestLogin(IWebTest):
         rsp = django_client.post(self.get_login_url())
         assert rsp.status_code == 403
         assert rsp.json()['message'] == (
-            "CSRF Error."
-            " CSRF cookie not set."
-            " You need to include valid CSRF tokens for any"
-            " POST, PUT, PATCH or DELETE operations."
-            " You have to include CSRF token in the POST data or"
-            " add the token to the HTTP header.")
+            "CSRF Failed: CSRF cookie not set.")
 
     def test_login_missing_csrf_token(self):
         """
@@ -113,12 +108,7 @@ class TestLogin(IWebTest):
         rsp = django_client.post(self.get_login_url())
         assert rsp.status_code == 403
         assert rsp.json()['message'] == (
-            "CSRF Error."
-            " CSRF token missing."
-            " You need to include valid CSRF tokens for any"
-            " POST, PUT, PATCH or DELETE operations."
-            " You have to include CSRF token in the POST data or"
-            " add the token to the HTTP header.")
+            "CSRF Failed: CSRF token missing.")
 
     def test_login_empty_csrf_token(self):
         """
@@ -131,13 +121,9 @@ class TestLogin(IWebTest):
             self.get_login_url(), data, headers={"X-CSRFToken": ""})
         assert rsp.status_code == 403
         assert rsp.json()['message'] == (
-            "CSRF Error."
-            " CSRF token from the 'X-Csrftoken' HTTP header has"
-            " incorrect length."
-            " You need to include valid CSRF tokens for any"
-            " POST, PUT, PATCH or DELETE operations."
-            " You have to include CSRF token in the POST data or"
-            " add the token to the HTTP header.")
+            "CSRF Failed: "
+            "CSRF token from the 'X-Csrftoken' HTTP header has incorrect "
+            "length.")
 
     def test_login_invalid_csrf_token(self):
         """
@@ -150,12 +136,8 @@ class TestLogin(IWebTest):
             self.get_login_url(), data, headers={"X-CSRFToken": "0" * 64})
         assert rsp.status_code == 403
         assert rsp.json()['message'] == (
-            "CSRF Error."
-            " CSRF token from the 'X-Csrftoken' HTTP header incorrect."
-            " You need to include valid CSRF tokens for any"
-            " POST, PUT, PATCH or DELETE operations."
-            " You have to include CSRF token in the POST data or"
-            " add the token to the HTTP header.")
+            "CSRF Failed: "
+            "CSRF token from the 'X-Csrftoken' HTTP header incorrect.")
 
     @pytest.mark.parametrize("credentials", [
         [{'username': 'guest', 'password': 'fake', 'server': 1},

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -85,9 +85,10 @@ class TestLogin(IWebTest):
         assert (rsp['message'] ==
                 "POST only with username, password, server and csrftoken")
 
-    def test_login_csrf(self):
+    def test_login_missing_csrf(self):
         """
-        Tests that we can only login with CSRF
+        Test POST with missing X-CSRFToken in HTTP header
+
         """
         django_client = self.django_root_client
         # test the most recent version
@@ -98,7 +99,31 @@ class TestLogin(IWebTest):
                         status_code=403)
         rsp = json.loads(rsp.content)
         assert (rsp['message'] ==
-                ("CSRF Error. You need to include valid CSRF tokens for any"
+                ("CSRF Error."
+                 " CSRF token missing."
+                 " You need to include valid CSRF tokens for any"
+                 " POST, PUT, PATCH or DELETE operations."
+                 " You have to include CSRF token in the POST data or"
+                 " add the token to the HTTP header."))
+
+    def test_login_empty_csrf(self):
+        """
+        Test POST with empty X-CSRFToken value in HTTP header
+        """
+        django_client = self.django_root_client
+        # test the most recent version
+        version = api_settings.API_VERSIONS[-1]
+        request_url = reverse('api_login', kwargs={'api_version': version})
+        # POST without adding CSRF token
+        django_client.cookies["csrftoken"].value = ""
+        data = {'username': 'guest', 'password': 'fake', 'server': 1}
+        rsp = django_client.post(request_url, data, status_code=403)
+        rsp = json.loads(rsp.content)
+        assert (rsp['message'] ==
+                ("CSRF Error."
+                 " CSRF token from the 'X-Csrftoken' HTTP header has"
+                 " incorrect length."
+                 " You need to include valid CSRF tokens for any"
                  " POST, PUT, PATCH or DELETE operations."
                  " You have to include CSRF token in the POST data or"
                  " add the token to the HTTP header."))

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -22,7 +22,7 @@ Tests logging in with webgateway json api
 """
 
 import pytest
-from omeroweb.testlib import IWebTest, get_json, _response, post
+from omeroweb.testlib import IWebTest, get_json, post
 from django.urls import reverse, NoReverseMatch
 from omeroweb.api import api_settings
 from django.test import Client
@@ -87,46 +87,66 @@ class TestLogin(IWebTest):
 
     def test_login_missing_csrf(self):
         """
-        Test POST with missing X-CSRFToken in HTTP header
+        Test POST with missing CSRF token
 
         """
         django_client = self.django_root_client
         # test the most recent version
         version = api_settings.API_VERSIONS[-1]
         request_url = reverse('api_login', kwargs={'api_version': version})
-        # POST without adding CSRF token
-        rsp = _response(django_client, request_url, method='post',
-                        status_code=403)
-        rsp = json.loads(rsp.content)
-        assert (rsp['message'] ==
-                ("CSRF Error."
-                 " CSRF token missing."
-                 " You need to include valid CSRF tokens for any"
-                 " POST, PUT, PATCH or DELETE operations."
-                 " You have to include CSRF token in the POST data or"
-                 " add the token to the HTTP header."))
+        # POST without CSRF token
+        rsp = django_client.post(request_url)
+        assert rsp.status_code == 403
+        assert rsp.json()['message'] == (
+            "CSRF Error."
+            " CSRF token missing."
+            " You need to include valid CSRF tokens for any"
+            " POST, PUT, PATCH or DELETE operations."
+            " You have to include CSRF token in the POST data or"
+            " add the token to the HTTP header.")
 
     def test_login_empty_csrf(self):
         """
-        Test POST with empty X-CSRFToken value in HTTP header
+        Test POST with empty X-CSRFToken
         """
         django_client = self.django_root_client
         # test the most recent version
         version = api_settings.API_VERSIONS[-1]
         request_url = reverse('api_login', kwargs={'api_version': version})
-        # POST without adding CSRF token
-        django_client.cookies["csrftoken"].value = ""
+        # POST with an empty X-CSRFToken
         data = {'username': 'guest', 'password': 'fake', 'server': 1}
-        rsp = django_client.post(request_url, data, status_code=403)
-        rsp = json.loads(rsp.content)
-        assert (rsp['message'] ==
-                ("CSRF Error."
-                 " CSRF token from the 'X-Csrftoken' HTTP header has"
-                 " incorrect length."
-                 " You need to include valid CSRF tokens for any"
-                 " POST, PUT, PATCH or DELETE operations."
-                 " You have to include CSRF token in the POST data or"
-                 " add the token to the HTTP header."))
+        rsp = django_client.post(
+            request_url, data, headers={"X-CSRFToken": ""})
+        assert rsp.status_code == 403
+        assert rsp.json()['message'] == (
+            "CSRF Error."
+            " CSRF token from the 'X-Csrftoken' HTTP header has"
+            " incorrect length."
+            " You need to include valid CSRF tokens for any"
+            " POST, PUT, PATCH or DELETE operations."
+            " You have to include CSRF token in the POST data or"
+            " add the token to the HTTP header.")
+
+    def test_login_invalid_csrf(self):
+        """
+        Test POST with invalid X-CSRFToken
+        """
+        django_client = self.django_root_client
+        # test the most recent version
+        version = api_settings.API_VERSIONS[-1]
+        request_url = reverse('api_login', kwargs={'api_version': version})
+        # POST with an incorrect X-CSRFToken
+        data = {'username': 'root', 'password': 'fake', 'server': 1}
+        rsp = django_client.post(
+            request_url, data, headers={"X-CSRFToken": "0" * 64})
+        assert rsp.status_code == 403
+        assert rsp.json()['message'] == (
+            "CSRF Error."
+            " CSRF token from the 'X-Csrftoken' HTTP header incorrect."
+            " You need to include valid CSRF tokens for any"
+            " POST, PUT, PATCH or DELETE operations."
+            " You have to include CSRF token in the POST data or"
+            " add the token to the HTTP header.")
 
     @pytest.mark.parametrize("credentials", [
         [{'username': 'guest', 'password': 'fake', 'server': 1},

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -35,6 +35,11 @@ class TestLogin(IWebTest):
     Tests login workflow: getting url, csfv tokens etc.
     """
 
+    def get_login_url(self):
+        # test the most recent version
+        version = api_settings.API_VERSIONS[-1]
+        return reverse('api_login', kwargs={'api_version': version})
+
     def test_versions(self):
         """
         Start at the base url, get versions

--- a/components/tools/OmeroWeb/test/integration/test_api_login.py
+++ b/components/tools/OmeroWeb/test/integration/test_api_login.py
@@ -57,7 +57,6 @@ class TestLogin(IWebTest):
         Tests that the base url for a given version provides other urls
         """
         django_client = self.django_root_client
-        # test the most recent version
         version = api_settings.API_VERSIONS[-1]
         request_url = reverse('api_base', kwargs={'api_version': version})
         rsp = get_json(django_client, request_url)
@@ -84,23 +83,34 @@ class TestLogin(IWebTest):
         Tests that we get a suitable message if we try to GET login_url
         """
         django_client = self.django_root_client
-        version = api_settings.API_VERSIONS[-1]
-        request_url = reverse('api_login', kwargs={'api_version': version})
-        rsp = get_json(django_client, request_url, status_code=405)
+        rsp = get_json(django_client, self.get_login_url(), status_code=405)
         assert (rsp['message'] ==
                 "POST only with username, password, server and csrftoken")
 
-    def test_login_missing_csrf(self):
+    def test_login_csrf_cookie_not_set(self):
+        """
+        Test POST with missing CSRF cookie
+
+        """
+        django_client = Client(enforce_csrf_checks=True)
+        rsp = django_client.post(self.get_login_url())
+        assert rsp.status_code == 403
+        assert rsp.json()['message'] == (
+            "CSRF Error."
+            " CSRF cookie not set."
+            " You need to include valid CSRF tokens for any"
+            " POST, PUT, PATCH or DELETE operations."
+            " You have to include CSRF token in the POST data or"
+            " add the token to the HTTP header.")
+
+    def test_login_missing_csrf_token(self):
         """
         Test POST with missing CSRF token
 
         """
-        django_client = self.django_root_client
-        # test the most recent version
-        version = api_settings.API_VERSIONS[-1]
-        request_url = reverse('api_login', kwargs={'api_version': version})
-        # POST without CSRF token
-        rsp = django_client.post(request_url)
+        django_client = Client(enforce_csrf_checks=True)
+        django_client.get(reverse("weblogin"))
+        rsp = django_client.post(self.get_login_url())
         assert rsp.status_code == 403
         assert rsp.json()['message'] == (
             "CSRF Error."
@@ -110,18 +120,15 @@ class TestLogin(IWebTest):
             " You have to include CSRF token in the POST data or"
             " add the token to the HTTP header.")
 
-    def test_login_empty_csrf(self):
+    def test_login_empty_csrf_token(self):
         """
-        Test POST with empty X-CSRFToken
+        Test POST with empty CSRF token
         """
-        django_client = self.django_root_client
-        # test the most recent version
-        version = api_settings.API_VERSIONS[-1]
-        request_url = reverse('api_login', kwargs={'api_version': version})
-        # POST with an empty X-CSRFToken
-        data = {'username': 'guest', 'password': 'fake', 'server': 1}
+        django_client = Client(enforce_csrf_checks=True)
+        django_client.get(reverse("weblogin"))
+        data = {'username': 'root', 'password': 'omero', 'server': 1}
         rsp = django_client.post(
-            request_url, data, headers={"X-CSRFToken": ""})
+            self.get_login_url(), data, headers={"X-CSRFToken": ""})
         assert rsp.status_code == 403
         assert rsp.json()['message'] == (
             "CSRF Error."
@@ -132,18 +139,15 @@ class TestLogin(IWebTest):
             " You have to include CSRF token in the POST data or"
             " add the token to the HTTP header.")
 
-    def test_login_invalid_csrf(self):
+    def test_login_invalid_csrf_token(self):
         """
-        Test POST with invalid X-CSRFToken
+        Test POST with invalid CSRF token
         """
-        django_client = self.django_root_client
-        # test the most recent version
-        version = api_settings.API_VERSIONS[-1]
-        request_url = reverse('api_login', kwargs={'api_version': version})
-        # POST with an incorrect X-CSRFToken
-        data = {'username': 'root', 'password': 'fake', 'server': 1}
+        django_client = Client(enforce_csrf_checks=True)
+        django_client.get(reverse("weblogin"))
+        data = {'username': 'root', 'password': 'omero', 'server': 1}
         rsp = django_client.post(
-            request_url, data, headers={"X-CSRFToken": "0" * 64})
+            self.get_login_url(), data, headers={"X-CSRFToken": "0" * 64})
         assert rsp.status_code == 403
         assert rsp.json()['message'] == (
             "CSRF Error."


### PR DESCRIPTION
Expand the scope of the integration tests to match the response message changes proposed https://github.com/ome/omero-web/pull/608 and cover additional CSRF protection scenarios

- Update the expected response message to include the reason
- Add integration tests including missing CSRF cookie, missing CSRF token, CSRF token with invalid length and CSRF token with incorrect value
