### PR TITLE
Use \d

### DIFF
--- a/components/antlib/scripts/parse_version
+++ b/components/antlib/scripts/parse_version
@@ -73,7 +73,7 @@ def snapshot_logic(omero_version):
     m = re.match((
         "^"
         "(?P<BASE>.*?)"
-        "(?P<STRIP>([-]DEV)?-\d+-[a-f0-9]+?(-dirty)?)"
+        "(?P<STRIP>([-]DEV)?-\\d+-[a-f0-9]+?(-dirty)?)"
         "(?P<ICE>-ice[0-9]+)?"
         "$"), omero_version)
     if m:
@@ -115,7 +115,7 @@ def incr_version(omero_version):
         omero_version = new_vers
     except:
         # But if that doesn't work, we brute force with regex
-        m = re.match("^([^\d]*\d+[.]\d+[.])(\d+)-SNAPSHOT$", omero_version)
+        m = re.match("^([^\\d]*\\d+[.]\\d+[.])(\\d+)-SNAPSHOT$", omero_version)
         if m:
             next = int(m.group(2)) + 1
             omero_version = "%s%s-SNAPSHOT" % (m.group(1), next)

--- a/components/antlib/scripts/parse_version
+++ b/components/antlib/scripts/parse_version
@@ -70,10 +70,11 @@ def snapshot_logic(omero_version):
 
     See gh-67 for the discussion.
     """
-    m = re.match((
+    re.compile()
+    m = re.match(r(
         "^"
         "(?P<BASE>.*?)"
-        "(?P<STRIP>([-]DEV)?-\\d+-[a-f0-9]+?(-dirty)?)"
+        "(?P<STRIP>([-]DEV)?-\d+-[a-f0-9]+?(-dirty)?)"
         "(?P<ICE>-ice[0-9]+)?"
         "$"), omero_version)
     if m:
@@ -115,7 +116,7 @@ def incr_version(omero_version):
         omero_version = new_vers
     except:
         # But if that doesn't work, we brute force with regex
-        m = re.match("^([^\\d]*\\d+[.]\\d+[.])(\\d+)-SNAPSHOT$", omero_version)
+        m = re.match(r"^([^\d]*\\d+[.]\d+[.])(\d+)-SNAPSHOT$", omero_version)
         if m:
             next = int(m.group(2)) + 1
             omero_version = "%s%s-SNAPSHOT" % (m.group(1), next)


### PR DESCRIPTION

Upgrading the GitHub action to run on Ubuntu 24.04 with Python 3.12 to synchronize the documentation from various repositories has led to some failures
See https://github.com/ome/omero-documentation/actions/runs/13825561909

This is the first part of the puzzle.
Changes are required in other repositories e.g. omeroweb-install and ansible 