### PR TITLE
Remove MaxPermSize flag in the build system

### DIFF
--- a/build.py
+++ b/build.py
@@ -72,7 +72,6 @@ def find_java():
 def calculate_memory_args():
     return (
         "-Xmx600M",
-        "-XX:MaxPermSize=256m",
         "-XX:+IgnoreUnrecognizedVMOptions"
     )
 

--- a/components/antlib/resources/lifecycle.xml
+++ b/components/antlib/resources/lifecycle.xml
@@ -205,7 +205,6 @@ omero.version=${omero.version}
                     <pathelement location="${classes.dir}"/>
                     <pathelement location="${test.dir}"/>
                 </classpath>
-                <jvmarg value="-XX:MaxPermSize=256m"/>
                 <jvmarg value="-XX:+IgnoreUnrecognizedVMOptions"/>
                 <jvmarg value="-Dlogback.configuration=logback-build.xml"/>
                 <jvmarg value="-Domero.db.name=${omero.db.name}"/>


### PR DESCRIPTION
Noticed while reviewing the output https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/

Support for PermSize and MaxPermSize was removed in Java 8 - see https://www.oracle.com/java/technologies/javase/8-compatibility-guide.html