### PR TITLE
Update integration tests to be compliant with pytest 8.4.0

### DIFF
--- a/components/tools/OmeroPy/test/integration/scriptstest/test_coverage.py
+++ b/components/tools/OmeroPy/test/integration/scriptstest/test_coverage.py
@@ -63,7 +63,7 @@ class TestCoverage(ITest):
             client = OS.client("testUploadScript")
             print("done")
             """)
-        return scriptID
+        assert scriptID
 
     def testUserCantUploadOfficalScript(self):
         with pytest.raises(omero.SecurityViolation):

--- a/components/tools/OmeroPy/test/integration/tablestest/test_service.py
+++ b/components/tools/OmeroPy/test/integration/tablestest/test_service.py
@@ -75,7 +75,7 @@ class TestTables(ITest):
         for i in range(len(x)):
             assert x[i] == y[i]
 
-    def testBlankTable(self):
+    def createBlankTable(self):
         grid = self.client.sf.sharedResources()
         repoMap = grid.repositories()
         repoObj = repoMap.descriptions[0]
@@ -92,7 +92,7 @@ class TestTables(ITest):
         # Not closing for re-use
 
     def testUpdate(self):
-        ofile = self.testBlankTable()
+        ofile = self.createBlankTable()
         grid = self.client.sf.sharedResources()
         table = grid.openTable(ofile)
         data = table.slice([0], [0])
@@ -656,7 +656,7 @@ class TestTables(ITest):
         Create an HDF5 file on the server, and then mark it read-only.
         The server should still allow you to load & read that file.
         """
-        self.testBlankTable()  # ofile
+        self.createBlankTable()  # ofile
 
         filename = self.unique_dir + "/file.txt"
         mrepo = self.get_managed_repo()

--- a/components/tools/OmeroPy/test/integration/test_isession.py
+++ b/components/tools/OmeroPy/test/integration/test_isession.py
@@ -74,7 +74,7 @@ class TestISession(ITest):
         finally:
             client.__del__()
 
-    def testJoinSession_Helper(self):
+    def testJoinSession(self):
         test_user = self.new_user()
 
         client = omero.client()  # ok rather than new_client since has __del__
@@ -88,8 +88,6 @@ class TestISession(ITest):
         finally:
             client.__del__()
 
-    def testJoinSession(self):
-        suuid = self.testJoinSession_Helper()
         c1 = omero.client()  # ok rather than new_client since has __del__
         try:
             sf1 = c1.joinSession(suuid)

--- a/components/tools/OmeroPy/test/integration/test_isession.py
+++ b/components/tools/OmeroPy/test/integration/test_isession.py
@@ -84,7 +84,6 @@ class TestISession(ITest):
             a = sf.getAdminService()
             suuid = a.getEventContext().sessionUuid
             sf.detachOnDestroy()
-            return suuid
         finally:
             client.__del__()
 

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -467,7 +467,6 @@ class TestIShare(ITest):
 
         owned = share1.getOwnShares(False)
         assert 1 == len(owned)
-        return client_user1, sid, expiration
 
     def test1201b(self):
         new_group = self.new_group()

--- a/components/tools/OmeroPy/test/integration/test_ishare.py
+++ b/components/tools/OmeroPy/test/integration/test_ishare.py
@@ -776,10 +776,36 @@ class TestIShare(ITest):
         a share that was created some time ago and is being
         accessed again.
         """
-        client, sid, expiration = self.test1201()
-        admin = client.sf.getAdminService()
+
+        # create two users in one group
+        admin = self.client.sf.getAdminService()
+        group = self.new_group()
+        client, user1 = self.new_client_and_user(group)
+        client2, user2 = self.new_client_and_user(group)
+        assert admin.getMemberOfGroupIds(user1) == admin\
+            .getMemberOfGroupIds(user2)
+
+        # create share
         share = client.sf.getShareService()
-        session = client.sf.getSessionService()
+        description = "my description"
+        timeout = None
+        objects = []
+        experimenters = [user2]
+        guests = ["ident@emaildomain.com"]
+        enabled = True
+        sid = share.createShare(description, timeout, objects,
+                                experimenters, guests, enabled)
+
+        # check that owner and member can access share
+        self.assert_access(client, sid)
+        self.assert_access(client2, sid)
+
+        expiration = int(time.time() * 1000) + 86400
+        share.setExpiration(sid, rtime(expiration))
+        self.assert_expiration(expiration, share.getShare(sid))
+
+        share.setActive(sid, False)
+        assert share.getShare(sid).active.val is False
 
         # Regular reloading
         share.setActive(sid, True)
@@ -790,6 +816,7 @@ class TestIShare(ITest):
         self.assert_expiration(expiration, share.getShare(sid))
 
         # Forced closing
+        session = client.sf.getSessionService()
         assert -2 == session.closeSession(share.getShare(sid))
         share.activate(sid)
         admin.getEventContext()  # Refreshes
@@ -806,7 +833,7 @@ class TestIShare(ITest):
             shares.createShare("my description", None, [omero.model.ScreenI()],
                                [], [], True)
 
-    def test_OS_regular_user(self):
+    def create_image_and_share(self):
         # test regular user can activate a share
         # Owner of share
         owner, owner_obj = self.new_client_and_user(perms="rw----")
@@ -834,7 +861,7 @@ class TestIShare(ITest):
     def test_OS_non_member(self):
         # Non-members should not be able to use this method
         # Run setup
-        img, sid = self.test_OS_regular_user()
+        img, sid = self.create_image_and_share()
         non_member = self.new_client(perms="rw----")
         non_member_query = non_member.sf.getQueryService()
 
@@ -849,7 +876,7 @@ class TestIShare(ITest):
 
     def test_OS_admin_user(self):
         # Admin should be able to log into any share
-        img, sid = self.test_OS_regular_user()
+        img, sid = self.create_image_and_share()
         root_query = self.root.sf.getQueryService()
 
         # Try to access direct (in wrong group)

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -152,8 +152,8 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         mrepo1 = self.get_managed_repo(client1)
         mrepo2 = self.get_managed_repo(client2)
 
-        testdir1 = self.test_dir(client1)
-        testdir2 = self.test_dir(client2)
+        testdir1 = self.create_test_dir(client1)
+        testdir2 = self.create_test_dir(client2)
 
         return self.Fixture(client1, mrepo1, testdir1), \
             self.Fixture(client2, mrepo2, testdir2)
@@ -250,7 +250,7 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         group1 = self.new_group(perms="rw----")
         client1, user = self.new_client_and_user(group=group1)
         client1.sf.setSecurityContext(group1)
-        testdir1 = self.test_dir(client1)
+        testdir1 = self.create_test_dir(client1)
         dirname = testdir1 + "/b/c"
         filename = dirname + "/file.txt"
 

--- a/components/tools/OmeroPy/test/integration/test_repository.py
+++ b/components/tools/OmeroPy/test/integration/test_repository.py
@@ -152,8 +152,8 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         mrepo1 = self.get_managed_repo(client1)
         mrepo2 = self.get_managed_repo(client2)
 
-        testdir1 = self.create_test_dir(client1)
-        testdir2 = self.create_test_dir(client2)
+        testdir1 = self.create_managed_dir(client1)
+        testdir2 = self.create_managed_dir(client2)
 
         return self.Fixture(client1, mrepo1, testdir1), \
             self.Fixture(client2, mrepo2, testdir2)
@@ -250,7 +250,7 @@ class TestManagedRepositoryMultiUser(AbstractRepoTest):
         group1 = self.new_group(perms="rw----")
         client1, user = self.new_client_and_user(group=group1)
         client1.sf.setSecurityContext(group1)
-        testdir1 = self.create_test_dir(client1)
+        testdir1 = self.create_managed_dir(client1)
         dirname = testdir1 + "/b/c"
         filename = dirname + "/file.txt"
 

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -76,7 +76,6 @@ class TestScripts(ITest):
         ofile = self.query.get("OriginalFile", id)
         assert "/" == ofile.path.val
         assert "%s.py" % uuid == ofile.name.val
-        return svc, ofile
 
     def testDelete6905(self):
         """

--- a/components/tools/OmeroPy/test/integration/test_scripts.py
+++ b/components/tools/OmeroPy/test/integration/test_scripts.py
@@ -44,7 +44,7 @@ class TestScripts(ITest):
 
     def testBasicUsage(self):
         svc = self.client.sf.getScriptService()
-        return svc
+        assert svc
 
     def testTicket1036(self):
         self.client.setInput("a", rstring("a"))
@@ -82,8 +82,16 @@ class TestScripts(ITest):
         """
         Delete of official scripts was broken in 4.3.2.
         """
-        svc, ofile = self.testUpload2562()
+        uuid = self.uuid()
+        f = self.pingfile()
+        svc = self.root.sf.getScriptService()
+        id = svc.uploadOfficialScript("../%s.py" % uuid, f.text())
+        ofile = self.query.get("OriginalFile", id)
+        assert "/" == ofile.path.val
+        assert "%s.py" % uuid == ofile.name.val
+
         svc.deleteScript(ofile.id.val)
+        assert self.query.find("OriginalFile", ofile.id.val) is None
 
     def testDelete11371(self):
         """


### PR DESCRIPTION
See https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/407, the release of [pytest 8.4.0](https://github.com/pytest-dev/pytest/releases/tag/8.4.0) is now failing the tests that return a value other than None.

This PR reviews all failing tests and adjusts them as necessary to either rename the utility method to not start with `test_` or duplicate the bootstrap logic for tests depending on another one. The changes in 086004082282f5bb421136d221d9e2ba7549db94 require the `omero.testlib` API changes introduced in https://github.com/ome/omero-py/pull/460