### PR TITLE
Update OMERO.py gateway test_wrapper integration test

### DIFF
--- a/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
+++ b/components/tools/OmeroPy/test/integration/gatewaytest/test_wrapper.py
@@ -53,7 +53,7 @@ class TestWrapper(object):
             image.getFormat(), omero.gateway.BlitzObjectWrapper), \
             "Should return a BlitzObjectWrapper"
         format = image.getFormat()
-        assert format.value == "Deltavision", \
+        assert format.value == "Fake", \
             "BlitzObjectWrapper should lazy-load the value"
         assert not hasattr(format.value, 'val'), "Shouldn't return rtype"
         assert not hasattr(format.getValue(), 'val'), "Shouldn't return rtype"


### PR DESCRIPTION
Depends on the upstream OMERO.py changes proposed in https://github.com/ome/omero-py/pull/443
