### PR TITLE
Ice Grid: set java.io.tmpdir to var/tmp for Java servers

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -365,6 +365,7 @@ To get started using Eclipse, execute "ant build-dev" and import the top-level
     <target name="create-workdirs" depends="init">
         <mkdir dir="${dist.dir}/etc/grid"/>
         <mkdir dir="${dist.dir}/var"/>
+        <mkdir dir="${dist.dir}/var/tmp"/>
     </target>
 
     <target name="copy-luts" depends="init">

--- a/etc/templates/grid/default.xml
+++ b/etc/templates/grid/default.xml
@@ -12,6 +12,7 @@
     <variable name="OMERO_ETC"     value="etc/"/>
     <variable name="OMERO_JARS"    value="lib/server/"/>
     <variable name="OMERO_LOGS"    value="var/log/"/>
+    <variable name="OMERO_TMP"     value="var/tmp/"/>
     <variable name="OMERO_LOGFILE" value="${OMERO_LOGS}$${omero.name}.log"/>
     <!-- Note: you will also need to modify the etc/master.cfg property
          file if you want var/log to be completely unused -->

--- a/etc/templates/grid/templates.xml
+++ b/etc/templates/grid/templates.xml
@@ -203,6 +203,7 @@
             <option>-agentlib:hprof=cpu=samples,cutoff=0,thread=y,interval=1,depth=50,force=y,file=${OMERO_LOGS}Blitz-${index}.hprof</option>
         </target>
         <option>-Djava.awt.headless=true</option>
+        <option>-Djava.io.tmpdir=${OMERO_TMP}</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback.xml</option>
         <option>-Domero.logfile=${OMERO_LOGFILE}</option>
         <option>-Domero.name=Blitz-${index}</option>
@@ -235,6 +236,7 @@
       <server id="Indexer-${index}" exe="${JAVA}" activation="always" pwd="${OMERO_HOME}">
         <option>MEMORY:indexer</option>
         <option>-Djava.awt.headless=true</option>
+        <option>-Djava.io.tmpdir=${OMERO_TMP}</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback-indexing.xml</option>
         <option>-Domero.logfile=${OMERO_LOGFILE}</option>
         <option>-Domero.name=Indexer-${index}</option>
@@ -266,6 +268,7 @@
       <server id="PixelData-${index}" exe="${JAVA}" activation="always" pwd="${OMERO_HOME}">
         <option>MEMORY:pixeldata</option>
         <option>-Djava.awt.headless=true</option>
+        <option>-Djava.io.tmpdir=${OMERO_TMP}</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback-indexing.xml</option>
         <option>-Domero.logfile=${OMERO_LOGFILE}</option>
         <option>-Domero.name=PixelData-${index}</option>
@@ -292,6 +295,7 @@
       <server id="Repository-${index}" exe="${JAVA}" activation="always" pwd="${OMERO_HOME}">
         <option>MEMORY:repository</option>
         <option>-Djava.awt.headless=true</option>
+        <option>-Djava.io.tmpdir=${OMERO_TMP}</option>
         <option>-Dlogback.configurationFile=${OMERO_ETC}logback.xml</option>
         <option>-Domero.logfile=${OMERO_LOGFILE}</option>
         <option>-Domero.name=Repository-${index}</option>


### PR DESCRIPTION
Fixes #6440 
Fixes https://github.com/ome/omero-py/issues/484

# What this PR does

This updates the Java servers started by Ice Grid to use `${OMERODIR}/var/tmp` as the temporary Java directory

- Create `var/tmp` directory at build time
- Define `OMERO_TMP` variable in the Ice Grid default configuration
- Use `OMERO_TMP` as the value of `-Djava.io.tmpdir` in Java services (Blitz, Indexer, Repository, PixelData)

2c0a18da0bcb5af220194d88f38e555faf3168d8 overrides the Java temporary directory for all Java servers. A reviewer question is whether it would be cautious to restrict this setting to the servers that are using Bio-Formats (`Blitz` & `PixelData` initially) since we have no concrete report of other functionalities affected by `/tmp` being mounted as `noexec`

# Testing this PR

Using the OMERO.server bundle built from this PR:

- start the application either via `omero admin start` or `systemctl start omero-server` 
  - check the applicatoin is properly initialised
  - check you can authenticate
- display the processes started by `icegridadmin` using `ps`
   -  check that `-Djava.io.tmpdir` is set to point at `var/tmp`.
- perform an operation requiring Bio-Formats ant the native library loading functionality e.g. import an NDPI file using one of the [public samples](https://downloads.openmicroscopy.org/images/Hamamatsu-NDPI/)
  - check that a temporary native lib loader folder associated with the process is created under `var/tmp`
  - check the image is properly imported and the thumbnails are generated
  - check the image is indexed via `Indexer-0.log`
- stop the application either via `omero admin stop` or `systemctl stop omero-servr` 
  - check the temporary folder under `var/tmp` is cleaned up on restart

# Related reading

See #6439 for a full description of the rationale behind this change