### PR TITLE
OMERO.web imgData: add integration test for multi-resolution image

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -238,7 +238,7 @@ class TestImgDetail(IWebTest):
             'model': "color",
             'invertAxis': False,
             'projection': "normal",
-            'defaultZ': 2
+            'defaultZ': 0
         }
 
         # Core image metadata

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -53,6 +53,7 @@ class TestImgDetail(IWebTest):
         assert 'levels' not in img_data
         assert 'zoomLevelScaling' not in img_data
         assert 'tile_size' not in img_data
+        assert 'resolutions' not in img_data
 
         # Channels metadata
         assert len(img_data['channels']) == 1
@@ -157,6 +158,28 @@ class TestImgDetail(IWebTest):
             "2": 0.25,
             "3": 0.125,
             "4": 0.0625
+        }
+        assert img_data['resolutions'] == {
+            "0": {
+              "sizeX": 20000,
+              "sizeY": 20000
+            },
+            "1": {
+              "sizeX": 10000,
+              "sizeY": 10000
+            },
+            "2": {
+              "sizeX": 5000,
+              "sizeY": 5000
+            },
+            "3": {
+              "sizeX": 2500,
+              "sizeY": 2500
+            },
+            "4": {
+              "sizeX": 1250,
+              "sizeY": 1250
+            }
         }
 
         # Channels metadata

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -48,7 +48,7 @@ class TestImgDetail(IWebTest):
         img_data = get_json(self.django_client, json_url, data,
                             status_code=200)
 
-        # Not a big image - tiles should be False with no other tiles metadata
+        # Not a multi-resolution image
         assert img_data['tiles'] is False
         assert 'levels' not in img_data
         assert 'zoomLevelScaling' not in img_data
@@ -148,7 +148,7 @@ class TestImgDetail(IWebTest):
         img_data = get_json(self.django_client, json_url, data,
                             status_code=200)
 
-        # Not a big image - tiles should be False with no other tiles metadata
+        # Test resolutions metadata
         assert img_data['tiles'] is True
         assert img_data['levels'] == 5
         assert 'tile_size' in img_data

--- a/components/tools/OmeroWeb/test/integration/test_marshal.py
+++ b/components/tools/OmeroWeb/test/integration/test_marshal.py
@@ -34,7 +34,7 @@ class TestImgDetail(IWebTest):
 
     def test_image_detail(self):
         """
-        Download of archived files for a non-SPW Image.
+        Marshalling of non-SPW single resolution single channel image
         """
         user_name = "%s %s" % (self.user.firstName.val, self.user.lastName.val)
 
@@ -129,4 +129,123 @@ class TestImgDetail(IWebTest):
                 'gridx': 1,
                 'height': 24
             }
+        }
+
+    def test_pyramidal_image(self):
+        """
+        Marshalling of non-SPW multi-resolution RGB image
+        """
+        user_name = "%s %s" % (self.user.firstName.val, self.user.lastName.val)
+
+        # Import image with metadata and get ImageID
+        images = self.import_fake_file(
+            client=self.client, sizeX=20000, sizeY=20000, sizeC=3, rgb=3,
+            resolutions=5)
+        iid = images[0].id.val
+        json_url = reverse('webgateway_imageData_json', args=[iid])
+        data = {}
+        img_data = get_json(self.django_client, json_url, data,
+                            status_code=200)
+
+        # Not a big image - tiles should be False with no other tiles metadata
+        assert img_data['tiles'] is True
+        assert img_data['levels'] == 5
+        assert 'tile_size' in img_data
+        assert img_data['zoomLevelScaling'] == {
+            "0": 1,
+            "1": 0.5,
+            "2": 0.25,
+            "3": 0.125,
+            "4": 0.0625
+        }
+
+        # Channels metadata
+        assert len(img_data['channels']) == 3
+        assert img_data['channels'][0] == {
+            'color': "FF0000",
+            'active': True,
+            'window': {
+                'min': 0,
+                'max': 255,
+                'start': 0,
+                'end': 255
+            },
+            'family': 'linear',
+            'coefficient': 1.0,
+            'reverseIntensity': False,
+            'inverted': False,
+            'emissionWave': None,
+            'label': "0"
+        }
+        assert img_data['channels'][1] == {
+            'color': "00FF00",
+            'active': True,
+            'window': {
+                'min': 0,
+                'max': 255,
+                'start': 0,
+                'end': 255
+            },
+            'family': 'linear',
+            'coefficient': 1.0,
+            'reverseIntensity': False,
+            'inverted': False,
+            'emissionWave': None,
+            'label': "1"
+        }
+        assert img_data['channels'][2] == {
+            'color': "0000FF",
+            'active': True,
+            'window': {
+                'min': 0,
+                'max': 255,
+                'start': 0,
+                'end': 255
+            },
+            'family': 'linear',
+            'coefficient': 1.0,
+            'reverseIntensity': False,
+            'inverted': False,
+            'emissionWave': None,
+            'label': "2"
+        }
+        assert img_data['pixel_range'] == [0, 255]
+        assert img_data['rdefs'] == {
+            'defaultT': 0,
+            'model': "color",
+            'invertAxis': False,
+            'projection': "normal",
+            'defaultZ': 2
+        }
+
+        # Core image metadata
+        assert img_data['size'] == {
+            'width': 20000,
+            'height': 20000,
+            'z': 1,
+            't': 1,
+            'c': 3
+        }
+        assert img_data['meta']['pixelsType'] == "uint8"
+        assert img_data['meta']['projectName'] == "Multiple"
+        assert img_data['meta']['imageId'] == iid
+        assert img_data['meta']['imageAuthor'] == user_name
+        assert img_data['meta']['datasetId'] is None
+        assert img_data['meta']['projectDescription'] == ""
+        assert img_data['meta']['datasetName'] == "Multiple"
+        assert img_data['meta']['wellSampleId'] == ""
+        assert img_data['meta']['projectId'] is None
+        assert img_data['meta']['imageDescription'] == ""
+        assert img_data['meta']['wellId'] == ""
+        assert img_data['meta']['imageName'].endswith(".fake")
+        assert img_data['meta']['datasetDescription'] == ""
+        # Don't know exact timestamp of import
+        assert 'imageTimestamp' in img_data['meta']
+
+        # Permissions - User is owner. All perms are True
+        assert img_data['perms'] == {
+            'canAnnotate': True,
+            'canEdit': True,
+            'canDelete': True,
+            'canLink': True
         }


### PR DESCRIPTION
Companion to https://github.com/ome/omero-web/pull/653

The JSON response of `webgateway/imgData` was only tested in the scenario of a single channel single resolution image. 3d96084e2851ec3e964809b4a1814320736ad5ea extends this coverage to also test the response for a typical RGB multi-resolution image as of OMERO.web 5.30.1.
559e032 supplements both tests to cover the new `resolutions` key/value proposed for addition to the response of the endpoint in  https://github.com/ome/omero-web/pull/653
