### PR TITLE
Remove omero-common-test dependency

### DIFF
--- a/components/tools/OmeroJava/build.gradle
+++ b/components/tools/OmeroJava/build.gradle
@@ -10,7 +10,6 @@ version = "5.6.0"
 ext {
     // Load omero.properties
     Properties omeroProps = loadOmeroProperties()
-    omeroCommonTestVersion = omeroProps.getProperty("versions.omero-common-test")
     omeroBlitzVersion = omeroProps.getProperty("versions.omero-blitz")
     omeroGatewayVersion = omeroProps.getProperty("versions.omero-gateway")
 }
@@ -40,7 +39,6 @@ dependencies {
     testImplementation("org.testng:testng:6.14.2")
     implementation('commons-collections:commons-collections:3.2.2')
     implementation('commons-beanutils:commons-beanutils:1.9.3')
-    implementation("org.openmicroscopy:omero-common-test:$omeroCommonTestVersion")
     implementation("org.openmicroscopy:omero-gateway:$omeroGatewayVersion")
 }
 

--- a/components/tools/OmeroJava/ivy.xml
+++ b/components/tools/OmeroJava/ivy.xml
@@ -27,7 +27,6 @@
 	    <artifact name="omero-blitz" type="zip" ext="zip" e:classifier="python"/>
     </dependency>
     <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
-    <dependency org="org.openmicroscopy" name="omero-common-test" rev="${versions.omero-common-test}"/>
   </dependencies>
 </ivy-module>
 

--- a/components/tools/OmeroJava/test.xml
+++ b/components/tools/OmeroJava/test.xml
@@ -11,7 +11,6 @@
   </publications>
   <dependencies defaultconfmapping="test->*">
     <dependency org="org.openmicroscopy" name="omero-blitz" rev="${versions.omero-blitz}"/>
-    <dependency org="org.openmicroscopy" name="omero-common" rev="${versions.omero-common-test}"/>
     <dependency org="org.openmicroscopy" name="omero-gateway" rev="${versions.omero-gateway}"/>
     <dependency org="velocity" name="velocity-dep" rev="${versions.velocity}"/>
     <dependency org="org.testng" name="testng" rev="${versions.testng}"/>

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -679,6 +679,10 @@ public class AdditionalDeleteTest extends AbstractServerTest {
     {
         OriginalFile file = new OriginalFileI();
         file.setName(omero.rtypes.rstring("testing"));
+        file.setPath(omero.rtypes.rstring("/dev/null"));
+        file.setHash(omero.rtypes.rstring("abc"));
+        file.setSize(omero.rtypes.rlong(1));
+        file.setMimetype(omero.rtypes.rstring("text/plain"));
         FileAnnotationI ann = new FileAnnotationI();
         ann.setFile(file);
         ann = (FileAnnotationI) iUpdate.saveAndReturnObject(ann);

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import ome.testing.ObjectFactory;
 import omero.ApiUsageException;
 import omero.RObject;
 import omero.RType;
@@ -678,7 +677,8 @@ public class AdditionalDeleteTest extends AbstractServerTest {
     private FileAnnotationI mockAnnotation()
         throws Exception
     {
-        OriginalFile file = (OriginalFileI) new IceMapper().map(ObjectFactory.createFile());
+        OriginalFile file = new OriginalFileI();
+        file.setName("testing");
         FileAnnotationI ann = new FileAnnotationI();
         ann.setFile(file);
         ann = (FileAnnotationI) iUpdate.saveAndReturnObject(ann);

--- a/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
+++ b/components/tools/OmeroJava/test/integration/delete/AdditionalDeleteTest.java
@@ -678,7 +678,7 @@ public class AdditionalDeleteTest extends AbstractServerTest {
         throws Exception
     {
         OriginalFile file = new OriginalFileI();
-        file.setName("testing");
+        file.setName(omero.rtypes.rstring("testing"));
         FileAnnotationI ann = new FileAnnotationI();
         ann.setFile(file);
         ann = (FileAnnotationI) iUpdate.saveAndReturnObject(ann);

--- a/etc/omero.properties
+++ b/etc/omero.properties
@@ -248,7 +248,6 @@ versions.omero-scripts-url=${versions.omero-pypi}
 
 ## Internal dependencies
 versions.omero-blitz=5.8.3
-versions.omero-common-test=5.7.3
 versions.omero-gateway=5.10.3
 versions.omero-scripts=5.9.1
 versions.OMEZarrReader=0.3.1

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -4,8 +4,8 @@
 # is available and updates the value in etc/omero.properties
 
 # Check the Java packages
-# dirs=("org/openmicroscopy/omero-blitz" "org/openmicroscopy/omero-common-test" "org/openmicroscopy/omero-gateway" "ome/OMEZarrReader")
-dirs=("org/openmicroscopy/omero-blitz" "org/openmicroscopy/omero-common-test" "org/openmicroscopy/omero-gateway")
+# dirs=("org/openmicroscopy/omero-blitz" "org/openmicroscopy/omero-gateway" "ome/OMEZarrReader")
+dirs=("org/openmicroscopy/omero-blitz" "org/openmicroscopy/omero-gateway")
 for dir in "${dirs[@]}"
 do
     : 


### PR DESCRIPTION
Possible replacement for #6353

In evaluating the implications of https://github.com/ome/omero-common/pull/55, it looks like the only place consuming `omero-common-test` is the `AdditionalDeleteTest` Java integration test when creating a `MockAnnotation` and using the `ObjectFactory.createFile` static method.

This PR proposes replace the usage of `ObjectFactory` by the OMERO API directly and removes `omero-common-test` entirely as a dependency