### PR TITLE
Omero.server 5.6.17 release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
           cd target
           tag_name="${GITHUB_REF##*/}"
           sha256sum ./*.zip >> SHASUMS
-          gh release create "$tag_name" ./*.zip SHASUMS
+          gh release create  --generate-notes "$tag_name" ./*.zip SHASUMS
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/history.rst
+++ b/history.rst
@@ -22,7 +22,7 @@ for the Java processes. This change allows the server and notably Bio-Formats to
 fully functional on hardened environments where the `noexec` mount option has been set on
 the `/tmp` partitition.
 
-This version of OMERO.server has been tested with OMERO.py 5.22.0 and OMERO.web 5.30.1. We
+This version of OMERO.server has been tested with OMERO.py 5.22.0 and OMERO.web 5.31.0. We
 recommend to upgrade Python version to at least 3.10 and Django to version 5.2.
 
 The following OMERO.server dependencies have been upgraded:

--- a/history.rst
+++ b/history.rst
@@ -5,6 +5,36 @@
 OMERO version history
 =====================
 
+5.6.17 (February 2026)
+----------------------
+
+This is a bug-fix release of OMERO.server which includes:
+
+- an upgrade of Bio-Formats from 8.2.0 to 8.4.0. The new version will invalidate
+  previous Bio-Formats cache files. Please refer to the upgrade documentation
+  for further information.
+- an upgrade of the OMERO scripts from 5.9.1 to 5.10.0. The new version includes
+  several bug fixes as well as the ability to specify custom labels in the Split
+  View Figure script
+
+The IceGrid templates have been updated to use a local temporary directory, `var/tmp`,
+for the Java processes. This change allows the server and notably Bio-Formats to remain
+fully functional on hardened environments where the `noexec` mount option has been set on
+the `/tmp` partitition.
+
+This version of OMERO.server has been tested with OMERO.py 5.22.0 and OMERO.web 5.30.1. We
+recommend to upgrade Python version to at least 3.10 and Django to version 5.2.
+
+The following OMERO.server dependencies have been upgraded:
+
+- `org.openmicroscopy:omero-blitz` from 5.8.3 to 5.8.4
+- `org.openmicroscopy:omero-common` from 5.7.3 to 5.7.4
+- `org.openmicroscopy:omero-gateway-java` from 5.10.3 to 5.10.5
+- `org.openmicroscopy:omero-model` from 5.7.3 to 5.7.4
+- `org.openmicroscopy:omero-server` from 5.7.3 to 5.7.4
+- `org.openmicroscopy:omero-renderer` from 5.6.3 to 5.6.4
+- `org.openmicroscopy:omero-romio` from 5.8.3 to 5.8.4
+
 5.6.16 (June 2025)
 ------------------
 


### PR DESCRIPTION
e2b9633d3af143b17ecd25afb30953e761359fdc adds the `--generate-notes` flag to the command generating a GitHub release on tags
e85f3e0b103b2b28808fd5e11fa3a2a0865091f9 adds an initial set of release notes for the upcoming release of OMERO.server 5.6.17

OMERO.py will be released later today or Monday and has been included in the builds lately. Depending on the timeline for OMERO.web 5.31.0 we might release and announce everything together to enforce the recommendation on Python 3.10+ / Django 5.2 @knabar 