### PR TITLE
Add image child count for expected tags

### DIFF
--- a/components/tools/OmeroWeb/test/integration/test_tree.py
+++ b/components/tools/OmeroWeb/test/integration/test_tree.py
@@ -242,7 +242,6 @@ def expected_tags(user, tags):
             'id': tag.id.val,
             'value': tag.textValue.val,
             'ownerId': tag.details.owner.id.val,
-            'childCount': len(tag.linkedAnnotationList()),
             'permsCss': get_perms(user, tag, "TagAnnotation")
         }
         if tag.description is not None:
@@ -250,8 +249,10 @@ def expected_tags(user, tags):
 
         if tag.ns is not None and tag.ns.val == NSINSIGHTTAGSET:
             t['set'] = True
+            t['childCount'] = len(tag.linkedAnnotationList())
         else:
             t['set'] = False
+            t['childCount'] = 2 if tag.textValue.val == 'TagA' else 0
         expected.append(t)
     return expected
 


### PR DESCRIPTION
This fixes tests for the changes in https://github.com/ome/omero-web/pull/676

The number of images linked to a tag is hardcoded since the fixtures are not currently set up in a way that the number of ImageAnnotationLinks can be easily determined from the fixture.

I tried to break up the creation of of the tagset and tag hierarchy in `tagset_hierarchy_userA_groupA`, but this quickly devolved into issues with objects not saving properly, etc. Note that there is also a tag annotation created for a different user that is not returned anywhere.