### PR TITLE
Fix test_pyramids.py little and big_endian

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
@@ -234,14 +234,39 @@ class TestRemovePyramidsFullAdmin(CLITest):
         assert reason in out
 
     def test_remove_pyramids_big_endian(self, tmpdir, capsys):
-        """Test removepyramids with litlle endian true"""
+        """Test removepyramids with big endian true"""
+
         name = "big&sizeX=3500&sizeY=3500&little=false.fake"
         img_id = self.import_pyramid(tmpdir, name=name, skip=None)
+
+        query_service = self.client.sf.getQueryService()
+        image = query_service.findByQuery(
+            "select i from Image i join fetch i.pixels p where i.id = :id",
+            ParametersI().addId(img_id)
+        )
+
+        pixels_id = next(iter(image.copyPixels())).id.val
+
+        pyramid = None
+        for _ in range(60):
+            for root, _, files in os.walk(
+                    "/home/omero/workspace/OMERO-test-integration/data/Pixels"):
+                if f"{pixels_id}_pyramid" in files:
+                    pyramid = os.path.join(root, f"{pixels_id}_pyramid")
+                    break
+            if pyramid:
+                break
+            time.sleep(1)
+
+        assert pyramid is not None, \
+            "Timed out waiting for pyramid file"
+
         self.args += ["--endian=big"]
         self.cli.invoke(self.args, strict=True)
+
         out, err = capsys.readouterr()
-        output_start = "Pyramid removed for image %s" % img_id
-        assert output_start in out
+
+        assert f"Pyramid removed for image {img_id}" in out
 
     def test_remove_pyramids(self, tmpdir, capsys):
         """Test removepyramids with litlle endian true"""

--- a/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
@@ -32,6 +32,7 @@ import omero.plugins.admin
 import pytest
 import datetime
 import hashlib
+import time
 
 
 class TestRemovePyramids(CLITest):
@@ -139,10 +140,37 @@ class TestRemovePyramidsFullAdmin(CLITest):
             new_sink.close()
 
     def test_remove_pyramids_little_endian(self, tmpdir, capsys):
-        """Test removepyramids with litlle endian true"""
+        """Test removepyramids with little endian true"""
         img_id = self.import_pyramid(tmpdir)
+
+        # Find the Pixels ID corresponding to the imported image
+        query_service = self.client.sf.getQueryService()
+        rows = unwrap(query_service.projection(
+            "select p.id from Image i join i.pixels p where i.id = :id",
+            ParametersI().addId(img_id)
+        ))
+        pixels_id = rows[0][0]
+
+        # Wait until the pyramid file actually exists on disk
+        pixels_dir = "/home/omero/workspace/OMERO-test-integration/data/Pixels"
+        expected = f"{pixels_id}_pyramid"
+        deadline = time.time() + 120
+
+        while time.time() < deadline:
+            found = False
+            for root, _, files in os.walk(pixels_dir):
+                if expected in files:
+                    found = True
+                    break
+            if found:
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"Timed out waiting for pyramid file {expected}")
+
         self.args += ["--endian=little"]
         self.cli.invoke(self.args, strict=True)
+
         out, err = capsys.readouterr()
         output_start = "Pyramid removed for image %s" % img_id
         assert output_start in out

--- a/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
@@ -139,6 +139,24 @@ class TestRemovePyramidsFullAdmin(CLITest):
             orig_source.close()
             new_sink.close()
 
+    def wait_for_pyramid_file(self, pixels_id, timeout=120):
+        pixels_dir = (
+            "/home/omero/workspace/"
+            "OMERO-test-integration/data/Pixels"
+        )
+        expected = f"{pixels_id}_pyramid"
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            for root, _, files in os.walk(pixels_dir):
+                if expected in files:
+                    return
+            time.sleep(1)
+
+        pytest.fail(
+            f"Timed out waiting for pyramid file {expected}"
+        )
+
     def test_remove_pyramids_little_endian(self, tmpdir, capsys):
         """Test removepyramids with little endian true"""
         img_id = self.import_pyramid(tmpdir)
@@ -151,22 +169,8 @@ class TestRemovePyramidsFullAdmin(CLITest):
         ))
         pixels_id = rows[0][0]
 
-        # Wait until the pyramid file actually exists on disk
-        pixels_dir = "/home/omero/workspace/OMERO-test-integration/data/Pixels"
-        expected = f"{pixels_id}_pyramid"
-        deadline = time.time() + 120
-
-        while time.time() < deadline:
-            found = False
-            for root, _, files in os.walk(pixels_dir):
-                if expected in files:
-                    found = True
-                    break
-            if found:
-                break
-            time.sleep(1)
-        else:
-            pytest.fail(f"Timed out waiting for pyramid file {expected}")
+        # Wait until the pyramid actuall exists on disk
+        self.wait_for_pyramid_file(pixels_id)
 
         self.args += ["--endian=little"]
         self.cli.invoke(self.args, strict=True)
@@ -246,24 +250,8 @@ class TestRemovePyramidsFullAdmin(CLITest):
         )
 
         pixels_id = next(iter(image.copyPixels())).id.val
-
-        pyramid = None
-        pixels_dir = "/home/omero/workspace/OMERO-test-integration/data/Pixels"
-        pyramid_name = f"{pixels_id}_pyramid"
-
-        for _ in range(60):
-            for root, _, files in os.walk(pixels_dir):
-                if pyramid_name in files:
-                    pyramid = os.path.join(root, pyramid_name)
-                    break
-
-            if pyramid:
-                break
-
-            time.sleep(1)
-
-        assert pyramid is not None, \
-            "Timed out waiting for pyramid file"
+        # Wait for pyramid to actually be on disk
+        self.wait_for_pyramid_file(pixels_id)
 
         self.args += ["--endian=big"]
         self.cli.invoke(self.args, strict=True)
@@ -276,8 +264,26 @@ class TestRemovePyramidsFullAdmin(CLITest):
         """Test removepyramids with litlle endian true"""
         name = "big&sizeX=3500&sizeY=3500&little=false.fake"
         big_id = self.import_pyramid(tmpdir, name=name, skip=None)
+        query_service = self.client.sf.getQueryService()
+
+        rows = unwrap(query_service.projection(
+            "select p.id from Image i join i.pixels p where i.id = :id",
+            ParametersI().addId(big_id)
+        ))
+        pixels_id = rows[0][0]
+
+        self.wait_for_pyramid_file(pixels_id)
         name = "little&sizeX=3500&sizeY=3500&little=true.fake"
         little_id = self.import_pyramid(tmpdir, name=name, skip=None)
+        query_service = self.client.sf.getQueryService()
+
+        rows = unwrap(query_service.projection(
+            "select p.id from Image i join i.pixels p where i.id = :id",
+            ParametersI().addId(little_id)
+        ))
+        pixels_id = rows[0][0]
+
+        self.wait_for_pyramid_file(pixels_id)
         self.cli.invoke(self.args, strict=True)
         out, err = capsys.readouterr()
         output_start = "Pyramid removed for image %s" % big_id

--- a/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
@@ -248,14 +248,18 @@ class TestRemovePyramidsFullAdmin(CLITest):
         pixels_id = next(iter(image.copyPixels())).id.val
 
         pyramid = None
+        pixels_dir = "/home/omero/workspace/OMERO-test-integration/data/Pixels"
+        pyramid_name = f"{pixels_id}_pyramid"
+
         for _ in range(60):
-            for root, _, files in os.walk(
-                    "/home/omero/workspace/OMERO-test-integration/data/Pixels"):
-                if f"{pixels_id}_pyramid" in files:
-                    pyramid = os.path.join(root, f"{pixels_id}_pyramid")
+            for root, _, files in os.walk(pixels_dir):
+                if pyramid_name in files:
+                    pyramid = os.path.join(root, pyramid_name)
                     break
+
             if pyramid:
                 break
+
             time.sleep(1)
 
         assert pyramid is not None, \


### PR DESCRIPTION
Fixes the [persistent failures](https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_pyramids/TestRemovePyramidsFullAdmin/test_remove_pyramids_little_endian/) of the following 3 tests
-  ``test/integration/clitest/test_pyramids.py::TestRemovePyramidsFullAdmin::test_remove_pyramids_little_endian``.
-  ``test/integration/clitest/test_pyramids.py::TestRemovePyramidsFullAdmin::test_remove_pyramids_big_endian``
-  ``test/integration/clitest/test_pyramids.py::TestRemovePyramidsFullAdmin::test_remove_pyramids``

# What this PR does

The test is creating pyramids first, relying on pyramids being written fast and then testing the removal. After move of the devspace testing framework to NFS, the speed of writing pyramid files dropped. This PR adds checks for really checking whether the files have been written to disk first, before the (actually to-be-tested) removal of them starts.
For that purpose, a new helper ``wait_for_pyramids`` was introduced in https://github.com/ome/openmicroscopy/pull/6464/commits/e4565f6c3d55dc641245678a78fa55017dcf3d19


# Testing this PR
Jenkins test ``test/integration/clitest/test_pyramids.py::TestRemovePyramidsFullAdmin::test_remove_pyramids_little_endian`` should pass.

# Related reading

The problematic is similar (definitely not fully identical though) to the already opened https://github.com/ome/openmicroscopy/pull/6462. On NFS, the speed of writing and deleting files is simply slower than the tests assume.

ToDo: 

Possibly remove the hardcoded ``pixels_dir = "/home/omero/workspace/OMERO-test-integration/data/Pixels"`` -> I think I would need another round of investigation to find our how to replace with an env variable (cc @jburel ) .

Thanks for any help. Lets see if it works tomorrow during the build.

cc @sbesson @joshmoore  @dominikl 
