### PR TITLE
Fix test_remove_pyramids_check_thumbs NFS

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_pyramids.py
@@ -301,28 +301,48 @@ class TestRemovePyramidsFullAdmin(CLITest):
             ParametersI().addId(img_id))
         tb = self.client.sf.createThumbnailStore()
         id = pix.id.val
+
+        # Wait until the initial pyramid has been created
+        # so the first thumbnail
+        # request returns the real thumbnail
+        # rather than the clock placeholder.
+        self.wait_for_pyramid_file(id)
+
         thumb_hash = None
         try:
-            thumbs = tb.getThumbnailByLongestSideSet(rint(64), [id],
-                                                     {'omero.group': '-1'})
+            thumbs = tb.getThumbnailByLongestSideSet(
+                rint(64), [id], {'omero.group': '-1'})
             assert len(thumbs) == 1
             thumb_hash = self.calculate_sha1(thumbs[id])
+
             # remove the pyramid and the thumbnail
             self.args += ["--endian=big"]
             self.cli.invoke(self.args, strict=True)
             out, err = capsys.readouterr()
-            thumbs = tb.getThumbnailByLongestSideSet(rint(64), [id],
-                                                     {'omero.group': '-1'})
-            assert len(thumbs) == 1
-            # The clock should be returned during the pyramid generation
-            digest = self.calculate_sha1(thumbs[id])
+            digest = None
+            # Wait until the thumb
+            # is removed.
+            # This takes longer on NFS.
+            for attempt in range(30):
+                thumbs = tb.getThumbnailByLongestSideSet(
+                    rint(64), [id], {'omero.group': '-1'})
+                assert len(thumbs) == 1
+
+                digest = self.calculate_sha1(thumbs[id])
+
+                if digest != thumb_hash:
+                    break
+
+                time.sleep(1)
+
             assert digest != thumb_hash
             # The pyramid generation has now been triggered.
-            self.wait_for_pyramid(id)
-            thumbs = tb.getThumbnailByLongestSideSet(rint(64), [id],
-                                                     {'omero.group': '-1'})
+            self.wait_for_pyramid_file(id)
+            thumbs = tb.getThumbnailByLongestSideSet(
+                rint(64), [id], {'omero.group': '-1'}
+            )
             digest = self.calculate_sha1(thumbs[id])
-            # The thumbnail should now be back
+            # The thumbnail now should be back
             assert digest == thumb_hash
         finally:
             tb.close()


### PR DESCRIPTION


# What this PR does

Fixes https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.clitest.test_pyramids/TestRemovePyramidsFullAdmin/test_remove_pyramids_check_thumbnails/

Adds the ``waits _for_pyramid_file`` in 2 places and waits for thumbs deletion: necessary for NFS. The test was suffering from race problems in 3 places. The pyramids have to be
- generated after import
- deleted in order to comply with test setup (this will delete the created thumb too)
- regenerated (and with them the new thumb which is identical to the originally imported)

All 3 actions ^^ are slower on NFS and the necessary checks were added here so that the test can go ahead smoothly.


# Testing this PR
Check that Jenkins is green.
Note: This was tested as passing in the Jenkins env itself (but the test was edited and triggered manually).


# Related reading

Similar to https://github.com/ome/openmicroscopy/pull/6464, but a bit more complex, as this ``...check_thumbnails`` test is multi-staged.
