### PR TITLE
Test thumbs

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -106,8 +106,6 @@ class TestThumbs(ITest):
             f"Timed out waiting for pyramid file {expected}"
         )
 
-
-
     @pytest.mark.parametrize("meth", ("one", "set",))
     def testThumbnailVersion(self, meth):
 

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -11,6 +11,8 @@
 
 from omero.testlib import ITest
 import pytest
+import time
+import os
 
 from omero import MissingPyramidException
 from omero.sys import ParametersI
@@ -86,6 +88,26 @@ class TestThumbs(ITest):
         finally:
             tb.close()
 
+    def wait_for_pyramid_file(self, pixels_id, timeout=120):
+        pixels_dir = (
+            "/home/omero/workspace/"
+            "OMERO-test-integration/data/Pixels"
+        )
+        expected = f"{pixels_id}_pyramid"
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            for root, _, files in os.walk(pixels_dir):
+                if expected in files:
+                    return
+            time.sleep(1)
+
+        pytest.fail(
+            f"Timed out waiting for pyramid file {expected}"
+        )
+
+
+
     @pytest.mark.parametrize("meth", ("one", "set",))
     def testThumbnailVersion(self, meth):
 
@@ -146,9 +168,11 @@ class TestThumbs(ITest):
             # the pyramid is generated.
             tb.close()
             tb = self.client.sf.createThumbnailStore()
+            self.wait_for_pyramid_file(pix)
             if not tb.setPixelsId(int(pix)):
                 tb.resetDefaults()
                 tb.close()
+
                 tb = self.client.sf.createThumbnailStore()
                 assert tb.setPixelsId(int(pix))
             after = tb.getThumbnail(i64, i64)

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -180,6 +180,7 @@ class TestThumbs(ITest):
             assert tb.thumbnailExists(i64, i64)
             assert not tb.isInProgress()
         elif meth == "set":
+            self.wait_for_pyramid_file(pix)
             tb.getThumbnailSet(i64, i64, [int(pix)])
         assert get().version.val >= 0
 

--- a/components/tools/OmeroPy/test/integration/test_thumbs.py
+++ b/components/tools/OmeroPy/test/integration/test_thumbs.py
@@ -168,6 +168,8 @@ class TestThumbs(ITest):
             # the pyramid is generated.
             tb.close()
             tb = self.client.sf.createThumbnailStore()
+            # Wait for pyramid gen - slower on NFS
+            # and needs a check via FS.
             self.wait_for_pyramid_file(pix)
             if not tb.setPixelsId(int(pix)):
                 tb.resetDefaults()


### PR DESCRIPTION
# What this PR does

Fixing the failure of 2 tests, one at https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.test_thumbs/TestThumbs/testThumbnailVersion_one_/ and another of https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/lastCompletedBuild/testReport/OmeroPy.test.integration.test_thumbs/TestThumbs/testThumbnailVersion_set_/

- ``test/integration/test_thumbs2.py::TestThumbs::testThumbnailVersion[one]``
- ``test/integration/test_thumbs2.py::TestThumbs::testThumbnailVersion[set]``

Again, the migration to NFS necessitates wait for pyramid gen and check via checking of the filesystem itself.
Reusing the method introduced in https://github.com/ome/openmicroscopy/pull/6464


# Testing this PR

Check Jenkins is green for that test.


# Related reading

Similar problematics as https://github.com/ome/openmicroscopy/pull/6464
