### PR TITLE
Rawpixelstore omero-pyramid tests

### DIFF
--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -82,6 +82,13 @@ class TestRPS(ITest):
             rps.close()
         self.check_pix(pix)
 
+    @pytest.mark.skipif(
+        "JENKINS_MASTER" in os.environ,
+        reason=(
+            "Disabled on Jenkins: requires the PixelData service "
+            "to provide OMERO-managed pyramids."
+        ),
+    )
     def testRomioToPyramid(self, tmpdir):
         """
         This test checks automatic pyramid generation
@@ -122,6 +129,13 @@ class TestRPS(ITest):
         finally:
             rps.close()
 
+    @pytest.mark.skipif(
+        "JENKINS_MASTER" in os.environ,
+        reason=(
+            "Disabled on Jenkins: requires the PixelData service "
+            "to provide OMERO-managed pyramids."
+        ),
+    )
     def test2RomioToPyramidWithNegOne(self, tmpdir):
         """
         This test is basically a repeat of testRomioToPyramid
@@ -162,6 +176,13 @@ class TestRPS(ITest):
         finally:
             rps.close()
 
+    @pytest.mark.skipif(
+        "JENKINS_MASTER" in os.environ,
+        reason=(
+            "Disabled on Jenkins: requires the PixelData service "
+            "to provide OMERO-managed pyramids."
+        ),
+    )
     def testPyramidConcurrentAccess(self, tmpdir):
         """
         The test checks thread-safety and concurrent access

--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -10,7 +10,10 @@
 """
 
 import omero
+import os
+import pytest
 import threading
+
 from omero.testlib import ITest
 from omero.util.tiles import TileLoopIteration
 from omero.util.tiles import RPSTileLoop

--- a/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
+++ b/components/tools/OmeroPy/test/integration/test_rawpixelsstore.py
@@ -84,6 +84,11 @@ class TestRPS(ITest):
 
     def testRomioToPyramid(self, tmpdir):
         """
+        This test checks automatic pyramid generation
+        and successful recovery from MissingPyramidException.
+        It cannot really work without omero-generated
+        pyramids.
+
         Here we create a pixels that is not big,
         then modify its metadata so that it IS big,
         in order to trick the service into throwing
@@ -119,6 +124,11 @@ class TestRPS(ITest):
 
     def test2RomioToPyramidWithNegOne(self, tmpdir):
         """
+        This test is basically a repeat of testRomioToPyramid
+        test above under cross-group context.
+        The test cannot really work without omero-generated
+        pyramids.
+
         Here we try the above but pass omero.group:-1
         to see if we can cause an exception.
         """
@@ -154,6 +164,11 @@ class TestRPS(ITest):
 
     def testPyramidConcurrentAccess(self, tmpdir):
         """
+        The test checks thread-safety and concurrent access
+        to a newly generated pyramid.
+        The test cannot really work without omero-generated
+        pyramids.
+
         See ticket:11709
         """
         all_context = {"omero.group": "-1"}


### PR DESCRIPTION
# What this PR does

Explains and skips on Jenkins 3 tests which fully depend on omero-pyramids generation in ``OmeroPy.test.integration.test_rawpixelsstore.TestRPS``:

- ``testRomioToPyramid``
- ``test2RomioToPyramidWithNegOne``
- ``testPyramidConcurrentAccess``


# Testing this PR
See the Jenkins build for these tests is passing.


# Related reading

See https://github.com/ome/openmicroscopy/issues/6470
